### PR TITLE
Add fingerprint for Minoston Z-Wave plug, model MP22ZP

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -803,11 +803,17 @@ zwaveManufacturer:
     productType: 0x1F01
     productId: 0x1000
     deviceProfileName: metering-switch
-  - id: 0312/FF00/FF0E
+  - id: 0312/FF00/FF0E # Minoston Model MP21ZP
     deviceLabel: Minoston Outlet
     manufacturerId: 0x0312
     productType: 0xFF00
     productId: 0xFF0E
+    deviceProfileName: metering-switch
+  - id: 0312/FF00/FF0F # Minoston Model MP22ZP
+    deviceLabel: Minoston Outlet
+    manufacturerId: 0x0312
+    productType: 0xFF00
+    productId: 0xFF0F
     deviceProfileName: metering-switch
   - id: Evolve/RelaySwitch
     deviceLabel: Evolve Switch


### PR DESCRIPTION
Edge support for Minoston Z-Wave outdoor energy monitor plug, model MP22ZP

Goovy DTH support here for reference --> https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/55f0754837783518f351becb936c6a183b2e44eb/devicetypes/smartthings/zwave-metering-switch.src/zwave-metering-switch.groovy#L56

Signed-off-by: Barry Andersen <barry@bright.ai>