### PR TITLE
Report lock/unlock events

### DIFF
--- a/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
@@ -153,6 +153,7 @@ local function alarm_report_handler(driver, device, cmd)
   end
 
   if (event ~= nil) then
+    event["state_change"] = true
     device:emit_event(event)
   end
 end


### PR DESCRIPTION
@posborne  @greens @varzac

The current code assumes that for every `lock` event sent by a lock there will be subsequent event with a different value, if the same value is sent again then it won't be reported by the framework to the upstream apps and it will likely fail under these scenarios.

1. When a code is used to unlock the door and then subsequently the same code is used to unlock the door again, it won't be reported to the app (user) as the value of the event didn't change. To assume that every unlock event will be followed by a lock (or vice verse) event isn't a valid real world assumption. Often when there is packet loss, mesh issues, lock firmware design issues (some locks don't report relocking event, e.g. the FE599 will relock itself a few seconds after it's unlocked but will not report that over z-wave), it will lead to loss of functionality and will lead to complaints from users about missing notifications. Each lock and unlock event should be reported, especially of the `event.data` member is not `nil` from the ALARM command class. If there are subsequent lock/unlock events received from other command classes, the `state_change` member doesn't need to set there as that doesn't contain additional information. Infact, other command class lock/unlock events should be delayed until this command class event is received so that that event with more information is reported first and processed.
1. If the lock is jammed, it sends a value of `unknown`, if the user tries to relock the door again and it jams again (of it's stuck on a hardware auto relock it will get into a loop of locking and unlocking continuously), the value `unknown` sent will be again, but since it didn't change it won't be reported and the hence the user will not be notified that the lock jammed a second (or it's stuck in a loop).

This change should also be considered for adding/deleting codes as for security purposes upstream apps should know each time a slot is programmed or deleted as the same slot can be reprogrammed or deleted multiple times.