### PR TITLE
CHAD-8998 Re-check device configuration on WakeUp

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
@@ -16,12 +16,15 @@
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Configuration
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 1 })
+--- @type st.zwave.CommandClass.WakeUp
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local SENSATIVE_MFR = 0x019A
 local SENSATIVE_MODEL = 0x000A
 local LEAKAGE_ALARM_PARAM = 12
 local LEAKAGE_ALARM_OFF = 0
 local SENSATIVE_COMFORT_PROFILE = "illuminance-temperature"
+local CONFIG_REPORT_RECEIVED = "configReportReceived"
 
 local function can_handle_sensative_strip(opts, driver, device, cmd, ...)
   return device:id_match(SENSATIVE_MFR, nil, SENSATIVE_MODEL)
@@ -31,8 +34,11 @@ local function configuration_report(driver, device, cmd)
   local parameter_number = cmd.args.parameter_number
   local configuration_value = cmd.args.configuration_value
 
-  if parameter_number == LEAKAGE_ALARM_PARAM and configuration_value == LEAKAGE_ALARM_OFF then
-    device:try_update_metadata({profile = SENSATIVE_COMFORT_PROFILE})
+  if parameter_number == LEAKAGE_ALARM_PARAM then
+    device:set_field(CONFIG_REPORT_RECEIVED, true, {persist = true})
+    if configuration_value == LEAKAGE_ALARM_OFF then
+      device:try_update_metadata({profile = SENSATIVE_COMFORT_PROFILE})
+    end
   end
 end
 
@@ -41,10 +47,19 @@ local function do_configure(driver, device)
   device:send(Configuration:Get({ parameter_number = LEAKAGE_ALARM_PARAM }))
 end
 
+local function wakeup_notification(driver, device, cmd)
+  if device:get_field(CONFIG_REPORT_RECEIVED) ~= true then
+    device:send(Configuration:Get({ parameter_number = LEAKAGE_ALARM_PARAM }))
+  end
+end
+
 local sensative_strip = {
   zwave_handlers = {
     [cc.CONFIGURATION] = {
       [Configuration.REPORT] = configuration_report
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
   lifecycle_handlers = {

--- a/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
@@ -17,6 +17,7 @@ local zw = require "st.zwave"
 local zw_test_utils = require "integration_test.zwave_test_utils"
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 1 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version = 5 })
 local t_utils = require "integration_test.utils"
 
@@ -76,6 +77,20 @@ test.register_coroutine_test(
   function()
     test.socket.zwave:__queue_receive({mock_sensor.id, Configuration:Report( { configuration_value = 0x00, parameter_number = 12 } )})
     mock_sensor:expect_metadata_update({ profile = "illuminance-temperature" })
+  end
+)
+
+test.register_coroutine_test(
+  "Wakeup Notification should prompt a configuration get until a report is received",
+  function ()
+    test.socket.zwave:__queue_receive({mock_sensor.id, WakeUp:Notification({})})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_sensor,
+      Configuration:Get({ parameter_number = 12})
+    ))
+    test.socket.zwave:__queue_receive({mock_sensor.id, Configuration:Report( { configuration_value = 0x00, parameter_number = 12 } )})
+    mock_sensor:expect_metadata_update({ profile = "illuminance-temperature" })
+    test.socket.zwave:__queue_receive({mock_sensor.id, WakeUp:Notification({})})
   end
 )
 


### PR DESCRIPTION
When migrating devices, only checking the device configuration on add would lead to sensative open/closed sensors continuing to display the water detection capability indefinitely. Now the driver will query the config on wakeup until it has received a report.