### PR TITLE
CHAD-9411: Edited zwave electric meter profile

### DIFF
--- a/drivers/SmartThings/zwave-electric-meter/profiles/qubino-3-phase-meter.yml
+++ b/drivers/SmartThings/zwave-electric-meter/profiles/qubino-3-phase-meter.yml
@@ -2,9 +2,9 @@ name: qubino-3-phase-meter
 components:
 - id: main
   capabilities:
-  - id: energyMeter
-    version: 1
   - id: powerMeter
+    version: 1
+  - id: energyMeter
     version: 1
   - id: refresh
     version: 1


### PR DESCRIPTION
Switched ordering of energy meter and power meter in qubino-3-phase profile to change join icon from energy consumption to power meter. 

https://smartthings.atlassian.net/browse/CHAD-9411?focusedCommentId=1205226&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1205226