### PR TITLE
CHAD-8872 - Add missing fingerprints in power-meter and vid for EZEX power meter

### DIFF
--- a/drivers/SmartThings/zigbee-power-meter/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-power-meter/fingerprints.yml
@@ -2,6 +2,21 @@ zigbeeManufacturer:
   - id: "E240-KR080Z0-HA"
     deviceLabel: Energy Monitor
     model: "E240-KR080Z0-HA"
+    deviceProfileName: power-meter-consumption-report
+  - id: "Develco/ZHEMI101"
+    deviceLabel: frient Energy Monitor
+    manufacturer: Develco
+    model: "ZHEMI101"
+    deviceProfileName: power-meter
+  - id: "Develco/EMIZB-132"
+    deviceLabel: frient Energy Monitor
+    manufacturer: Develco Products A/S
+    model: "EMIZB-132"
+    deviceProfileName: power-meter
+  - id: "ShinaSystem/PMM-300Z1"
+    deviceLabel: SiHAS Energy Monitor
+    manufacturer: ShinaSystem
+    model: "PMM-300Z1"
     deviceProfileName: power-meter
 zigbeeGeneric:
   - id: "genericMeter"

--- a/drivers/SmartThings/zigbee-power-meter/profiles/power-meter-consumption-report.yml
+++ b/drivers/SmartThings/zigbee-power-meter/profiles/power-meter-consumption-report.yml
@@ -1,0 +1,19 @@
+name: power-meter-consumption-report
+components:
+- id: main
+  capabilities:
+  - id: powerMeter
+    version: 1
+  - id: energyMeter
+    version: 1
+  - id: powerConsumptionReport
+    version: 1    
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: CurbPowerMeter
+metadata:
+  mnmn: SmartThingsEdge
+  vid: STES-1-EZEX-Zigbee_Power_Meter

--- a/drivers/SmartThings/zigbee-power-meter/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/ezex/init.lua
@@ -1,0 +1,79 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local ZigbeeDriver = require "st.zigbee"
+local defaults = require "st.zigbee.defaults"
+local constants = require "st.zigbee.constants"
+local clusters = require "st.zigbee.zcl.clusters"
+local ElectricalMeasurement = clusters.ElectricalMeasurement
+local SimpleMetering = clusters.SimpleMetering
+
+local ZIGBEE_POWER_METER_FINGERPRINTS = {
+  { model = "E240-KR080Z0-HA" }
+}
+
+local is_ezex_power_meter = function(opts, driver, device)
+  for _, fingerprint in ipairs(ZIGBEE_POWER_METER_FINGERPRINTS) do
+      if device:get_model() == fingerprint.model then
+          return true
+      end
+  end
+
+  return false
+end
+
+local do_configure = function(self, device)
+  device:refresh()
+  device:configure()
+end
+
+local device_init = function(self, device)
+  device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1000000, {persist = true})
+  device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 10, {persist = true})
+end
+
+local function energy_meter_handler(driver, device, value, zb_rx)
+  local raw_value_miliwatts = value.value
+  local raw_value_watts = raw_value_miliwatts / 1000
+  local delta_energy = 0.0
+  local current_power_consumption = device:get_latest_state("main", capabilities.powerConsumptionReport.ID, capabilities.powerConsumptionReport.powerConsumption.NAME)
+  if current_power_consumption ~= nil then
+    delta_energy = math.max(raw_value_watts - current_power_consumption.energy, 0.0)
+  end
+  device:emit_event(capabilities.powerConsumptionReport.powerConsumption({energy = raw_value_watts, deltaEnergy = delta_energy })) -- the unit of these values should be 'Wh'
+
+  local multiplier = device:get_field(constants.SIMPLE_METERING_MULTIPLIER_KEY) or 1
+  local divisor = device:get_field(constants.SIMPLE_METERING_DIVISOR_KEY) or 1000000
+  local converted_value = raw_value_miliwatts * multiplier/divisor -- unit: kWh
+  device:emit_event(capabilities.energyMeter.energy({value = converted_value, unit = "kWh"}))
+end
+
+local ezex_power_meter_handler = {
+  NAME = "ezex power meter handler",
+  zigbee_handlers = {
+    attr = {
+      [SimpleMetering.ID] = {
+        [SimpleMetering.attributes.CurrentSummationDelivered.ID] = energy_meter_handler
+      }
+    }
+  },
+  lifecycle_handlers = {
+    init = device_init,
+    doConfigure = do_configure,
+  },
+  can_handle = is_ezex_power_meter
+}
+
+return ezex_power_meter_handler

--- a/drivers/SmartThings/zigbee-power-meter/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/frient/init.lua
@@ -1,0 +1,57 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local ZigbeeDriver = require "st.zigbee"
+local defaults = require "st.zigbee.defaults"
+local constants = require "st.zigbee.constants"
+local clusters = require "st.zigbee.zcl.clusters"
+local ElectricalMeasurement = clusters.ElectricalMeasurement
+local SimpleMetering = clusters.SimpleMetering
+
+local ZIGBEE_POWER_METER_FINGERPRINTS = {
+  { model = "ZHEMI101" },
+  { model = "EMIZB-132" },
+}
+
+local is_frient_power_meter = function(opts, driver, device)
+  for _, fingerprint in ipairs(ZIGBEE_POWER_METER_FINGERPRINTS) do
+      if device:get_model() == fingerprint.model then
+          return true
+      end
+  end
+
+  return false
+end
+
+local do_configure = function(self, device)
+  device:refresh()
+  device:configure()
+end
+
+local device_init = function(self, device)
+  device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1000, {persist = true})
+  device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 10000, {persist = true})
+end
+
+local frient_power_meter_handler = {
+  NAME = "frient power meter handler",
+  lifecycle_handlers = {
+    init = device_init,
+    doConfigure = do_configure,
+  },
+  can_handle = is_frient_power_meter
+}
+
+return frient_power_meter_handler

--- a/drivers/SmartThings/zigbee-power-meter/src/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/init.lua
@@ -42,7 +42,7 @@ local device_init = function(self, device)
   end
 
   if device:get_field(zigbee_constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY) == nil then
-    device:set_field(zigbee_constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 10, {persist = true})
+    device:set_field(zigbee_constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 1000, {persist = true})
   end
 end
 
@@ -50,9 +50,14 @@ local zigbee_power_meter_driver_template = {
   supported_capabilities = {
     capabilities.refresh,
     capabilities.powerMeter,
-    capabilities.energyMeter
+    capabilities.energyMeter,
+    capabilities.powerConsumptionReport,
   },
-  sub_drivers = {},
+  sub_drivers = {
+    require("ezex"),
+    require("frient"),
+    require("shinasystems"),
+  },
   lifecycle_handlers = {
     init = device_init,
     doConfigure = do_configure,

--- a/drivers/SmartThings/zigbee-power-meter/src/shinasystems/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/shinasystems/init.lua
@@ -1,0 +1,56 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local ZigbeeDriver = require "st.zigbee"
+local defaults = require "st.zigbee.defaults"
+local constants = require "st.zigbee.constants"
+local clusters = require "st.zigbee.zcl.clusters"
+local ElectricalMeasurement = clusters.ElectricalMeasurement
+local SimpleMetering = clusters.SimpleMetering
+
+local ZIGBEE_POWER_METER_FINGERPRINTS = {
+  { model = "PMM-300Z1" }
+}
+
+local is_shinasystems_power_meter = function(opts, driver, device)
+  for _, fingerprint in ipairs(ZIGBEE_POWER_METER_FINGERPRINTS) do
+      if device:get_model() == fingerprint.model then
+          return true
+      end
+  end
+
+  return false
+end
+
+local do_configure = function(self, device)
+  device:refresh()
+  device:configure()
+end
+
+local device_init = function(self, device)
+  device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1000, {persist = true})
+  device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 1000, {persist = true})
+end
+
+local shinasystems_power_meter_handler = {
+  NAME = "shinasystems power meter handler",
+  lifecycle_handlers = {
+    init = device_init,
+    doConfigure = do_configure,
+  },
+  can_handle = is_shinasystems_power_meter
+}
+
+return shinasystems_power_meter_handler

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_consumption_report.lua
@@ -1,0 +1,149 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Mock out globals
+local test = require "integration_test"
+local clusters = require "st.zigbee.zcl.clusters"
+local ElectricalMeasurement = clusters.ElectricalMeasurement
+local SimpleMetering = clusters.SimpleMetering
+local capabilities = require "st.capabilities"
+local zigbee_test_utils = require "integration_test.zigbee_test_utils"
+local t_utils = require "integration_test.utils"
+
+local mock_device = test.mock_device.build_test_zigbee_device(
+    {
+      profile = t_utils.get_profile_definition("power-meter-consumption-report.yml"),
+      zigbee_endpoints = {
+        [1] = {
+          id = 1,
+          model = "E240-KR080Z0-HA",
+          server_clusters = {}
+        }
+      }
+    }
+)
+
+zigbee_test_utils.prepare_zigbee_env_info()
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
+  zigbee_test_utils.init_noop_health_check_timer()
+end
+
+test.set_test_init_function(test_init)
+
+test.register_message_test(
+    "ActivePower Report should be handled. Sensor value is in W, capability attribute value is in hectowatts",
+    {
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_device.id, ElectricalMeasurement.attributes.ACPowerDivisor:build_test_attr_report(mock_device, 0x0A) }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_device.id, ElectricalMeasurement.attributes.ActivePower:build_test_attr_report(mock_device,
+                                                                                                        27) },
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 2.7, unit = "W" }))
+      }
+    }
+)
+
+test.register_message_test(
+  "SimpleMetering event should be handled by powerConsumptionReport capability",
+  {
+    {
+      channel = "zigbee",
+      direction = "receive",
+      message = { mock_device.id, SimpleMetering.attributes.CurrentSummationDelivered:build_test_attr_report(mock_device, 1000) }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({energy = 1.0, deltaEnergy = 0.0 }))
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 0.001, unit = "kWh"}))
+    },
+    {
+      channel = "zigbee",
+      direction = "receive",
+      message = { mock_device.id, SimpleMetering.attributes.CurrentSummationDelivered:build_test_attr_report(mock_device, 1500) }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({energy = 1.5, deltaEnergy = 0.5 }))
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 0.0015, unit = "kWh"}))
+    }
+  }
+)
+
+test.register_coroutine_test(
+    "lifecycle configure event should configure device",
+    function ()
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.InstantaneousDemand:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.CurrentSummationDelivered:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ElectricalMeasurement.attributes.ActivePower:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              SimpleMetering.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 1, 3600, 1)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.CurrentSummationDelivered:configure_reporting(mock_device, 5, 3600, 1)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              ElectricalMeasurement.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 1, 3600, 1)
+                                       })
+      mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    end
+)
+
+
+test.run_registered_tests()


### PR DESCRIPTION
[CHAD-8872](https://smartthings.atlassian.net/browse/CHAD-8872)
- Add specific vid for EZEX power meter to display in Energy plugin.
- Fix bug

[CHAD-8897](https://smartthings.atlassian.net/browse/CHAD-8897)
- Add missing fingerprints in [DTH](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/zigbee-power-meter.src/zigbee-power-meter.groovy) and add sub-drivers for them.