### PR TITLE
[CHAD-8781] zwave-sensor/zigbee-illuminance-sensor: Set correct range on illuminance measurement values

### DIFF
--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/base-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/base-illuminance.yml
@@ -5,8 +5,8 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   categories:
   - name: LightSensor

--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/base-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/base-illuminance.yml
@@ -4,7 +4,7 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/base-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/base-illuminance.yml
@@ -4,5 +4,9 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   categories:
   - name: LightSensor

--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
@@ -5,9 +5,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: battery
     version: 1
   categories:

--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
@@ -4,7 +4,7 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/profiles/battery-illuminance.yml
@@ -4,6 +4,10 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: battery
     version: 1
   categories:

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -11,9 +11,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: ultravioletIndex
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -10,7 +10,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]
@@ -31,7 +31,7 @@ preferences:
     title: "Motion Sensor Delay Time"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         20: "20 seconds"
         30: "30 seconds"
@@ -45,7 +45,7 @@ preferences:
     title: "Motion Sensor Sensitivity"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         5: "maximum"
         3: "normal"
@@ -57,7 +57,7 @@ preferences:
     description: "How often the device should report"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         60: "1 minute"
         120: "2 minutes"

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -10,6 +10,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: ultravioletIndex
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -11,9 +11,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: ultravioletIndex
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -10,6 +10,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: ultravioletIndex
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -10,7 +10,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]
@@ -31,7 +31,7 @@ preferences:
     title: "Motion Sensor Delay Time"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         20: "20 seconds"
         30: "30 seconds"
@@ -45,7 +45,7 @@ preferences:
     title: "Motion Sensor Sensitivity"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         11: "maximum"
         6: "normal"
@@ -57,7 +57,7 @@ preferences:
     description: "How often the device should report"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         60: "1 minute"
         120: "2 minutes"

--- a/drivers/SmartThings/zwave-sensor/profiles/fibaro-motion-sensor.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/fibaro-motion-sensor.yml
@@ -9,9 +9,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/zwave-sensor/profiles/fibaro-motion-sensor.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/fibaro-motion-sensor.yml
@@ -8,7 +8,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/fibaro-motion-sensor.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/fibaro-motion-sensor.yml
@@ -8,6 +8,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/zwave-sensor/profiles/generic-sensor.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/generic-sensor.yml
@@ -20,7 +20,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/generic-sensor.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/generic-sensor.yml
@@ -20,6 +20,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: relativeHumidityMeasurement
     version: 1
   - id: temperatureMeasurement

--- a/drivers/SmartThings/zwave-sensor/profiles/generic-sensor.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/generic-sensor.yml
@@ -21,9 +21,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: relativeHumidityMeasurement
     version: 1
   - id: temperatureMeasurement

--- a/drivers/SmartThings/zwave-sensor/profiles/illuminance-battery.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/illuminance-battery.yml
@@ -4,6 +4,10 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: battery
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/illuminance-battery.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/illuminance-battery.yml
@@ -4,7 +4,7 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/illuminance-battery.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/illuminance-battery.yml
@@ -5,9 +5,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: battery
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/illuminance-temperature.yml
@@ -4,7 +4,7 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/illuminance-temperature.yml
@@ -5,9 +5,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/zwave-sensor/profiles/illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/illuminance-temperature.yml
@@ -4,6 +4,10 @@ components:
   capabilities:
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature-interval.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature-interval.yml
@@ -8,7 +8,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature-interval.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature-interval.yml
@@ -8,6 +8,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature-interval.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature-interval.yml
@@ -9,9 +9,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature.yml
@@ -8,7 +8,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature.yml
@@ -8,6 +8,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance-temperature.yml
@@ -9,9 +9,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance.yml
@@ -9,9 +9,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: refresh
     version: 1
   categories:

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance.yml
@@ -8,7 +8,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-illuminance.yml
@@ -8,6 +8,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: refresh
     version: 1
   categories:

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-temperature-illuminance-humidity.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-temperature-illuminance-humidity.yml
@@ -10,7 +10,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-temperature-illuminance-humidity.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-temperature-illuminance-humidity.yml
@@ -11,9 +11,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: battery
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-battery-temperature-illuminance-humidity.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-battery-temperature-illuminance-humidity.yml
@@ -10,6 +10,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: battery
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-switch-color-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-switch-color-illuminance-temperature.yml
@@ -10,7 +10,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-switch-color-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-switch-color-illuminance-temperature.yml
@@ -11,9 +11,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/motion-switch-color-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/motion-switch-color-illuminance-temperature.yml
@@ -10,6 +10,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zwave-sensor/profiles/multi-functional-motion.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/multi-functional-motion.yml
@@ -10,7 +10,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/multi-functional-motion.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/multi-functional-motion.yml
@@ -11,9 +11,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: tamperAlert
     version: 1
   - id: battery

--- a/drivers/SmartThings/zwave-sensor/profiles/multi-functional-motion.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/multi-functional-motion.yml
@@ -10,6 +10,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: tamperAlert
     version: 1
   - id: battery

--- a/drivers/SmartThings/zwave-sensor/profiles/water-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-illuminance-temperature.yml
@@ -7,9 +7,9 @@ components:
   - id: illuminanceMeasurement
     version: 1
     configuration:
-      - values:
-        key: "illuminance.value"
-        range: [0, 32000]
+      values:
+        - key: "illuminance.value"
+          range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/zwave-sensor/profiles/water-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-illuminance-temperature.yml
@@ -6,7 +6,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-    configuration:
+    config:
       values:
         - key: "illuminance.value"
           range: [0, 32000]

--- a/drivers/SmartThings/zwave-sensor/profiles/water-illuminance-temperature.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-illuminance-temperature.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
+    configuration:
+      - values:
+        key: "illuminance.value"
+        range: [0, 32000]
   - id: temperatureMeasurement
     version: 1
   - id: battery


### PR DESCRIPTION
Updated Zwave-sensor file. All illuminance range has been configured to 0 - 32000 lux.