### PR TITLE
Update file-changes-action version to 1.2.4

### DIFF
--- a/.github/workflows/duplicate-profiles.yml
+++ b/.github/workflows/duplicate-profiles.yml
@@ -16,7 +16,7 @@ jobs:
       # Creates file "$/files.csv", among others
       - id: file_changes
         name: Gather file changes
-        uses: trilom/file-changes-action@1.2.3
+        uses: trilom/file-changes-action@1.2.4
         with:
           output: ','
           fileOutput: ','


### PR DESCRIPTION
Update to version to 1.2.4 to avoid bug when dealing with files that are renamed in a PR.