### PR TITLE
Add zigbee-switch for Vimar xx592, xx593, xx595 and 03981

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -8,19 +8,19 @@ zigbeeManufacturer:
   - id: "Vimar/xx592-2-way-smart-switch"
     deviceLabel: Vimar 2-way Smart Switch
     model: "On_Off_Switch_v1.0"
-    deviceProfileName: on-off-bulb
+    deviceProfileName: vimar-on-off-bulb
   - id: "Vimar/03981-smart-actuator-module"
     deviceLabel: Vimar Smart Actuator Module
     model: "On_Off_Switch_Module_v1.0"
-    deviceProfileName: basic-switch
+    deviceProfileName: vimar-basic-switch
   - id: "Vimar/xx593-smart-actuator-power"
     deviceLabel: Vimar Smart Actuator with Power Metering
     model: "Mains_Power_Outlet_v1.0"
-    deviceProfileName: switch-power-smartplug
+    deviceProfileName: vimar-switch-power-smartplug
   - id: "Vimar/xx595-smart-dimmer-switch"
     deviceLabel: Vimar Smart Dimmer Switch
     model: "DimmerSwitch_v1.0"
-    deviceProfileName: on-off-level
+    deviceProfileName: vimar-on-off-level
   # EZEX
   - id: "eZEX/E220-KR2N0Z0-HA"
     deviceLabel: eZEX Switch

--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -4,6 +4,23 @@ zigbeeManufacturer:
     manufacturer: LUMI
     model: lumi.switch.b1laus01
     deviceProfileName: basic-switch
+  # VIMAR
+  - id: "Vimar/xx592-2-way-smart-switch"
+    deviceLabel: Vimar 2-way Smart Switch
+    model: "On_Off_Switch_v1.0"
+    deviceProfileName: on-off-bulb
+  - id: "Vimar/03981-smart-actuator-module"
+    deviceLabel: Vimar Smart Actuator Module
+    model: "On_Off_Switch_Module_v1.0"
+    deviceProfileName: basic-switch
+  - id: "Vimar/xx593-smart-actuator-power"
+    deviceLabel: Vimar Smart Actuator with Power Metering
+    model: "Mains_Power_Outlet_v1.0"
+    deviceProfileName: switch-power-smartplug
+  - id: "Vimar/xx595-smart-dimmer-switch"
+    deviceLabel: Vimar Smart Dimmer Switch
+    model: "DimmerSwitch_v1.0"
+    deviceProfileName: on-off-level
   # EZEX
   - id: "eZEX/E220-KR2N0Z0-HA"
     deviceLabel: eZEX Switch

--- a/drivers/SmartThings/zigbee-switch/profiles/vimar-basic-switch.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/vimar-basic-switch.yml
@@ -1,0 +1,10 @@
+name: vimar-basic-switch
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+    - name: Switch

--- a/drivers/SmartThings/zigbee-switch/profiles/vimar-on-off-bulb.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/vimar-on-off-bulb.yml
@@ -1,0 +1,10 @@
+name: vimar-on-off-bulb
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Light

--- a/drivers/SmartThings/zigbee-switch/profiles/vimar-on-off-level.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/vimar-on-off-level.yml
@@ -1,0 +1,12 @@
+name: vimar-on-off-level
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: switchLevel
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Light

--- a/drivers/SmartThings/zigbee-switch/profiles/vimar-switch-power-smartplug.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/vimar-switch-power-smartplug.yml
@@ -1,0 +1,12 @@
+name: vimar-switch-power-smartplug
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: powerMeter
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartPlug

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
@@ -19,6 +19,7 @@ local OnOff = clusters.OnOff
 local Level = clusters.Level
 
 local DIMMING_LIGHT_FINGERPRINTS = {
+  {mfr = "Vimar", model = "DimmerSwitch_v1.0"},               -- Vimar Smart Dimmer Switch
   {mfr = "OSRAM", model = "LIGHTIFY A19 ON/OFF/DIM"},         -- SYLVANIA Smart A19 Soft White
   {mfr = "OSRAM", model = "LIGHTIFY A19 ON/OFF/DIM 10 Year"}, -- SYLVANIA Smart 10-Year A19
   {mfr = "OSRAM SYLVANIA", model = "iQBR30"},                 -- SYLVANIA Ultra iQ

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/init.lua
@@ -20,6 +20,7 @@ local SimpleMetering = clusters.SimpleMetering
 local ElectricalMeasurement = clusters.ElectricalMeasurement
 
 local SWITCH_POWER_FINGERPRINTS = {
+  { mfr = "Vimar", model = "Mains_Power_Outlet_v1.0" },
   { model = "PAN18-v1.0.7" },
   { model = "E210-KR210Z1-HA" },
   { mfr = "Aurora", model = "Smart16ARelay51AU" },
@@ -74,7 +75,8 @@ local zigbee_switch_power = {
     }
   },
   sub_drivers = {
-    require("zigbee-switch-power/aurora-relay")
+    require("zigbee-switch-power/aurora-relay"),
+    require("zigbee-switch-power/vimar")
   },
   can_handle = can_handle_zigbee_switch_power
 }

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/init.lua
@@ -1,0 +1,51 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local constants = require "st.zigbee.constants"
+local device_management = require "st.zigbee.device_management"
+local zcl_clusters = require "st.zigbee.zcl.clusters"
+
+local ElectricalMeasurement = zcl_clusters.ElectricalMeasurement
+
+local VIMAR_FINGERPRINTS = {
+  { mfr = "Vimar", model = "Mains_Power_Outlet_v1.0" }
+}
+
+local function can_handle_vimar_switch_power(opts, driver, device)
+  for _, fingerprint in ipairs(VIMAR_FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true
+    end
+  end
+  return false
+end
+
+local function do_configure(driver, device)
+  device:configure()
+  device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1, {persist = true})
+  device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 1, {persist = true})
+  device:send(device_management.build_bind_request(device, ElectricalMeasurement.ID, driver.environment_info.hub_zigbee_eui))
+  device:send(ElectricalMeasurement.attributes.ActivePower:configure_reporting(device, 1, 15, 1))
+  device:refresh()
+end
+
+local vimar_switch_power = {
+  NAME = "Vimar Smart Actuator with Power Metering",
+  lifecycle_handlers = {
+    doConfigure = do_configure
+  },
+  can_handle = can_handle_vimar_switch_power
+}
+
+return vimar_switch_power


### PR DESCRIPTION
Add support for: 

- Vimar 2-way Smart Switch (xx592)
- Vimar Smart Actuator with Power Metering (xx593)
- Vimar Smart Actuator Module (03981)
- Vimar Smart Dimmer Switch (xx595)