### PR TITLE
Fix multi-component issues in duplicate profile check

### DIFF
--- a/.github/workflows/duplicate-profiles.yml
+++ b/.github/workflows/duplicate-profiles.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           cat $HOME/files.csv
 
-      - name: Test python script
+      - name: Run python script
         run: |
           python ./.github/scripts/check_duplicates.py
 


### PR DESCRIPTION
Fix logic in duplicate profile checking script to account for profiles with multiple components. Previously, the script would indicate a duplicate if just one of the components in a profile matches another profile.

Also, refactored some of the logic for readability and brevity