### PR TITLE
switched profile orders in zigbee humidity sensor

### DIFF
--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
@@ -2,9 +2,9 @@ name: humidity-temp-battery
 components:
 - id: main
   capabilities:
-  - id: relativeHumidityMeasurement
-    version: 1
   - id: temperatureMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
     version: 1
   - id: battery
     version: 1

--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml
@@ -2,9 +2,9 @@ name: humidity-temperature
 components:
 - id: main
   capabilities:
-  - id: relativeHumidityMeasurement
-    version: 1
   - id: temperatureMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
     version: 1
   - id: firmwareUpdate
     version: 1


### PR DESCRIPTION
Changed temperatureMeasurement to be first in zigbee humidity sensor profiles (where applicable) so temperature is the default presentation. 

https://smartthings.atlassian.net/browse/BUG-6075