### PR TITLE
Added Aeotec Range Extender 7 Zi to fingerprints

### DIFF
--- a/drivers/SmartThings/zigbee-range-extender/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-range-extender/fingerprints.yml
@@ -19,3 +19,8 @@ zigbeeManufacturer:
     manufacturer: IKEA of Sweden
     model: TRADFRI signal repeater
     deviceProfileName: range-extender
+  - id: "AEOTEC/WG001-Z01"
+    manufacturer: AL001
+    model: WG001-Z01
+    deviceLabel: Aeotec Range Extender
+    deviceProfileName: range-extender


### PR DESCRIPTION
Hi,

please add this fingerprint, it is for the edge driver certification.

thank you.

Regards,
zwave-mke