### PR TITLE
CHAD-9650 Waxman valve: add fingerprint

### DIFF
--- a/drivers/SmartThings/zigbee-valve/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-valve/fingerprints.yml
@@ -24,6 +24,11 @@ zigbeeManufacturer :
     manufacturer: WAXMAN
     model: House Water Valve - MDL-TBD
     deviceProfileName: valve-battery-powerSource
+  - id: WAXMAN/HouseWaterValve/MDL-8810300L
+    deviceLabel: Waxman Valve
+    manufacturer: WAXMAN
+    model: House Water Valve - MDL-8810300L
+    deviceProfileName: valve-battery-powerSource
   - id: GasValve/E253-KR0B0ZX-HA
     deviceLabel: Valve
     manufacturer: ""


### PR DESCRIPTION
Adds the fingerprint for the production model. I'm guessing the "TBD" fingerprint was literally that.