### PR TITLE
Add IKEA Shortcut button

### DIFF
--- a/drivers/SmartThings/zigbee-button/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-button/fingerprints.yml
@@ -44,6 +44,11 @@ zigbeeManufacturer:
     manufacturer: KE
     model: TRADFRI open/close remote
     deviceProfileName: two-buttons-battery
+  - id: "IKEA of Sweden/TRADFRI shortcut"
+    deviceLabel: IKEA Remote Control
+    manufacturer: IKEA of Sweden
+    model: TRADFRI Shortcut Button
+    deviceProfileName: two-buttons-battery    
   - id: "CentraLite/3450-L"
     deviceLabel: Iris Remote Control
     manufacturer: CentraLite


### PR DESCRIPTION
Add Edge Driver support for the [IKEA Shortcut button](https://www.ikea.com/gb/en/p/tradfri-shortcut-button-white-40467765/)

![20220106_142337](https://user-images.githubusercontent.com/1678318/148397947-27d708c5-3f20-4dad-a2e5-592740d1b571.jpg)
