### PR TITLE
Chad 8645 zigbee-button: Make button status visible in dashboard

### DIFF
--- a/drivers/SmartThings/zigbee-button/profiles/iris-one-button-battery.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/iris-one-button-battery.yml
@@ -2,9 +2,9 @@ name: iris-one-button-battery
 components:
 - id: main
   capabilities:
-  - id: battery
-    version: 1
   - id: button
+    version: 1
+  - id: battery
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/zigbee-button/profiles/one-button-battery.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/one-button-battery.yml
@@ -2,9 +2,9 @@ name: one-button-battery
 components:
   - id: main
     capabilities:
-      - id: battery
-        version: 1
       - id: button
+        version: 1
+      - id: battery
         version: 1
       - id: firmwareUpdate
         version: 1

--- a/drivers/SmartThings/zigbee-button/profiles/one-button-temp-battery.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/one-button-temp-battery.yml
@@ -2,9 +2,9 @@ name: one-button-temp-battery
 components:
 - id: main
   capabilities:
-  - id: battery
-    version: 1
   - id: button
+    version: 1
+  - id: battery
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/zigbee-button/src/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/init.lua
@@ -65,6 +65,7 @@ end
 local function added_handler(self, device)
   device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
+  device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end
 
 local zigbee_button_driver_template = {

--- a/drivers/SmartThings/zigbee-button/src/test/test_zigbee_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_zigbee_button.lua
@@ -182,6 +182,13 @@ test.register_coroutine_test(
           }
         }
       )
+      test.socket.capability:__expect_send({
+	mock_device.id,
+	{
+	  capability_id = "button", component_id = "main",
+	  attribute_id = "button", state = { value = "pushed"}
+	}
+      })
       test.wait_for_events()
 
       test.mock_time.advance_time(50000) -- Battery has a max reporting interval of 21600


### PR DESCRIPTION
Default presentation uses the first capability listed for the dashboard status and a couple profiles in this driver listed battery first, thus showing battery percentage rather than button status. This fixes the problem by listing button first in the capabilities and adding an emit_event to the added_handler.

https://smartthings.atlassian.net/browse/CHAD-8645