### PR TITLE
Add supported_capabilities field to matter driver templates

### DIFF
--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -548,6 +548,11 @@ local matter_lock_driver = {
     },
   },
   lifecycle_handlers = {init = device_init, added = device_added, doConfigure = do_configure},
+  supported_capabilities = {
+    capabilities.lock,
+    capabilities.lockCodes,
+    capabilities.tamperAlert,
+  },
 }
 
 -----------------------------------------------------------------------------------------------------------------------------

--- a/drivers/SmartThings/matter-media/src/init.lua
+++ b/drivers/SmartThings/matter-media/src/init.lua
@@ -255,6 +255,14 @@ local matter_driver_template = {
       [capabilities.keypadInput.commands.sendKey.NAME] = handle_send_key
     }
   },
+  supported_capabilities = {
+    capabilities.audioMute,
+    capabilities.audioVolume,
+    capabilities.switch,
+    capabilities.mediaPlayback,
+    capabilities.mediaTrackControl,
+    capabilities.keypadInput,
+  },
 }
 
 local matter_driver = MatterDriver("matter-media", matter_driver_template)

--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -107,7 +107,15 @@ local matter_driver_template = {
     }
   },
   capability_handlers = {
-  }
+  },
+  supported_capabilities = {
+    capabilities.temperatureMeasurement,
+    capabilities.contactSensor,
+    capabilities.motionSensor,
+    capabilities.battery,
+    capabilities.relativeHumidityMeasurement,
+    capabilities.illuminanceMeasurement,
+  },
 }
 
 local matter_driver = MatterDriver("matter-sensor", matter_driver_template)

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -283,6 +283,12 @@ local matter_driver_template = {
       [capabilities.colorTemperature.commands.setColorTemperature.NAME] = handle_set_color_temperature,
     },
   },
+  supported_capabilities = {
+    capabilities.switch,
+    capabilities.switchLevel,
+    capabilities.colorControl,
+    capabilities.colorTemperature,
+  },
 }
 
 local matter_driver = MatterDriver("matter-switch", matter_driver_template)

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -412,6 +412,14 @@ local matter_driver_template = {
       [capabilities.thermostatHeatingSetpoint.commands.setHeatingSetpoint.NAME] = set_setpoint(clusters.Thermostat.attributes.OccupiedHeatingSetpoint)
     }
   },
+  supported_capabilities = {
+    capabilities.thermostatMode,
+    capabilities.thermostatHeatingSetpoint,
+    capabilities.thermostatCoolingSetpoint,
+    capabilities.thermostatFanMode,
+    capabilities.thermostatOperatingState,
+    capabilities.battery,
+  },
 }
 
 local matter_driver = MatterDriver("matter-thermostat", matter_driver_template)

--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -183,6 +183,12 @@ local matter_driver_template = {
       [capabilities.windowShadeLevel.commands.setShadeLevel.NAME] = handle_shade_level,
     },
   },
+  supported_capabilities = {
+    capabilities.windowShadeLevel,
+    capabilities.windowShade,
+    capabilities.windowshadePreset,
+    capabilities.battery,
+  },
 }
 
 local matter_driver = MatterDriver("matter-window-covering", matter_driver_template)


### PR DESCRIPTION
This is needed for devices to have the correct provisioning state set with the default driver switch handler when devices switch drivers.