### PR TITLE
Remove require hack for previous matter SDK cluster attribute renames

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -15,10 +15,6 @@
 local capabilities = require "st.capabilities"
 local log = require "log"
 local clusters = require "st.matter.clusters"
--- TODO remove require hack from sdk renames
-local ColorTemperatureAttribute = pcall(function() return clusters.ColorControl.attributes.ColorTemperature end) and
-                                  clusters.ColorControl.attributes.ColorTemperature or
-                                  clusters.ColorControl.attributes.ColorTemperatureMireds
 local MatterDriver = require "st.matter.driver"
 local utils = require "st.utils"
 
@@ -242,7 +238,7 @@ local matter_driver_template = {
       [clusters.ColorControl.ID] = {
         [clusters.ColorControl.attributes.CurrentHue.ID] = hue_attr_handler,
         [clusters.ColorControl.attributes.CurrentSaturation.ID] = sat_attr_handler,
-        [ColorTemperatureAttribute.ID] = temp_attr_handler,
+        [clusters.ColorControl.attributes.ColorTemperatureMireds.ID] = temp_attr_handler,
         [clusters.ColorControl.attributes.CurrentX.ID] = x_attr_handler,
         [clusters.ColorControl.attributes.CurrentY.ID] = y_attr_handler,
         [clusters.ColorControl.attributes.ColorCapabilities.ID] = color_cap_attr_handler,
@@ -264,7 +260,7 @@ local matter_driver_template = {
       clusters.ColorControl.attributes.CurrentY,
     },
     [capabilities.colorTemperature.ID] = {
-      ColorTemperatureAttribute,
+      clusters.ColorControl.attributes.ColorTemperatureMireds,
     },
   },
   capability_handlers = {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -17,10 +17,6 @@ local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 
 local clusters = require "st.matter.clusters"
--- TODO remove require hack from sdk renames
-local ColorTemperatureAttribute = pcall(function() return clusters.ColorControl.attributes.ColorTemperature end) and
-                                  clusters.ColorControl.attributes.ColorTemperature or
-                                  clusters.ColorControl.attributes.ColorTemperatureMireds
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("switch-color-level.yml"),
   manufacturer_info = {
@@ -75,7 +71,7 @@ local function test_init()
     clusters.ColorControl.attributes.CurrentSaturation,
     clusters.ColorControl.attributes.CurrentX,
     clusters.ColorControl.attributes.CurrentY,
-    ColorTemperatureAttribute,
+    clusters.ColorControl.attributes.ColorTemperatureMireds,
   }
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
@@ -350,7 +346,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        ColorTemperatureAttribute:build_test_report_data(mock_device, 1, 556)
+        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, 1, 556)
       }
     },
     {


### PR DESCRIPTION
This hack was needed prior to matter release, but is no longer needed, since all hubs have the correct name in their lua libs now.