### PR TITLE
HCS-2732: Always start a presence timeout on init

### DIFF
--- a/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
@@ -122,6 +122,7 @@ local function init_handler(self, device, event, args)
       )
     end
   )
+  presence_utils.create_presence_timeout(device)
 end
 
 local arrival_sensor_v1 = {

--- a/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
@@ -117,8 +117,6 @@ local function init_handler(self, device, event, args)
               3 * CHECKIN_INTERVAL + 1,
               function()
                 device:emit_event(PresenceSensor.presence("not present"))
-                device:emit_event(SignalStrength.lqi(0))
-                device:emit_event(SignalStrength.rssi({value = -100, unit = 'dBm'}))
                 device:set_field(presence_utils.PRESENCE_CALLBACK_TIMER, nil)
               end
       )

--- a/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
@@ -43,7 +43,7 @@ local NUMBER_OF_BEEPS = 5
 local LEGACY_DEVICE_BATTERY_COMMAND = 0x00
 local LEGACY_DEVICE_PRESENCE_COMMAND = 0x01
 local LEGACY_DEVICE_PRESENCE_REPORT_EXT = 0x02
-local timer_const = require "constants/timer-constants"
+local presence_utils = require "presence_utils"
 
 local CHECKIN_INTERVAL = 20 -- seconds
 
@@ -111,7 +111,7 @@ end
 
 local function init_handler(self, device, event, args)
   device:set_field(
-    timer_const.PRESENCE_CALLBACK_CREATE_FN,
+    presence_utils.PRESENCE_CALLBACK_CREATE_FN,
     function(device)
       return device.thread:call_with_delay(
               3 * CHECKIN_INTERVAL + 1,
@@ -119,7 +119,7 @@ local function init_handler(self, device, event, args)
                 device:emit_event(PresenceSensor.presence("not present"))
                 device:emit_event(SignalStrength.lqi(0))
                 device:emit_event(SignalStrength.rssi({value = -100, unit = 'dBm'}))
-                device:set_field(timer_const.PRESENCE_CALLBACK_TIMER, nil)
+                device:set_field(presence_utils.PRESENCE_CALLBACK_TIMER, nil)
               end
       )
     end

--- a/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
@@ -89,17 +89,6 @@ local function create_poll_schedule(device)
     device:set_field(presence_utils.RECURRING_POLL_TIMER, new_timer)
   elseif timer ~= nil then
     device.thread:cancel_timer(timer)
-    device:set_field(timer_const.RECURRING_POLL_TIMER, nil)
-  end
-end
-
-local function create_presence_timeout(device)
-  local timer = device:get_field(timer_const.PRESENCE_CALLBACK_TIMER)
-  if timer ~= nil then
-    device.thread:cancel_timer(timer)
-  end
-  local no_rep_timer = device:get_field(timer_const.PRESENCE_CALLBACK_CREATE_FN)
-  if (no_rep_timer ~= nil) then
     device:set_field(presence_utils.RECURRING_POLL_TIMER, nil)
   end
 end
@@ -142,8 +131,8 @@ local function init_handler(self, device, event, args)
   local should_schedule_recurring_polling = not (device:get_field(IS_PRESENCE_BASED_ON_BATTERY_REPORTS) or true)
   if should_schedule_recurring_polling then
     create_poll_schedule(device)
-    create_presence_timeout(device)
   end
+  presence_utils.create_presence_timeout(device)
 end
 
 local function beep_handler(self, device, command)
@@ -159,7 +148,7 @@ end
 local function poke(device)
   -- If we receive any message from the device, we should mark it present and start the timeout to mark it offline
   device:emit_event(PresenceSensor.presence("present"))
-  create_presence_timeout(device)
+  presence_utils.create_presence_timeout(device)
 end
 
 local function all_zigbee_message_handler(self, message_channel)

--- a/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
@@ -15,7 +15,7 @@
 local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
-local timer_const = require "constants/timer-constants"
+local presence_utils = require "presence_utils"
 
 -- Capabilities
 local capabilities   = require "st.capabilities"
@@ -67,17 +67,17 @@ local battery_table = {
 local function battery_config_response_handler(self, device, zb_rx)
   if zb_rx.body.zcl_body.global_status.value == Status.SUCCESS then
     device:set_field(IS_PRESENCE_BASED_ON_BATTERY_REPORTS, true, {persist = true})
-    local poll_timer = device:get_field(timer_const.RECURRING_POLL_TIMER)
+    local poll_timer = device:get_field(presence_utils.RECURRING_POLL_TIMER)
     if poll_timer ~= nil then
       device.thread:cancel_timer(poll_timer)
-      device:set_field(timer_const.RECURRING_POLL_TIMER, nil)
+      device:set_field(presence_utils.RECURRING_POLL_TIMER, nil)
     end
   end
 end
 
 local function create_poll_schedule(device)
   local should_schedule_recurring_polling = not (device:get_field(IS_PRESENCE_BASED_ON_BATTERY_REPORTS) or true)
-  local timer = device:get_field(timer_const.RECURRING_POLL_TIMER)
+  local timer = device:get_field(presence_utils.RECURRING_POLL_TIMER)
   if should_schedule_recurring_polling then
     if timer ~= nil then
       device.thread:cancel_timer(timer)
@@ -86,7 +86,7 @@ local function create_poll_schedule(device)
     local new_timer = device.thread:call_on_schedule(math.floor(device.preferences.check_interval / 2) - 1, function()
       device:send(Basic.attributes.ZCLVersion:read(device))
     end, "polling_schedule_timer")
-    device:set_field(timer_const.RECURRING_POLL_TIMER, new_timer)
+    device:set_field(presence_utils.RECURRING_POLL_TIMER, new_timer)
   elseif timer ~= nil then
     device.thread:cancel_timer(timer)
     device:set_field(timer_const.RECURRING_POLL_TIMER, nil)
@@ -100,7 +100,7 @@ local function create_presence_timeout(device)
   end
   local no_rep_timer = device:get_field(timer_const.PRESENCE_CALLBACK_CREATE_FN)
   if (no_rep_timer ~= nil) then
-    device:set_field(timer_const.PRESENCE_CALLBACK_TIMER, no_rep_timer(device))
+    device:set_field(presence_utils.RECURRING_POLL_TIMER, nil)
   end
 end
 
@@ -127,13 +127,13 @@ local function init_handler(self, device, event, args)
   device:remove_configured_attribute(PowerConfiguration.ID, PowerConfiguration.attributes.BatteryPercentageRemaining.ID)
 
   device:set_field(
-      timer_const.PRESENCE_CALLBACK_CREATE_FN,
+      presence_utils.PRESENCE_CALLBACK_CREATE_FN,
       function(device)
         return device.thread:call_with_delay(
                   get_check_interval_int(device),
                   function()
                     device:emit_event(PresenceSensor.presence("not present"))
-                    device:set_field(timer_const.PRESENCE_CALLBACK_TIMER, nil)
+                    device:set_field(presence_utils.PRESENCE_CALLBACK_TIMER, nil)
                   end
         )
       end

--- a/drivers/SmartThings/zigbee-presence-sensor/src/presence_utils.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/presence_utils.lua
@@ -25,4 +25,15 @@ presence_utils.PRESENCE_CALLBACK_TIMER = "presenceCallbackTimer"
 -- events are based on recurring poll of Basic cluster's attribute
 presence_utils.RECURRING_POLL_TIMER = "recurringPollTimer"
 
+function presence_utils.create_presence_timeout(device)
+  local timer = device:get_field(presence_utils.PRESENCE_CALLBACK_TIMER)
+  if timer ~= nil then
+    device.thread:cancel_timer(timer)
+  end
+  local no_rep_timer = device:get_field(presence_utils.PRESENCE_CALLBACK_CREATE_FN)
+  if (no_rep_timer ~= nil) then
+    device:set_field(presence_utils.PRESENCE_CALLBACK_TIMER, no_rep_timer(device))
+  end
+end
+
 return presence_utils

--- a/drivers/SmartThings/zigbee-presence-sensor/src/presence_utils.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/presence_utils.lua
@@ -12,9 +12,17 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-return {
-  LAST_CHECKIN_TIMESTAMP = "lastCheckinTimestamp", -- used when presence events are based on battery reports
-  PRESENCE_CALLBACK_CREATE_FN = "presenceCallbackCreateFn",
-  PRESENCE_CALLBACK_TIMER = "presenceCallbackTimer", -- events are based on battery reports
-  RECURRING_POLL_TIMER = "recurringPollTimer"       -- events are based on recurring poll of Basic cluster's attribute
-}
+local presence_utils = {}
+
+-- used when presence events are based on battery reports
+presence_utils.LAST_CHECKIN_TIMESTAMP = "lastCheckinTimestamp"
+
+presence_utils.PRESENCE_CALLBACK_CREATE_FN = "presenceCallbackCreateFn"
+
+-- events are based on battery reports
+presence_utils.PRESENCE_CALLBACK_TIMER = "presenceCallbackTimer"
+
+-- events are based on recurring poll of Basic cluster's attribute
+presence_utils.RECURRING_POLL_TIMER = "recurringPollTimer"
+
+return presence_utils

--- a/drivers/SmartThings/zigbee-presence-sensor/src/test/test_st_arrival_sensor_v1.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/test/test_st_arrival_sensor_v1.lua
@@ -183,4 +183,21 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+    "init followed by no action should result in timeout",
+    function ()
+      test.mock_device.add_test_device(mock_simple_device)
+      test.timer.__create_and_queue_test_time_advance_timer(120, "oneshot")
+      test.socket.device_lifecycle:__queue_receive({ mock_simple_device.id, "init"})
+      test.wait_for_events()
+      test.mock_time.advance_time(121)
+      test.socket.capability:__expect_send( mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("not present")) )
+    end,
+    {
+      test_init = function()
+        zigbee_test_utils.init_noop_health_check_timer()
+      end
+    }
+)
+
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-presence-sensor/src/test/test_zigbee_presence_sensor.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/test/test_zigbee_presence_sensor.lua
@@ -184,11 +184,29 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Added lifecycle should be handlded",
-  function ()
-    add_device()
-  end
+    "Added lifecycle should be handlded",
+    function ()
+      add_device()
+    end
 )
+
+test.register_coroutine_test(
+    "init followed by no action should result in timeout",
+    function ()
+      test.mock_device.add_test_device(mock_simple_device)
+      test.timer.__create_and_queue_test_time_advance_timer(120, "oneshot")
+      test.socket.device_lifecycle:__queue_receive({ mock_simple_device.id, "init"})
+      test.wait_for_events()
+      test.mock_time.advance_time(121)
+      test.socket.capability:__expect_send( mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("not present")) )
+    end,
+    {
+      test_init = function()
+        zigbee_test_utils.init_noop_health_check_timer()
+      end
+    }
+)
+
 
 test.register_coroutine_test(
   "Device should be marked not present when default check interval elapses without a battery report",


### PR DESCRIPTION
This changes the logic to always start a presence timeout timer on device init.
This means that even if the device was in the offline state it will trigger a
not present event.