### PR TITLE
CHAD-9693 - fixes mapping scenes to components

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/inovelli-lzw31sn/init.lua
@@ -54,11 +54,12 @@ local function device_added(driver, device)
   device:refresh()
 end
 
-local function button_to_component(buttonId)
-  if buttonId > 0 then
-    return string.format("button%d", buttonId)
-  end
-end
+local map_scene_number_to_component = {
+  [1] = "button2",
+  [2] = "button1",
+  [3] = "button3"
+}
+
 
 local map_key_attribute_to_capability = {
   [CentralScene.key_attributes.KEY_PRESSED_1_TIME] = capabilities.button.button.pushed,
@@ -70,7 +71,6 @@ local map_key_attribute_to_capability = {
 
 local function central_scene_notification_handler(self, device, cmd)
   if ( cmd.args.scene_number ~= nil and cmd.args.scene_number ~= 0 ) then
-    local button_number = cmd.args.scene_number
     local capability_attribute = map_key_attribute_to_capability[cmd.args.key_attributes]
     local additional_fields = {
       state_change = true
@@ -83,7 +83,7 @@ local function central_scene_notification_handler(self, device, cmd)
 
     if event ~= nil then
       -- device reports scene notifications from endpoint 0 (main) but central scene events have to be emitted for button components: 1,2,3
-      local comp = device.profile.components[button_to_component(button_number)]
+      local comp = device.profile.components[map_scene_number_to_component[cmd.args.scene_number]]
       if comp ~= nil then
         device:emit_component_event(comp, event)
       end

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
@@ -115,7 +115,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id,
-                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME, scene_number = 1},
+                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME, scene_number = 2},
                   { encap = zw.ENCAP.AUTO, src_channel = 1, dst_channels = {0} }))
       }
     },
@@ -139,7 +139,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id,
-                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_4_TIMES, scene_number = 2},
+                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_4_TIMES, scene_number = 1},
                     { encap = zw.ENCAP.AUTO, src_channel = 2, dst_channels = {0} }))
       }
     },

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
@@ -25,6 +25,10 @@ local INOVELLI_LZW31_SN_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
 local LED_BAR_COMPONENT_NAME = "LEDColorConfiguration"
 
+local BUTTON_UP_SCENE_2 = 2
+local BUTTON_DOWN_SCENE_1 = 1
+local BUTTON_CONFIGURE_SCENE_3 = 3
+
 local inovelli_dimmer_endpoints = {
   {
     command_classes = {
@@ -115,7 +119,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id,
-                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME, scene_number = 2},
+                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME, scene_number = BUTTON_UP_SCENE_2},
                   { encap = zw.ENCAP.AUTO, src_channel = 1, dst_channels = {0} }))
       }
     },
@@ -139,7 +143,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id,
-                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_4_TIMES, scene_number = 1},
+                  zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_4_TIMES, scene_number = BUTTON_DOWN_SCENE_1},
                     { encap = zw.ENCAP.AUTO, src_channel = 2, dst_channels = {0} }))
       }
     },
@@ -163,7 +167,7 @@ test.register_message_test(
         channel = "zwave",
         direction = "receive",
         message = { mock_inovelli_dimmer.id,
-                    zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME, scene_number = 3},
+                    zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({ key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME, scene_number = BUTTON_CONFIGURE_SCENE_3},
                       { encap = zw.ENCAP.AUTO, src_channel = 3, dst_channels = {0} }))
         }
       },

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_scenes.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_scenes.lua
@@ -23,6 +23,10 @@ local INOVELLI_MANUFACTURER_ID = 0x031E
 local INOVELLI_LZW31_PRODUCT_TYPE = 0x0001
 local INOVELLI_DIMMER_PRODUCT_ID = 0x0001
 
+local BUTTON_UP_SCENE_2 = 2
+local BUTTON_DOWN_SCENE_1 = 1
+local BUTTON_CONFIGURE_SCENE_3 = 3
+
 local inovelli_dimmer_endpoints = {
   {
     command_classes = {
@@ -54,7 +58,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
+        scene_number = BUTTON_UP_SCENE_2,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME}))
       }
     },
@@ -74,7 +78,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
+        scene_number = BUTTON_UP_SCENE_2,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES}))
       }
     },
@@ -94,7 +98,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
+        scene_number = BUTTON_UP_SCENE_2,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_3_TIMES}))
       }
     },
@@ -114,7 +118,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
+        scene_number = BUTTON_UP_SCENE_2,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_4_TIMES}))
       }
     },
@@ -134,7 +138,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 1,
+        scene_number = BUTTON_UP_SCENE_2,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_5_TIMES}))
       }
     },
@@ -154,7 +158,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
+        scene_number = BUTTON_DOWN_SCENE_1,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME}))
       }
     },
@@ -174,7 +178,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
+        scene_number = BUTTON_DOWN_SCENE_1,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_2_TIMES}))
       }
     },
@@ -194,7 +198,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
+        scene_number = BUTTON_DOWN_SCENE_1,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_3_TIMES}))
       }
     },
@@ -214,7 +218,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
+        scene_number = BUTTON_DOWN_SCENE_1,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_4_TIMES}))
       }
     },
@@ -234,7 +238,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 2,
+        scene_number = BUTTON_DOWN_SCENE_1,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_5_TIMES}))
       }
     },
@@ -254,7 +258,7 @@ test.register_message_test(
       channel = "zwave",
       direction = "receive",
       message = { mock_inovelli_dimmer.id, zw_test_utils.zwave_test_build_receive_command(CentralScene:Notification({
-        scene_number = 3,
+        scene_number = BUTTON_CONFIGURE_SCENE_3,
         key_attributes=CentralScene.key_attributes.KEY_PRESSED_1_TIME}))
       }
     },


### PR DESCRIPTION
CHAD-9693 - fixes mapping scenes to components

in a [DTH](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/78747fa5a3b42a0c801f1095f8f7521da968ba42/devicetypes/smartthings/inovelli-dimmer.src/inovelli-dimmer.groovy#L422):
- scene 2 is mapped to the button1 (UP)
- scene 1 is mapped to the button2 (DOWN)
- scene 3 is mapped to the button3 (CONFIGURE)

@SmartThingsCommunity/srpol-pe-team 