### PR TITLE
Set switchLevel range to [1,100] for zwave/zigbee dimmers

### DIFF
--- a/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2200K-4000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2200K-4000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2200K-5000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2200K-5000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2200K-6500K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2200K-6500K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2500K-6000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2500K-6000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2700K-5000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2700K-5000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2700K-6500K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/color-temp-bulb-2700K-6500K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-1800K-6500K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-1800K-6500K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2000K-6500K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2000K-6500K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2200K-4000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2200K-4000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2200K-5000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2200K-5000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2200K-6500K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2200K-6500K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2500K-6000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2500K-6000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2700K-5000K.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/rgbw-bulb-2700K-5000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/zwave-switch/profiles/multichannel-switch-level.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/multichannel-switch-level.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: refresh
     version: 1
   - id: zwMultichannel

--- a/drivers/SmartThings/zwave-switch/profiles/switch-level-indicator.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/switch-level-indicator.yml
@@ -6,6 +6,10 @@ components:
       version: 1
     - id: switchLevel
       version: 1
+      config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
     - id: refresh
       version: 1
   categories:

--- a/drivers/SmartThings/zwave-switch/profiles/zooz-zen-30-dimmer-relay-new.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/zooz-zen-30-dimmer-relay-new.yml
@@ -6,6 +6,10 @@ components:
         version: 1
       - id: switchLevel
         version: 1
+        config:
+          values:
+            - key: "level.value"
+              range: [1, 100]
       - id: button
         version: 1
       - id: refresh

--- a/drivers/SmartThings/zwave-switch/profiles/zooz-zen-30-dimmer-relay.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/zooz-zen-30-dimmer-relay.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: button
     version: 1
   - id: refresh


### PR DESCRIPTION
Some zwave/zigbee profiles have been added since https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/160, so this essentially extends that work to these new profiles. 

https://smartthings.atlassian.net/browse/CHAD-8941