### PR TITLE
[CHAD-8804] zigbee-thermostat/zigbee-valve/zwave-sensor: Set correct possible options for power source

### DIFF
--- a/drivers/SmartThings/zigbee-thermostat/profiles/thermostat-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-thermostat/profiles/thermostat-battery-powerSource.yml
@@ -17,11 +17,11 @@ components:
   - id: powerSource
     version: 1
     configuration:
-      - values:
-        key: "powerSource.value"
-        enabledValues:
-          - battery
-          - mains
+      values:
+        - key: "powerSource.value"
+          enabledValues:
+            - battery
+            - mains
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/zigbee-thermostat/profiles/thermostat-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-thermostat/profiles/thermostat-battery-powerSource.yml
@@ -16,7 +16,7 @@ components:
     version: 1
   - id: powerSource
     version: 1
-    configuration:
+    config:
       values:
         - key: "powerSource.value"
           enabledValues:

--- a/drivers/SmartThings/zigbee-thermostat/profiles/thermostat-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-thermostat/profiles/thermostat-battery-powerSource.yml
@@ -16,6 +16,12 @@ components:
     version: 1
   - id: powerSource
     version: 1
+    configuration:
+      - values:
+        key: "powerSource.value"
+        enabledValues:
+          - battery
+          - mains
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
@@ -8,6 +8,12 @@ components:
     version: 1
   - id: powerSource
     version: 1
+    configuration:
+      - values:
+        key: "powerSource.value"
+        enabledValues:
+          - battery
+          - mains
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
@@ -9,11 +9,11 @@ components:
   - id: powerSource
     version: 1
     configuration:
-      - values:
+      values:
         key: "powerSource.value"
-        enabledValues:
-          - battery
-          - mains
+          enabledValues:
+            - battery
+            - mains
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
@@ -10,7 +10,7 @@ components:
     version: 1
     configuration:
       values:
-        key: "powerSource.value"
+        - key: "powerSource.value"
           enabledValues:
             - battery
             - mains

--- a/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
+++ b/drivers/SmartThings/zigbee-valve/profiles/valve-battery-powerSource.yml
@@ -8,7 +8,7 @@ components:
     version: 1
   - id: powerSource
     version: 1
-    configuration:
+    config:
       values:
         - key: "powerSource.value"
           enabledValues:

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -21,11 +21,11 @@ components:
   - id: powerSource
     version: 1
     configuration:
-      - values:
+      values:
         key: "powerSource.value"
-        enabledValues:
-          - battery
-          - mains
+          enabledValues:
+            - battery
+            - mains
   categories:
   - name: MultiFunctionalSensor
 preferences:
@@ -33,7 +33,7 @@ preferences:
     title: "Motion Sensor Delay Time"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         20: "20 seconds"
         30: "30 seconds"
@@ -47,7 +47,7 @@ preferences:
     title: "Motion Sensor Sensitivity"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         5: "maximum"
         3: "normal"
@@ -59,7 +59,7 @@ preferences:
     description: "How often the device should report"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         60: "1 minute"
         120: "2 minutes"

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -20,6 +20,12 @@ components:
     version: 1
   - id: powerSource
     version: 1
+    configuration:
+      - values:
+        key: "powerSource.value"
+        enabledValues:
+          - battery
+          - mains
   categories:
   - name: MultiFunctionalSensor
 preferences:

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -20,7 +20,7 @@ components:
     version: 1
   - id: powerSource
     version: 1
-    configuration:
+    config:
       values:
         - key: "powerSource.value"
           enabledValues:

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -22,7 +22,7 @@ components:
     version: 1
     configuration:
       values:
-        key: "powerSource.value"
+        - key: "powerSource.value"
           enabledValues:
             - battery
             - mains

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -20,6 +20,12 @@ components:
     version: 1
   - id: powerSource
     version: 1
+    configuration:
+      - values:
+        key: "powerSource.value"
+        enabledValues:
+          - battery
+          - mains
   categories:
   - name: MultiFunctionalSensor
 preferences:

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -20,7 +20,7 @@ components:
     version: 1
   - id: powerSource
     version: 1
-    configuration:
+    config:
       values:
         - key: "powerSource.value"
           enabledValues:

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -21,11 +21,11 @@ components:
   - id: powerSource
     version: 1
     configuration:
-      - values:
+      values:
         key: "powerSource.value"
-        enabledValues:
-          - battery
-          - mains
+          enabledValues:
+            - battery
+            - mains
   categories:
   - name: MultiFunctionalSensor
 preferences:
@@ -33,7 +33,7 @@ preferences:
     title: "Motion Sensor Delay Time"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         20: "20 seconds"
         30: "30 seconds"
@@ -47,7 +47,7 @@ preferences:
     title: "Motion Sensor Sensitivity"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         11: "maximum"
         6: "normal"
@@ -59,7 +59,7 @@ preferences:
     description: "How often the device should report"
     required: false
     preferenceType: enumeration
-    definition: 
+    definition:
       options:
         60: "1 minute"
         120: "2 minutes"

--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-7.yml
@@ -22,7 +22,7 @@ components:
     version: 1
     configuration:
       values:
-        key: "powerSource.value"
+        - key: "powerSource.value"
           enabledValues:
             - battery
             - mains

--- a/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
@@ -9,11 +9,11 @@ components:
   - id: powerSource
     version: 1
     configuration:
-      - values:
+      values:
         key: "powerSource.value"
-        enabledValues:
-          - battery
-          - mains
+          enabledValues:
+            - battery
+            - mains
   - id: refresh
     version: 1
   categories:

--- a/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
@@ -10,7 +10,7 @@ components:
     version: 1
     configuration:
       values:
-        key: "powerSource.value"
+        - key: "powerSource.value"
           enabledValues:
             - battery
             - mains

--- a/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
@@ -8,6 +8,12 @@ components:
     version: 1
   - id: powerSource
     version: 1
+    configuration:
+      - values:
+        key: "powerSource.value"
+        enabledValues:
+          - battery
+          - mains
   - id: refresh
     version: 1
   categories:

--- a/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/water-battery-powersource.yml
@@ -8,7 +8,7 @@ components:
     version: 1
   - id: powerSource
     version: 1
-    configuration:
+    config:
       values:
         - key: "powerSource.value"
           enabledValues:


### PR DESCRIPTION
Updated all zigbee-valve profiles. All powerSources now only consist of battery and mains.