### PR TITLE
luacheck: Fix some of the "accessing undefined variable" bugs

### DIFF
--- a/drivers/SmartThings/bose/src/command.lua
+++ b/drivers/SmartThings/bose/src/command.lua
@@ -13,10 +13,10 @@
 
 local cosock = require "cosock"
 local http = cosock.asyncify "socket.http" -- TODO use luncheon instead
+local log = require "log"
 local ltn12 = require "ltn12"
 local xml2lua = require "xml2lua"
 local xml_handler = require "xmlhandler.tree"
-local utils = require "st.utils"
 
 local SOUNDTOUCH_HTTP_PORT = 8090
 

--- a/drivers/SmartThings/zigbee-thermostat/src/sinope/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/sinope/init.lua
@@ -16,6 +16,7 @@ local device_management                    = require "st.zigbee.device_managemen
 local clusters                             = require "st.zigbee.zcl.clusters"
 local cluster_base                         = require "st.zigbee.cluster_base"
 local data_types                           = require "st.zigbee.data_types"
+local log                                  = require "log"
 local Thermostat                           = clusters.Thermostat
 local ThermostatUserInterfaceConfiguration = clusters.ThermostatUserInterfaceConfiguration
 

--- a/drivers/SmartThings/zwave-bulb/src/fibaro-rgbw-controller/init.lua
+++ b/drivers/SmartThings/zwave-bulb/src/fibaro-rgbw-controller/init.lua
@@ -74,7 +74,7 @@ local function set_color(driver, device, command)
   device.thread:call_with_delay(constants.DEFAULT_GET_STATUS_DELAY + constants.DEFAULT_DIMMING_DURATION, query_color)
 end
 
-local function switch_color_report(driver, device, command)
+local function switch_color_report(self, device, command)
   local event
   if command.args.color_component_id == SwitchColor.color_component_id.WARM_WHITE then
     local value = command.args.value
@@ -96,7 +96,7 @@ local function switch_color_report(driver, device, command)
   end
 end
 
-local function switch_multilevel_report(driver, device, command)
+local function switch_multilevel_report(self, device, command)
   local endpoint = command.src_channel
   -- ignore multilevel reports from endpoints [1, 2, 3, 4] which mirror SwitchColor values
   -- and in addition cause wrong SwitchLevel events

--- a/drivers/SmartThings/zwave-smoke-alarm/src/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/init.lua
@@ -64,7 +64,7 @@ end
 --- @param device st.zwave.Device
 --- @param event table
 --- @param args
-local function info_changed(driver, device, event, args)
+local function info_changed(self, device, event, args)
   if not device:is_cc_supported(cc.WAKE_UP) then
     update_preferences(self, device, args)
   end

--- a/drivers/SmartThings/zwave-switch/src/aeon-smart-strip/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/aeon-smart-strip/init.lua
@@ -109,9 +109,6 @@ local aeon_smart_strip = {
       [Meter.REPORT] = meter_report_handler
     }
   },
-  lifecycle_handlers = {
-    init = device_init
-  },
   can_handle = can_handle_aeon_smart_strip,
 }
 

--- a/drivers/SmartThings/zwave-switch/src/eaton-5-scene-keypad/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/eaton-5-scene-keypad/init.lua
@@ -12,6 +12,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+local bit32 = require "bit32"
+
 --- @type st.capabilities
 local capabilities = require "st.capabilities"
 --- @type st.zwave.constants

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
@@ -64,10 +64,9 @@ end
 
 local function configuration_report_handler(self, device, cmd)
   if (cmd.args.parameter_number == 3) then
-    local sensor_status = device:get_field(EXTRA_TEMP_SENSOR_STATUS)
     if cmd.args.configuration_value == 1 then
       if utils.table_size(device.st_store.profile.components) == 1 then
-        --- change profile to one with additionall component
+        --- change profile to one with additional component
         device:try_update_metadata({profile = "fibaro-heat-extra-sensor"})
       end
       device:send_to_component(SensorMultilevel:Get({}), "extraTemperatureSensor")

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
@@ -24,7 +24,7 @@ local ApplicationStatus = (require "st.zwave.CommandClass.ApplicationStatus")({v
 local zw = require "st.zwave"
 local t_utils = require "integration_test.utils"
 
--- supported comand classes
+-- supported command classes
 local thermostat_endpoints = {
   {
     command_classes = {

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_qubino_flush_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_qubino_flush_shutter.lua
@@ -609,7 +609,7 @@ do
         mock_qubino_flush_shutter:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(targetValue))
       )
       test.socket.capability:__expect_send(
-        mock_qubino_flush_shutter:generate_test_message("main", capabilities.powerMeter.power(10))
+        mock_qubino_flush_shutter:generate_test_message("main", capabilities.powerMeter.power({value = 10, unit = "W"}))
       )
     end
   )
@@ -640,7 +640,7 @@ do
         )
       )
       test.socket.capability:__expect_send(
-        mock_qubino_flush_shutter:generate_test_message("main", capabilities.powerMeter.power(0))
+        mock_qubino_flush_shutter:generate_test_message("main", capabilities.powerMeter.power({value = 0, unit = "W"}))
       )
     end
   )
@@ -665,7 +665,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_qubino_flush_shutter:generate_test_message("main", capabilities.energyMeter.energy(50))
+      message = mock_qubino_flush_shutter:generate_test_message("main", capabilities.energyMeter.energy({value = 50, unit = "kWh"}))
     }
   }
 )

--- a/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/qubino-flush-shutter/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/qubino-flush-shutter/init.lua
@@ -38,6 +38,9 @@ local SLATS_TURN_TIME = "slatsTurnTime"
 local BLINDS_LAST_COMMAND = "blinds_last_command"
 local SHADE_TARGET = "shade_target"
 
+local ENERGY_UNIT_KWH = "kWh"
+local POWER_UNIT_WATT = "W"
+
 local QUBINO_FLUSH_SHUTTER_FINGERPRINTS = {
   {mfr = 0x0159, prod = 0x0003, model = 0x0052}, -- Qubino Flush Shutter AC
   {mfr = 0x0159, prod = 0x0003, model = 0x0053}, -- Qubino Flush Shutter DC


### PR DESCRIPTION
Ran `luacheck --std lua53 ./ | grep "accessing undefined variable"` against the repo and found some bugs. This PR doesn't fix all of the issues found, but the remainder will take a bit more time and I didn't want to wait to get these fixes in.