### PR TITLE
Bugfix/matter lock max codes calculation

### DIFF
--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -30,13 +30,17 @@ local lock_utils = require "lock_utils"
 local YALE_LOCK_FINGERPRINT = {{vendorId = 0x101D, productId = 0x1}}
 
 local function set_cota_credential(device)
-  -- Device requires pin for remote operation if it supports COTA and PIN features.
-  local eps = device:get_endpoints(DoorLock.ID, {feature_bitmap = DoorLock.types.DoorLockFeature.CREDENTIALSOTA | DoorLock.types.DoorLockFeature.PIN_CREDENTIALS})
-  if #eps == 0 then
-    device.log.debug("Device should not require PIN for remote operation, so not setting COTA credential")
+  local eps = device:get_endpoints(DoorLock.ID)
+  local cota_cred = device:get_field(lock_utils.COTA_CRED)
+  if cota_cred == nil then
+    -- Shouldn't happen but defensive to try to figure out if we need the cota cred and set it.
+    device:send(DoorLock.attributes.RequirePINforRemoteOperation:read(device, #eps > 0 and eps[1] or 1))
+    device.thread:call_with_delay(2, function(t) set_cota_credential(device) end)
+  elseif not cota_cred then
+    -- Defensive, but shouldn't happen
+    device.log.debug("Device should not require PIN for remote operation. Not setting COTA credential")
     return
   end
-  local endpoint = eps[1]
 
   -- If we are scanning codes, we should wait to set the cota credential until scanning completes
   -- to help avoid replacing an existing code, and ensure we have queried the max codes on the device.
@@ -49,10 +53,6 @@ local function set_cota_credential(device)
     return
   end
 
-  local len = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodeLength.NAME) or 4
-  local cred_data = math.floor(math.random() * (10 ^ len))
-  cred_data = string.format("%0" .. tostring(len) .. "d", cred_data)
-  device:set_field(lock_utils.COTA_CRED, cred_data, {persist = true})
   --try to use last code slot in hopes that it wont overwrite existing codes on the device
   local credential_index = device:get_field(lock_utils.TOTAL_PIN_USERS) or
     device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME) or 1
@@ -63,7 +63,7 @@ local function set_cota_credential(device)
     --Note we dont set lock_utils.DELETEING_CODE field to avoid re-setting cota credential this time
     device:send(DoorLock.server.commands.ClearCredential(
       device,
-      endpoint,
+      #eps > 0 and eps[1] or 1,
       credential
     ))
   end)
@@ -72,7 +72,9 @@ local function set_cota_credential(device)
   device.thread:call_with_delay(2, function(t)
     device:set_field(lock_utils.SET_CREDENTIAL, credential_index)
     device:send(DoorLock.server.commands.SetCredential(
-      device, endpoint, DoorLock.types.DlDataOperationType.ADD,
+      device,
+      #eps > 0 and eps[1] or 1,
+      DoorLock.types.DlDataOperationType.ADD,
       credential,
       device:get_field(lock_utils.COTA_CRED),
       nil, -- nil user_index creates a new user
@@ -115,6 +117,23 @@ end
 local function num_pin_users_handler(driver, device, ib, response)
   device:set_field(lock_utils.TOTAL_PIN_USERS, ib.data.value)
   device:emit_event(capabilities.lockCodes.maxCodes(ib.data.value, {visibility = {displayed = false}}))
+end
+
+local function require_remote_pin_handler(driver, device, ib, response)
+  if ib.data.value then
+    --Process after all other info blocks have been dispatched to ensure MaxPINCodeLength has been processed
+    device.thread:call_with_delay(0, function(t)
+      local len = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodeLength.NAME) or 4
+      local cred_data = math.floor(math.random() * (10 ^ len))
+      cred_data = string.format("%0" .. tostring(len) .. "d", cred_data)
+      device:set_field(lock_utils.COTA_CRED, cred_data, {persist = true})
+      device.thread:call_with_delay(0, function(t)
+        set_cota_credential(device)
+      end)
+    end)
+  else
+    device:set_field(lock_utils.COTA_CRED, false, {persist = true})
+  end
 end
 
 local function clear_credential_response_handler(driver, device, ib, response)
@@ -305,7 +324,7 @@ local function lock_user_change_event_handler(driver, device, ib, response)
         lock_utils.code_deleted(device, cs)
       end
       lock_utils.lock_codes_event(device, {})
-      set_cota_credential(device)
+      if device:get_field(lock_utils.COTA_CRED) ~= nil then set_cota_credential(device) end
     else
       device.log.info("Not handling LockUserChange event")
     end
@@ -361,21 +380,6 @@ local function handle_delete_code(driver, device, command)
 end
 
 local function handle_reload_all_codes(driver, device, command)
-  local endpoint_id = device:component_to_endpoint(command.component)
-  -- starts at first user code index then iterates through all lock codes as they come in
-  local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
-  if (device:get_latest_state(
-    "main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodeLength.NAME
-  ) == nil) then req:merge(clusters.DoorLock.attributes.MaxPINCodeLength:read(device, endpoint_id)) end
-  if (device:get_latest_state(
-    "main", capabilities.lockCodes.ID, capabilities.lockCodes.minCodeLength.NAME
-  ) == nil) then req:merge(clusters.DoorLock.attributes.MinPINCodeLength:read(device, endpoint_id)) end
-  if (device:get_latest_state(
-    "main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME
-  ) == nil) then
-    req:merge(clusters.DoorLock.attributes.NumberOfPINUsersSupported:read(device, endpoint_id))
-  end
-  device:send(req)
   if (device:get_field(lock_utils.CHECKING_CODE) == nil) then
     device:set_field(lock_utils.CHECKING_CODE, 1)
   end
@@ -383,7 +387,7 @@ local function handle_reload_all_codes(driver, device, command)
   device:set_field(lock_utils.CHECKING_CREDENTIAL, device:get_field(lock_utils.CHECKING_CODE))
   device:send(
     clusters.DoorLock.server.commands.GetCredentialStatus(
-      device, endpoint_id,
+      device, device:component_to_endpoint(command.component),
       {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = device:get_field(lock_utils.CHECKING_CODE)}
     )
   )
@@ -459,16 +463,25 @@ local function do_configure(driver, device)
     device.log.debug("Device does not support lockCodes")
     device:try_update_metadata({profile = "lock-without-codes"})
   else
+    local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
+    req:merge(DoorLock.attributes.MaxPINCodeLength:read(device, eps[1]))
+    req:merge(DoorLock.attributes.MinPINCodeLength:read(device, eps[1]))
+    req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(device, eps[1]))
     driver:inject_capability_command(device, {
       capability = capabilities.lockCodes.ID,
       command = capabilities.lockCodes.commands.reloadAllCodes.NAME,
       args = {}
     })
 
-    -- TODO delay setting device to provisioned until a COTA cred has been set on the device if we need to set it.
-    device.thread:call_with_delay(0, function(t)
-      set_cota_credential(device)
-    end)
+    --Device may require pin for remote operation if it supports COTA and PIN features.
+    eps = device:get_endpoints(DoorLock.ID, {feature_bitmap = DoorLock.types.DoorLockFeature.CREDENTIALSOTA | DoorLock.types.DoorLockFeature.PIN_CREDENTIALS})
+    if #eps == 0 then
+      device.log.debug("Device will not require PIN for remote operation")
+      device:set_field(lock_utils.COTA_CRED, false, {persist = true})
+    else
+      req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(device, eps[1]))
+    end
+    device:send(req)
   end
 end
 
@@ -480,6 +493,7 @@ local matter_lock_driver = {
         [DoorLock.attributes.MaxPINCodeLength.ID] = max_pin_code_len_handler,
         [DoorLock.attributes.MinPINCodeLength.ID] = min_pin_code_len_handler,
         [DoorLock.attributes.NumberOfPINUsersSupported.ID] = num_pin_users_handler,
+        [DoorLock.attributes.RequirePINforRemoteOperation.ID] = require_remote_pin_handler,
       },
       [PowerSource.ID] = {
         [PowerSource.attributes.BatPercentRemaining.ID] = handle_battery_percent_remaining,

--- a/drivers/SmartThings/matter-lock/src/lock_utils.lua
+++ b/drivers/SmartThings/matter-lock/src/lock_utils.lua
@@ -20,7 +20,6 @@ local lock_utils = {
   CODE_STATE = "codeState",
   DELETING_CODE = "deletingCode",
   CREDENTIALS_PER_USER = "credsPerUser",
-  TOTAL_USERS = "totalUsers",
   TOTAL_PIN_USERS = "totalPinUsers",
   SET_CREDENTIAL = "setCredential",
   COTA_CRED = "cotaCred",

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
@@ -255,32 +255,15 @@ test.register_message_test(
   }
 )
 
-
-test.register_message_test(
-  "Device added clears tamper alert.", {
-    {
-      channel = "device_lifecycle",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        "added",
-      },
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear()),
-    },
-  }
-)
-
 test.register_coroutine_test(
-  "Profile change on doConfigure lifecycle event due to cluster feature map",
+  "Added lifecycle event lock without codes",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
 
     mock_device:expect_metadata_update({ profile = "lock-without-codes" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+    )
 end
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -92,10 +92,6 @@ test.set_test_init_function(test_init)
 
 local expect_reload_all_codes_messages = function(dev)
   local credential = types.DlCredential({credential_type = types.DlCredentialType.PIN, credential_index = 1})
-  local req = DoorLock.attributes.MaxPINCodeLength:read(dev, 1)
-  req:merge(DoorLock.attributes.MinPINCodeLength:read(dev, 1))
-  req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(dev, 1))
-  test.socket.matter:__expect_send({dev.id, req})
   test.socket.capability:__expect_send(
     dev:generate_test_message(
       "main", capabilities.lockCodes.scanCodes("Scanning")
@@ -104,13 +100,6 @@ local expect_reload_all_codes_messages = function(dev)
   test.socket.matter:__expect_send(
     {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 1, credential)}
   )
-  test.wait_for_events()
-
-  test.socket.capability:__expect_send(dev:generate_test_message("main", capabilities.lockCodes.maxCodes(16, {visibility = {displayed = false}})))
-  test.socket.matter:__queue_receive({
-    dev.id,
-    DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(dev, 1, 16),
-  })
   test.wait_for_events()
 
   local next_credential_index = 2
@@ -252,23 +241,55 @@ test.register_coroutine_test(
     test.socket.matter:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    local req = DoorLock.attributes.MaxPINCodeLength:read(mock_device, 1)
+    req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_device, 1))
+    req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device, 1))
+    test.socket.matter:__expect_send({mock_device.id, req})
     expect_reload_all_codes_messages(mock_device)
   end
 )
 
 test.register_coroutine_test(
   "Configure should set cota cred for device that supports the feature", function()
-    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
-    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
-    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
-
     test.socket.matter:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle:__queue_receive({ mock_cota_device.id, "doConfigure" })
     mock_cota_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    local req = DoorLock.attributes.MaxPINCodeLength:read(mock_cota_device, 1)
+    req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_cota_device, 1))
+    req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_cota_device, 1))
+    req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(mock_cota_device, 1))
+    test.socket.matter:__expect_send({mock_cota_device.id, req})
     expect_reload_all_codes_messages(mock_cota_device)
     test.wait_for_events()
 
-    test.mock_time.advance_time(1)
+    test.socket.capability:__expect_send(mock_cota_device:generate_test_message("main", capabilities.lockCodes.maxCodes(16, {visibility = {displayed = false}})))
+    test.socket.matter:__queue_receive({
+      mock_cota_device.id,
+      DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(mock_cota_device, 1, 16),
+    })
+
+    -- The creation of advance timers, advancing time, and waiting for events
+    -- is done to ensure a correct order of operations and allow for all the
+    -- `call_with_delay(0, ...)` calls to execute at the correct time.
+    test.wait_for_events()
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+
+    test.socket.matter:__queue_receive(
+      {
+        mock_cota_device.id,
+        DoorLock.attributes.RequirePINforRemoteOperation:build_test_report_data(
+          mock_cota_device, 1, true
+        ),
+      }
+    )
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.mock_time.advance_time(1) --trigger remote pin handling
+    test.wait_for_events()
+    mock_cota_device:set_field("cotaCred", "12345678", {persist = true}) --overwrite random cred for test expectation
+    test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
+    test.timer.__create_and_queue_test_time_advance_timer(5, "oneshot")
+    test.mock_time.advance_time(1) --trigger set cota cred function delay,
+    test.wait_for_events()
     test.socket.matter:__expect_send({
       mock_cota_device.id,
       DoorLock.server.commands.ClearCredential(
@@ -277,10 +298,10 @@ test.register_coroutine_test(
         {credential_type = types.DlCredentialType.PIN, credential_index = 16} --max codes
       )
     })
-    test.wait_for_events()
     test.mock_time.advance_time(2)
+    test.wait_for_events()
 
-    mock_cota_device:set_field("cotaCred", "12345678") --overwrite random cred for test expectation
+
     test.socket.matter:__expect_send(
       {
         mock_cota_device.id,
@@ -297,6 +318,7 @@ test.register_coroutine_test(
         ),
       }
     )
+    test.mock_time.advance_time(2)
   end,
   {test_init = test_init_cota}
 )

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -237,10 +237,12 @@ local function init_code_slot(slot_number, name, device)
 end
 
 test.register_coroutine_test(
-  "Configure should configure all necessary attributes and begin reading codes", function()
+  "Added should configure all necessary attributes and begin reading codes", function()
     test.socket.matter:__set_channel_ordering("relaxed")
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+    )
     local req = DoorLock.attributes.MaxPINCodeLength:read(mock_device, 1)
     req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_device, 1))
     req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device, 1))
@@ -252,8 +254,10 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Configure should set cota cred for device that supports the feature", function()
     test.socket.matter:__set_channel_ordering("relaxed")
-    test.socket.device_lifecycle:__queue_receive({ mock_cota_device.id, "doConfigure" })
-    mock_cota_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.device_lifecycle:__queue_receive({ mock_cota_device.id, "added" })
+    test.socket.capability:__expect_send(
+      mock_cota_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+    )
     local req = DoorLock.attributes.MaxPINCodeLength:read(mock_cota_device, 1)
     req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_cota_device, 1))
     req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_cota_device, 1))


### PR DESCRIPTION
Previously calculating the max credential index available for pin codes
we used the formula `NumberOfPINUsersSupported *
NumberOfCredentialsSupportedPerUser`, but this calculation was misguided
and results in an index out of range for some devices. The max credential
index available on a lock is actually bounded by
`NumberOfPINUsersSupported`. This is not super clear in the spec, but
has been confirmed by some of the lock companies, and other CSA members.

This change also checks the RequirePINForRemoteOperation attribute when determining if a COTA credential is needed.

An improvement that will be done in a follow up PR is to select the COTA credential index based on the scanned credentials rather than always picking the highest credential slot.