### PR TITLE
Add Aeotec Range Extender 7 Zi fingerprint

### DIFF
--- a/drivers/SmartThings/zigbee-range-extender/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-range-extender/fingerprints.yml
@@ -22,5 +22,5 @@ zigbeeManufacturer:
   - id: "AEOTEC/WG001-Z01"
     manufacturer: AL001
     model: WG001-Z01
-    deviceLabel: Aeotec Range Extender
+    deviceLabel: Aeotec Range Extender Zi
     deviceProfileName: range-extender

--- a/drivers/SmartThings/zigbee-range-extender/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-range-extender/fingerprints.yml
@@ -19,3 +19,8 @@ zigbeeManufacturer:
     manufacturer: IKEA of Sweden
     model: TRADFRI signal repeater
     deviceProfileName: range-extender
+  - id: "AEOTEC/WG001-Z01"
+    manufacturer: AL001
+    model: WG001-Z01
+    deviceLabel: Aeotec Range Extender
+    deviceProfileName: range-extender


### PR DESCRIPTION
Hi,

we would like to add the Aeotec Range Extender 7 Zi fingerprint due it's already in the edge driver certification process.

(Please excuse the faulty pull requests before - there was a Github user mismatch on the windows Github client, so the user was not able to sign the CLA agreement)

Thank you in advance.

Regards,
zwave-mke