### PR TITLE
CHAD-9229 - hides configuration events

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
@@ -51,7 +51,7 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and 2 or 1
     device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
-    device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
+    device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}, {visibility = { displayed = false }}))
   end
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))

--- a/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
@@ -50,7 +50,7 @@ end
 local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and 2 or 1
-    device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
+    device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
@@ -50,7 +50,7 @@ end
 local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and 2 or 1
-    device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
+    device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/dimming-remote/init.lua
@@ -50,7 +50,7 @@ end
 local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and 2 or 1
-    device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
+    device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/frient/init.lua
@@ -50,7 +50,7 @@ local function init_handler(self, device, event, args)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/frient/init.lua
@@ -50,7 +50,7 @@ local function init_handler(self, device, event, args)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, { visibility = { displayed = false } }))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/frient/init.lua
@@ -50,7 +50,7 @@ local function init_handler(self, device, event, args)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/init.lua
@@ -66,8 +66,8 @@ local ias_zone_status_change_handler = function(driver, device, zb_rx)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}))
-  device:emit_event(capabilities.button.numberOfButtons({value = 1}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}, {visibility = { displayed = false }}))
+  device:emit_event(capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end
 

--- a/drivers/SmartThings/zigbee-button/src/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/init.lua
@@ -66,7 +66,7 @@ local ias_zone_status_change_handler = function(driver, device, zb_rx)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}, { visibility = { displayed = false } }))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/init.lua
@@ -66,7 +66,7 @@ local ias_zone_status_change_handler = function(driver, device, zb_rx)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/iris/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/iris/init.lua
@@ -60,7 +60,7 @@ local function ias_zone_status_change_handler(self, device, zb_rx)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/iris/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/iris/init.lua
@@ -61,7 +61,7 @@ end
 
 local function added_handler(self, device)
   device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
-  device:emit_event(capabilities.button.numberOfButtons({value = 1}))
+  device:emit_event(capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))
 end

--- a/drivers/SmartThings/zigbee-button/src/iris/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/iris/init.lua
@@ -60,7 +60,7 @@ local function ias_zone_status_change_handler(self, device, zb_rx)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/iris/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/iris/init.lua
@@ -60,7 +60,7 @@ local function ias_zone_status_change_handler(self, device, zb_rx)
 end
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
@@ -26,7 +26,7 @@
 local capabilities = require "st.capabilities"
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
@@ -27,7 +27,7 @@ local capabilities = require "st.capabilities"
 
 local function added_handler(self, device)
   device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, {visibility = { displayed = false }}))
-  device:emit_event(capabilities.button.numberOfButtons({value = 1}))
+  device:emit_event(capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end
 

--- a/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
@@ -26,7 +26,7 @@
 local capabilities = require "st.capabilities"
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/pushButton/init.lua
@@ -26,7 +26,7 @@
 local capabilities = require "st.capabilities"
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, { visibility = { displayed = false } }))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/test/test_aduro_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_aduro_button.lua
@@ -146,36 +146,32 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 4 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-          }
-        })
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+          )
+        )
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_centralite_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_centralite_button.lua
@@ -198,36 +198,32 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 4 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-          }
-        })
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
+          )
+        )
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_dimming_remote.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_dimming_remote.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- Mock out globals
-local base64 = require "st.base64"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
@@ -181,51 +180,42 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__set_channel_ordering("relaxed")
-
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 2 }
-      }
-    })
-
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "button1",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "button1",
-        attribute_id = "numberOfButtons", state = { value = 1 }
-      }
-    })
-
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "button2",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "button2",
-        attribute_id = "numberOfButtons", state = { value = 1 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 2 }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "button1",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "button1",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "button2",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "button2",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+      )
+    )
     test.socket.capability:__expect_send({
       mock_device.id,
       {

--- a/drivers/SmartThings/zigbee-button/src/test/test_ewelink_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ewelink_button.lua
@@ -50,10 +50,16 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", button.supportedButtonValues({ "pushed", "held", "double" }))
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed", "held", "double" }, { visibility = { displayed = false } })
+      )
     )
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", button.numberOfButtons({ value = 1 }))
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+      )
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", button.button.pushed({ state_change = false }))

--- a/drivers/SmartThings/zigbee-button/src/test/test_heiman_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_heiman_button.lua
@@ -217,36 +217,32 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 4 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed"}, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-          }
-        })
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+          )
+        )
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- Mock out globals
-local base64 = require "st.base64"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local mgmt_bind_response = require "st.zigbee.zdo.mgmt_bind_response"
@@ -192,46 +191,41 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 5 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed", "held"  }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 5 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
         if button_name ~= "button5" then
-          test.socket.capability:__expect_send({
-            mock_device.id,
-            {
-              capability_id = "button", component_id = button_name,
-              attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-            }
-          })
+          test.socket.capability:__expect_send(
+            mock_device:generate_test_message(
+              button_name,
+              capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
+            )
+          )
         else
-          test.socket.capability:__expect_send({
-            mock_device.id,
-            {
-              capability_id = "button", component_id = button_name,
-              attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-            }
-          })
+          test.socket.capability:__expect_send(
+            mock_device:generate_test_message(
+              button_name,
+              capabilities.button.supportedButtonValues({ "pushed"}, { visibility = { displayed = false } })
+            )
+          )
         end
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.zigbee:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_iris_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_iris_button.lua
@@ -133,21 +133,18 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__set_channel_ordering("relaxed")
-
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
         "main",
-        capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false }})
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } })
       )
     )
-
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 1 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+      )
+    )
     test.socket.capability:__expect_send({
       mock_device.id,
       {

--- a/drivers/SmartThings/zigbee-button/src/test/test_iris_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_iris_button.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- Mock out globals
-local base64 = require "st.base64"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
@@ -134,13 +133,14 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held" } }
-      }
-    })
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false }})
+      )
+    )
+
     test.socket.capability:__expect_send({
       mock_device.id,
       {

--- a/drivers/SmartThings/zigbee-button/src/test/test_push_only_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_push_only_button.lua
@@ -20,10 +20,7 @@ local PowerConfiguration = clusters.PowerConfiguration
 local capabilities = require "st.capabilities"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local IasEnrollResponseCode = require "st.zigbee.generated.zcl_clusters.IASZone.types.EnrollResponseCode"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
-
-
 local ZoneStatusAttribute = IASZone.attributes.ZoneStatus
 local button_attr = capabilities.button.button
 
@@ -112,22 +109,16 @@ test.register_coroutine_test(
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
       test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "main",
-            attribute_id = "supportedButtonValues", state = { value= { "pushed" } }
-          }
-        }
+        mock_device:generate_test_message(
+          "main",
+          capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+        )
       )
       test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "main",
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        }
+        mock_device:generate_test_message(
+          "main",
+          capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+        )
       )
       test.socket.capability:__expect_send({
         mock_device.id,

--- a/drivers/SmartThings/zigbee-button/src/test/test_samjin_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_samjin_button.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- Mock out globals
-local base64 = require "st.base64"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
@@ -110,20 +109,18 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held", "double" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 1 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed", "held", "double" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+      )
+    )
     test.socket.capability:__expect_send({
       mock_device.id,
       {

--- a/drivers/SmartThings/zigbee-button/src/test/test_shinasystem_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_shinasystem_button.lua
@@ -235,36 +235,32 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed", "held", "double" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 4 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed", "held", "double" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed", "held", "double" } }
-          }
-        })
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.supportedButtonValues({ "pushed", "held", "double" }, { visibility = { displayed = false } })
+          )
+        )
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_1_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_1_button.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- Mock out globals
-local base64 = require "st.base64"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local mgmt_bind_response = require "st.zigbee.zdo.mgmt_bind_response"
@@ -147,36 +146,32 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 3 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 3 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-          }
-        })
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+          )
+        )
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_4_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_4_button.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- Mock out globals
-local base64 = require "st.base64"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local mgmt_bind_response = require "st.zigbee.zdo.mgmt_bind_response"
@@ -200,36 +199,32 @@ test.register_coroutine_test(
   "added lifecycle event",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-      }
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "button", component_id = "main",
-        attribute_id = "numberOfButtons", state = { value = 12 }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 12 }, { visibility = { displayed = false } })
+      )
+    )
     for button_name, _ in pairs(mock_device.profile.components) do
       if button_name ~= "main" then
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-          }
-        })
-        test.socket.capability:__expect_send({
-          mock_device.id,
-          {
-            capability_id = "button", component_id = button_name,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        })
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+          )
+        )
+        test.socket.capability:__expect_send(
+          mock_device:generate_test_message(
+            button_name,
+            capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+          )
+        )
       end
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/test/test_zigbee_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_zigbee_button.lua
@@ -20,7 +20,6 @@ local PowerConfiguration = clusters.PowerConfiguration
 local capabilities = require "st.capabilities"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local IasEnrollResponseCode = require "st.zigbee.generated.zcl_clusters.IASZone.types.EnrollResponseCode"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
 
 local ZoneStatusAttribute = IASZone.attributes.ZoneStatus
@@ -165,22 +164,16 @@ test.register_coroutine_test(
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
       test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "main",
-            attribute_id = "supportedButtonValues", state = { value= { "pushed", "held", "double" } }
-          }
-        }
+        mock_device:generate_test_message(
+          "main",
+          capabilities.button.supportedButtonValues({ "pushed", "held", "double" }, { visibility = { displayed = false } })
+        )
       )
       test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "main",
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        }
+        mock_device:generate_test_message(
+          "main",
+          capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+        )
       )
       test.socket.capability:__expect_send({
         mock_device.id,

--- a/drivers/SmartThings/zigbee-button/src/test/test_zigbee_ecosmart_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_zigbee_ecosmart_button.lua
@@ -69,41 +69,31 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "main",
-            attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-          }
-        }
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
       )
-      test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "main",
-            attribute_id = "numberOfButtons", state = { value = 4 }
-          }
-        }
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, { visibility = { displayed = false } })
       )
+    )
+
     for button_number = 1, 4 do
       test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "button" .. button_number,
-            attribute_id = "supportedButtonValues", state = { value = { "pushed" } }
-          }
-        }
+        mock_device:generate_test_message(
+          "button" .. button_number,
+          capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })
+        )
       )
       test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "button", component_id = "button" .. button_number,
-            attribute_id = "numberOfButtons", state = { value = 1 }
-          }
-        }
+        mock_device:generate_test_message(
+          "button" .. button_number,
+          capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } })
+        )
       )
     end
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -47,9 +47,9 @@ end
 local function added_handler(self, device)
   for comp_name, comp in pairs(device.profile.components) do
     if comp_name == "button5" then
-      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed"}, { visibility = { displayed = false } }))
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed"}))
     else
-      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}))
     end
     if comp_name == "main" then
       device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 5}))

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -52,9 +52,9 @@ local function added_handler(self, device)
       device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
     end
     if comp_name == "main" then
-      device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 5}))
+      device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 5}, {visibility = { displayed = false }}))
     else
-      device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 1}))
+      device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
     end
   end
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -47,9 +47,9 @@ end
 local function added_handler(self, device)
   for comp_name, comp in pairs(device.profile.components) do
     if comp_name == "button5" then
-      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed"}))
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed"}, { visibility = { displayed = false } }))
     else
-      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}))
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
     end
     if comp_name == "main" then
       device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 5}))

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -47,9 +47,9 @@ end
 local function added_handler(self, device)
   for comp_name, comp in pairs(device.profile.components) do
     if comp_name == "button5" then
-      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed"}))
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed"}, {visibility = { displayed = false }}))
     else
-      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}))
+      device:emit_component_event(comp, capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
     end
     if comp_name == "main" then
       device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 5}))

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
@@ -55,9 +55,9 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
-      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES, { visibility = { displayed = false } }))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES))
     else
-      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
     end
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
@@ -55,9 +55,9 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
-      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES), {visibility = { displayed = false }})
     else
-      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
     end
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
@@ -55,9 +55,9 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
-      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES, { visibility = { displayed = false } }))
     else
-      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
     end
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
@@ -51,11 +51,11 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
-      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES, {visibility = { displayed = false }}))
     else
-      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }}))
     end
-    device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
+    device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}, {visibility = { displayed = false }}))
   end
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
@@ -51,9 +51,9 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
-      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES, { visibility = { displayed = false } }))
     else
-      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
     end
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
@@ -51,9 +51,9 @@ local function added_handler(self, device)
   for _, component in pairs(device.profile.components) do
     local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
-      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES, { visibility = { displayed = false } }))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES))
     else
-      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
+      device:emit_component_event(component, capabilities.button.supportedButtonValues({"pushed", "held"}))
     end
     device:emit_component_event(component, capabilities.button.numberOfButtons({value = number_of_buttons}))
   end

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/init.lua
@@ -124,8 +124,8 @@ end
 local device_added = function(self, device)
   generate_switch_onoff_event(device, "on")
   generate_switch_level_event(device, 100)
-  device:emit_event(capabilities.button.numberOfButtons({value = 1}))
-  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}))
+  device:emit_event(capabilities.button.numberOfButtons({value = 1}, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"}, { visibility = { displayed = false } }))
   device:emit_event(capabilities.button.button.pushed({state_change = true}))
 end
 

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -111,8 +111,7 @@ local power_source_handler = function(driver, device, battery_alarm_mask)
 end
 
 local supported_thermostat_modes_handler = function(driver, device, supported_modes)
-  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value]))
-  --device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value], { visibility = { displayed = false } }))
+  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value], { visibility = { displayed = false } }))
 end
 
 local thermostat_mode_handler = function(driver, device, thermostat_mode)
@@ -134,8 +133,7 @@ local thermostat_operating_state_handler = function(driver, device, operating_st
 end
 
 local supported_fan_modes_handler = function(driver, device, fan_mode)
-  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value]))
-  --device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false } }))
+  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false } }))
 end
 
 local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -111,7 +111,8 @@ local power_source_handler = function(driver, device, battery_alarm_mask)
 end
 
 local supported_thermostat_modes_handler = function(driver, device, supported_modes)
-  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value], { visibility = { displayed = false } }))
+  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value]))
+  --device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value], { visibility = { displayed = false } }))
 end
 
 local thermostat_mode_handler = function(driver, device, thermostat_mode)
@@ -133,14 +134,15 @@ local thermostat_operating_state_handler = function(driver, device, operating_st
 end
 
 local supported_fan_modes_handler = function(driver, device, fan_mode)
-  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false } }))
+  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value]))
+  --device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false } }))
 end
 
 local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)
   if (FAN_MODE_MAP[attr_fan_mode.value]) then
     local supported_fan_modes = device:get_latest_state("main", ThermostatFanMode.ID, ThermostatFanMode.supportedThermostatFanModes.NAME)
     if supported_fan_modes then
-      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}))
+      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}}))
     else
       device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -139,7 +139,7 @@ local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)
   if (FAN_MODE_MAP[attr_fan_mode.value]) then
     local supported_fan_modes = device:get_latest_state("main", ThermostatFanMode.ID, ThermostatFanMode.supportedThermostatFanModes.NAME)
     if supported_fan_modes then
-      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes, visibility = { displayed = false }} }))
+      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}}))
     else
       device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -140,7 +140,7 @@ local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)
   if (FAN_MODE_MAP[attr_fan_mode.value]) then
     local supported_fan_modes = device:get_latest_state("main", ThermostatFanMode.ID, ThermostatFanMode.supportedThermostatFanModes.NAME)
     if supported_fan_modes then
-      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes, visibility = { displayed = false }}}))
+      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}))
     else
       device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -111,7 +111,7 @@ local power_source_handler = function(driver, device, battery_alarm_mask)
 end
 
 local supported_thermostat_modes_handler = function(driver, device, supported_modes)
-  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value]))
+  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[supported_modes.value], { visibility = { displayed = false } }))
 end
 
 local thermostat_mode_handler = function(driver, device, thermostat_mode)
@@ -133,7 +133,7 @@ local thermostat_operating_state_handler = function(driver, device, operating_st
 end
 
 local supported_fan_modes_handler = function(driver, device, fan_mode)
-  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value]))
+  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false } }))
 end
 
 local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -139,7 +139,7 @@ local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)
   if (FAN_MODE_MAP[attr_fan_mode.value]) then
     local supported_fan_modes = device:get_latest_state("main", ThermostatFanMode.ID, ThermostatFanMode.supportedThermostatFanModes.NAME)
     if supported_fan_modes then
-      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}, visibility = { displayed = false }}))
+      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes, visibility = { displayed = false }} }))
     else
       device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -140,7 +140,7 @@ local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)
   if (FAN_MODE_MAP[attr_fan_mode.value]) then
     local supported_fan_modes = device:get_latest_state("main", ThermostatFanMode.ID, ThermostatFanMode.supportedThermostatFanModes.NAME)
     if supported_fan_modes then
-      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}}))
+      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes, visibility = { displayed = false }}}))
     else
       device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -17,7 +17,6 @@ local ZigbeeDriver      = require "st.zigbee"
 local device_management = require "st.zigbee.device_management"
 local defaults          = require "st.zigbee.defaults"
 local utils             = require "st.utils"
-local log               = require "log"
 
 -- Zigbee Spec Utils
 local clusters                      = require "st.zigbee.zcl.clusters"
@@ -133,14 +132,14 @@ local thermostat_operating_state_handler = function(driver, device, operating_st
 end
 
 local supported_fan_modes_handler = function(driver, device, fan_mode)
-  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false } }))
+  device:emit_event(ThermostatFanMode.supportedThermostatFanModes(SUPPORTED_FAN_MODES[fan_mode.value], { visibility = { displayed = false }}))
 end
 
 local thermostat_fan_mode_handler = function(driver, device, attr_fan_mode)
   if (FAN_MODE_MAP[attr_fan_mode.value]) then
     local supported_fan_modes = device:get_latest_state("main", ThermostatFanMode.ID, ThermostatFanMode.supportedThermostatFanModes.NAME)
     if supported_fan_modes then
-      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}}))
+      device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]({data = {supportedThermostatFanModes = supported_fan_modes}, visibility = { displayed = false }}))
     else
       device:emit_event(FAN_MODE_MAP[attr_fan_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/leviton/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/leviton/init.lua
@@ -56,7 +56,7 @@ local function added(driver, device)
     capabilities.thermostatMode.thermostatMode.heat.NAME,
     capabilities.thermostatMode.thermostatMode.cool.NAME,
     capabilities.thermostatMode.thermostatMode.auto.NAME
-  }))
+  }, { visibility = { displayed = false } } ))
   do_refresh(driver, device, nil)
 end
 

--- a/drivers/SmartThings/zigbee-thermostat/src/lux-konoz/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/lux-konoz/init.lua
@@ -34,7 +34,7 @@ end
 
 -- LUX KONOz reports extra ["auto", "emergency heat"] which, actually, aren't supported
 local supported_thermostat_modes_handler = function(driver, device, supported_modes)
-  device:emit_event(ThermostatMode.supportedThermostatModes({"off", "heat", "cool"}))
+  device:emit_event(ThermostatMode.supportedThermostatModes({"off", "heat", "cool"}, { visibility = { displayed = false } }))
 end
 
 local lux_konoz = {

--- a/drivers/SmartThings/zigbee-thermostat/src/popp_danfoss/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/popp_danfoss/init.lua
@@ -20,7 +20,7 @@ local is_popp_danfoss_thermostat = function(opts, driver, device)
 end
 
 local supported_thermostat_modes_handler = function(driver, device, supported_modes)
-  device:emit_event(ThermostatMode.supportedThermostatModes({"heat"}))
+  device:emit_event(ThermostatMode.supportedThermostatModes({"heat"}, { visibility = { displayed = false } }))
 end
 
 local popp_danfoss_thermostat = {

--- a/drivers/SmartThings/zigbee-thermostat/src/stelpro-ki-zigbee-thermostat/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/stelpro-ki-zigbee-thermostat/init.lua
@@ -310,7 +310,7 @@ local function do_configure(self, device)
 end
 
 local function device_added(self, device)
-  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_MODES))
+  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_MODES, { visibility = { displayed = false } }))
   device:emit_event(TemperatureAlarm.temperatureAlarm.cleared())
 end
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_ki_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_ki_zigbee_thermostat.lua
@@ -414,7 +414,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "eco" }))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "eco" }, { visibility = { displayed = false } }))
     },
     {
       channel = "capability",

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
@@ -144,7 +144,7 @@ test.register_coroutine_test(
       mock_device:generate_test_message(
         "main",
         capabilities.thermostatFanMode.thermostatFanMode.on(
-          { data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}}
+          { data = {supportedThermostatFanModes = {"on", "auto"}}}
         )
       )
     )

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
@@ -144,7 +144,7 @@ test.register_coroutine_test(
       mock_device:generate_test_message(
         "main",
         capabilities.thermostatFanMode.thermostatFanMode.on(
-          { data = {supportedThermostatFanModes = {"on", "auto"}} }
+          { data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}}
         )
       )
     )
@@ -271,7 +271,7 @@ test.register_coroutine_test(
         PowerConfiguration.attributes.BatteryVoltage:configure_reporting(mock_device, 30, 21600, 1)
       })
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "cool" }, { visibility = { displayed = false } }))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "cool" }, { visibility = { displayed = false }}))
       )
       test.socket.zigbee:__queue_receive(
         {
@@ -309,7 +309,7 @@ test.register_coroutine_test(
       test.socket.environment_update:__queue_receive({ "zigbee", { hub_zigbee_id = base64.encode(zigbee_test_utils.mock_hub_eui) } })
       test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed(updates))
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat", "cool" },{ visibility = { displayed = false } }))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat", "cool" },{ visibility = { displayed = false }}))
       )
       test.wait_for_events()
       test.socket.zigbee:__queue_receive(
@@ -319,7 +319,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.cool({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }, visibility = { displayed = false } }}))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.cool({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }, visibility = { displayed = false }}}))
       )
       test.wait_for_events()
       test.mock_time.advance_time(10)
@@ -402,7 +402,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.heat({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }, visibility = { displayed = false } }}))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.heat({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }, visibility = { displayed = false }}}))
       )
       test.wait_for_events()
       test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
@@ -127,7 +127,7 @@ test.register_message_test(
       {
         channel = "capability",
         direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }))
+        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }, { visibility = { displayed = false } }))
       },
       {
         channel = "zigbee",
@@ -139,7 +139,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.thermostatFanMode.on({
-          data = {supportedThermostatFanModes = {"on", "auto"}}
+          data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}
         }))
       }
     }
@@ -202,7 +202,7 @@ test.register_coroutine_test(
         PowerConfiguration.attributes.BatteryVoltage:configure_reporting(mock_device, 30, 21600, 1)
       })
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "cool" }))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "cool" }, { visibility = { displayed = false } }))
       )
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end
@@ -265,7 +265,7 @@ test.register_coroutine_test(
         PowerConfiguration.attributes.BatteryVoltage:configure_reporting(mock_device, 30, 21600, 1)
       })
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "cool" }))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "cool" }, { visibility = { displayed = false } }))
       )
       test.socket.zigbee:__queue_receive(
         {
@@ -303,7 +303,7 @@ test.register_coroutine_test(
       test.socket.environment_update:__queue_receive({ "zigbee", { hub_zigbee_id = base64.encode(zigbee_test_utils.mock_hub_eui) } })
       test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed(updates))
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat", "cool" }))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat", "cool" },{ visibility = { displayed = false } }))
       )
       test.wait_for_events()
       test.socket.zigbee:__queue_receive(
@@ -313,7 +313,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.cool({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }}}))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.cool({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }, visibility = { displayed = false } }}))
       )
       test.wait_for_events()
       test.mock_time.advance_time(10)
@@ -396,7 +396,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.heat({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }}}))
+        mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.heat({data={supportedThermostatModes={ "off", "auto", "heat", "cool" }, visibility = { displayed = false } }}))
       )
       test.wait_for_events()
       test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -156,7 +156,7 @@ test.register_message_test(
       {
         channel = "capability",
         direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "auto", "cool", "emergency heat" }))
+        message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "auto", "cool", "emergency heat" }, { visibility = { displayed = false } }))
       }
     }
 )
@@ -173,7 +173,7 @@ test.register_message_test(
       {
         channel = "capability",
         direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }))
+        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }, { visibility = { displayed = false } }))
       }
     }
 )
@@ -207,7 +207,7 @@ test.register_message_test(
       {
         channel = "capability",
         direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }))
+        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }, { visibility = { displayed = false } }))
       },
       {
         channel = "zigbee",
@@ -219,7 +219,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.thermostatFanMode.on({
-          data = {supportedThermostatFanModes = {"on", "auto"}}
+          data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}
         }))
       }
     }

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -20,7 +20,6 @@ local Thermostat = clusters.Thermostat
 local FanControl = clusters.FanControl
 local capabilities = require "st.capabilities"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
 
 local mock_device = test.mock_device.build_test_zigbee_device(
@@ -144,38 +143,48 @@ test.register_message_test(
     }
 )
 
-test.register_message_test(
-    "Supported modes reports are handled",
-    {
+test.register_coroutine_test(
+  "Supported thermostat modes reports are handled",
+  function()
+    test.socket.zigbee:__queue_receive(
       {
-        channel = "zigbee",
-        direction = "receive",
-        message = { mock_device.id, Thermostat.attributes.ControlSequenceOfOperation:build_test_attr_report(mock_device,
-                                                                                                            04) }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({ "off", "heat", "auto", "cool", "emergency heat" }, { visibility = { displayed = false } }))
+        mock_device.id,
+        Thermostat.attributes.ControlSequenceOfOperation:build_test_attr_report(mock_device, 04)
       }
-    }
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.thermostatMode.supportedThermostatModes(
+          { "off", "heat", "auto", "cool", "emergency heat" },
+          { visibility = { displayed = false }}
+        )
+      )
+    )
+  end
 )
 
-test.register_message_test(
-    "Supported fan modes reports are handled",
-    {
+test.register_coroutine_test(
+  "Supported fan modes reports are handled",
+  function()
+    test.socket.zigbee:__queue_receive(
       {
-        channel = "zigbee",
-        direction = "receive",
-        message = { mock_device.id, FanControl.attributes.FanModeSequence:build_test_attr_report(mock_device,
-                                                                                                 04) }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }, { visibility = { displayed = false } }))
+        mock_device.id,
+        FanControl.attributes.FanModeSequence:build_test_attr_report(mock_device, 04)
       }
-    }
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.thermostatFanMode.supportedThermostatFanModes(
+          { "on", "auto" },
+          { visibility = { displayed = false }}
+        )
+      )
+    )
+  end
 )
 
 test.register_message_test(
@@ -219,7 +228,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.thermostatFanMode.on({
-          data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}
+          data = {supportedThermostatFanModes = {"on", "auto"}}
         }))
       }
     }

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -235,7 +235,7 @@ test.register_coroutine_test(
       mock_device:generate_test_message(
         "main",
           capabilities.thermostatFanMode.thermostatFanMode.on(
-          { data = {supportedThermostatFanModes = {"on", "auto"}} }
+          { data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}}
         )
       )
     )

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -204,34 +204,43 @@ test.register_message_test(
     }
 )
 
-test.register_message_test(
-    "Fan operating state reports are handled",
-    {
+test.register_coroutine_test(
+  "Fan operating state reports are handled",
+  function()
+    test.socket.zigbee:__queue_receive(
       {
-        channel = "zigbee",
-        direction = "receive",
-        message = { mock_device.id, FanControl.attributes.FanModeSequence:build_test_attr_report(mock_device,
-                                                                                                 04) }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({ "on", "auto" }, { visibility = { displayed = false } }))
-      },
-      {
-        channel = "zigbee",
-        direction = "receive",
-        message = { mock_device.id, FanControl.attributes.FanMode:build_test_attr_report(mock_device,
-                                                                                         4), }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.thermostatFanMode.on({
-          data = {supportedThermostatFanModes = {"on", "auto"}}
-        }))
+        mock_device.id,
+        FanControl.attributes.FanModeSequence:build_test_attr_report(mock_device, 04)
       }
-    }
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.thermostatFanMode.supportedThermostatFanModes(
+          { "on", "auto" },
+          { visibility = { displayed = false }}
+        )
+      )
+    )
+
+    test.socket.zigbee:__queue_receive(
+      {
+        mock_device.id,
+        FanControl.attributes.FanMode:build_test_attr_report(mock_device, 04)
+      }
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+          capabilities.thermostatFanMode.thermostatFanMode.on(
+          { data = {supportedThermostatFanModes = {"on", "auto"}} }
+        )
+      )
+    )
+
+  end
 )
 
 test.register_message_test(

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -235,11 +235,10 @@ test.register_coroutine_test(
       mock_device:generate_test_message(
         "main",
           capabilities.thermostatFanMode.thermostatFanMode.on(
-          { data = {supportedThermostatFanModes = {"on", "auto"}, visibility = { displayed = false }}}
+          { data = {supportedThermostatFanModes = {"on", "auto"}}}
         )
       )
     )
-
   end
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/zenwithin/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/zenwithin/init.lua
@@ -173,7 +173,7 @@ local thermostat_mode_handler = function(driver, device, thermostat_mode)
   if THERMOSTAT_SYSTEM_MODE_MAP[thermostat_mode.value] then
     local current_supported_modes = device:get_latest_state("main", ThermostatMode.ID, ThermostatMode.supportedThermostatModes.NAME)
     if current_supported_modes then
-      device:emit_event(THERMOSTAT_SYSTEM_MODE_MAP[thermostat_mode.value]({data = {supportedThermostatModes = current_supported_modes}}))
+      device:emit_event(THERMOSTAT_SYSTEM_MODE_MAP[thermostat_mode.value]({data = {supportedThermostatModes = current_supported_modes, visibility = { displayed = false } }}))
     else
       device:emit_event(THERMOSTAT_SYSTEM_MODE_MAP[thermostat_mode.value]())
     end

--- a/drivers/SmartThings/zigbee-thermostat/src/zenwithin/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/zenwithin/init.lua
@@ -71,16 +71,7 @@ local do_configure = function(self, device)
   device:send(Thermostat.attributes.ThermostatRunningState:configure_reporting(device, 5, 300))
   device:send(FanControl.attributes.FanMode:configure_reporting(device, 5, 300))
   device:send(PowerConfiguration.attributes.BatteryVoltage:configure_reporting(device, 30, 21600, 1))
-  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[3]))-- default: { "off", "heat", "cool" }
-end
-
-local battery_voltage_handler = function(driver, device, battery_voltage)
-  local perc_value = utils.round((battery_voltage.value - BAT_MIN)/(BAT_MAX - BAT_MIN) * 100)
-  if (perc_value < 100) then
-    device:emit_event(Battery.battery(utils.clamp_value(perc_value, 0, 100)))
-  else
-    device:emit_event(Battery.battery(100))
-  end
+  device:emit_event(ThermostatMode.supportedThermostatModes(SUPPORTED_THERMOSTAT_MODES[3], { visibility = { displayed = false } }))-- default: { ModeAttribute.off.NAME, ModeAttribute.heat.NAME, ModeAttribute.cool.NAME }
 end
 
 local supported_thermostat_modes_handler = function(driver, device, supported_modes)

--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
@@ -88,7 +88,7 @@ end
 local function device_added(driver, device)
   local main_comp = device.profile.components["main"]
   device:emit_component_event(main_comp,
-    capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }))
+    capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, { visibility = { displayed = false } }))
   device:emit_component_event(main_comp,
     deviceInitialization.supportedInitializedState({ "notInitialized", "initializing", "initialized" }))
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/axis/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/axis/init.lua
@@ -113,7 +113,7 @@ local do_configure = function(self, device)
 end
 
 local device_added = function(self, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, { visibility = { displayed = false } }))
   device:set_field(SOFTWARE_VERSION, 0)
   device:send(Basic.attributes.SWBuildID:read(device))
 end

--- a/drivers/SmartThings/zigbee-window-treatment/src/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/init.lua
@@ -17,7 +17,7 @@ local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, { visibility = { displayed = false } }))
 end
 
 local zigbee_window_treatment_driver_template = {

--- a/drivers/SmartThings/zigbee-window-treatment/src/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/init.lua
@@ -17,7 +17,7 @@ local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, { visibility = { displayed = false }}))
 end
 
 local zigbee_window_treatment_driver_template = {

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment.lua
@@ -17,7 +17,6 @@ local test = require "integration_test"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
 
 local mock_device = test.mock_device.build_test_zigbee_device(
@@ -230,13 +229,9 @@ test.register_coroutine_test(
     "Refresh necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
 
       test.socket.zigbee:__set_channel_ordering("relaxed")
@@ -257,13 +252,9 @@ test.register_coroutine_test(
     "Configure should configure all necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
 
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
@@ -62,13 +62,9 @@ test.register_coroutine_test(
   "Handle added lifecycle",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "windowShade", component_id = "main",
-        attribute_id = "supportedWindowShadeCommands", state = { value = { "open", "close", "pause" } }
-      }
-    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+    )
     test.socket.capability:__expect_send({
       mock_device.id,
       {

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_axis.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_axis.lua
@@ -512,13 +512,9 @@ test.register_coroutine_test(
     function()
       test.socket.environment_update:__queue_receive({ "zigbee", { hub_zigbee_id = base64.encode(zigbee_test_utils.mock_hub_eui) } })
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.socket.zigbee:__expect_send({
         mock_device.id,
         Basic.attributes.SWBuildID:read(mock_device)
@@ -558,13 +554,9 @@ test.register_coroutine_test(
     function()
       test.socket.environment_update:__queue_receive({ "zigbee", { hub_zigbee_id = base64.encode(zigbee_test_utils.mock_hub_eui) } })
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.socket.zigbee:__expect_send({
         mock_device.id,
         Basic.attributes.SWBuildID:read(mock_device)
@@ -597,13 +589,9 @@ test.register_coroutine_test(
     function()
       test.socket.environment_update:__queue_receive({ "zigbee", { hub_zigbee_id = base64.encode(zigbee_test_utils.mock_hub_eui) } })
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.socket.zigbee:__expect_send({
         mock_device.id,
         Basic.attributes.SWBuildID:read(mock_device)

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_feibit.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_feibit.lua
@@ -17,7 +17,6 @@ local test = require "integration_test"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
 
 local Level = clusters.Level
@@ -332,13 +331,9 @@ test.register_coroutine_test(
     "Refresh necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
 
       test.socket.zigbee:__set_channel_ordering("relaxed")
@@ -359,13 +354,9 @@ test.register_coroutine_test(
     "Configure should configure all necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
 
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_rooms.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_rooms.lua
@@ -18,8 +18,6 @@ local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"
 local data_types = require "st.zigbee.data_types"
-local dkjson = require 'dkjson'
-local utils = require "st.utils"
 local t_utils = require "integration_test.utils"
 local test = require "integration_test"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
@@ -285,13 +283,9 @@ test.register_coroutine_test(
     "Refresh necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
 
       test.socket.zigbee:__set_channel_ordering("relaxed")
@@ -324,13 +318,9 @@ test.register_coroutine_test(
     "Handle Configure lifecycle",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
       test.socket.zigbee:__set_channel_ordering("relaxed")

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_somfy.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_somfy.lua
@@ -17,7 +17,6 @@ local test = require "integration_test"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
 
 local WindowCovering = clusters.WindowCovering
@@ -450,15 +449,10 @@ test.register_coroutine_test(
     "Refresh necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
-
       test.socket.zigbee:__set_channel_ordering("relaxed")
       test.socket.capability:__queue_receive({
         mock_device.id,
@@ -477,13 +471,9 @@ test.register_coroutine_test(
     "Configure should configure all necessary attributes",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})
-      test.socket.capability:__expect_send({
-        mock_device.id,
-        {
-          capability_id = "windowShade", component_id = "main",
-          attribute_id = "supportedWindowShadeCommands", state = { value= { "open", "close", "pause" } }
-        }
-      })
+      test.socket.capability:__expect_send(
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },{ visibility = { displayed = false }}))
+      )
       test.wait_for_events()
 
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })

--- a/drivers/SmartThings/zwave-button/src/init.lua
+++ b/drivers/SmartThings/zwave-button/src/init.lua
@@ -26,8 +26,8 @@ local function added_handler(self, device)
     for _, comp in pairs(device.profile.components) do
       if device:supports_capability_by_id(capabilities.button.ID, comp.id) then
         local number_of_buttons = comp.id == "main" and configs.number_of_buttons or 1
-        device:emit_component_event(comp, capabilities.button.numberOfButtons({ value=number_of_buttons }))
-        device:emit_component_event(comp, capabilities.button.supportedButtonValues(configs.supported_button_values))
+        device:emit_component_event(comp, capabilities.button.numberOfButtons({ value=number_of_buttons }, { visibility = { displayed = false } }))
+        device:emit_component_event(comp, capabilities.button.supportedButtonValues(configs.supported_button_values, { visibility = { displayed = false } }))
       end
     end
   end

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
@@ -112,41 +112,33 @@ test.register_message_test(
     }
   )
 
-  test.register_message_test(
+test.register_coroutine_test(
     "Device Add should bootstrap UI state",
-    {
-      {
-        channel = "device_lifecycle",
-        direction = "receive",
-        message = { mock.id, "added" },
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock:generate_test_message("main", capabilities.button.supportedButtonValues(
-          {"pushed", "held"}
-        ))
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock:generate_test_message("main", capabilities.button.numberOfButtons(
-          { value = 1 }
-        ))
-      },
-      {
-        channel = "zwave",
-        direction = "send",
-        message = zw_test_utils.zwave_test_build_send_command(
+    function()
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.device_lifecycle:__queue_receive({ mock.id, "added" })
+
+      test.socket.capability:__expect_send(
+        mock:generate_test_message(
+          "main",
+          capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }})
+        )
+      )
+      test.socket.capability:__expect_send(
+        mock:generate_test_message(
+          "main",
+          capabilities.button.numberOfButtons({ value = 1 }, {visibility = { displayed = false }})
+        )
+      )
+      test.socket.zwave:__expect_send(
+        zw_test_utils.zwave_test_build_send_command(
           mock,
           Battery:Get({})
         )
-      }
-    },
-    {
-      inner_block_ordering = "relaxed"
-    }
+      )
+    end
   )
+
 
   test.register_message_test(
     "WakeUp.Notification should evoke state refresh Z-Wave GETs",

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_fibaro_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_fibaro_button.lua
@@ -41,39 +41,31 @@ local function  test_init()
 end
 test.set_test_init_function(test_init)
 
-test.register_message_test(
-        "Fibaro button's supported button values",
-        {
-            {
-                channel = "device_lifecycle",
-                direction = "receive",
-                message = { mock_fibaro_button.id, "added" }
-            },
-            {
-                channel = "capability",
-                direction = "send",
-                message = mock_fibaro_button:generate_test_message("main",
-                        capabilities.button.supportedButtonValues({"pushed", "held", "down_hold", "double", "pushed_3x", "pushed_4x", "pushed_5x"}))
-            },
-            {
-                channel = "capability",
-                direction = "send",
-                message = mock_fibaro_button:generate_test_message("main", capabilities.button.numberOfButtons(
-                  { value = 1 }
-                ))
-            },
-            {
-                channel = "zwave",
-                direction = "send",
-                message = zw_test_utils.zwave_test_build_send_command(
-                  mock_fibaro_button,
-                  Battery:Get({})
-                )
-            }
-        },
-        {
-            inner_block_ordering = "relaxed"
-        }
+test.register_coroutine_test(
+    "Fibaro button's supported button values",
+    function()
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.device_lifecycle:__queue_receive({ mock_fibaro_button.id, "added" })
+
+      test.socket.capability:__expect_send(
+        mock_fibaro_button:generate_test_message(
+          "main",
+          capabilities.button.supportedButtonValues({"pushed", "held", "down_hold", "double", "pushed_3x", "pushed_4x", "pushed_5x"}, {visibility = { displayed = false }})
+        )
+      )
+      test.socket.capability:__expect_send(
+        mock_fibaro_button:generate_test_message(
+          "main",
+          capabilities.button.numberOfButtons({ value = 1 }, {visibility = { displayed = false }})
+        )
+      )
+      test.socket.zwave:__expect_send(
+        zw_test_utils.zwave_test_build_send_command(
+          mock_fibaro_button,
+          Battery:Get({})
+        )
+      )
+    end
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
@@ -808,7 +808,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "V2 - Device added event should make proper event for everspring wall switch",
+  "Device added event should make proper event for everspring wall switch",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_everspring.id, "added" })

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
@@ -487,15 +487,87 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Device added event should make proper event for aeotec keyfob",
-  function ()
+  "V2 - Device added event should make proper event for aeotec keyfob",
+  function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_aeotec_keyfob_button.id, "added" })
-    added_events(mock_aeotec_keyfob_button, 4, {"pushed", "held"})
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_aeotec_keyfob_button,
-      Battery:Get({})
-    ))
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button1",
+        capabilities.button.numberOfButtons({ value = 1 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button1",
+        capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button2",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button2",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button3",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button3",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button4",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_keyfob_button:generate_test_message(
+        "button4",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_aeotec_keyfob_button,
+        Battery:Get({})
+      )
+    )
   end
 )
 
@@ -538,41 +610,257 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Device added event should make proper event for fibaro keyfob",
-  function ()
+  "V2 - Device added event should make proper event for fibaro keyfob",
+  function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_fibaro_keyfob_button.id, "added" })
-    added_events(mock_fibaro_keyfob_button, 6, {"pushed", "held", "double", "down_hold", "pushed_3x"})
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_keyfob_button,
-      Battery:Get({})
-    ))
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 6 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button1",
+        capabilities.button.numberOfButtons({ value = 1 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button1",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button2",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button2",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button3",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button3",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button4",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button4",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button5",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button5",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button6",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_fibaro_keyfob_button:generate_test_message(
+        "button6",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double", "down_hold", "pushed_3x"}, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_fibaro_keyfob_button,
+        Battery:Get({})
+      )
+    )
   end
 )
 
 test.register_coroutine_test(
-  "Device added event should make proper event for aeotec wallmote quad",
-  function ()
+  "V2 - Device added event should make proper event for aeotec wallmote quad",
+  function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_aeotec_wallmote_quad.id, "added" })
-    added_events(mock_aeotec_wallmote_quad, 4, {"pushed", "held"})
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_aeotec_wallmote_quad,
-      Battery:Get({})
-    ))
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 4 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button1",
+        capabilities.button.numberOfButtons({ value = 1 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button1",
+        capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button2",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button2",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button3",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button3",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button4",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_aeotec_wallmote_quad:generate_test_message(
+        "button4",
+        capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_aeotec_wallmote_quad,
+        Battery:Get({})
+      )
+    )
   end
 )
 
 test.register_coroutine_test(
-  "Device added event should make proper event for everspring wall switch",
-  function ()
+  "V2 - Device added event should make proper event for everspring wall switch",
+  function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_everspring.id, "added" })
-    added_events(mock_everspring, 2, {"pushed", "held", "double"})
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_everspring,
-      Battery:Get({})
-    ))
+
+    test.socket.capability:__expect_send(
+      mock_everspring:generate_test_message(
+        "main",
+        capabilities.button.numberOfButtons({ value = 2 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_everspring:generate_test_message(
+        "main",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_everspring:generate_test_message(
+        "button1",
+        capabilities.button.numberOfButtons({ value = 1 }, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_everspring:generate_test_message(
+        "button1",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double"}, {visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_everspring:generate_test_message(
+        "button2",
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.capability:__expect_send(
+      mock_everspring:generate_test_message(
+        "button2",
+        capabilities.button.supportedButtonValues({"pushed", "held", "double"}, { visibility = { displayed = false }})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+          mock_everspring,
+          Battery:Get({})
+      )
+    )
   end
 )
 

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
@@ -84,11 +84,11 @@ local function added_events(device, numberOfButtons, supportedButtonValues)
   end
   for _, component in pairs(components) do
     if (component == "main") then
-      test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.numberOfButtons({value = numberOfButtons})))
+      test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.numberOfButtons({value = numberOfButtons}, {visibility = { displayed = false }})))
     else
-      test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.numberOfButtons({value = 1})))
+      test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }})))
     end
-    test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.supportedButtonValues(supportedButtonValues)))
+    test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.supportedButtonValues(supportedButtonValues, {visibility = { displayed = false }})))
   end
 end
 
@@ -487,7 +487,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "V2 - Device added event should make proper event for aeotec keyfob",
+  "Device added event should make proper event for aeotec keyfob",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_aeotec_keyfob_button.id, "added" })
@@ -610,7 +610,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "V2 - Device added event should make proper event for fibaro keyfob",
+  "Device added event should make proper event for fibaro keyfob",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_fibaro_keyfob_button.id, "added" })
@@ -723,7 +723,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "V2 - Device added event should make proper event for aeotec wallmote quad",
+  "Device added event should make proper event for aeotec wallmote quad",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_aeotec_wallmote_quad.id, "added" })

--- a/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
@@ -103,14 +103,14 @@ local function alarm_report_handler(driver, device, cmd)
     for code_id, _ in pairs(lock_codes) do
       lock_code_defaults.code_deleted(device, code_id)
     end
-    device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device))))
+    device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device)), { visibility = { displayed = false } }))
   elseif (alarm_type == 33) then
     -- user code deleted
     if (code_id ~= nil) then
       lock_code_defaults.clear_code_state(device, code_id)
       if (lock_codes[code_id] ~= nil) then
         lock_code_defaults.code_deleted(device, code_id)
-        device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device))))
+        device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device)), { visibility = { displayed = false } }))
       end
     end
   elseif (alarm_type == 13 or alarm_type == 112) then

--- a/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
@@ -103,14 +103,14 @@ local function alarm_report_handler(driver, device, cmd)
     for code_id, _ in pairs(lock_codes) do
       lock_code_defaults.code_deleted(device, code_id)
     end
-    device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device)), { visibility = { displayed = false } }))
+    device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device))))
   elseif (alarm_type == 33) then
     -- user code deleted
     if (code_id ~= nil) then
       lock_code_defaults.clear_code_state(device, code_id)
       if (lock_codes[code_id] ~= nil) then
         lock_code_defaults.code_deleted(device, code_id)
-        device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device)), { visibility = { displayed = false } }))
+        device:emit_event(capabilities.lockCodes.lockCodes(json.encode(lock_code_defaults.get_lock_codes(device))))
       end
     end
   elseif (alarm_type == 13 or alarm_type == 112) then

--- a/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
@@ -103,8 +103,8 @@ local function central_scene_notification_handler(driver, device, cmd)
 end
 
 local function added_handler(driver, device)
-  device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES))
-  device:emit_event(capabilities.button.numberOfButtons({ value = 3 }))
+  device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES, { visibility = { displayed = false }}))
+  device:emit_event(capabilities.button.numberOfButtons({ value = 3 }, { visibility = { displayed = false }}))
 end
 
 local function do_refresh(driver, device)

--- a/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
@@ -103,7 +103,7 @@ local function central_scene_notification_handler(driver, device, cmd)
 end
 
 local function added_handler(driver, device)
-  device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES, { visibility = { displayed = false } }))
+  device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES))
   device:emit_event(capabilities.button.numberOfButtons({ value = 3 }))
 end
 

--- a/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
@@ -103,7 +103,7 @@ local function central_scene_notification_handler(driver, device, cmd)
 end
 
 local function added_handler(driver, device)
-  device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES))
+  device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES, { visibility = { displayed = false } }))
   device:emit_event(capabilities.button.numberOfButtons({ value = 3 }))
 end
 

--- a/drivers/SmartThings/zwave-thermostat/src/aeotec-radiator-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/aeotec-radiator-thermostat/init.lua
@@ -92,7 +92,7 @@ local function device_added(self, device)
     capabilities.thermostatMode.thermostatMode.heat.NAME,
     capabilities.thermostatMode.thermostatMode.emergency_heat.NAME
   }
-  device:emit_event(capabilities.thermostatMode.supportedThermostatModes(supported_modes))
+  device:emit_event(capabilities.thermostatMode.supportedThermostatModes(supported_modes, { visibility = { displayed = false } }))
 
   do_refresh(self, device)
 end

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
@@ -159,7 +159,7 @@ local function device_added(self, device)
     capabilities.thermostatMode.thermostatMode.heat.NAME,
     capabilities.thermostatMode.thermostatMode.emergency_heat.NAME
   }
-  device:emit_event(capabilities.thermostatMode.supportedThermostatModes(supported_modes))
+  device:emit_event(capabilities.thermostatMode.supportedThermostatModes(supported_modes, { visibility = { displayed = false } }))
 
   do_refresh(self, device)
 end

--- a/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/init.lua
@@ -92,7 +92,7 @@ local function configuration_report(driver, device, cmd)
       table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.heat.NAME)
       device:try_update_metadata({profile = "qubino-flush-thermostat"})
     end
-    device:emit_event(capabilities.thermostatMode.supportedThermostatModes(supported_modes))
+    device:emit_event(capabilities.thermostatMode.supportedThermostatModes(supported_modes, { visibility = { displayed = false } }))
   end
 
 end

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
@@ -251,7 +251,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({
                                                             capabilities.thermostatMode.thermostatMode.off.NAME,
                                                             capabilities.thermostatMode.thermostatMode.heat.NAME
-                                                          })))
+                                                          }, { visibility = { displayed = false } })))
     mock_device:expect_metadata_update({profile = "qubino-flush-thermostat"})
   end
 )
@@ -263,7 +263,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({
                                                             capabilities.thermostatMode.thermostatMode.off.NAME,
                                                             capabilities.thermostatMode.thermostatMode.cool.NAME
-                                                          })))
+                                                          }, { visibility = { displayed = false } })))
     mock_device:expect_metadata_update({profile = "qubino-flush-thermostat-cooling"})
   end
 )

--- a/drivers/SmartThings/zwave-window-treatment/src/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/init.lua
@@ -22,7 +22,7 @@ local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=
 local preferencesMap = require "preferences"
 
 local function added_handler(self, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, { visibility = { displayed = false } }))
 end
 
 --- Handle preference changes

--- a/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/qubino-flush-shutter/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/qubino-flush-shutter/init.lua
@@ -161,7 +161,7 @@ local function device_added(self, device)
   device:send(Association:Set({grouping_identifier = 7, node_ids = {self.environment_info.hub_zwave_id}}))
   device:send(Configuration:Set({parameter_number = 40, size = 1, configuration_value = 1}))
   device:send(Configuration:Set({parameter_number = 71, size = 1, configuration_value = 0}))
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, { visibility = { displayed = false } }))
   device:refresh()
 end
 


### PR DESCRIPTION
@greens 
I added `{ visibility = { displayed = false } }` to configuration events only.
I didn't change anything in the unit tests yet (to see how the testing framework will handle those changes).
@SmartThingsCommunity/srpol-pe-team