### PR TITLE
zigbee-switch: Fix color handling for Ikea RGB bulbs

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
@@ -96,7 +96,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Added lifecycle should be handlded",
+  "Added lifecycle should be handled",
   function()
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
@@ -158,7 +158,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Capability 'switchLevel' command 'setLevel' on should be handled",
+  "Capability 'switchLevel' command 'setLevel' should be handled",
   function()
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
@@ -179,45 +179,166 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Set Hue command test",
   function()
-    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
-    test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setHue", args = { 75 } } })
+    local test_data = {
+      { hue = 75, saturation = 65,  x = 0x3E51, y = 0x255D },
+      { hue = 75, saturation = nil, x = 0x500F, y = 0x543B }
+    }
 
-    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
+    for _, data in ipairs(test_data) do
+      if data.saturation ~= nil then
+        mock_device.wrapped_device.state_cache = {["main"] = {["colorControl"] = {["saturation"] = {["value"] = data.saturation}}}}
+      else
+        mock_device.wrapped_device.state_cache = {}
+      end
 
-    test.socket.zigbee:__expect_send(
-      {
-        mock_device.id,
-        ColorControl.commands.MoveToColor(mock_device, 0x500F, 0x543B, 0x0000)
-      }
-    )
+      test.timer.__create_and_queue_test_time_advance_timer(0.2, "oneshot")
+      test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+      test.socket.capability:__queue_receive({mock_device.id,
+        {
+          capability = "colorControl",
+          component = "main",
+          command = "setHue",
+          args = { data.hue } }
+        }
+      )
 
-    test.wait_for_events()
+      test.wait_for_events()
+      test.mock_time.advance_time(0.2)
 
-    test.mock_time.advance_time(2)
-    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentX:read(mock_device) })
-    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
+      test.socket.zigbee:__expect_send(
+        {
+          mock_device.id,
+          ColorControl.commands.MoveToColor(mock_device, data.x, data.y, 0x0000)
+        }
+      )
+
+      test.wait_for_events()
+      test.mock_time.advance_time(2)
+
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentX:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
+      end
   end
 )
 
 test.register_coroutine_test(
   "Set Saturation command test",
   function()
-    test.socket.zigbee:__set_channel_ordering("relaxed")
+    local test_data = {
+      { hue = 75, saturation = 65, x = 0x3E51, y = 0x255D },
+      { hue = nil, saturation = 65, x = 0x86EF, y = 0x5465 }
+    }
+
+    for _, data in ipairs(test_data) do
+      if data.saturation ~= nil then
+        mock_device.wrapped_device.state_cache = {["main"] = {["colorControl"] = {["hue"] = {["value"] = data.hue}}}}
+      else
+        mock_device.wrapped_device.state_cache = {}
+      end
+
+      test.timer.__create_and_queue_test_time_advance_timer(0.2, "oneshot")
+      test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+      test.socket.capability:__queue_receive({mock_device.id,
+        {
+          capability = "colorControl",
+          component = "main",
+          command = "setSaturation",
+          args = { data.saturation } }
+        }
+      )
+
+      test.wait_for_events()
+      test.mock_time.advance_time(0.2)
+
+      test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
+      test.socket.zigbee:__expect_send(
+        {
+          mock_device.id,
+          ColorControl.commands.MoveToColor(mock_device, data.x, data.y, 0x0000)
+        }
+      )
+
+      test.wait_for_events()
+      test.mock_time.advance_time(2)
+
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentX:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
+    end
+  end
+)
+
+test.register_coroutine_test(
+  "Set Hue/Saturation command test",
+  function()
+    test.timer.__create_and_queue_test_time_advance_timer(0.2, "oneshot")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
-    test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setSaturation", args = { 65 } } })
+    test.socket.capability:__queue_receive({mock_device.id,
+      {
+        capability = "colorControl",
+        component = "main",
+        command = "setHue",
+        args = { 75 } }
+      }
+    )
+    test.socket.capability:__queue_receive({mock_device.id,
+      {
+        capability = "colorControl",
+        component = "main",
+        command = "setSaturation",
+        args = { 65 } }
+      }
+    )
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
-
     test.socket.zigbee:__expect_send(
       {
         mock_device.id,
-        ColorControl.commands.MoveToColor(mock_device, 0x86EF, 0x5465, 0x0000)
+        ColorControl.commands.MoveToColor(mock_device, 0x3E51, 0x255D, 0x0000)
       }
     )
 
     test.wait_for_events()
-
     test.mock_time.advance_time(2)
+
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentX:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
+  end
+)
+
+test.register_coroutine_test(
+  "Set Hue followed by Set Color command test",
+  function()
+    test.timer.__create_and_queue_test_time_advance_timer(0.2, "oneshot")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.capability:__queue_receive({mock_device.id,
+      {
+        capability = "colorControl",
+        component = "main",
+        command = "setHue",
+        args = { 75 } }
+      }
+    )
+    test.socket.capability:__queue_receive({mock_device.id,
+      {
+        capability = "colorControl",
+        component = "main",
+        command = "setColor",
+        args = { { hue = 20, saturation = 100 } } }
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.commands.MoveToColor(mock_device, 0x6239, 0x8896, 0x0000)
+      }
+    )
+
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentX:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end
@@ -235,7 +356,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send(
       {
         mock_device.id,
-        ColorControl.commands.MoveToColor(mock_device, 15953, 9565, 0x0000)
+        ColorControl.commands.MoveToColor(mock_device, 0x3E51, 0x255D, 0x0000)
       }
     )
 

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
@@ -23,6 +23,9 @@ local ColorControl = clusters.ColorControl
 local CURRENT_X = "current_x_value" -- y value from xyY color space
 local CURRENT_Y = "current_y_value" -- x value from xyY color space
 local Y_TRISTIMULUS_VALUE = "y_tristimulus_value" -- Y tristimulus value which is used to convert color xyY -> RGB -> HSV
+local HUESAT_TIMER = "huesat_timer"
+local TARGET_HUE = "target_hue"
+local TARGET_SAT = "target_sat"
 
 local IKEA_XY_COLOR_BULB_FINGERPRINTS = {
   ["IKEA of Sweden"] = {
@@ -64,38 +67,73 @@ local query_device = function(device)
 end
 
 local function set_color_handler(driver, device, cmd)
-  local hue = cmd.args.color.hue > 99 and 99 or cmd.args.color.hue
+  -- Cancel the hue/sat timer if it's running, since setColor includes both hue and saturation
+  local huesat_timer = device:get_field(HUESAT_TIMER)
+  if huesat_timer ~= nil then
+    device.thread:cancel_timer(huesat_timer)
+    device:set_field(HUESAT_TIMER, nil)
+  end
+
+  local hue = (cmd.args.color.hue ~= nil and cmd.args.color.hue > 99) and 99 or cmd.args.color.hue
   local sat = cmd.args.color.saturation
+
   local x, y, Y = utils.safe_hsv_to_xy(hue, sat)
   store_xyY_values(device, x, y, Y)
-  switch_defaults.on(driver,device,cmd)
+  switch_defaults.on(driver, device, cmd)
 
   device:send(ColorControl.commands.MoveToColor(device, x, y, 0x0000))
 
+  device:set_field(TARGET_HUE, nil)
+  device:set_field(TARGET_SAT, nil)
   device.thread:call_with_delay(2, query_device(device))
+end
+
+local huesat_timer_callback = function(driver, device, cmd)
+  return function()
+    local hue = device:get_field(TARGET_HUE)
+    local sat = device:get_field(TARGET_SAT)
+    hue = hue ~= nil and hue or device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.hue.NAME)
+    sat = sat ~= nil and sat or device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.saturation.NAME)
+    cmd.args = {
+      color = {
+        hue = hue,
+        saturation = sat
+      }
+    }
+    set_color_handler(driver, device, cmd)
+  end
+end
+
+local function set_hue_sat_helper(driver, device, cmd, hue, sat)
+  local huesat_timer = device:get_field(HUESAT_TIMER)
+  if huesat_timer ~= nil then
+    device.thread:cancel_timer(huesat_timer)
+    device:set_field(HUESAT_TIMER, nil)
+  end
+  if hue ~= nil and sat ~= nil then
+    cmd.args = {
+      color = {
+        hue = hue,
+        saturation = sat
+      }
+    }
+    set_color_handler(driver, device, cmd)
+  else
+    if hue ~= nil then
+      device:set_field(TARGET_HUE, hue)
+    elseif sat ~= nil then
+      device:set_field(TARGET_SAT, sat)
+    end
+    device:set_field(HUESAT_TIMER, device.thread:call_with_delay(0.2, huesat_timer_callback(driver, device, cmd)))
+  end
 end
 
 local function set_hue_handler(driver, device, cmd)
-  local sat = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.saturation.NAME)
-  local hue = cmd.args.hue > 99 and 99 or cmd.args.hue
-  local x, y, Y = utils.safe_hsv_to_xy(hue, sat)
-  store_xyY_values(device, x, y, Y)
-  switch_defaults.on(driver,device,cmd)
-
-  device:send(ColorControl.commands.MoveToColor(device, x, y, 0x0000))
-
-  device.thread:call_with_delay(2, query_device(device))
+  set_hue_sat_helper(driver, device, cmd, cmd.args.hue, device:get_field(TARGET_SAT))
 end
 
 local function set_saturation_handler(driver, device, cmd)
-  local hue = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.hue.NAME)
-  local x, y, Y = utils.safe_hsv_to_xy(hue, cmd.args.saturation)
-  store_xyY_values(device, x, y, Y)
-  switch_defaults.on(driver,device,cmd)
-
-  device:send(ColorControl.commands.MoveToColor(device, x, y, 0x0000))
-
-  device.thread:call_with_delay(2, query_device(device))
+  set_hue_sat_helper(driver, device, cmd, device:get_field(TARGET_HUE), cmd.args.saturation)
 end
 
 local function current_x_attr_handler(driver, device, value, zb_rx)


### PR DESCRIPTION
The original code wasn't handling the setHue and setSaturation commands
correctly. The light would flash but not change to the desired color. To
fix the problem, a short timer is started when receiving either the setHue
or setSaturation commands instead of sending a command to the device right
away. The hue (or saturation) value is cached temporarily, and if the other
command is received before the timer expires then both the cached value and
the value from the second command are used to calculate the x/y and are sent
to the device. If only one of the two commands is sent before the timer
expires then the value from that command is combined with the latest known
color state to calculate the x/y.

https://smartthings.atlassian.net/browse/CHAD-8948