### PR TITLE
CHAD-8847 - adds tempOffset to the device profile

### DIFF
--- a/drivers/SmartThings/zigbee-contact/profiles/contact-battery-temperature.yml
+++ b/drivers/SmartThings/zigbee-contact/profiles/contact-battery-temperature.yml
@@ -14,3 +14,6 @@ components:
     version: 1
   categories:
   - name: ContactSensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true


### PR DESCRIPTION
CHAD-8847 - adds tempOffset to the device profile
@greens @SmartThingsCommunity/srpol-pe-team 