### PR TITLE
Add Contributing Guidelines and Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at build@smartthings.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to SmartThingsEdgeDrivers
+
+Want to contribute? Great! First, read this page (including the small print at
+the end). By submitting a pull request, you represent that you have the right to
+license your contribution to SmartThings and agree by submitting the patch that
+your contributions are licensed under the [Apache 2.0 license](LICENSE). Before
+submitting the pull request, please make sure you have tested your changes and that
+they follow the project guidelines for contributing code.
+
+Before contributions can be merged, all contributors must agree to the [SmartThings
+Individual Contributor License
+Agreement](https://cla-assistant.io/SmartThingsCommunity/SmartThingsEdgeDrivers).

--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ Alternatively, you can extract the API release to a location of your choice and 
 Library source in the Lua Language Server [settings](https://github.com/sumneko/lua-language-server#setting). **NOTE**:
 this is the internal folder, not a top level folder you potentially created when unzipping (i.e. it should not include 
 the docs folder).
+
+## Code of Conduct
+
+The code of conduct for SmartThingsEdgeDrivers can be found in
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
+
+## How to Contribute
+
+We welcome contributions to SmartThingsEdgeDrivers. Read our contribution
+guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+SmartThingsEdgeDrivers is released under the [Apache 2.0 License](LICENSE).


### PR DESCRIPTION
cla-assistant is now configured to ensure contributors have
agreed to the CLA before contributions will be accepted.