### PR TITLE
Fix yaml issue in siren embedded configs

### DIFF
--- a/drivers/SmartThings/zigbee-siren/profiles/switch-alarm-generic-siren-7.yml
+++ b/drivers/SmartThings/zigbee-siren/profiles/switch-alarm-generic-siren-7.yml
@@ -10,11 +10,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - siren
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - siren
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/aeon-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/aeon-siren.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: switch
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren-battery.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren-battery.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -30,11 +30,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -48,11 +48,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -68,11 +68,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -88,11 +88,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -108,11 +108,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -126,11 +126,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -144,11 +144,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/aeotec-doorbell-siren.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -30,11 +30,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -48,11 +48,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -66,11 +66,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -84,11 +84,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -102,11 +102,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -120,11 +120,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1
@@ -138,11 +138,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/alarm-battery-tamper.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/alarm-battery-tamper.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: battery
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/alarm-battery.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/alarm-battery.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: battery
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/ecolink-wireless-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/ecolink-wireless-siren.yml
@@ -8,11 +8,11 @@ components:
         values:
           - key: "alarm.value"
             enabledValues:
-              - off
+              - 'off'
               - both
           - key: "{{enumCommands}}"
             enabledValues:
-              - off
+              - 'off'
               - both
     - id: refresh
       version: 1
@@ -26,11 +26,11 @@ components:
         values:
           - key: "alarm.value"
             enabledValues:
-              - off
+              - 'off'
               - both
           - key: "{{enumCommands}}"
             enabledValues:
-              - off
+              - 'off'
               - both
     categories:
       - name: Siren
@@ -42,11 +42,11 @@ components:
         values:
           - key: "alarm.value"
             enabledValues:
-              - off
+              - 'off'
               - both
           - key: "{{enumCommands}}"
             enabledValues:
-              - off
+              - 'off'
               - both
     categories:
       - name: Siren
@@ -58,11 +58,11 @@ components:
         values:
           - key: "alarm.value"
             enabledValues:
-              - off
+              - 'off'
               - both
           - key: "{{enumCommands}}"
             enabledValues:
-              - off
+              - 'off'
               - both
     categories:
       - name: Siren

--- a/drivers/SmartThings/zwave-siren/profiles/everspring-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/everspring-siren.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: tamperAlert
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/multifunctional-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/multifunctional-siren.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: battery
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/philio-sound-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/philio-sound-siren.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: chime
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/yale-siren-tamper.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/yale-siren-tamper.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: tamperAlert
     version: 1

--- a/drivers/SmartThings/zwave-siren/profiles/yale-siren.yml
+++ b/drivers/SmartThings/zwave-siren/profiles/yale-siren.yml
@@ -8,11 +8,11 @@ components:
       values:
         - key: "alarm.value"
           enabledValues:
-            - off
+            - 'off'
             - both
         - key: "{{enumCommands}}"
           enabledValues:
-            - off
+            - 'off'
             - both
   - id: battery
     version: 1


### PR DESCRIPTION
In yaml, the word 'off' can be treated as a keyword that is equivalent to boolean false. This causes an issue where the enabled value of 'off' is incorrectly translated to false.

This is specific to YAML 1.1, as described here:
https://yaml.org/type/bool.html