### PR TITLE
CHAD-9560: fixed on function in zwave virtual momentary contact

### DIFF
--- a/drivers/SmartThings/zwave-virtual-momentary-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-virtual-momentary-switch/src/init.lua
@@ -35,18 +35,14 @@ local function info_changed(self, device, event, args)
 end
 
 local function switch_off(driver, device)
-  print("off")
   device:send(Basic:Set({value = SwitchBinary.value.OFF_DISABLE}))
   device:send(SwitchBinary:Get({}))
 end
 
 local function momentary_switch_on(driver, device)
-  print("On")
   device:send(Basic:Set({value = SwitchBinary.value.ON_ENABLE}))
   device:send(SwitchBinary:Get({}))
-  print("call delay")
   driver:call_with_delay(3, function() switch_off(driver, device) end)
-  --device.thread:call_with_delay(3, switch_off(driver, device))
 end
 
 -------------------------------------------------------------------------------------------

--- a/drivers/SmartThings/zwave-virtual-momentary-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-virtual-momentary-switch/src/init.lua
@@ -35,14 +35,18 @@ local function info_changed(self, device, event, args)
 end
 
 local function switch_off(driver, device)
+  print("off")
   device:send(Basic:Set({value = SwitchBinary.value.OFF_DISABLE}))
   device:send(SwitchBinary:Get({}))
 end
 
 local function momentary_switch_on(driver, device)
+  print("On")
   device:send(Basic:Set({value = SwitchBinary.value.ON_ENABLE}))
   device:send(SwitchBinary:Get({}))
-  driver:call_with_delay(3, switch_off(driver, device))
+  print("call delay")
+  driver:call_with_delay(3, function() switch_off(driver, device) end)
+  --device.thread:call_with_delay(3, switch_off(driver, device))
 end
 
 -------------------------------------------------------------------------------------------

--- a/drivers/SmartThings/zwave-virtual-momentary-switch/src/test/test_zwave_virtual_momentary_switch.lua
+++ b/drivers/SmartThings/zwave-virtual-momentary-switch/src/test/test_zwave_virtual_momentary_switch.lua
@@ -135,7 +135,8 @@ test.register_message_test(
 test.register_coroutine_test(
   "Switch on should generate correct zwave messages",
   function()
-    test.timer.__create_and_queue_test_time_advance_timer(5, "oneshot")
+    test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
+    test.wait_for_events()
     test.socket.capability:__queue_receive(
       {
         mock_momentary_switch.id,
@@ -157,6 +158,8 @@ test.register_coroutine_test(
         SwitchBinary:Get({})
       )
     )
+    test.wait_for_events()
+    test.mock_time.advance_time(3)
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -176,56 +179,11 @@ test.register_coroutine_test(
   end
 )
 
-test.register_message_test(
-  "Switch on should generate correct zwave messages (ver.2)",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-              mock_momentary_switch.id,
-              { capability = "switch", command = "on", args = {} }
-      }
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              Basic:Set({value = SwitchBinary.value.ON_ENABLE})
-      )
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              SwitchBinary:Get({})
-      )
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              Basic:Set({value = SwitchBinary.value.OFF_DISABLE})
-      )
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              SwitchBinary:Get({})
-      )
-    }
-  }
-)
 
 test.register_coroutine_test(
   "Momentary push should generate correct zwave messages",
   function()
-    test.timer.__create_and_queue_test_time_advance_timer(5, "oneshot")
+    test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
     test.socket.capability:__queue_receive(
       {
         mock_momentary_switch.id,
@@ -247,6 +205,8 @@ test.register_coroutine_test(
         SwitchBinary:Get({})
       )
     )
+    test.wait_for_events()
+    test.mock_time.advance_time(3)
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -264,52 +224,6 @@ test.register_coroutine_test(
       )
     )
   end
-)
-
-test.register_message_test(
-  "Momentary push should generate correct zwave messages (ver.2)",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-              mock_momentary_switch.id,
-              { capability = "momentary", command = "push", args = {} }
-      }
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              Basic:Set({value = SwitchBinary.value.ON_ENABLE})
-      )
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              SwitchBinary:Get({})
-      )
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              Basic:Set({value = SwitchBinary.value.OFF_DISABLE})
-      )
-    },
-    {
-      channel = "zwave",
-      direction = "send",
-      message = zw_test_utils.zwave_test_build_send_command(
-              mock_momentary_switch,
-              SwitchBinary:Get({})
-      )
-    }
-  }
 )
 
 test.register_coroutine_test(


### PR DESCRIPTION
The on function in zwave virtual momentary contact immediately sent the off command after the on command without the three second delay.  The `momentary_switch_on` function was edited to include the 3 second delay. The issue was that the value of the `switch_off` function was being passed into the delay command not the actual function, so `switch_off` was called and then its return value was passed into the delay function, which was a `nil` value. Tests were also edited to test for 3 second delay.

https://smartthings.atlassian.net/browse/CHAD-9560