### PR TITLE
Add checks for child existence on device added events

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
@@ -59,28 +59,30 @@ local function get_children_amount(device)
   end
 end
 
+local function find_child(parent, ep_id)
+  return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
+end
+
 local function device_added(driver, device, event)
   if device.network_type == st_device.NETWORK_TYPE_ZIGBEE then
     local children_amount = get_children_amount(device)
     for i = 2, children_amount+1, 1 do
       local device_name_without_number = string.sub(device.label, 0,-2)
       local name = string.format("%s%d", device_name_without_number, i)
-      local metadata = {
-        type = "EDGE_CHILD",
-        label = name,
-        profile = "basic-switch",
-        parent_device_id = device.id,
-        parent_assigned_child_key = string.format("%02X", i),
-        vendor_provided_label = name,
-      }
-      driver:try_create_device(metadata)
+      if find_child(device, i) == nil then
+        local metadata = {
+          type = "EDGE_CHILD",
+          label = name,
+          profile = "basic-switch",
+          parent_device_id = device.id,
+          parent_assigned_child_key = string.format("%02X", i),
+          vendor_provided_label = name,
+        }
+        driver:try_create_device(metadata)
+      end
     end
   end
   device:refresh()
-end
-
-local function find_child(parent, ep_id)
-  return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
 end
 
 local function device_init(driver, device, event)

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/init.lua
@@ -37,8 +37,14 @@ local function do_refresh(self, device)
   device:send(ElectricalMeasurement.attributes.ActivePower:read(device))
 end
 
+local function find_child(parent, ep_id)
+  return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
+end
+
 local function device_added(driver, device, event)
-  if device.network_type == st_device.NETWORK_TYPE_ZIGBEE then
+  if device.network_type == st_device.NETWORK_TYPE_ZIGBEE and
+    find_child(device, CHILD_ENDPOINT) == nil then
+
     local name = "AURORA Outlet 2"
     local metadata = {
       type = "EDGE_CHILD",
@@ -51,10 +57,6 @@ local function device_added(driver, device, event)
     driver:try_create_device(metadata)
   end
   do_refresh(driver, device)
-end
-
-local function find_child(parent, ep_id)
-  return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
 end
 
 local function device_init(driver, device)

--- a/drivers/SmartThings/zwave-switch/src/fibaro-double-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/fibaro-double-switch/init.lua
@@ -79,8 +79,18 @@ local function do_refresh(driver, device, command)
   device:send_to_component(Meter:Get({ scale = Meter.scale.electric_meter.KILOWATT_HOURS }), component)
 end
 
+local function find_child(parent, ep_id)
+  if ep_id == ENDPOINTS.parent then
+    return parent
+  else
+    return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
+  end
+end
+
 local function device_added(driver, device, event)
-  if device.network_type == st_device.NETWORK_TYPE_ZWAVE then
+  if device.network_type == st_device.NETWORK_TYPE_ZWAVE and
+    find_child(device, ENDPOINTS.child) == nil then
+
     local name = string.format("%s %s", device.label, "(CH2)")
     local metadata = {
       type = "EDGE_CHILD",
@@ -93,14 +103,6 @@ local function device_added(driver, device, event)
     driver:try_create_device(metadata)
   end
   do_refresh(driver, device)
-end
-
-local function find_child(parent, ep_id)
-  if ep_id == ENDPOINTS.parent then
-    return parent
-  else
-    return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
-  end
 end
 
 local function component_to_endpoint(device, component)

--- a/drivers/SmartThings/zwave-switch/src/qubino-switches/qubino-relays/qubino-flush-2-relay/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/qubino-switches/qubino-relays/qubino-flush-2-relay/init.lua
@@ -93,8 +93,11 @@ end
 
 local function device_added(driver, device)
   if device.network_type ~= st_device.NETWORK_TYPE_CHILD then
-    driver:try_create_device(get_child_metadata(device, CHILD_SWITCH_EP))
-    if device:is_cc_supported(cc.SENSOR_MULTILEVEL) then
+    if find_child(device, CHILD_SWITCH_EP) == nil then
+      driver:try_create_device(get_child_metadata(device, CHILD_SWITCH_EP))
+    end
+    if device:is_cc_supported(cc.SENSOR_MULTILEVEL) and
+       find_child(device, CHILD_TEMP_SENSOR_EP) == nil then
       driver:try_create_device(get_child_metadata(device, CHILD_TEMP_SENSOR_EP))
     end
   end

--- a/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
@@ -115,16 +115,17 @@ end
 
 local function device_added(driver, device)
   if device.network_type ~= st_device.NETWORK_TYPE_CHILD then
-    local child_metadata = {
-      type = "EDGE_CHILD",
-      label = string.format("%s Relay", device.label),
-      profile = "child-switch",
-      parent_device_id = device.id,
-      parent_assigned_child_key = string.format("%02X", ENDPOINTS.relay),
-      vendor_provided_label = string.format("%s Relay", device.label)
-    }
-
-    driver:try_create_device(child_metadata)
+    if find_child(device, ENDPOINTS.relay) == nil then
+      local child_metadata = {
+        type = "EDGE_CHILD",
+        label = string.format("%s Relay", device.label),
+        profile = "child-switch",
+        parent_device_id = device.id,
+        parent_assigned_child_key = string.format("%02X", ENDPOINTS.relay),
+        vendor_provided_label = string.format("%s Relay", device.label)
+      }
+      driver:try_create_device(child_metadata)
+    end
 
     device:emit_event(capabilities.button.supportedButtonValues(BUTTON_VALUES, { visibility = { displayed = false } }))
     device:emit_event(capabilities.button.numberOfButtons({ value = 3 }, { visibility = { displayed = false } }))

--- a/drivers/SmartThings/zwave-switch/src/zwave-dual-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zwave-dual-switch/init.lua
@@ -66,7 +66,7 @@ local function device_added(driver, device)
   if device.network_type ~= st_device.NETWORK_TYPE_CHILD then
     local dual_switch_configuration = dualSwitchConfigurationsMap.get_child_device_configuration(device)
 
-    if dual_switch_configuration ~= nil then
+    if dual_switch_configuration ~= nil and find_child(device, 2) == nil then
       local name = generate_child_name(device.label)
       local childDeviceProfile = dual_switch_configuration.child_switch_device_profile
       local metadata = {


### PR DESCRIPTION
This mitigates a situation where when a device is switched from one driver to another, there is an Added event that creates duplicate children. Note this situation should be prevented by the ST platform, and will be fixed in a future release.