### PR TITLE
Z-Wave Mouse Trap: Fix icon by changing category to GenericSensor

### DIFF
--- a/drivers/SmartThings/zwave-mouse-trap/profiles/pest-control-battery.yml
+++ b/drivers/SmartThings/zwave-mouse-trap/profiles/pest-control-battery.yml
@@ -9,4 +9,4 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: ContactSensor
+  - name: GenericSensor


### PR DESCRIPTION
The profile was using the ContactSensor category but GenericSensor is more appropriate since this device doesn't have a contact sensor and there isn't a more specific category available for a device like this.

https://smartthings.atlassian.net/browse/CHAD-8638