### PR TITLE
Adding fingerprint for an alternate Fibaro radiator thermostat model

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zwave-thermostat/fingerprints.yml
@@ -50,7 +50,6 @@ zwaveManufacturer:
   - id: "fibaro/thermostat/1"
     deviceLabel: Fibaro Thermostat
     manufacturerId: 0x010F
-    productId: 0x1000
     productType: 0x1301
     deviceProfileName: base-radiator-thermostat
   - id: "0239/0001/0001"

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
@@ -30,12 +30,21 @@ local ApplicationStatus = (require "st.zwave.CommandClass.ApplicationStatus")({v
 
 local utils = require "st.utils"
 
-local FIBARO_HEAT_FINGERPRINT = {mfr = 0x010F, prod = 0x1301, model = 0x1000}
+local FIBARO_HEAT_FINGERPRINTS = {
+    {mfr = 0x010F, prod = 0x1301, model = 0x1000}, -- Fibaro Heat Controller
+    {mfr = 0x010F, prod = 0x1301, model = 0x1001} -- Fibaro Heat Controller
+}
 
 local FORCED_REFRESH_THREAD = "forcedRefreshThread"
 
 local function can_handle_fibaro_heat_controller(opts, driver, device, ...)
-  return device:id_match(FIBARO_HEAT_FINGERPRINT.mfr, FIBARO_HEAT_FINGERPRINT.prod, FIBARO_HEAT_FINGERPRINT.model)
+  for _, fingerprint in ipairs(FIBARO_HEAT_FINGERPRINTS) do
+      if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+          return true
+      end
+  end
+
+  return false
 end
 
 local function thermostat_mode_report_handler(self, device, cmd)


### PR DESCRIPTION
Fibaro has a _slightly_ different model of this device that functions the same but has a small difference in fingerprint. Adding the fingerprint for this other model so it pairs correctly.