### PR TITLE
CHAD-9856: added Aeon Multisensor 5 fingerprint

### DIFF
--- a/drivers/SmartThings/zwave-sensor/fingerprints.yml
+++ b/drivers/SmartThings/zwave-sensor/fingerprints.yml
@@ -456,6 +456,11 @@ zwaveManufacturer:
     manufacturerId: 0x0086
     productId: 0x0005
     deviceProfileName: motion-battery-temperature-illuminance-humidity
+  - id: "aeon/multisensor/gen5"
+    deviceLabel: Aeon Multipurpose Sensor
+    manufactureId: 0x0086
+    productId: 0x004A
+    deviceProfileName: motion-battery-temperature-illuminance-humidity
   - id: 021F/0003/0085
     deviceLabel: Dome Water Leak Sensor
     manufacturerId: 0x021F


### PR DESCRIPTION
added Aeon Multisensor 5 fingerprint to zwave-sensor driver

https://smartthings.atlassian.net/browse/CHAD-9856