### PR TITLE
Add zigbee-switch for Vimar xx593

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -25,7 +25,7 @@ zigbeeManufacturer:
   - id: "Vimar/xx593-smart-actuator-power"
     deviceLabel: Vimar Smart Actuator with Power Metering
     model: "Mains_Power_Outlet_v1.0"
-    deviceProfileName: vimar-switch-power-smartplug
+    deviceProfileName: switch-power-smartplug-no-firmware-update
   # EZEX
   - id: "eZEX/E220-KR2N0Z0-HA"
     deviceLabel: eZEX Switch 1

--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -22,6 +22,10 @@ zigbeeManufacturer:
     deviceLabel: Vimar Smart Dimmer Switch
     model: "DimmerSwitch_v1.0"
     deviceProfileName: on-off-level-no-firmware-update 
+  - id: "Vimar/xx593-smart-actuator-power"
+    deviceLabel: Vimar Smart Actuator with Power Metering
+    model: "Mains_Power_Outlet_v1.0"
+    deviceProfileName: vimar-switch-power-smartplug
   # EZEX
   - id: "eZEX/E220-KR2N0Z0-HA"
     deviceLabel: eZEX Switch 1

--- a/drivers/SmartThings/zigbee-switch/profiles/switch-power-smartplug-no-firmware-update.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/switch-power-smartplug-no-firmware-update.yml
@@ -1,4 +1,4 @@
-name: vimar-switch-power-smartplug
+name: switch-power-smartplug-no-firmware-update
 components:
 - id: main
   capabilities:

--- a/drivers/SmartThings/zigbee-switch/profiles/vimar-switch-power-smartplug.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/vimar-switch-power-smartplug.yml
@@ -1,0 +1,12 @@
+name: vimar-switch-power-smartplug
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: powerMeter
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartPlug

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/init.lua
@@ -20,6 +20,7 @@ local SimpleMetering = clusters.SimpleMetering
 local ElectricalMeasurement = clusters.ElectricalMeasurement
 
 local SWITCH_POWER_FINGERPRINTS = {
+  { mfr = "Vimar", model = "Mains_Power_Outlet_v1.0" },
   { model = "PAN18-v1.0.7" },
   { model = "E210-KR210Z1-HA" },
   { mfr = "Aurora", model = "Smart16ARelay51AU" },
@@ -74,7 +75,8 @@ local zigbee_switch_power = {
     }
   },
   sub_drivers = {
-    require("zigbee-switch-power/aurora-relay")
+    require("zigbee-switch-power/aurora-relay"),
+    require("zigbee-switch-power/vimar")
   },
   can_handle = can_handle_zigbee_switch_power
 }

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/init.lua
@@ -1,0 +1,51 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local constants = require "st.zigbee.constants"
+local device_management = require "st.zigbee.device_management"
+local zcl_clusters = require "st.zigbee.zcl.clusters"
+
+local ElectricalMeasurement = zcl_clusters.ElectricalMeasurement
+
+local VIMAR_FINGERPRINTS = {
+  { mfr = "Vimar", model = "Mains_Power_Outlet_v1.0" }
+}
+
+local function can_handle_vimar_switch_power(opts, driver, device)
+  for _, fingerprint in ipairs(VIMAR_FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true
+    end
+  end
+  return false
+end
+
+local function do_configure(driver, device)
+  device:configure()
+  device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1, {persist = true})
+  device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 1, {persist = true})
+  device:send(device_management.build_bind_request(device, ElectricalMeasurement.ID, driver.environment_info.hub_zigbee_eui))
+  device:send(ElectricalMeasurement.attributes.ActivePower:configure_reporting(device, 1, 15, 1))
+  device:refresh()
+end
+
+local vimar_switch_power = {
+  NAME = "Vimar Smart Actuator with Power Metering",
+  lifecycle_handlers = {
+    doConfigure = do_configure
+  },
+  can_handle = can_handle_vimar_switch_power
+}
+
+return vimar_switch_power


### PR DESCRIPTION
Add support with a custom sub-driver for:

- Vimar Smart Actuator with Power Metering (xx593)