### PR TITLE
Modified Search Target in M-SEARCH Discovery

### DIFF
--- a/drivers/SmartThings/wemo/src/discovery.lua
+++ b/drivers/SmartThings/wemo/src/discovery.lua
@@ -80,7 +80,7 @@ local function find(deviceid, callback)
       'HOST: 239.255.255.250:1900',
       'MAN: "ssdp:discover"', -- yes, there are really supposed to be quotes in this one
       'MX: 2',
-      'ST: ' .. (deviceid or 'urn:Belkin:device:*'),
+      'ST: urn:Belkin:device:*',
       '\r\n'
     },
     "\r\n"


### PR DESCRIPTION
https://smartthings.atlassian.net/browse/CHAD-9941 => Fix for the ST (Search Target) field to handle edge migration (DTH -> LUA)