### PR TITLE
added read request for battery percent for ikea remote control

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/init.lua
@@ -69,6 +69,7 @@ local function added_handler(self, device)
   device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
+  print("hello?")
 end
 
 local zigbee_button_driver_template = {

--- a/drivers/SmartThings/zigbee-button/src/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/init.lua
@@ -69,7 +69,6 @@ local function added_handler(self, device)
   device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
-  print("hello?")
 end
 
 local zigbee_button_driver_template = {

--- a/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
@@ -233,11 +233,7 @@ test.register_coroutine_test(
       PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device)
     })
 
-    test.socket.zigbee:__expect_send({
-      mock_device.id,
-      PowerConfiguration.attributes.BatteryVoltage:read(mock_device)
-    })
-    test.socket.capability:__expect_send({
+   test.socket.capability:__expect_send({
       mock_device.id,
       {
         capability_id = "button", component_id = "main",

--- a/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
@@ -230,6 +230,11 @@ test.register_coroutine_test(
     end
     test.socket.zigbee:__expect_send({
       mock_device.id,
+      PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device)
+    })
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
       PowerConfiguration.attributes.BatteryVoltage:read(mock_device)
     })
     test.socket.capability:__expect_send({

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -57,6 +57,7 @@ local function added_handler(self, device)
       device:emit_component_event(comp, capabilities.button.numberOfButtons({value = 1}, {visibility = { displayed = false }}))
     end
   end
+  device:send(PowerConfiguration.attributes.BatteryPercentageRemaining:read(device))
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -43,7 +43,7 @@ local function build_button_payload_handler(pressed_type)
     end
   end
 end
-
+--[[
 local function added_handler(self, device)
   for comp_name, comp in pairs(device.profile.components) do
     if comp_name == "button5" then
@@ -61,7 +61,7 @@ local function added_handler(self, device)
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end
-
+--]]
 local remote_control = {
   NAME = "Remote Control",
   zigbee_handlers = {
@@ -81,10 +81,10 @@ local remote_control = {
         [0x08] = build_button_payload_handler(capabilities.button.button.held)
       }
     }
-  },
+  }, --[[
   lifecycle_handlers = {
     added = added_handler
-  },
+  }, --]]
   can_handle = function(opts, driver, device, ...)
     return device:get_model() == "TRADFRI remote control"
   end

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/ikea/TRADFRI_remote_control.lua
@@ -43,7 +43,7 @@ local function build_button_payload_handler(pressed_type)
     end
   end
 end
---[[
+
 local function added_handler(self, device)
   for comp_name, comp in pairs(device.profile.components) do
     if comp_name == "button5" then
@@ -58,10 +58,9 @@ local function added_handler(self, device)
     end
   end
   device:send(PowerConfiguration.attributes.BatteryPercentageRemaining:read(device))
-  device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end
---]]
+
 local remote_control = {
   NAME = "Remote Control",
   zigbee_handlers = {
@@ -81,10 +80,10 @@ local remote_control = {
         [0x08] = build_button_payload_handler(capabilities.button.button.held)
       }
     }
-  }, --[[
+  }, 
   lifecycle_handlers = {
     added = added_handler
-  }, --]]
+  }, 
   can_handle = function(opts, driver, device, ...)
     return device:get_model() == "TRADFRI remote control"
   end


### PR DESCRIPTION
Added read request in added handler for Ikea remote control in zigbee button driver. Will send a read `BatteryPercentageRemaining` upon the device being handled to fix initial nil battery status, also fixed tests. 

https://smartthings.atlassian.net/browse/BUG-6272