### PR TITLE
Expect lock code device data field to be string

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/lock_utils.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock_utils.lua
@@ -78,7 +78,8 @@ function lock_utils.populate_state_from_data(device)
   if device.data.lockCodes ~= nil and device:get_field(lock_utils.MIGRATION_COMPLETE) ~= true then
     -- build the lockCodes table
     local lockCodes = {}
-    for k, v in pairs(device.data.lockCodes) do
+    local lc_data = json.decode(device.data.lockCodes)
+    for k, v in pairs(lc_data) do
       lockCodes[k] = v
     end
     -- Populate the devices `lockCodes` field

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_code_migration.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_code_migration.lua
@@ -30,10 +30,10 @@ local mock_device = test.mock_device.build_test_zigbee_device(
     {
       profile = t_utils.get_profile_definition("base-lock.yml"),
       data = {
-        lockCodes = {
+        lockCodes = json.encode({
           ["1"] = "Zach",
           ["2"] = "Steven"
-        }
+        })
       }
     }
 )
@@ -155,7 +155,7 @@ test.register_coroutine_test(
       test.socket.device_lifecycle():__queue_receive(mock_device_no_data:generate_info_changed(
           {
             data = {
-              lockCodes = { ["1"] = "Zach", ["2"] = "Steven" }
+              lockCodes = json.encode({ ["1"] = "Zach", ["2"] = "Steven" })
             }
           }
       ))

--- a/drivers/SmartThings/zwave-lock/src/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/init.lua
@@ -52,7 +52,8 @@ local function populate_state_from_data(device)
   if device.data.lockCodes ~= nil and device:get_field(MIGRATION_COMPLETE) ~= true then
     -- build the lockCodes table
     local lockCodes = {}
-    for k, v in pairs(device.data.lockCodes) do
+    local lc_data = json.decode(device.data.lockCodes)
+    for k, v in pairs(lc_data) do
       lockCodes[k] = v
     end
     -- Populate the devices `lockCodes` field

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
@@ -54,7 +54,7 @@ local mock_device = test.mock_device.build_test_zwave_device(
       profile = t_utils.get_profile_definition("base-lock-tamper.yml"),
       zwave_endpoints = zwave_lock_endpoints,
       data = {
-        lockCodes = utils.deep_copy(lockCodes)
+        lockCodes = json.encode(utils.deep_copy(lockCodes))
       }
     }
 )
@@ -171,7 +171,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-    "Device init after added shouldn't change the datastores",
+    "Device init after added with no data should update the datastores",
     function()
       test.mock_device.add_test_device(mock_device_no_data)
       test.socket.device_lifecycle:__queue_receive({ mock_device_no_data.id, "added" })
@@ -199,7 +199,7 @@ test.register_coroutine_test(
       test.socket.device_lifecycle():__queue_receive(mock_device_no_data:generate_info_changed(
           {
             data = {
-              lockCodes = utils.deep_copy(lockCodes)
+              lockCodes = json.encode(utils.deep_copy(lockCodes))
             }
           }
       ))


### PR DESCRIPTION
The data field for lock codes being used in migration is a string of encoded JSON not a JSON field itself.  So it must be decoded before use.

CHAD-9084
CHAD-8772