### PR TITLE
HCS-2892 Change order of capabilities

### DIFF
--- a/drivers/SmartThings/zwave-electric-meter/profiles/base-electric-meter.yml
+++ b/drivers/SmartThings/zwave-electric-meter/profiles/base-electric-meter.yml
@@ -2,9 +2,9 @@ name: base-electric-meter
 components:
 - id: main
   capabilities:
-  - id: energyMeter
-    version: 1
   - id: powerMeter
+    version: 1
+  - id: energyMeter
     version: 1
   - id: refresh
     version: 1


### PR DESCRIPTION
Aeon Energy Meter capabilities should be ordered as they were with the DTH