### PR TITLE
fixes CHAD-9781, HCS-3775

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
@@ -29,13 +29,19 @@ local INOVELLI_LZW31SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
 local LED_BAR_COMPONENT_NAME = "LEDColorConfiguration"
 
+local supported_button_values = {
+  ["button1"] = {"pushed", "pushed_2x", "pushed_3x", "pushed_4x", "pushed_5x"},
+  ["button2"] = {"pushed", "pushed_2x", "pushed_3x", "pushed_4x", "pushed_5x"},
+  ["button3"] = {"pushed"}
+}
+
 local function device_added(driver, device)
   for _, component in pairs(device.profile.components) do
     if component.id ~= "main" and component.id ~= LED_BAR_COMPONENT_NAME then
       device:emit_component_event(
         component,
         capabilities.button.supportedButtonValues(
-          {"pushed","held","down_hold","pushed_2x","pushed_3x","pushed_4x","pushed_5x"},
+          supported_button_values[component.id],
           { visibility = { displayed = false } }
         )
       )
@@ -56,8 +62,6 @@ end
 
 local map_key_attribute_to_capability = {
   [CentralScene.key_attributes.KEY_PRESSED_1_TIME] = capabilities.button.button.pushed,
-  [CentralScene.key_attributes.KEY_RELEASED] = capabilities.button.button.held,
-  [CentralScene.key_attributes.KEY_HELD_DOWN] = capabilities.button.button.down_hold,
   [CentralScene.key_attributes.KEY_PRESSED_2_TIMES] = capabilities.button.button.pushed_2x,
   [CentralScene.key_attributes.KEY_PRESSED_3_TIMES] = capabilities.button.button.pushed_3x,
   [CentralScene.key_attributes.KEY_PRESSED_4_TIMES] = capabilities.button.button.pushed_4x,

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_scenes.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_scenes.lua
@@ -75,46 +75,6 @@ test.register_message_test(
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
         scene_number = 1,
-        key_attributes=CentralScene.key_attributes.KEY_RELEASED}))
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_inovelli_dimmer:generate_test_message("button1", capabilities.button.button.held({
-        state_change = true }))
-    }
-  }
-)
-
-test.register_message_test(
-  "Central Scene notification Button held should be handled",
-  {
-    {
-      channel = "zwave",
-      direction = "receive",
-      message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
-        key_attributes=CentralScene.key_attributes.KEY_HELD_DOWN}))
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_inovelli_dimmer:generate_test_message("button1", capabilities.button.button.down_hold({
-        state_change = true }))
-    }
-  }
-)
-
-test.register_message_test(
-  "Central Scene notification Button held should be handled",
-  {
-    {
-      channel = "zwave",
-      direction = "receive",
-      message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES}))
       }
     },
@@ -202,46 +162,6 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_inovelli_dimmer:generate_test_message("button2", capabilities.button.button.pushed({
-        state_change = true }))
-    }
-  }
-)
-
-test.register_message_test(
-  "Central Scene notification Button held should be handled",
-  {
-    {
-      channel = "zwave",
-      direction = "receive",
-      message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
-        key_attributes=CentralScene.key_attributes.KEY_RELEASED}))
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_inovelli_dimmer:generate_test_message("button2", capabilities.button.button.held({
-        state_change = true }))
-    }
-  }
-)
-
-test.register_message_test(
-  "Central Scene notification Button held should be handled",
-  {
-    {
-      channel = "zwave",
-      direction = "receive",
-      message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
-        key_attributes=CentralScene.key_attributes.KEY_HELD_DOWN}))
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_inovelli_dimmer:generate_test_message("button2", capabilities.button.button.down_hold({
         state_change = true }))
     }
   }


### PR DESCRIPTION
fixes CHAD-9781, HCS-3775 
- removes unsupported button states from button1, button2, button3
- fixes in unit tests

@greens @SmartThingsCommunity/srpol-pe-team 
