### PR TITLE
Add metadata to window-covering-profile

### DIFF
--- a/drivers/SmartThings/matter-window-covering/profiles/window-covering-profile.yml
+++ b/drivers/SmartThings/matter-window-covering/profiles/window-covering-profile.yml
@@ -17,3 +17,6 @@ components:
 preferences:
   - preferenceId: presetPosition
     explicit: true
+metadata:
+  mnmn: SmartThingsEdge
+  vid: matter-window-covering


### PR DESCRIPTION
There are some clusters which is supported exclusive on Routines. users can make a wrong routine. so this PR is needed.