### PR TITLE
Bugfix require socket.ltn12 rather than ltn12 in wemo driver

### DIFF
--- a/drivers/SmartThings/samsung-audio/src/disco.lua
+++ b/drivers/SmartThings/samsung-audio/src/disco.lua
@@ -22,7 +22,7 @@ local xml_handler = require "xmlhandler.tree"
 local utils = require "st.utils"
 local command = require "command"
 
-local ltn12 = require "socket.ltn12"
+local ltn12 = require "ltn12"
 
 --- @module samsung-audio.Disco
 local Disco = {}

--- a/drivers/SmartThings/wemo/src/discovery.lua
+++ b/drivers/SmartThings/wemo/src/discovery.lua
@@ -1,7 +1,7 @@
 local cosock = require "cosock"
 local socket = require "cosock.socket"
 local http = cosock.asyncify "socket.http"
-local ltn12 = require "socket.ltn12"
+local ltn12 = require "ltn12"
 local log = require "log"
 local tablefind = require "util".tablefind
 local xml2lua = require "xml2lua"

--- a/drivers/SmartThings/wemo/src/protocol.lua
+++ b/drivers/SmartThings/wemo/src/protocol.lua
@@ -4,7 +4,7 @@ local log = require "log"
 local cosock = require "cosock"
 local socket = require "cosock.socket"
 local http = cosock.asyncify "socket.http"
-local ltn12 = require "socket.ltn12"
+local ltn12 = require "ltn12"
 
 local utils = require "st.utils"
 


### PR DESCRIPTION
I tried to onboard a few wemo devices, but the driver discovery crashed due to this require failing.