### PR TITLE
Fix migration discovery issue

### DIFF
--- a/drivers/SmartThings/bose/src/disco.lua
+++ b/drivers/SmartThings/bose/src/disco.lua
@@ -73,11 +73,14 @@ function Disco.find(deviceid, callback)
                    deviceid, rip, ip))
         log.debug(rip, "!=", ip)
       elseif ip and id then
-        callback({id = id, ip = ip, raw = val})
-
         if deviceid then
           -- check if the speaker we just found was the one we were looking for
-          if deviceid == id then break end
+          if deviceid == id then
+            callback({id = id, ip = ip, raw = val})
+            break
+          end
+        else
+          callback({id = id, ip = ip, raw = val})
         end
       end
     elseif rip == "timeout" then

--- a/drivers/SmartThings/bose/src/handlers.lua
+++ b/drivers/SmartThings/bose/src/handlers.lua
@@ -14,6 +14,7 @@
 local command = require "command"
 local log = require "log"
 local utils = require "st.utils"
+local bose_utils = require "utils"
 
 --- @module bose.CapabilityHandlers
 local CapabilityHandlers = {}
@@ -21,7 +22,7 @@ local CapabilityHandlers = {}
 function CapabilityHandlers.handle_on(driver, device, cmd)
   if device.state_cache.main.switch.switch.value == "off" then
     local ip = device:get_field("ip")
-    log.info(string.format("[%s](%s) BoseCmd: toggle on {%s}", device.device_network_id,
+    log.info(string.format("[%s](%s) BoseCmd: toggle on {%s}", bose_utils.get_serial_number(device),
                            device.label, ip))
     local err = command.toggle_power(ip)
     if err then log.error(string.format("failed to handle power toggle: %s", err)) end
@@ -31,7 +32,7 @@ end
 function CapabilityHandlers.handle_off(driver, device, cmd)
   if device.state_cache.main.switch.switch.value == "on" then
     local ip = device:get_field("ip")
-    log.info(string.format("[%s](%s) BoseCmd: toggle off {%s}", device.device_network_id,
+    log.info(string.format("[%s](%s) BoseCmd: toggle off {%s}", bose_utils.get_serial_number(device),
                            device.label, ip))
     local err = command.toggle_power(ip)
     if err then log.error(string.format("failed to handle power toggle: %s", err)) end
@@ -40,7 +41,7 @@ end
 
 function CapabilityHandlers.handle_play_preset(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: play preset %s", device.device_network_id, device.label,
+  log.info(string.format("[%s](%s) BoseCmd: play preset %s", bose_utils.get_serial_number(device), device.label,
                          cmd.args.presetId))
   local err = command.preset(ip, tonumber(cmd.args.presetId))
   if err then log.error(string.format("failed to handle preset%d: %s", tonumber(cmd.args.presetId), err)) end
@@ -48,7 +49,7 @@ end
 
 function CapabilityHandlers.handle_play(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: play {%s}", device.device_network_id, device.label, ip))
+  log.info(string.format("[%s](%s) BoseCmd: play {%s}", bose_utils.get_serial_number(device), device.label, ip))
   CapabilityHandlers.handle_on(driver, device, nil) --turn on if device is off
   local err = command.play(ip)
   if err then log.error(string.format("failed to handle play: %s", err)) end
@@ -56,14 +57,14 @@ end
 
 function CapabilityHandlers.handle_pause(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: pause {%s}", device.device_network_id, device.label, ip))
+  log.info(string.format("[%s](%s) BoseCmd: pause {%s}", bose_utils.get_serial_number(device), device.label, ip))
   local err = command.pause(ip)
   if err then log.error(string.format("failed to handle pause: %s", err)) end
 end
 
 function CapabilityHandlers.handle_stop(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: stop (pause) {%s}", device.device_network_id,
+  log.info(string.format("[%s](%s) BoseCmd: stop (pause) {%s}", bose_utils.get_serial_number(device),
                          device.label, ip))
   local err = command.pause(ip)
   if err then log.error(string.format("failed to handle stop: %s", err)) end
@@ -71,7 +72,7 @@ end
 
 function CapabilityHandlers.handle_next_track(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: next track {%s}", device.device_network_id,
+  log.info(string.format("[%s](%s) BoseCmd: next track {%s}", bose_utils.get_serial_number(device),
                          device.label, ip))
   local err = command.next(ip)
   if err then log.error(string.format("failed to handle next track: %s", err)) end
@@ -79,7 +80,7 @@ end
 
 function CapabilityHandlers.handle_previous_track(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: previous track {%s}", device.device_network_id,
+  log.info(string.format("[%s](%s) BoseCmd: previous track {%s}", bose_utils.get_serial_number(device),
                          device.label, ip))
   local err = command.previous(ip)
   if err then log.error(string.format("failed to handle previous track: %s", err)) end
@@ -87,7 +88,7 @@ end
 
 function CapabilityHandlers.handle_mute(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: mute {%s}", device.device_network_id, device.label, ip))
+  log.info(string.format("[%s](%s) BoseCmd: mute {%s}", bose_utils.get_serial_number(device), device.label, ip))
   local err = command.mute(ip)
   if err then log.error(string.format("failed to handle mute: %s", err)) end
 end
@@ -95,14 +96,14 @@ end
 function CapabilityHandlers.handle_unmute(driver, device, cmd)
   local ip = device:get_field("ip")
   log.info(
-    string.format("[%s](%s) BoseCmd: unmute {%s}", device.device_network_id, device.label, ip))
+    string.format("[%s](%s) BoseCmd: unmute {%s}", bose_utils.get_serial_number(device), device.label, ip))
   local err = command.mute(ip)
   if err then log.error(string.format("failed to handle unmute: %s", err)) end
 end
 
 function CapabilityHandlers.handle_set_mute(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: set mute {%s}", device.device_network_id, device.label,
+  log.info(string.format("[%s](%s) BoseCmd: set mute {%s}", bose_utils.get_serial_number(device), device.label,
                          ip))
   local err = command.mute(ip)
   if err then log.error(string.format("failed to handle set mute: %s", err)) end
@@ -112,7 +113,7 @@ function CapabilityHandlers.handle_volume_up(driver, device, cmd)
   local ip = device:get_field("ip")
   local vol, _ = command.volume(ip)
   if vol then
-    log.info(string.format("[%s](%s) BoseCmd: volume up +5 {%s}", device.device_network_id,
+    log.info(string.format("[%s](%s) BoseCmd: volume up +5 {%s}", bose_utils.get_serial_number(device),
                            device.label, ip))
     local err = command.set_volume(ip, vol.actual + 5)
     if err then log.error(string.format("failed to handle volume up: %s", err)) end
@@ -123,7 +124,7 @@ function CapabilityHandlers.handle_volume_down(driver, device, cmd)
   local ip = device:get_field("ip")
   local vol, _ = command.volume(ip)
   if vol then
-    log.info(string.format("[%s](%s) BoseCmd: volume down -5 {%s}", device.device_network_id,
+    log.info(string.format("[%s](%s) BoseCmd: volume down -5 {%s}", bose_utils.get_serial_number(device),
                            device.label, ip))
     local err = command.set_volume(ip, vol.actual - 5)
     if err then log.error(string.format("failed to handle volume down: %s", err)) end
@@ -132,7 +133,7 @@ end
 
 function CapabilityHandlers.handle_set_volume(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: volume set to %d", device.device_network_id,
+  log.info(string.format("[%s](%s) BoseCmd: volume set to %d", bose_utils.get_serial_number(device),
                          device.label, cmd.args.volume))
   local err = command.set_volume(ip, cmd.args.volume)
   if err then log.error(string.format("failed to handle set volume: %s", err)) end
@@ -140,7 +141,7 @@ end
 
 function CapabilityHandlers.handle_audio_notification(driver, device, cmd)
   local ip = device:get_field("ip")
-  log.info(string.format("[%s](%s) BoseCmd: audio notification with uri %s at level %d", device.device_network_id,
+  log.info(string.format("[%s](%s) BoseCmd: audio notification with uri %s at level %d", bose_utils.get_serial_number(device),
                          device.label, cmd.args.uri, cmd.args.level))
   local err = command.play_streaming_uri(ip, cmd.args.uri, cmd.args.level)
   if err then log.error(string.format("failed to handle set volume: %s", err)) end

--- a/drivers/SmartThings/bose/src/init.lua
+++ b/drivers/SmartThings/bose/src/init.lua
@@ -28,6 +28,7 @@ local Driver = require "st.driver"
 local log = require "log"
 local json = require "dkjson"
 local utils = require "st.utils"
+local bose_utils = require "utils"
 local command = require "command"
 local socket = require "cosock.socket"
 
@@ -42,7 +43,7 @@ local function discovery_handler(driver, _, should_continue)
 
   local device_list = driver:get_devices()
   for _, device in ipairs(device_list) do
-    local id = device.device_network_id
+    local id = bose_utils.get_serial_number(device)
     known_devices[id] = true
   end
 
@@ -180,9 +181,10 @@ end
 
 local function device_init(driver, device)
   local backoff = backoff_builder(60, 1, 0.1)
+  local serial_number = bose_utils.get_serial_number(device)
   local dev_info
   while true do -- todo should we limit this? I think this will just spin forever if the device goes down
-    discovery.find(device.device_network_id, function(found) dev_info = found end)
+    discovery.find(serial_number, function(found) dev_info = found end)
     if dev_info then break end
     socket.sleep(backoff())
   end

--- a/drivers/SmartThings/bose/src/utils.lua
+++ b/drivers/SmartThings/bose/src/utils.lua
@@ -1,0 +1,30 @@
+
+--  Copyright 2021 SmartThings
+--
+--  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+--  except in compliance with the License. You may obtain a copy of the License at:
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+--  Unless required by applicable law or agreed to in writing, software distributed under the
+--  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+--  either express or implied. See the License for the specific language governing permissions
+--  and limitations under the License.
+
+local utils = {}
+
+--- This gets the serial number for the device which is how we identify unique speakers on the LAN
+--- Devices that were migrated from DTHs will have the value stored in device.data.
+---
+--- @param device table
+--- @return string the serial number of the device
+utils.get_serial_number = function(device)
+  local res = device:get_field("serial_number")
+  if res == nil then
+    res = device.data and device.data.deviceID or device.device_network_id
+    device:set_field("serial_number", res)
+  end
+  return res
+end
+
+return utils


### PR DESCRIPTION
When devices are migrated, we must pull the serial number from the device data rather than the device_network_id (which is what devices joined via the driver use) because the DTH backed devices use MAC addresses for the dni, which are not available to edge driver devices.

This also fixes a bug with discovery on device init where when multiple devices are discovered at the same time, the last discovered device IP is used for all the websocket connections. This situation happens exclusively during migration