### PR TITLE
Add initial value event for colorTemp in zigbee bulbs

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/init.lua
@@ -124,6 +124,10 @@ local function set_color_temperature_handler(driver, device, cmd)
   end)
 end
 
+local function device_added(driver, device)
+  device:send(ColorControl.attributes.ColorTemperatureMireds:read(device))
+end
+
 local rgbw_bulb = {
   NAME = "RGBW Bulb",
   capability_handlers = {
@@ -135,7 +139,8 @@ local rgbw_bulb = {
     }
   },
   lifecycle_handlers = {
-    doConfigure = do_configure
+    doConfigure = do_configure,
+    added = device_added,
   },
   can_handle = can_handle_rgbw_bulb
 }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
@@ -256,4 +256,15 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "added lifecycle event",
+  function()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
+
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+    test.wait_for_events()
+  end
+)
+
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
@@ -153,4 +153,15 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "added lifecycle event",
+  function()
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
+
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+    test.wait_for_events()
+  end
+)
+
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/init.lua
@@ -122,12 +122,19 @@ local function set_color_temperature_handler(driver, device, cmd)
   end)
 end
 
+local function device_added(driver, device)
+  device:send(ColorControl.attributes.ColorTemperatureMireds:read(device))
+end
+
 local white_color_temp_bulb = {
   NAME = "White Color Temp Bulb",
   capability_handlers = {
     [capabilities.colorTemperature.ID] = {
       [capabilities.colorTemperature.commands.setColorTemperature.NAME] = set_color_temperature_handler
     }
+  },
+  lifecycle_handlers = {
+    added = device_added
   },
   can_handle = can_handle_white_color_temp_bulb
 }


### PR DESCRIPTION
OneApp can have issues when an initial value is not reported for an attribute. Add an initial value for colorTemperature to prevent this issue.