### PR TITLE
[BUG-6167] Removed metadata from alarm-switch profile

### DIFF
--- a/drivers/SmartThings/zwave-siren/profiles/alarm-switch.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/alarm-switch.yml
@@ -8,6 +8,3 @@ components:
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: SmartAlert_Siren  # Filtering non-supported alarm values (signal/strobe only)


### PR DESCRIPTION
@SmartThingsCommunity/srpol-pe-team 