### PR TITLE
Do not emit unsupported button events

### DIFF
--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
@@ -77,6 +77,21 @@ local function  test_init()
 end
 test.set_test_init_function(test_init)
 
+local function added_events(device, numberOfButtons, supportedButtonValues)
+  local components = {"main"}
+  for i = 1,numberOfButtons do
+    table.insert(components, "button"..i)
+  end
+  for _, component in pairs(components) do
+    if (component == "main") then
+      test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.numberOfButtons({value = numberOfButtons})))
+    else
+      test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.numberOfButtons({value = 1})))
+    end
+    test.socket.capability:__expect_send(device:generate_test_message(component, capabilities.button.supportedButtonValues(supportedButtonValues)))
+  end
+end
+
 --central scene notification
 test.register_message_test(
   "Central scene notification command (scene number 1 & pushed) generate capability to proper component",
@@ -130,30 +145,27 @@ test.register_message_test(
   }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "Central scene notification command (scene number 1 & double) generate capability to proper component",
-  {
-    {
-      channel = "zwave",
-      direction = "receive",
-      message = {
-        mock_everspring.id,
-        zw_test_utils.zwave_test_build_receive_command(
-          CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES, scene_number = 1})
-        )
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("button1", capabilities.button.button.double({state_change = true}))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("main", capabilities.button.button.double({state_change = true}))
-    }
-  }
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_everspring.id, "added" })
+    added_events(mock_everspring, 2, {"pushed", "held", "double"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_everspring,
+      Battery:Get({})
+    ))
+    test.wait_for_events()
+    test.socket.zwave:__queue_receive({mock_everspring.id,
+      CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES, scene_number = 1 })
+    })
+    test.socket.capability:__expect_send(mock_everspring:generate_test_message(
+      "button1",
+      capabilities.button.button.double({state_change = true})))
+    test.socket.capability:__expect_send(mock_everspring:generate_test_message(
+      "main",
+      capabilities.button.button.double({state_change = true})))
+  end
 )
 
 test.register_message_test(
@@ -208,30 +220,27 @@ test.register_message_test(
   }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "Central scene notification command (scene number 2 & double) generate capability to proper component",
-  {
-    {
-      channel = "zwave",
-      direction = "receive",
-      message = {
-        mock_everspring.id,
-        zw_test_utils.zwave_test_build_receive_command(
-          CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES, scene_number = 2})
-        )
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("button2", capabilities.button.button.double({state_change = true}))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("main", capabilities.button.button.double({state_change = true}))
-    }
-  }
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_everspring.id, "added" })
+    added_events(mock_everspring, 2, {"pushed", "held", "double"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_everspring,
+      Battery:Get({})
+    ))
+    test.wait_for_events()
+    test.socket.zwave:__queue_receive({mock_everspring.id,
+      CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES, scene_number = 2 })
+    })
+    test.socket.capability:__expect_send(mock_everspring:generate_test_message(
+      "button2",
+      capabilities.button.button.double({state_change = true})))
+    test.socket.capability:__expect_send(mock_everspring:generate_test_message(
+      "main",
+      capabilities.button.button.double({state_change = true})))
+  end
 )
 
 test.register_message_test(
@@ -312,8 +321,30 @@ test.register_message_test(
   }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "Central scene notification command (scene number 4 & held) generate capability to proper component",
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_aeotec_wallmote_quad.id, "added" })
+    added_events(mock_aeotec_wallmote_quad, 4, {"pushed", "held"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_aeotec_wallmote_quad,
+      Battery:Get({})
+    ))
+    test.socket.zwave:__queue_receive({mock_aeotec_wallmote_quad.id,
+      CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_RELEASED, scene_number = 4 })
+    })
+    test.socket.capability:__expect_send(mock_aeotec_wallmote_quad:generate_test_message(
+      "button4",
+      capabilities.button.button.held({state_change = true})))
+    test.socket.capability:__expect_send(mock_aeotec_wallmote_quad:generate_test_message(
+      "main",
+      capabilities.button.button.held({state_change = true})))
+  end
+)
+
+test.register_message_test(
+  "Central scene notification command for an unsupported action should not generate an event",
   {
     {
       channel = "zwave",
@@ -321,19 +352,9 @@ test.register_message_test(
       message = {
         mock_aeotec_wallmote_quad.id,
         zw_test_utils.zwave_test_build_receive_command(
-          CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_RELEASED, scene_number = 4})
+          CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_HELD_DOWN, scene_number = 4})
         )
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button4", capabilities.button.button.held({state_change = true}))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("main", capabilities.button.button.held({state_change = true}))
     }
   }
 )
@@ -465,96 +486,17 @@ test.register_coroutine_test(
   end
 )
 
-test.register_message_test(
-  "Device added event should make proper event for fibaro keyfob",
-  {
-    {
-      channel = "device_lifecycle",
-      direction = "receive",
-      message = { mock_aeotec_keyfob_button.id, "added" },
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("main", capabilities.button.numberOfButtons(
-        { value = 4 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("main", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button1", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button1", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button2", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button2", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button3", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button3", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button4", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_keyfob_button:generate_test_message("button4", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-        mock_aeotec_keyfob_button,
-        Battery:Get({})
-      )
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
-  }
+test.register_coroutine_test(
+  "Device added event should make proper event for aeotec keyfob",
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_aeotec_keyfob_button.id, "added" })
+    added_events(mock_aeotec_keyfob_button, 4, {"pushed", "held"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_aeotec_keyfob_button,
+      Battery:Get({})
+    ))
+  end
 )
 
 --configuration for fibaro keyfob
@@ -595,280 +537,43 @@ test.register_coroutine_test(
   end
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "Device added event should make proper event for fibaro keyfob",
-  {
-    {
-      channel = "device_lifecycle",
-      direction = "receive",
-      message = { mock_fibaro_keyfob_button.id, "added" },
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("main", capabilities.button.numberOfButtons(
-        { value = 6 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("main", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button1", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button1", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button2", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button2", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button3", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button3", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button4", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button4", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button5", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button5", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button6", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_fibaro_keyfob_button:generate_test_message("button6", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double", "down_hold", "pushed_3x"}
-      ))
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-        mock_fibaro_keyfob_button,
-        Battery:Get({})
-      )
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
-  }
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_fibaro_keyfob_button.id, "added" })
+    added_events(mock_fibaro_keyfob_button, 6, {"pushed", "held", "double", "down_hold", "pushed_3x"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_fibaro_keyfob_button,
+      Battery:Get({})
+    ))
+  end
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "Device added event should make proper event for aeotec wallmote quad",
-  {
-    {
-      channel = "device_lifecycle",
-      direction = "receive",
-      message = { mock_aeotec_wallmote_quad.id, "added" },
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("main", capabilities.button.numberOfButtons(
-        { value = 4 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("main", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button1", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button1", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button2", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button2", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button3", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button3", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button4", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_aeotec_wallmote_quad:generate_test_message("button4", capabilities.button.supportedButtonValues(
-        {"pushed", "held"}
-      ))
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-        mock_aeotec_wallmote_quad,
-        Battery:Get({})
-      )
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
-  }
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_aeotec_wallmote_quad.id, "added" })
+    added_events(mock_aeotec_wallmote_quad, 4, {"pushed", "held"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_aeotec_wallmote_quad,
+      Battery:Get({})
+    ))
+  end
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "Device added event should make proper event for everspring wall switch",
-  {
-    {
-      channel = "device_lifecycle",
-      direction = "receive",
-      message = { mock_everspring.id, "added" },
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("main", capabilities.button.numberOfButtons(
-        { value = 2 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("main", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("button1", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("button1", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double"}
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("button2", capabilities.button.numberOfButtons(
-        { value = 1 }
-      ))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_everspring:generate_test_message("button2", capabilities.button.supportedButtonValues(
-        {"pushed", "held", "double"}
-      ))
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-        mock_everspring,
-        Battery:Get({})
-      )
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
-  }
+  function ()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_everspring.id, "added" })
+    added_events(mock_everspring, 2, {"pushed", "held", "double"})
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_everspring,
+      Battery:Get({})
+    ))
+  end
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-button/src/zwave-multi-button/init.lua
+++ b/drivers/SmartThings/zwave-button/src/zwave-multi-button/init.lua
@@ -58,8 +58,20 @@ local map_key_attribute_to_capability = {
 
 local function central_scene_notification_handler(self, device, cmd)
   local event = map_key_attribute_to_capability[cmd.args.key_attributes]({state_change = true})
-  device:emit_event_for_endpoint(cmd.args.scene_number, event)
-  device:emit_event(event)
+  if event ~= nil then
+    local supportedEvents = device:get_latest_state(
+      device:endpoint_to_component(cmd.args.scene_number),
+      capabilities.button.ID,
+      capabilities.button.supportedButtonValues.NAME,
+      {capabilities.button.button.pushed.NAME, capabilities.button.button.held.NAME} -- default value
+    )
+    for _, event_name in pairs(supportedEvents) do
+      if event.value.value == event_name then
+        device:emit_event_for_endpoint(cmd.args.scene_number, event)
+        device:emit_event(event)
+      end
+    end
+  end
 end
 
 local function scene_activation_handler(self, device, cmd)


### PR DESCRIPTION
Some remotes send two events when the button is held, one on the hold and one on the release. To maintain parity with DTHs this will be disabled for now