### PR TITLE
CHAD-9392 - Inovelli dimmers - moves ledBar to separate component, fixes unit tests

### DIFF
--- a/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer-power-energy.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer-power-energy.yml
@@ -1,5 +1,4 @@
 name: inovelli-dimmer-power-energy
-
 components:
 - id: main
   capabilities:
@@ -17,6 +16,14 @@ components:
     version: 1
   categories:
   - name: Switch
+- id: ledBar
+  capabilities:
+  - id: colorControl
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Light
 - id: button1
   capabilities:
   - id: button
@@ -35,7 +42,6 @@ components:
       version: 1
   categories:
     - name: RemoteController
-
 preferences:
   - name: "dimmingSpeed"
     title: "Dimming Speed"

--- a/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer-power-energy.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer-power-energy.yml
@@ -16,7 +16,7 @@ components:
     version: 1
   categories:
   - name: Switch
-- id: ledBar
+- id: LEDColorConfiguration
   capabilities:
   - id: colorControl
     version: 1

--- a/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer-power-energy.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer-power-energy.yml
@@ -10,8 +10,6 @@ components:
     version: 1
   - id: energyMeter
     version: 1
-  - id: colorControl
-    version: 1
   - id: refresh
     version: 1
   categories:

--- a/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer.yml
@@ -10,7 +10,7 @@ components:
         version: 1
     categories:
       - name: Switch
-  - id: ledBar
+  - id: LEDColorConfiguration
     capabilities:
       - id: colorControl
         version: 1

--- a/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/inovelli-dimmer.yml
@@ -6,12 +6,18 @@ components:
         version: 1
       - id: switchLevel
         version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: Switch
+  - id: ledBar
+    capabilities:
       - id: colorControl
         version: 1
       - id: refresh
         version: 1
     categories:
-      - name: Switch
+      - name: Light
 preferences:
   - name: "dimmingSpeed"
     title: "Dimming Speed"

--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/init.lua
@@ -28,6 +28,7 @@ local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_LZW31_PRODUCT_TYPE = 0x0003
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
+local LED_BAR_COMPONENT_NAME = "ledBar"
 
 local function huePercentToZwaveValue(value)
   if value <= 2 then
@@ -52,8 +53,12 @@ end
 local function configuration_report(driver, device, cmd)
   if cmd.args.parameter_number == LED_COLOR_CONTROL_PARAMETER_NUMBER then
     local hue = zwaveValueToHuePercent(cmd.args.configuration_value)
-    device:emit_event(capabilities.colorControl.hue(hue))
-    device:emit_event(capabilities.colorControl.saturation(LED_GENERIC_SATURATION))
+
+    local ledBarComponent = device.profile.components[LED_BAR_COMPONENT_NAME]
+    if ledBarComponent ~= nil then
+      device:emit_component_event(ledBarComponent, capabilities.colorControl.hue(hue))
+      device:emit_component_event(ledBarComponent, capabilities.colorControl.saturation(LED_GENERIC_SATURATION))
+    end
   end
 end
 

--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/init.lua
@@ -28,7 +28,7 @@ local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_LZW31_PRODUCT_TYPE = 0x0003
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
-local LED_BAR_COMPONENT_NAME = "ledBar"
+local LED_BAR_COMPONENT_NAME = "LEDColorConfiguration"
 
 local function huePercentToZwaveValue(value)
   if value <= 2 then

--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
@@ -27,7 +27,7 @@ local CentralScene = (require "st.zwave.CommandClass.CentralScene")({version=3})
 local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
-local LED_BAR_COMPONENT_NAME = "ledBar"
+local LED_BAR_COMPONENT_NAME = "LEDColorConfiguration"
 
 local function device_added(driver, device)
   for _, component in pairs(device.profile.components) do

--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
@@ -27,10 +27,11 @@ local CentralScene = (require "st.zwave.CommandClass.CentralScene")({version=3})
 local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
+local LED_BAR_COMPONENT_NAME = "ledBar"
 
 local function device_added(driver, device)
   for _, component in pairs(device.profile.components) do
-    if component.id ~= "main" then
+    if component.id ~= "main" and component.id ~= LED_BAR_COMPONENT_NAME then
       device:emit_component_event(
         component,
         capabilities.button.supportedButtonValues(

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
@@ -23,7 +23,7 @@ local t_utils = require "integration_test.utils"
 local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31_SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
-local LED_BAR_COMPONENT_NAME = "ledBar"
+local LED_BAR_COMPONENT_NAME = "LEDColorConfiguration"
 
 local inovelli_dimmer_endpoints = {
   {

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
@@ -23,6 +23,7 @@ local t_utils = require "integration_test.utils"
 local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31_SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
+local LED_BAR_COMPONENT_NAME = "ledBar"
 
 local inovelli_dimmer_endpoints = {
   {
@@ -67,7 +68,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_inovelli_dimmer.id, "added" })
 
     for button_name, _ in pairs(mock_inovelli_dimmer.profile.components) do
-      if button_name ~= "main" then
+      if button_name ~= "main" and button_name ~= LED_BAR_COMPONENT_NAME then
         test.socket.capability:__expect_send(
           mock_inovelli_dimmer:generate_test_message(
             button_name,

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer.lua
@@ -125,7 +125,7 @@ do
           mock_inovelli_dimmer.id,
           zw_test_utils.zwave_test_build_receive_command(
             SwitchMultilevel:Report({
-              current_value = 0,
+              current_value = level,
               target_value = level,
               duration = 0
             })

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_led.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_led.lua
@@ -25,6 +25,7 @@ local LED_GENERIC_SATURATION = 100
 local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31_PRODUCT_TYPE = 0x0003
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
+local LED_BAR_COMPONENT_NAME = "LEDColorConfiguration"
 
 local function huePercentToZwaveValue(value)
   if value <= 2 then
@@ -132,12 +133,12 @@ do
       {
         channel = "capability",
         direction = "send",
-        message = mock_inovelli_dimmer:generate_test_message("ledBar", capabilities.colorControl.hue(zwaveValueToHuePercent(color)))
+        message = mock_inovelli_dimmer:generate_test_message(LED_BAR_COMPONENT_NAME, capabilities.colorControl.hue(zwaveValueToHuePercent(color)))
       },
       {
         channel = "capability",
         direction = "send",
-        message = mock_inovelli_dimmer:generate_test_message("ledBar", capabilities.colorControl.saturation(LED_GENERIC_SATURATION))
+        message = mock_inovelli_dimmer:generate_test_message(LED_BAR_COMPONENT_NAME, capabilities.colorControl.saturation(LED_GENERIC_SATURATION))
       }
     }
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_led.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_led.lua
@@ -132,12 +132,12 @@ do
       {
         channel = "capability",
         direction = "send",
-        message = mock_inovelli_dimmer:generate_test_message("main", capabilities.colorControl.hue(zwaveValueToHuePercent(color)))
+        message = mock_inovelli_dimmer:generate_test_message("ledBar", capabilities.colorControl.hue(zwaveValueToHuePercent(color)))
       },
       {
         channel = "capability",
         direction = "send",
-        message = mock_inovelli_dimmer:generate_test_message("main", capabilities.colorControl.saturation(LED_GENERIC_SATURATION))
+        message = mock_inovelli_dimmer:generate_test_message("ledBar", capabilities.colorControl.saturation(LED_GENERIC_SATURATION))
       }
     }
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_power_energy.lua
@@ -28,6 +28,11 @@ local inovelli_dimmer_endpoints = {
       { value = zw.SWITCH_MULTILEVEL },
       { value = zw.METER }
     }
+  },
+  {
+    command_classes = {
+      {value = zw.CONFIGURATION}
+    }
   }
 }
 
@@ -209,7 +214,7 @@ do
           mock_inovelli_dimmer.id,
           zw_test_utils.zwave_test_build_receive_command(
             SwitchMultilevel:Report({
-              current_value = 0,
+              current_value = level,
               target_value = level,
               duration = 0
             })


### PR DESCRIPTION
CHAD-9392 - changes in the Inovelli dimmer driver
- moves ledBar to separate component, 
- fixes unit tests