### PR TITLE
Matter thermostat setpoint limits

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -15,6 +15,7 @@
 local capabilities = require "st.capabilities"
 local log = require "log"
 local clusters = require "st.matter.clusters"
+local im = require "st.matter.interaction_model"
 
 local MatterDriver = require "st.matter.driver"
 local utils = require "st.utils"
@@ -34,6 +35,14 @@ local THERMOSTAT_OPERATING_MODE_MAP = {
   [2]		= capabilities.thermostatOperatingState.thermostatOperatingState.fan_only,
 }
 
+local setpoint_limit_device_field = {
+  MIN_HEAT = "MIN_HEAT",
+  MAX_HEAT = "MAX_HEAT",
+  MIN_COOL = "MIN_COOL",
+  MAX_COOL = "MAX_COOL",
+  MIN_DEADBAND = "MIN_DEADBAND",
+}
+
 local function device_init(driver, device)
   device:subscribe()
 end
@@ -41,6 +50,7 @@ end
 local function do_configure(driver, device)
   local heat_eps = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.HEATING})
   local cool_eps = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.COOLING})
+  local auto_eps = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE})
   local thermo_eps = device:get_endpoints(clusters.Thermostat.ID)
   local fan_eps = device:get_endpoints(clusters.FanControl.ID)
   local humidity_eps = device:get_endpoints(clusters.RelativeHumidityMeasurement.ID)
@@ -76,6 +86,27 @@ local function do_configure(driver, device)
     device:try_update_metadata({profile = profile_name})
   else
     log.warn_with({hub_logs=true}, "Device does not support thermostat cluster")
+  end
+
+  --Query setpoint limits if needed
+  local setpoint_limit_read = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
+  if #heat_eps ~= 0 and device:get_field(setpoint_limit_device_field.MIN_HEAT) == nil then
+    setpoint_limit_read:merge(clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:read())
+  end
+  if #heat_eps ~= 0 and device:get_field(setpoint_limit_device_field.MAX_HEAT) == nil then
+    setpoint_limit_read:merge(clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:read())
+  end
+  if #cool_eps ~= 0 and device:get_field(setpoint_limit_device_field.MIN_COOL) == nil then
+    setpoint_limit_read:merge(clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:read())
+  end
+  if #cool_eps ~= 0 and device:get_field(setpoint_limit_device_field.MAX_COOL) == nil then
+    setpoint_limit_read:merge(clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:read())
+  end
+  if #auto_eps ~= 0 and device:get_field(setpoint_limit_device_field.MIN_DEADBAND) == nil then
+    setpoint_limit_read:merge(clusters.Thermostat.attributes.MinSetpointDeadBand:read())
+  end
+  if #setpoint_limit_read.info_blocks ~= 0 then
+    device:send(setpoint_limit_read)
   end
 end
 
@@ -202,20 +233,95 @@ local function thermostat_fan_mode_setter(mode_name)
   end
 end
 
-local function f_to_c(f)
-  local res = (f - 32) * (5 / 9.0)
-  return res
-end
-
 local function set_setpoint(setpoint)
   return function(driver, device, cmd)
     local value = cmd.args.setpoint
     if (value >= 40) then -- assume this is a fahrenheit value
-      value = f_to_c(value)
+      value = utils.f_to_c(value)
     end
 
+    -- Gather cached setpoint values when considering setpoint limits
+    -- Note: cached values should always exist, but defaults are chosen just in case to prevent
+    -- nil operation errors, and deadband logic from triggering.
+    local cached_cooling_val, cooling_setpoint = device:get_latest_state(
+      cmd.component, capabilities.thermostatCoolingSetpoint.ID,
+      capabilities.thermostatCoolingSetpoint.coolingSetpoint.NAME,
+      100, { value = 100, unit = "C" }
+    )
+    if cooling_setpoint and cooling_setpoint.unit == "F" then
+      cached_cooling_val = utils.f_to_c(cached_cooling_val)
+    end
+    local cached_heating_val, heating_setpoint = device:get_latest_state(
+      cmd.component, capabilities.thermostatHeatingSetpoint.ID,
+      capabilities.thermostatHeatingSetpoint.heatingSetpoint.NAME,
+      0, { value = 0, unit = "C" }
+    )
+    if heating_setpoint and heating_setpoint.unit == "F" then
+      cached_heating_val = utils.f_to_c(cached_heating_val)
+    end
+    local is_auto_capable = #device:get_endpoints(
+      clusters.Thermostat.ID,
+      {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE}
+    ) > 0
+
+    --Check setpoint limits for the device
+    local setpoint_type = string.match(setpoint.NAME, "Heat") or "Cool"
+    local deadband = device:get_field(setpoint_limit_device_field.MIN_DEADBAND) or 2.5 --spec default
+    if setpoint_type == "Heat" then
+      local min = device:get_field(setpoint_limit_device_field.MIN_HEAT) or 0
+      local max = device:get_field(setpoint_limit_device_field.MAX_HEAT) or 100
+      if value < min or value > max then
+        log.warn(string.format(
+          "Invalid setpoint (%s) outside the min (%s) and the max (%s)",
+          value, min, max
+        ))
+        device:emit_event(capabilities.thermostatHeatingSetpoint.heatingSetpoint(heating_setpoint))
+        return
+      end
+      if is_auto_capable and value > (cached_cooling_val - deadband) then
+        log.warn(string.format(
+          "Invalid setpoint (%s) is greater than the cooling setpoint (%s) with the deadband (%s)",
+          value, cooling_setpoint, deadband
+        ))
+        device:emit_event(capabilities.thermostatHeatingSetpoint.heatingSetpoint(heating_setpoint))
+        return
+      end
+    else
+      local min = device:get_field(setpoint_limit_device_field.MIN_COOL) or 0
+      local max = device:get_field(setpoint_limit_device_field.MAX_COOL) or 100
+      if value < min or value > max then
+        log.warn(string.format(
+          "Invalid setpoint (%s) outside the min (%s) and the max (%s)",
+          value, min, max
+        ))
+        device:emit_event(capabilities.thermostatCoolingSetpoint.coolingSetpoint(cooling_setpoint))
+        return
+      end
+      if is_auto_capable and value < (cached_heating_val + deadband) then
+        log.warn(string.format(
+          "Invalid setpoint (%s) is less than the heating setpoint (%s) with the deadband (%s)",
+          value, heating_setpoint, deadband
+        ))
+        device:emit_event(capabilities.thermostatCoolingSetpoint.coolingSetpoint(cooling_setpoint))
+        return
+      end
+    end
     device:send(setpoint:write(device, device:component_to_endpoint(cmd.component), utils.round(value * 100.0)))
   end
+end
+
+local function setpoint_limit_handler(limit_field)
+  return function(driver, device, ib, response)
+    local val = ib.data.value / 100.0
+    log.info("Setting " .. limit_field .. " to " .. string.format("%s", val))
+    device:set_field(limit_field, val, { persist = true })
+  end
+end
+
+local function min_deadband_limit_handler(driver, device, ib, response)
+  local val = ib.data.value / 10.0
+  log.info("Setting " .. setpoint_limit_device_field.MIN_DEADBAND .. " to " .. string.format("%s", val))
+  device:set_field(setpoint_limit_device_field.MIN_DEADBAND, val, { persist = true })
 end
 
 local function battery_percent_remaining_attr_handler(driver, device, ib, response)
@@ -239,6 +345,11 @@ local matter_driver_template = {
         [clusters.Thermostat.attributes.SystemMode.ID] = system_mode_handler,
         [clusters.Thermostat.attributes.ThermostatRunningState.ID] = running_state_handler,
         [clusters.Thermostat.attributes.ControlSequenceOfOperation.ID] = sequence_of_operation_handler,
+        [clusters.Thermostat.attributes.AbsMinHeatSetpointLimit.ID] = setpoint_limit_handler(setpoint_limit_device_field.MIN_HEAT),
+        [clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit.ID] = setpoint_limit_handler(setpoint_limit_device_field.MAX_HEAT),
+        [clusters.Thermostat.attributes.AbsMinCoolSetpointLimit.ID] = setpoint_limit_handler(setpoint_limit_device_field.MIN_COOL),
+        [clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit.ID] = setpoint_limit_handler(setpoint_limit_device_field.MAX_COOL),
+        [clusters.Thermostat.attributes.MinSetpointDeadBand.ID] = min_deadband_limit_handler,
       },
       [clusters.FanControl.ID] = {
         [clusters.FanControl.attributes.FanModeSequence.ID] = fan_mode_sequence_handler,

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -148,7 +148,10 @@ test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event due to cluster feature map",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    --TODO why does provisionng state get added in the do configure event handle, but not the refres?
+  local read_limits = clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:read()
+  read_limits:merge(clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:read())
+  test.socket.matter:__expect_send({mock_device.id, read_limits})
+    --TODO why does provisiong state get added in the do configure event handle, but not the refres?
     mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only-nostate" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
@@ -158,6 +161,9 @@ test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event due to cluster feature map",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device_simple.id, "doConfigure" })
+    local read_limits = clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:read()
+    read_limits:merge(clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:read())
+    test.socket.matter:__expect_send({mock_device_simple.id, read_limits})
     mock_device_simple:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
     mock_device_simple:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -1,0 +1,202 @@
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local t_utils = require "integration_test.utils"
+local utils = require "st.utils"
+
+local clusters = require "st.matter.clusters"
+
+local mock_device = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = clusters.Thermostat.ID,
+          cluster_revision=5,
+          cluster_type="SERVER",
+          feature_map=35, -- Heat, Cool, and Auto features.
+        },
+      }
+    }
+  }
+})
+
+local function test_init()
+  local cluster_subscribe_list = {
+    clusters.Thermostat.attributes.LocalTemperature,
+    clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+    clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+    clusters.Thermostat.attributes.SystemMode,
+    clusters.Thermostat.attributes.ThermostatRunningState,
+    clusters.Thermostat.attributes.ControlSequenceOfOperation,
+    clusters.Thermostat.attributes.LocalTemperature,
+  }
+  test.socket.matter:__set_channel_ordering("relaxed")
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+end
+test.set_test_init_function(test_init)
+
+local cached_heating_setpoint = capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 24.44, unit = "C" })
+local cached_cooling_setpoint = capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 26.67, unit = "C" })
+
+local function configure(device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  local read_limits = clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:read()
+  read_limits:merge(clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:read())
+  read_limits:merge(clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:read())
+  read_limits:merge(clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:read())
+  read_limits:merge(clusters.Thermostat.attributes.MinSetpointDeadBand:read())
+  test.socket.matter:__expect_send({device.id, read_limits})
+  mock_device:expect_metadata_update({ profile = "thermostat-nostate" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.wait_for_events()
+  --Populate setpoint limits
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:build_test_report_data(device, 1, 1000)
+  })
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:build_test_report_data(device, 1, 3222)
+  })
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:build_test_report_data(device, 1, 1000) --10.0 celcius
+  })
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:build_test_report_data(device, 1, 3222) --32.22 celcius
+  })
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.MinSetpointDeadBand:build_test_report_data(device, 1, 16) --1.6 celcius
+  })
+
+  --populate cached setpoint values. This would normally happen due to subscription setup.
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.OccupiedHeatingSetpoint:build_test_report_data(mock_device, 1, 2444) --24.44 celcius
+  })
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.Thermostat.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, 1, 2667) --26.67 celcius
+  })
+  test.socket.capability:__expect_send(
+    device:generate_test_message("main", cached_heating_setpoint)
+  )
+  test.socket.capability:__expect_send(
+    device:generate_test_message("main", cached_cooling_setpoint)
+  )
+  test.wait_for_events()
+end
+
+test.register_coroutine_test(
+  "Heat setpoint lower than min",
+  function()
+    configure(mock_device)
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 9 } }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", cached_heating_setpoint)
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Cool setpoint lower than min",
+  function()
+    configure(mock_device)
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "thermostatCoolingSetpoint", component = "main", command = "setCoolingSetpoint", args = { 9 } }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", cached_cooling_setpoint)
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Heat setpoint higher than max",
+  function()
+    configure(mock_device)
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 33 } }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", cached_heating_setpoint)
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Cool setpoint higher than max",
+  function()
+    configure(mock_device)
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "thermostatCoolingSetpoint", component = "main", command = "setCoolingSetpoint", args = { 33 } }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", cached_cooling_setpoint)
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Heat setpoint inside deadband",
+  function()
+    configure(mock_device)
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 26 } }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", cached_heating_setpoint)
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Cool setpoint inside deadband",
+  function()
+    configure(mock_device)
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "thermostatCoolingSetpoint", component = "main", command = "setCoolingSetpoint", args = { 25 } }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", cached_cooling_setpoint)
+    )
+  end
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
This implements setpoint limits for thermostats according to the spec. 

When the device is configured, the driver reads the min/max heat/cool setpoint limits and the min setpoint deadband limit attributes; these values are persisted on the device object. Note that we only consider the AbsX variety of  setpoint limit attributes (i.e. AbsMinHeatingSetpoint not MinHeatingSetpoint).

If a set point command has a value outside the min/max or deadband, we will log a warning with the relevant information and then emit a capability event with the current cached setpoint value. This will prevent a timeout error in the app, and will indicate to the user that the setpoint did not actually change.

- [x] Unit test fixes and tests for changes.