### PR TITLE
Everspring Dimmer Switch AD147-6 added

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -725,6 +725,12 @@ zwaveManufacturer:
     productType: 0x0103
     productId: 0x0025
     deviceProfileName: switch-level
+  - id: 0060/1101/0003
+    deviceLabel: Everspring Dimmer Switch
+    manufacturerId: 0x0060
+    productType: 0x1101
+    productId: 0x0003
+    deviceProfileName: switch-level
   - id: 0086/0003/0012
     deviceLabel: Aeotec Switch
     manufacturerId: 0x0086


### PR DESCRIPTION
Hello,

Since other Everspring devices are already present in this driver, I thought about adding this one here. Tested OK by myself.
Here is the official product page: https://www.everspring.com/portfolio-item/ad147-mini-onoff-and-dimmer-plug/
