### PR TITLE
Remove samsung fingerprints for matter devices

### DIFF
--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -1,20 +1,3 @@
-matterManufacturer:
-  # Samsung SVT
-  - id: "Samsung/DoorLock/Android"
-    deviceLabel: Samsung Door Lock Android
-    vendorId: 0x10E1
-    productId: 0x1002
-    deviceProfileName: base-lock
-  - id: "Samsung/DoorLock/Thread"
-    deviceLabel: Samsung Door Lock Thread
-    vendorId: 0x10E1
-    productId: 0x2002
-    deviceProfileName: base-lock
-  - id: "Samsung/DoorLock/Wifi"
-    deviceLabel: Samsung Door Lock WiFi
-    vendorId: 0x10E1
-    productId: 0x3002
-    deviceProfileName: base-lock
 matterGeneric:
   - id: "matter/door-lock"
     deviceLabel: Matter Door Lock

--- a/drivers/SmartThings/matter-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/matter-thermostat/fingerprints.yml
@@ -1,20 +1,3 @@
-matterManufacturer:
-  - id: "Samsung/Thermostat/Android"
-    deviceLabel: Samsung Thermostat Android
-    vendorId: 0x10E1
-    productId: 0x1004
-    deviceProfileName: thermostat
-  - id: "Samsung/Thermostat/Thread"
-    deviceLabel: Samsung Thermostat Thread
-    vendorId: 0x10E1
-    productId: 0x2004
-    deviceProfileName: thermostat
-  - id: "Samsung/Thermostat/Wifi"
-    deviceLabel: Samsung Thermostat WiFi
-    vendorId: 0x10E1
-    productId: 0x3004
-    deviceProfileName: thermostat
-
 matterGeneric:
   - id: "matter/hvac/heatcool"
     deviceLabel: Matter Thermostat

--- a/drivers/SmartThings/matter-window-covering/fingerprints.yml
+++ b/drivers/SmartThings/matter-window-covering/fingerprints.yml
@@ -1,24 +1,6 @@
-matterManufacturer:
-  - id: "Samsung/WindowCovering/Android"
-    deviceLabel: Samsung Window Covering Android
-    vendorId: 0x10E1
-    productId: 0x1005
-    deviceProfileName: window-covering-profile
-  - id: "Samsung/WindowCovering/Thread"
-    deviceLabel: Samsung Window Covering Thread
-    vendorId: 0x10E1
-    productId: 0x2005
-    deviceProfileName: window-covering-profile
-  - id: "Samsung/WindowCovering/Wifi"
-    deviceLabel: Samsung Window Covering WiFi
-    vendorId: 0x10E1
-    productId: 0x3005
-    deviceProfileName: window-covering-profile
-
 matterGeneric:
   - id: "windowcovering"
     deviceLabel: Matter Window Covering
     deviceTypes:
       - id: 0x0202 # Window Covering
     deviceProfileName: window-covering-profile
-  


### PR DESCRIPTION
The fingerprinting logic can find the driver of the device by using the generic fingerprint instead of manufacturer specific fingerprint. For this reason, this change removes samsung fingerprints for matter devices.