### PR TITLE
Bose utilize get_latest_state

### DIFF
--- a/drivers/SmartThings/bose/src/init.lua
+++ b/drivers/SmartThings/bose/src/init.lua
@@ -87,7 +87,6 @@ local function discovery_handler(driver, _, should_continue)
   log.info("Ending discovery")
 end
 
-local toggle = true
 local function do_refresh(driver, device, cmd)
   -- get speaker playback state
   local info, err = command.now_playing(device:get_field("ip"))

--- a/drivers/SmartThings/bose/src/listener.lua
+++ b/drivers/SmartThings/bose/src/listener.lua
@@ -67,14 +67,18 @@ function Listener:now_playing_update(info)
     if not is_empty(info.art_url) then trackdata.albumArtUrl = info.art_url end
     if not is_empty(info.source) then
       trackdata.mediaSource = info.source
+      local cached_track_control_cmds = self.device:get_latest_state(
+        "main", capabilities.mediaTrackControl.ID,
+        capabilities.mediaTrackControl.supportedTrackControlCommands.NAME
+      )
       -- Note changing supportedTrackControlCommands after join does not seem to take effect in the app immediately.
       -- This indicates a bug in the mobile app.
       if info.source == "TUNEIN" and
-        utils.table_size(self.device.state_cache.main.mediaTrackControl.supportedTrackControlCommands.value) > 0 then
+        (cached_track_control_cmds == nil or utils.table_size(cached_track_control_cmds) > 0) then
         -- Switching to radio source which disables track controls
         self.device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({ }))
-      elseif utils.table_size(self.device.state_cache.main.mediaTrackControl.supportedTrackControlCommands.value) == 0 and
-        info.source ~= "TUNEIN" then
+      elseif info.source ~= "TUNEIN" and
+        (cached_track_control_cmds == nil or utils.table_size(cached_track_control_cmds) == 0) then
         self.device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
           capabilities.mediaTrackControl.commands.nextTrack.NAME,
           capabilities.mediaTrackControl.commands.previousTrack.NAME,


### PR DESCRIPTION
Handle a situation where we receive a now playing update over the websocket before having set supportedMediaPlaybackCommands due to device init/refresh. This can happen during migration.