### PR TITLE
HCS-2748 Duplicate lock deleted event

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/init.lua
@@ -150,7 +150,9 @@ local programming_event_handler = function(driver, device, zb_mess)
       lock_utils.lock_codes_event(device, {})
     else
       -- One code deleted
-      lock_utils.lock_codes_event(device, lock_utils.code_deleted(device, code_slot))
+      if (lock_utils.get_lock_codes(device)[code_slot] ~= nil) then
+        lock_utils.lock_codes_event(device, lock_utils.code_deleted(device, code_slot))
+      end
     end
   elseif (zb_mess.body.zcl_body.program_event_code.value == ProgrammingEventCodeEnum.PIN_CODE_ADDED or
           zb_mess.body.zcl_body.program_event_code.value == ProgrammingEventCodeEnum.PIN_CODE_CHANGED) then


### PR DESCRIPTION
When deleting a code, locks will respond to our getPIN request and also send a programming event. Both indicate that a code has been deleted, but only the first should generate an event.