### PR TITLE
HCS-2753: Added '000B' as fingerprint to zwave-thermostat

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zwave-thermostat/fingerprints.yml
@@ -47,6 +47,12 @@ zwaveManufacturer:
     productType: 0x6501
     productId: 0x000C
     deviceProfileName: base-thermostat
+  - id: "0098/6501/000B"
+    deviceLabel: Iris Thermostat
+    manufacturerId: 0x0098
+    productType: 0x6501
+    productId: 0x000B
+    deviceProfileName: base-thermostat
   - id: "fibaro/thermostat/1"
     deviceLabel: Fibaro Thermostat
     manufacturerId: 0x010F


### PR DESCRIPTION
Bugfix HCS-2753: Added '000B' as fingerprint to zwave-thermostat