### PR TITLE
Add leviton-dimmer profile to zwave-switch driver for DZ6HD/DZ1KD configuration

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -603,7 +603,7 @@ zwaveManufacturer:
     deviceLabel: Leviton Dimmer Switch
     manufacturerId: 0x001D
     productId: 0x0001
-    deviceProfileName: switch-level
+    deviceProfileName: leviton-dimmer
   - id: 001D/1B03/0334
     deviceLabel: Leviton Dimmer Switch
     manufacturerId: 0x001D

--- a/drivers/SmartThings/zwave-switch/profiles/leviton-dimmer.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/leviton-dimmer.yml
@@ -1,0 +1,77 @@
+name: leviton-dimmer
+components:
+- id: main
+  capabilities:
+    - id: switch
+      version: 1
+    - id: switchLevel
+      version: 1
+    - id: refresh
+      version: 1
+  categories:
+    - name: Switch
+preferences:
+  - name: "fadeOnTime"
+    title: "Fade On Time"
+    description: "0 = Instant On; 1 - 127 = Seconds: 1 - 127 seconds; 128 - 253 = Minutes: 1 - 126 minutes"
+    preferenceType: integer
+    definition:
+      minimum: 0
+      maximum: 253
+      default: 2
+  - name: "fadeOffTime"
+    title: "Fade Off Time"
+    description: "0 = Instant Off; 1 - 127 = Seconds: 1 - 127 seconds; 128 - 253 = Minutes: 1 - 126 minutes"
+    preferenceType: integer
+    definition:
+      minimum: 0
+      maximum: 253
+      default: 2
+  - name: "minimumLightLevel"
+    title: "Minimum Light Level"
+    preferenceType: integer
+    definition:
+      minimum: 0
+      maximum: 100
+      default: 10
+  - name: "maximumLightLevel"
+    title: "Maximum Light Level"
+    preferenceType: integer
+    definition:
+      minimum: 0
+      maximum: 100
+      default: 100
+  - name: "presetLightLevel"
+    title: "Preset Light Level"
+    description: "0 = Memory Dim - Last dim state; 1 - 100 = Level"
+    preferenceType: integer
+    definition:
+      minimum: 0
+      maximum: 100
+      default: 0
+  - name: "levelIndicatorTimeout"
+    title: "LED Dim Level Indicator Timeout"
+    description: "0 = Level Indicators Off; 1 - 254 = Level Indicator Timeout (seconds); 255 = Levels Always On"
+    preferenceType: integer
+    definition:
+      minimum: 0
+      maximum: 255
+      default: 3
+  - name: "locatorLedStatus"
+    title: "Locator LED Status"
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "LED Off"
+        254: "Status Mode"
+        255: "Locator Mode"
+      default: 255
+  - name: "loadType"
+    title: "Load Type"
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "Incandescent"
+        1: "LED"
+        2: "CFL"
+      default: 0

--- a/drivers/SmartThings/zwave-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/init.lua
@@ -66,6 +66,11 @@ local function info_changed(driver, device, event, args)
   for id, value in pairs(device.preferences) do
     if args.old_st_store.preferences[id] ~= value and preferences and preferences[id] then
       local new_parameter_value = preferencesMap.to_numeric_value(device.preferences[id])
+      if preferences[id].size == 2 and new_parameter_value > 32767 and new_parameter_value < 65536 then
+        new_parameter_value = new_parameter_value - 65536
+      elseif preferences[id].size == 1 and new_parameter_value > 127 and new_parameter_value < 256 then
+        new_parameter_value = new_parameter_value - 256
+      end
       device:send(Configuration:Set({parameter_number = preferences[id].parameter_number, size = preferences[id].size, configuration_value = new_parameter_value}))
     end
   end

--- a/drivers/SmartThings/zwave-switch/src/preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/preferences.lua
@@ -301,6 +301,23 @@ local devices = {
       dimmerPaddleControl = {parameter_number = 27, size = 1}
     }
   },
+  LEVITON_DIMMER = {
+    MATCHING_MATRIX = {
+      mfrs = 0x001D,
+      product_types = {0x3201, 0x3301},
+      product_ids = 0x0001
+    },
+    PARAMETERS = {
+      fadeOnTime = {parameter_number = 1, size = 1},
+      fadeOffTime = {parameter_number = 2, size = 1},
+      minimumLightLevel = {parameter_number = 3, size = 1},
+      maximumLightLevel = {parameter_number = 4, size = 1},
+      presetLightLevel = {parameter_number = 5, size = 1},
+      levelIndicatorTimeout = {parameter_number = 6, size = 1},
+      locatorLedStatus = {parameter_number = 7, size = 1},
+      loadType = {parameter_number = 8, size = 1}
+    }
+  },
   SWITCH_LEVEL_INDICATOR = {
     MATCHING_MATRIX = {
       mfrs = 0x0063,


### PR DESCRIPTION
Add a leviton-dimmer profile to the zwave-switch driver, allowing configuration of the Leviton DZ6HD 600W dimmer and the similar Leviton DZ1KD 1000W dimmer. See https://www.leviton.com/en/docs/DI-000-DZ6HD-02B-W.pdf and https://www.leviton.com/en/docs/DI-000-DZ1KD-02A-W.pdf for details on available parameters.

Note that Configuration:Set treats parameters as signed, so a conversion is done in init.lua to accommodate the use of unsigned 1-byte values 128-255 (see https://community.smartthings.com/t/smartthings-edge-issue-with-default-function-to-send-z-wave-configuration-parameters/241970/18). If this isn't an acceptable workaround, most functionality can be maintained by setting the integer maximum to 127 and converting enumerated values to their two's complement equivalents.

I don't own a DZ1KD, but I tested each parameter on my DZ6HD and they behaved as expected.