### PR TITLE
Use python shebang line that respsects virtualenvs

### DIFF
--- a/tools/run_driver_tests.py
+++ b/tools/run_driver_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os, sys
 import re


### PR DESCRIPTION
See https://peps.python.org/pep-0394/#for-python-script-publishers. When running in a virtualenv, the actual "python3" executable is not at the fully qualified path.  Using "/usr/bin/env" is a best practice that allows virtualenv to work properly as per the PEP.