### PR TITLE
Enhancements to test-running

### DIFF
--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           workflow: upload-driver-packages.yml
           name: ${{ matrix.driver }}
+          run_id: ${{ github.event.workflow_run.id }}
       - name: Upload the driver
         id: driver
         run: |

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,21 @@
+name: Publish test results
+on:
+  workflow_run:
+    workflows: [Run driver tests]
+    types:
+      - completed
+
+jobs:
+  publish-test-results:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: run-tests.yml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: tests
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: "*.xml"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,6 @@ jobs:
         if: steps.cached-libs.outputs.cache-hit != 'true'
         working-directory: '/home/runner/work/lua_libs'
         run: tar -xf *.tar.gz --wildcards -C . --strip-components=1 '*.lua'
-      - run: ls /home/runner/work/lua_libs
       - name: Install lua
         run: |
           sudo apt-get update
@@ -44,7 +43,9 @@ jobs:
         run: mkdir test-output
       - name: Run the tests
         run: python tools/run_driver_tests.py -j test-output/tests.xml
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+      - name: Upload test artifact
+        uses: actions/upload-artifact@v3
         with:
-          files: "test-output/*.xml"
+          name: tests
+          path: |
+            test-output/tests.xml


### PR DESCRIPTION
Test results could not be published from forks. This uses artifact uploads to enable that.