### PR TITLE
CHAD-9609 IKEA button zigbee group binding fix

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/init.lua
@@ -70,10 +70,10 @@ local function zdo_binding_table_handler(driver, device, zb_rx)
     if binding_table.dest_addr_mode.value == binding_table.DEST_ADDR_MODE_SHORT then
       -- send add hub to zigbee group command
       driver:add_hub_to_zigbee_group(binding_table.dest_addr.value)
-    else
-      driver:add_hub_to_zigbee_group(0x0000)
+      return
     end
   end
+  driver:add_hub_to_zigbee_group(0x0000) -- fallback if no binding table entries found
 end
 
 local battery_perc_attr_handler = function(driver, device, value, zb_rx)

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/somfy/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/somfy/init.lua
@@ -19,6 +19,7 @@ local function zdo_binding_table_handler(driver, device, zb_rx)
     if binding_table.dest_addr_mode.value == binding_table.DEST_ADDR_MODE_SHORT then
       -- send add hub to zigbee group command
       driver:add_hub_to_zigbee_group(binding_table.dest_addr.value)
+      return
     end
   end
 end

--- a/drivers/SmartThings/zigbee-motion-sensor/src/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/ikea/init.lua
@@ -60,6 +60,7 @@ local function zdo_binding_table_handler(driver, device, zb_rx)
     if binding_table.dest_addr_mode.value == binding_table.DEST_ADDR_MODE_SHORT then
       -- send add hub to zigbee group command
       driver:add_hub_to_zigbee_group(binding_table.dest_addr.value)
+      return
     end
   end
 end


### PR DESCRIPTION
Properly fall back to group 0 only if no other binding table entries are found.