### PR TITLE
zigbee-water-leak-sensor: changed Nortek profile

### DIFF
--- a/drivers/SmartThings/zigbee-water-leak-sensor/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/fingerprints.yml
@@ -83,7 +83,7 @@ zigbeeManufacturer:
     deviceLabel: ADT Water Leak Detector
     manufacturer: Nortek Security and Control
     model: F-ADT-WTR-1
-    deviceProfileName: water-temp-battery
+    deviceProfileName: water-temp-battery-tempOffset
   - id: ThirdReality/3RWS18BZ/1
     deviceLabel: ThirdReality Water Leak Sensor
     manufacturer: Third Reality, Inc


### PR DESCRIPTION
changed profile to one that includes tempOffset, fix for CHAD-9312

https://smartthings.atlassian.net/browse/CHAD-9312?focusedCommentId=1196390&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1196390