### PR TITLE
CHAD-8725 - adds a new device profile for Aeotec aerQ sensors

### DIFF
--- a/drivers/SmartThings/zwave-sensor/fingerprints.yml
+++ b/drivers/SmartThings/zwave-sensor/fingerprints.yml
@@ -204,7 +204,7 @@ zwaveManufacturer:
     deviceLabel: Aeotec Multipurpose Sensor
     manufacturerId: 0x0371
     productId: 0x0009
-    deviceProfileName: temp-humidity-dew-mold
+    deviceProfileName: aeotec-temp-humidity-dew-mold
   - id: POPP/moldDetector # all regions
     deviceLabel: POPP Multipurpose Sensor
     manufacturerId: 0x0154

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-temp-humidity-dew-mold.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-temp-humidity-dew-mold.yml
@@ -1,0 +1,18 @@
+name: aeotec-temp-humidity-dew-mold
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: dewPoint
+    version: 1
+  - id: moldHealthConcern
+    version: 1
+  - id: battery
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat


### PR DESCRIPTION
CHAD-8725 - new device profile for Aeotec aerQ sensors
@SmartThingsCommunity/srpol-pe-team @greens 