### PR TITLE
Add battery-illuminance profile for default illuminance profile

### DIFF
--- a/drivers/SmartThings/zigbee-illuminance-sensor/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/fingerprints.yml
@@ -7,3 +7,12 @@ zigbeeGeneric:
       server: 
         - 0x0400 # Illuminance Measurement Cluster
     deviceProfileName: base-illuminance
+  - id: "battery-illuminance-sensor"
+    deviceLabel: Illuminance Sensor
+    deviceIdentifiers:
+      - 0x0106
+    clusters:
+      server:
+        - 0x0400 # Illuminance Measurement Cluster
+        - 0x0001 # PowerConfiguration
+    deviceProfileName: battery-illuminance

--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
@@ -1,0 +1,10 @@
+name: battery-illuminance
+components:
+- id: main
+  capabilities:
+  - id: illuminanceMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  categories:
+  - name: LightSensor

--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/init.lua
@@ -23,7 +23,8 @@ local IlluminanceMeasurement = clusters.IlluminanceMeasurement
 
 local zigbee_illuminance_driver = {
   supported_capabilities = {
-    capabilities.illuminanceMeasurement
+    capabilities.illuminanceMeasurement,
+    capabilities.battery
   },
 }
 


### PR DESCRIPTION
Most zigbee illuminance sensors are battery powered sensors, so the driver should be updated to include that capability.

Adds unit tests for battery percentage report handling and configurations