### PR TITLE
Create new profile for fibaro radiator thermostat with [10, 30C] heat…

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zwave-thermostat/fingerprints.yml
@@ -57,7 +57,7 @@ zwaveManufacturer:
     deviceLabel: Fibaro Thermostat
     manufacturerId: 0x010F
     productType: 0x1301
-    deviceProfileName: base-radiator-thermostat
+    deviceProfileName: base-radiator-thermostat-10to30C
   - id: "0239/0001/0001"
     deviceLabel: Stelpro Ki Thermostat
     manufacturerId: 0x0239

--- a/drivers/SmartThings/zwave-thermostat/profiles/base-radiator-thermostat-10to30C.yml
+++ b/drivers/SmartThings/zwave-thermostat/profiles/base-radiator-thermostat-10to30C.yml
@@ -1,0 +1,20 @@
+name: base-radiator-thermostat-10to30C
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+    config:
+      values:
+        - key: "heatingSetpoint.value"
+          range: [ 10, 30 ]
+  - id: thermostatMode
+    version: 1
+  - id: battery
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat


### PR DESCRIPTION
…ing range

Based on feedback here: https://smartthings.atlassian.net/browse/CHAD-9316

I created a new profile to set the heating range to [10, 30C] for the fibaro radiator thermostat when the extra sensor is not connected.