### PR TITLE
CHAD-9317 - customized device profiles in zwave and zigbee sirens drivers

### DIFF
--- a/drivers/SmartThings/zigbee-siren/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-siren/fingerprints.yml
@@ -3,17 +3,17 @@ zigbeeManufacturer :
     deviceLabel : Ozom Siren
     manufacturer: ClimaxTechnology
     model: SRAC_00.00.00.16TC
-    deviceProfileName: switch-alarm
+    deviceProfileName: switch-alarm-generic-siren-7
   - id : Heiman/WarningDevice
     deviceLabel : HEIMAN Siren
     manufacturer : Heiman
     model : WarningDevice
-    deviceProfileName : switch-alarm
+    deviceProfileName : switch-alarm-generic-siren-7
   - id : frient/SIRZB-110
     deviceLabel : frient Siren
     manufacturer : frient A/S
     model : SIRZB-110
-    deviceProfileName : switch-alarm
+    deviceProfileName : switch-alarm-generic-siren-7
   - id: "Sercomm Corp./SZ-SRN12N"
     deviceLabel: SmartThings Siren
     manufacturer: Sercomm Corp.

--- a/drivers/SmartThings/zigbee-siren/profiles/switch-alarm-generic-siren-7.yml
+++ b/drivers/SmartThings/zigbee-siren/profiles/switch-alarm-generic-siren-7.yml
@@ -1,7 +1,9 @@
-name: alarm-battery-tamper
+name: switch-alarm-generic-siren-7
 components:
 - id: main
   capabilities:
+  - id: switch
+    version: 1
   - id: alarm
     version: 1
     config:
@@ -9,14 +11,14 @@ components:
         - key: "alarm.value"
           enabledValues:
             - off
-            - both
+            - siren
         - key: "{{enumCommands}}"
           enabledValues:
             - off
-            - both
-  - id: battery
+            - siren
+  - id: firmwareUpdate
     version: 1
-  - id: tamperAlert
+  - id: refresh
     version: 1
-  categories:
+  categories :
   - name: Siren

--- a/drivers/SmartThings/zwave-siren/fingerprints.yml
+++ b/drivers/SmartThings/zwave-siren/fingerprints.yml
@@ -22,7 +22,7 @@ zwaveManufacturer:
     manufacturerId: 0x014A
     productType: 0x0005
     productId: 0x000A
-    deviceProfileName: alarm-switch-3
+    deviceProfileName: ecolink-wireless-siren
   - id: 013C/0004/000A
     deviceLabel: Philio Siren
     manufacturerId: 0x013C

--- a/drivers/SmartThings/zwave-siren/profiles/aeon-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/aeon-siren.yml
@@ -4,15 +4,22 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: switch
     version: 1
   - id: refresh
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: Aeon_Siren  # Filtering non-supported alarm values (signal/strobe only)
 preferences:
 - name: type
   title: Sound type

--- a/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren-battery.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren-battery.yml
@@ -4,6 +4,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   - id: tamperAlert
@@ -16,6 +26,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -24,6 +44,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   - id: battery
@@ -34,6 +64,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   - id: battery
@@ -44,6 +84,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   - id: battery
@@ -54,6 +104,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -62,6 +122,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -70,13 +140,20 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: Aeotec_Doorbell_Siren_6_Battery
 preferences:
   - name: "componentName"
     title: "Component name"

--- a/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren.yml
@@ -4,6 +4,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   - id: tamperAlert
@@ -16,6 +26,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -24,6 +44,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -32,6 +62,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -40,6 +80,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -48,6 +98,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -56,6 +116,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
@@ -64,13 +134,20 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: Aeotec_Doorbell_Siren_6
 preferences:
   - name: "componentName"
     title: "Component name"

--- a/drivers/SmartThings/zwave-siren/profiles/alarm-battery.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/alarm-battery.yml
@@ -4,10 +4,17 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: battery
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: generic-siren-13  # Filtering non-supported alarm values (signal/strobe only)

--- a/drivers/SmartThings/zwave-siren/profiles/ecolink-wireless-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/ecolink-wireless-siren.yml
@@ -1,0 +1,68 @@
+name: ecolink-wireless-siren
+components:
+  - id: main
+    capabilities:
+    - id: alarm
+      version: 1
+      config:
+        values:
+          - key: "alarm.value"
+            enabledValues:
+              - off
+              - both
+          - key: "{{enumCommands}}"
+            enabledValues:
+              - off
+              - both
+    - id: refresh
+      version: 1
+    categories:
+      - name: Siren
+  - id: siren1
+    capabilities:
+    - id: alarm
+      version: 1
+      config:
+        values:
+          - key: "alarm.value"
+            enabledValues:
+              - off
+              - both
+          - key: "{{enumCommands}}"
+            enabledValues:
+              - off
+              - both
+    categories:
+      - name: Siren
+  - id: siren2
+    capabilities:
+    - id: alarm
+      version: 1
+      config:
+        values:
+          - key: "alarm.value"
+            enabledValues:
+              - off
+              - both
+          - key: "{{enumCommands}}"
+            enabledValues:
+              - off
+              - both
+    categories:
+      - name: Siren
+  - id: siren3
+    capabilities:
+    - id: alarm
+      version: 1
+      config:
+        values:
+          - key: "alarm.value"
+            enabledValues:
+              - off
+              - both
+          - key: "{{enumCommands}}"
+            enabledValues:
+              - off
+              - both
+    categories:
+      - name: Siren

--- a/drivers/SmartThings/zwave-siren/profiles/everspring-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/everspring-siren.yml
@@ -4,6 +4,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: tamperAlert
     version: 1
   - id: battery

--- a/drivers/SmartThings/zwave-siren/profiles/multifunctional-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/multifunctional-siren.yml
@@ -4,6 +4,16 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: battery
     version: 1
   - id: refresh
@@ -12,10 +22,11 @@ components:
     version: 1
   - id: temperatureMeasurement
     version: 1
+    config:
+      values:
+        - key: "temperature.value"
+          range: [-20, 100]
   - id: relativeHumidityMeasurement
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: generic-siren-11   # Filtering non-supported alarm values

--- a/drivers/SmartThings/zwave-siren/profiles/philio-sound-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/philio-sound-siren.yml
@@ -8,8 +8,12 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - both
             - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: chime
     version: 1
   - id: switch

--- a/drivers/SmartThings/zwave-siren/profiles/yale-siren-tamper.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/yale-siren-tamper.yml
@@ -4,15 +4,22 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: tamperAlert
     version: 1
   - id: battery
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: generic-siren-12  # Filtering non-supported alarm values (signal/strobe only)
 preferences:
 - preferenceId: certifiedpreferences.alarmLength
   explicit: true

--- a/drivers/SmartThings/zwave-siren/profiles/yale-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/yale-siren.yml
@@ -4,13 +4,20 @@ components:
   capabilities:
   - id: alarm
     version: 1
+    config:
+      values:
+        - key: "alarm.value"
+          enabledValues:
+            - off
+            - both
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - off
+            - both
   - id: battery
     version: 1
   categories:
   - name: Siren
-metadata:
-  mnmn: SmartThingsEdge
-  vid: generic-siren-13  # Filtering non-supported alarm values (signal/strobe only)
 preferences:
 - preferenceId: certifiedpreferences.alarmLength
   explicit: true


### PR DESCRIPTION
**CHAD-9317 - fixes zwave and zigbee sirens**

I updated following device profiles so they don't use generic or device specific UI metadata anymore:

- aeon-siren
- aeotec-doorbell-siren
- aeotec-doorbell-siren-battery
- alarm-battery
- alarm-battery-tamper
- ecolink-wireless-siren
- everspring-siren
- multifunctional-siren
- philio-sound-siren
- switch-alarm-generic-siren-7
- yale-siren
- yale-siren-tamper

@greens @SmartThingsCommunity/srpol-pe-team 