### PR TITLE
Matter-lock lock state configuration to exclude unsupported states

### DIFF
--- a/drivers/SmartThings/matter-lock/profiles/base-lock.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock.yml
@@ -4,6 +4,13 @@ components:
   capabilities:
   - id: lock
     version: 1
+    config:
+      values:
+      - key: "lock.value"
+        enabledValues:
+        - locked
+        - unlocked
+        - unknown
   - id: lockCodes
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/matter-lock/profiles/lock-without-codes.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-without-codes.yml
@@ -4,6 +4,13 @@ components:
   capabilities:
   - id: lock
     version: 1
+    config:
+      values:
+      - key: "lock.value"
+        enabledValues:
+        - locked
+        - unlocked
+        - unknown
   - id: battery
     version: 1
   - id: tamperAlert


### PR DESCRIPTION
The Lock Capability supports locked, unknown, unlocked, and unlocked with timeout. Matter cluster only ever maps to locked, unknown, and unlocked, so we should only have those states available in the devices capability to not mislead the user when setting automations based on state. 

This is an alternative to #308 that doesn't require managing metadata separately. 

@greens @bflorian I am currently unable to package this driver in prod, and am curious if the capability configuration feature has been released yet or not?