### PR TITLE
Bugfix: Supported track control cmds on device init

### DIFF
--- a/drivers/SmartThings/bose/src/init.lua
+++ b/drivers/SmartThings/bose/src/init.lua
@@ -114,6 +114,16 @@ local function do_refresh(driver, device, cmd)
     trackdata.album = info.album
     trackdata.albumArtUrl = info.art_url
     trackdata.mediaSource = info.source
+    if info.source == "TUNEIN" then
+      -- Switching to radio source which disables track controls
+      device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({ }))
+    else
+      device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
+        capabilities.mediaTrackControl.commands.nextTrack.NAME,
+        capabilities.mediaTrackControl.commands.previousTrack.NAME,
+      }))
+    end
+
     if info.track then
       trackdata.title = info.track
     elseif info.station then
@@ -189,10 +199,6 @@ local function device_init(driver, device)
     capabilities.mediaPlayback.commands.play.NAME,
     capabilities.mediaPlayback.commands.pause.NAME,
     capabilities.mediaPlayback.commands.stop.NAME,
-  }))
-  device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
-    capabilities.mediaTrackControl.commands.nextTrack.NAME,
-    capabilities.mediaTrackControl.commands.previousTrack.NAME,
   }))
   do_refresh(driver, device)
 

--- a/drivers/SmartThings/bose/src/listener.lua
+++ b/drivers/SmartThings/bose/src/listener.lua
@@ -73,7 +73,8 @@ function Listener:now_playing_update(info)
         utils.table_size(self.device.state_cache.main.mediaTrackControl.supportedTrackControlCommands.value) > 0 then
         -- Switching to radio source which disables track controls
         self.device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({ }))
-      elseif utils.table_size(self.device.state_cache.main.mediaTrackControl.supportedTrackControlCommands.value) == 0 then
+      elseif utils.table_size(self.device.state_cache.main.mediaTrackControl.supportedTrackControlCommands.value) == 0 and
+        info.source ~= "TUNEIN" then
         self.device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
           capabilities.mediaTrackControl.commands.nextTrack.NAME,
           capabilities.mediaTrackControl.commands.previousTrack.NAME,


### PR DESCRIPTION
When initializing a device that is currently playing from radio, this fixes a situation where the supportedTrackControlCommands attribute is not set properly. This also fixes a situation where multiple now playing updates for a TUNEIN source end up setting the
supportedTrackControlCommands incorrectly due to not checking the cached value