### PR TITLE
Add lock support for lock codes after migration from DTHs

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/init.lua
@@ -249,12 +249,19 @@ local name_slot = function(driver, device, command)
 end
 
 local function device_added(driver, device)
+  lock_utils.populate_state_from_data(device)
+
   driver:inject_capability_command(device, {
     capability = capabilities.refresh.ID,
     command = capabilities.refresh.commands.refresh.NAME,
     args = {}
   })
 end
+
+local function init(driver, device)
+  lock_utils.populate_state_from_data(device)
+end
+
 
 local zigbee_lock_driver = {
   supported_capabilities = {
@@ -301,7 +308,8 @@ local zigbee_lock_driver = {
   },
   lifecycle_handlers = {
     doConfigure = do_configure,
-    added = device_added
+    added = device_added,
+    init = init,
   }
 }
 

--- a/drivers/SmartThings/zigbee-lock/src/lock_utils.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock_utils.lua
@@ -21,7 +21,8 @@ local lock_utils =  {
   -- Constants
   LOCK_CODES      = "lockCodes",
   CHECKING_CODE   = "checkingCode",
-  CODE_STATE      = "codeState"
+  CODE_STATE      = "codeState",
+  MIGRATION_COMPLETE = "migrationComplete",
 }
 
 lock_utils.get_lock_codes = function(device)
@@ -71,6 +72,24 @@ function lock_utils.code_deleted(device, code_slot)
   device:emit_event(event)
   lock_utils.reset_code_state(device, code_slot)
   return lock_codes
+end
+
+function lock_utils.populate_state_from_data(device)
+  if device.data.lockCodes ~= nil and device:get_field(lock_utils.MIGRATION_COMPLETE) ~= true then
+    -- build the lockCodes table
+    local lockCodes = {}
+    for k, v in pairs(device.data.lockCodes) do
+      lockCodes[k] = v
+    end
+    -- Populate the devices `lockCodes` field
+    device:set_field(lock_utils.LOCK_CODES, utils.deep_copy(lockCodes), { persist = true })
+    -- Populate the devices state history cache
+    device.state_cache["main"] = device.state_cache["main"] or {}
+    device.state_cache["main"][capabilities.lockCodes.ID] = device.state_cache["main"][capabilities.lockCodes.ID] or {}
+    device.state_cache["main"][capabilities.lockCodes.ID][capabilities.lockCodes.lockCodes.NAME] = {value = json.encode(utils.deep_copy(lockCodes))}
+
+    device:set_field(lock_utils.MIGRATION_COMPLETE, true, { persist = true })
+  end
 end
 
 return lock_utils

--- a/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
@@ -18,6 +18,7 @@ local capabilities = require "st.capabilities"
 local cluster_base = require "st.zigbee.cluster_base"
 local DoorLock = clusters.DoorLock
 local Lock = capabilities.lock
+local lock_utils = require "lock_utils"
 
 local SAMSUNG_SDS_MFR_SPECIFIC_UNLOCK_COMMAND = 0x1F
 local SAMSUNG_SDS_MFR_CODE = 0x0003
@@ -49,8 +50,16 @@ local function unlock_cmd_handler(driver, device, command)
 end
 
 local device_added = function(self, device)
+  lock_utils.populate_state_from_data(device)
   device:emit_event(capabilities.lock.lock.unlocked())
   device:emit_event(capabilities.battery.battery(100))
+end
+
+local battery_init = battery_defaults.build_linear_voltage_init(4.0, 6.0)
+
+local device_init = function(driver, device, event)
+  battery_init(driver, device, event)
+  lock_utils.populate_state_from_data(device)
 end
 
 local samsung_sds_driver = {
@@ -74,7 +83,7 @@ local samsung_sds_driver = {
   },
   lifecycle_handlers = {
     added = device_added,
-    init = battery_defaults.build_linear_voltage_init(4.0, 6.0)
+    init = device_init
   },
   can_handle = function(opts, driver, device, ...)
     return device:get_manufacturer() == "SAMSUNG SDS"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_code_migration.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_code_migration.lua
@@ -1,0 +1,182 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Mock out globals
+local test = require "integration_test"
+local zigbee_test_utils = require "integration_test.zigbee_test_utils"
+local t_utils = require "integration_test.utils"
+
+local clusters = require "st.zigbee.zcl.clusters"
+local PowerConfiguration = clusters.PowerConfiguration
+local DoorLock = clusters.DoorLock
+local Alarm = clusters.Alarms
+
+local json = require "st.json"
+
+local mock_datastore = require "integration_test.mock_env_datastore"
+
+local mock_device = test.mock_device.build_test_zigbee_device(
+    {
+      profile = t_utils.get_profile_definition("base-lock.yml"),
+      data = {
+        lockCodes = {
+          ["1"] = "Zach",
+          ["2"] = "Steven"
+        }
+      }
+    }
+)
+
+local mock_device_no_data = test.mock_device.build_test_zigbee_device(
+    {
+      profile = t_utils.get_profile_definition("base-lock.yml"),
+      data = {}
+    }
+)
+zigbee_test_utils.prepare_zigbee_env_info()
+local function test_init()
+  zigbee_test_utils.init_noop_health_check_timer()
+end
+
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+    "Device added data lock codes population",
+    function()
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+      test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.LockState:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, Alarm.attributes.AlarmCount:read(mock_device) })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "lockCodes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      mock_datastore.__assert_device_store_contains(mock_device.id, "__state_cache",
+          {
+            main = {
+              lockCodes = {
+                lockCodes = {value = json.encode({ ["1"] = "Zach", ["2"] = "Steven" }) }
+              }
+            }
+          }
+      )
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", true)
+    end
+)
+
+test.register_coroutine_test(
+    "Device added without data should function",
+    function()
+      test.mock_device.add_test_device(mock_device_no_data)
+      test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "added" })
+      test.socket.zigbee:__expect_send({ mock_device_no_data.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device_no_data) })
+      test.socket.zigbee:__expect_send({ mock_device_no_data.id, DoorLock.attributes.LockState:read(mock_device_no_data) })
+      test.socket.zigbee:__expect_send({ mock_device_no_data.id, Alarm.attributes.AlarmCount:read(mock_device_no_data) })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "lockCodes", nil)
+      -- Validate state cache
+      mock_datastore.__assert_device_store_contains(mock_device.id, "__state_cache", nil)
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", nil)
+    end
+)
+
+test.register_coroutine_test(
+    "Device init after added shouldn't change the datastores",
+    function()
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+      test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.LockState:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, Alarm.attributes.AlarmCount:read(mock_device) })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "lockCodes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      mock_datastore.__assert_device_store_contains(mock_device.id, "__state_cache",
+          {
+            main = {
+              lockCodes = {
+                lockCodes = {value = json.encode({ ["1"] = "Zach", ["2"] = "Steven" }) }
+              }
+            }
+          }
+      )
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", true)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "lockCodes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      mock_datastore.__assert_device_store_contains(mock_device.id, "__state_cache",
+          {
+            main = {
+              lockCodes = {
+                lockCodes = {value = json.encode({ ["1"] = "Zach", ["2"] = "Steven" }) }
+              }
+            }
+          }
+      )
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", true)
+    end
+)
+
+test.register_coroutine_test(
+    "Device init with new data should populate fields",
+    function()
+      test.mock_device.add_test_device(mock_device_no_data)
+      test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "added" })
+      test.socket.zigbee:__expect_send({ mock_device_no_data.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device_no_data) })
+      test.socket.zigbee:__expect_send({ mock_device_no_data.id, DoorLock.attributes.LockState:read(mock_device_no_data) })
+      test.socket.zigbee:__expect_send({ mock_device_no_data.id, Alarm.attributes.AlarmCount:read(mock_device_no_data) })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "lockCodes", nil)
+      -- Validate state cache
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "__state_cache", {})
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "migrationComplete", nil)
+      test.socket.device_lifecycle():__queue_receive(mock_device_no_data:generate_info_changed(
+          {
+            data = {
+              lockCodes = { ["1"] = "Zach", ["2"] = "Steven" }
+            }
+          }
+      ))
+      test.wait_for_events()
+      test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "init" })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "lockCodes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "__state_cache",
+          {
+            main = {
+              lockCodes = {
+                lockCodes = {value = json.encode({ ["1"] = "Zach", ["2"] = "Steven" }) }
+              }
+            }
+          }
+      )
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "migrationComplete", true)
+    end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/zwave-lock/src/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/init.lua
@@ -23,8 +23,12 @@ local defaults = require "st.zwave.defaults"
 local DoorLock = (require "st.zwave.CommandClass.DoorLock")({ version = 1 })
 --- @type st.zwave.CommandClass.Battery
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
+local constants = require "st.zwave.constants"
+local utils = require "st.utils"
+local json = require "st.json"
 
 local SCAN_CODES_CHECK_INTERVAL = 30
+local MIGRATION_COMPLETE = "migrationComplete"
 
 local function periodic_codes_state_verification(driver, device)
   local scan_codes_state = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.scanCodes.NAME)
@@ -44,11 +48,30 @@ local function periodic_codes_state_verification(driver, device)
   end
 end
 
+local function populate_state_from_data(device)
+  if device.data.lockCodes ~= nil and device:get_field(MIGRATION_COMPLETE) ~= true then
+    -- build the lockCodes table
+    local lockCodes = {}
+    for k, v in pairs(device.data.lockCodes) do
+      lockCodes[k] = v
+    end
+    -- Populate the devices `lockCodes` field
+    device:set_field(constants.LOCK_CODES, utils.deep_copy(lockCodes), { persist = true })
+    -- Populate the devices state history cache
+    device.state_cache["main"] = device.state_cache["main"] or {}
+    device.state_cache["main"][capabilities.lockCodes.ID] = device.state_cache["main"][capabilities.lockCodes.ID] or {}
+    device.state_cache["main"][capabilities.lockCodes.ID][capabilities.lockCodes.lockCodes.NAME] = {value = json.encode(utils.deep_copy(lockCodes))}
+
+    device:set_field(MIGRATION_COMPLETE, true, { persist = true })
+  end
+end
+
 --- Builds up initial state for the device
 ---
 --- @param self st.zwave.Driver
 --- @param device st.zwave.Device
 local function added_handler(self, device)
+  populate_state_from_data(device)
   if (device:supports_capability(capabilities.lockCodes)) then
     self:inject_capability_command(device,
             { capability = capabilities.lockCodes.ID,
@@ -68,6 +91,10 @@ local function added_handler(self, device)
   end
 end
 
+local init_handler = function(driver, device, event)
+  populate_state_from_data(device)
+end
+
 local driver_template = {
   supported_capabilities = {
     capabilities.lock,
@@ -76,7 +103,8 @@ local driver_template = {
     capabilities.tamperAlert
   },
   lifecycle_handlers = {
-    added = added_handler
+    added = added_handler,
+    init = init_handler,
   },
   sub_drivers = {
     require("zwave-alarm-v1-lock"),

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
@@ -1,0 +1,217 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Mock out globals
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local zw = require "st.zwave"
+--- @type st.zwave.CommandClass.DoorLock
+local DoorLock = (require "st.zwave.CommandClass.DoorLock")({ version = 1 })
+local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
+--- @type st.zwave.CommandClass.Notification
+local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
+--- @type st.zwave.CommandClass.UserCode
+local UserCode = (require "st.zwave.CommandClass.UserCode")({ version = 1 })
+--- @type st.zwave.CommandClass.Alarm
+local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 1 })
+local t_utils = require "integration_test.utils"
+local zw_test_utils = require "integration_test.zwave_test_utils"
+local utils = require "st.utils"
+
+local mock_datastore = require "integration_test.mock_env_datastore"
+
+local json = require "dkjson"
+
+local zwave_lock_endpoints = {
+  {
+    command_classes = {
+      { value = zw.BATTERY },
+      { value = DoorLock },
+      { value = zw.USER_CODE },
+      { value = zw.NOTIFICATION }
+    }
+  }
+}
+
+local lockCodes = {
+  ["1"] = "Zach",
+  ["2"] = "Steven"
+}
+
+local mock_device = test.mock_device.build_test_zwave_device(
+    {
+      profile = t_utils.get_profile_definition("base-lock-tamper.yml"),
+      zwave_endpoints = zwave_lock_endpoints,
+      data = {
+        lockCodes = utils.deep_copy(lockCodes)
+      }
+    }
+)
+
+local mock_device_no_data = test.mock_device.build_test_zwave_device(
+    {
+      profile = t_utils.get_profile_definition("base-lock-tamper.yml"),
+      data = {}
+    }
+)
+
+local expect_reload_all_codes_messages = function(dev, lc)
+  test.socket.capability:__expect_send(dev:generate_test_message("main",
+      capabilities.lockCodes.lockCodes(json.encode(lc))
+  ))
+  test.socket.zwave:__expect_send( UserCode:UsersNumberGet({}):build_test_tx(dev.id) )
+  test.socket.capability:__expect_send(dev:generate_test_message("main", capabilities.lockCodes.scanCodes("Scanning")))
+  test.socket.zwave:__expect_send( UserCode:Get({ user_identifier = 1 }):build_test_tx(dev.id) )
+end
+
+test.register_coroutine_test(
+    "Device added data lock codes population",
+    function()
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+      expect_reload_all_codes_messages(mock_device, lockCodes)
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              DoorLock:OperationGet({})
+          )
+      )
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              Battery:Get({})
+          )
+      )
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "_lock_codes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      assert(mock_device.state_cache.main.lockCodes.lockCodes.value == json.encode(utils.deep_copy(lockCodes)))
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", true)
+    end
+)
+
+test.register_coroutine_test(
+    "Device added without data should function",
+    function()
+      test.mock_device.add_test_device(mock_device_no_data)
+      test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "added" })
+      expect_reload_all_codes_messages(mock_device_no_data,{})
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device_no_data,
+              DoorLock:OperationGet({})
+          )
+      )
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device_no_data,
+              Battery:Get({})
+          )
+      )
+      test.socket.capability:__expect_send(mock_device_no_data:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "_lock_codes", nil)
+      -- Validate state cache
+      assert(mock_device_no_data.state_cache.main.lockCodes.lockCodes.value == json.encode({}))
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "migrationComplete", nil)
+    end
+)
+
+test.register_coroutine_test(
+    "Device init after added shouldn't change the datastores",
+    function()
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+      expect_reload_all_codes_messages(mock_device, lockCodes)
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              DoorLock:OperationGet({})
+          )
+      )
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device,
+              Battery:Get({})
+          )
+      )
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "_lock_codes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      assert(mock_device.state_cache.main.lockCodes.lockCodes.value == json.encode(utils.deep_copy(lockCodes)))
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", true)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device.id, "_lock_codes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      assert(mock_device.state_cache.main.lockCodes.lockCodes.value == json.encode(utils.deep_copy(lockCodes)))
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device.id, "migrationComplete", true)
+    end
+)
+
+test.register_coroutine_test(
+    "Device init after added shouldn't change the datastores",
+    function()
+      test.mock_device.add_test_device(mock_device_no_data)
+      test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "added" })
+      expect_reload_all_codes_messages(mock_device_no_data, {})
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device_no_data,
+              DoorLock:OperationGet({})
+          )
+      )
+      test.socket.zwave:__expect_send(
+          zw_test_utils.zwave_test_build_send_command(
+              mock_device_no_data,
+              Battery:Get({})
+          )
+      )
+      test.socket.capability:__expect_send(mock_device_no_data:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "_lock_codes", nil)
+      -- Validate state cache
+      assert(mock_device_no_data.state_cache.main.lockCodes.lockCodes.value == json.encode({}))
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "migrationComplete", nil)
+      test.socket.device_lifecycle():__queue_receive(mock_device_no_data:generate_info_changed(
+          {
+            data = {
+              lockCodes = utils.deep_copy(lockCodes)
+            }
+          }
+      ))
+      test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "init" })
+      test.wait_for_events()
+      -- Validate lockCodes field
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "_lock_codes", { ["1"] = "Zach", ["2"] = "Steven" })
+      -- Validate state cache
+      assert(mock_device_no_data.state_cache.main.lockCodes.lockCodes.value == json.encode(utils.deep_copy(lockCodes)))
+      -- Validate migration complete flag
+      mock_datastore.__assert_device_store_contains(mock_device_no_data.id, "migrationComplete", true)
+    end
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
This allows us to use the lock codes synced as a part of the DTH->Edge migration to pre-populate our lock state to avoid extra events, and give us necessary context.