### PR TITLE
zigbee-button: Change category (and icon) for SmartThings button

### DIFF
--- a/drivers/SmartThings/zigbee-button/profiles/one-button-temp-battery.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/one-button-temp-battery.yml
@@ -13,7 +13,7 @@ components:
   - id: temperatureMeasurement
     version: 1
   categories:
-    - name: RemoteController
+    - name: Button
 preferences:
   - preferenceId: tempOffset
     explicit: true


### PR DESCRIPTION
The default icon for the RemoteController category is different than the icon the SmartThings button uses when using a DTH. The new Button category will be mapped to the same icon that device uses when backed by a DTH.

https://smartthings.atlassian.net/browse/CHAD-8642