### PR TITLE
Add metadata info to matter-lock base-lock profile

### DIFF
--- a/drivers/SmartThings/matter-lock/profiles/base-lock.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock.yml
@@ -14,3 +14,6 @@ components:
     version: 1
   categories:
   - name: SmartLock
+metadata:
+  mnmn: SmartThingsEdge
+  vid: matter-lock


### PR DESCRIPTION
This PR adds UI metadata of matter-lock device. Since Matter Clusters and SmartThings Capabilities is different, it should be displayed as a different UI.