### PR TITLE
Matter lock cota edge cases

### DIFF
--- a/drivers/SmartThings/matter-lock/profiles/nonfunctional-lock.yml
+++ b/drivers/SmartThings/matter-lock/profiles/nonfunctional-lock.yml
@@ -1,0 +1,14 @@
+name: nonfunctional-lock
+components:
+- id: main
+  capabilities:
+  - id: lockCodes
+    version: 1
+  - id: tamperAlert
+    version: 1
+  - id: battery
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -14,74 +14,62 @@
 
 local MatterDriver = require "st.matter.driver"
 local interaction_model = require "st.matter.interaction_model"
-local Status = interaction_model.InteractionResponse.Status
 local clusters = require "st.matter.clusters"
 
 local DoorLock = clusters.DoorLock
 local PowerSource = clusters.PowerSource
 
 local capabilities = require "st.capabilities"
-local log = require "log"
-local json = require "st.json"
 local im = require "st.matter.interaction_model"
-local utils = require "st.utils"
 local lock_utils = require "lock_utils"
 
-local YALE_LOCK_FINGERPRINT = {{vendorId = 0x101D, productId = 0x1}}
+local INITIAL_COTA_INDEX = 1
 
---- If a device needs a cota credential this function attempts to clear the credential
---- at the max credential index and then set the device's COTA credential 2 seconds later.
---- It will delay doing so until we are no longer scanning credentials.
-local function set_cota_credential(device)
+--- If a device needs a cota credential this function attempts to set the credential
+--- at the index provided. The set_credential_response_handler handles all failures
+--- and retries with the appropriate index when necessary.
+local function set_cota_credential(device, credential_index)
   local eps = device:get_endpoints(DoorLock.ID)
   local cota_cred = device:get_field(lock_utils.COTA_CRED)
   if cota_cred == nil then
     -- Shouldn't happen but defensive to try to figure out if we need the cota cred and set it.
     device:send(DoorLock.attributes.RequirePINforRemoteOperation:read(device, #eps > 0 and eps[1] or 1))
-    device.thread:call_with_delay(2, function(t) set_cota_credential(device) end)
+    device.thread:call_with_delay(2, function(t) set_cota_credential(device, credential_index) end)
   elseif not cota_cred then
     device.log.debug("Device does not require PIN for remote operation. Not setting COTA credential")
     return
   end
 
-  if device:get_latest_state(
-    "main", capabilities.lockCodes.ID, capabilities.lockCodes.scanCodes.NAME
-  ) == "Scanning" then
+  if device:get_field(lock_utils.SET_CREDENTIAL) ~= nil then
+    device.log.debug("delaying setting COTA credential since a credential is currently being set")
     device.thread:call_with_delay(2, function(t)
-      set_cota_credential(device)
+      set_cota_credential(device, credential_index)
     end)
     return
   end
 
-  --try to use last code slot in hopes that it wont overwrite existing codes on the device
-  local credential_index = device:get_field(lock_utils.TOTAL_PIN_USERS) or
-    device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME) or 1
+  device:set_field(lock_utils.COTA_CRED_INDEX, credential_index, {persist = true})
   local credential = {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = credential_index}
-
-  -- Clear the credential to make sure that we have an open slot for the cota credential
-  device.thread:call_with_delay(0, function(t)
-    --Note we dont set lock_utils.DELETEING_CODE field to avoid re-setting cota credential this time
-    device:send(DoorLock.server.commands.ClearCredential(
-      device,
-      #eps > 0 and eps[1] or 1,
-      credential
-    ))
-  end)
-
   -- Set the credential to a code
-  device.thread:call_with_delay(2, function(t)
-    device:set_field(lock_utils.SET_CREDENTIAL, credential_index)
-    device:send(DoorLock.server.commands.SetCredential(
-      device,
-      #eps > 0 and eps[1] or 1,
-      DoorLock.types.DlDataOperationType.ADD,
-      credential,
-      device:get_field(lock_utils.COTA_CRED),
-      nil, -- nil user_index creates a new user
-      DoorLock.types.DlUserStatus.OCCUPIED_ENABLED,
-      DoorLock.types.DlUserType.REMOTE_ONLY_USER
-    ))
-  end)
+  device:set_field(lock_utils.SET_CREDENTIAL, credential_index)
+  device.log.info(string.format("Attempting to set COTA credential at index %s", credential_index))
+  device:send(DoorLock.server.commands.SetCredential(
+    device,
+    #eps > 0 and eps[1] or 1,
+    DoorLock.types.DlDataOperationType.ADD,
+    credential,
+    device:get_field(lock_utils.COTA_CRED),
+    nil, -- nil user_index creates a new user
+    DoorLock.types.DlUserStatus.OCCUPIED_ENABLED,
+    DoorLock.types.DlUserType.REMOTE_ONLY_USER
+  ))
+end
+
+local function generate_cota_cred_for_device(device)
+  local len = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodeLength.NAME) or 4
+  local cred_data = math.floor(math.random() * (10 ^ len))
+  cred_data = string.format("%0" .. tostring(len) .. "d", cred_data)
+  device:set_field(lock_utils.COTA_CRED, cred_data, {persist = true})
 end
 
 local function lock_state_handler(driver, device, ib, response)
@@ -123,12 +111,11 @@ local function require_remote_pin_handler(driver, device, ib, response)
   if ib.data.value then
     --Process after all other info blocks have been dispatched to ensure MaxPINCodeLength has been processed
     device.thread:call_with_delay(0, function(t)
-      local len = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodeLength.NAME) or 4
-      local cred_data = math.floor(math.random() * (10 ^ len))
-      cred_data = string.format("%0" .. tostring(len) .. "d", cred_data)
-      device:set_field(lock_utils.COTA_CRED, cred_data, {persist = true})
+      generate_cota_cred_for_device(device)
+      -- delay needed to allow test to override the random credential data
       device.thread:call_with_delay(0, function(t)
-        set_cota_credential(device)
+        -- Attempt to set cota credential at the lowest index
+        set_cota_credential(device, INITIAL_COTA_INDEX)
       end)
     end)
   else
@@ -142,11 +129,12 @@ local function clear_credential_response_handler(driver, device, ib, response)
     device.log.debug("Cleared space in lock credential db for COTA credential")
     return
   end
-  local max_codes = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME)
   if ib.status == im.InteractionResponse.Status.SUCCESS then
     lock_utils.lock_codes_event(device, lock_utils.code_deleted(device, tostring(deleted_code_slot)))
-    if deleted_code_slot == max_codes then --make sure cota credential exists if the user deletes it
-      set_cota_credential(device)
+    --make sure cota credential exists if the user deletes it or if space was created for the COTA cred
+    if deleted_code_slot == device:get_field(lock_utils.COTA_CRED_INDEX) or
+      device:get_field(lock_utils.NONFUNCTIONAL) then
+      set_cota_credential(device, device:get_field(lock_utils.COTA_CRED_INDEX) or INITIAL_COTA_INDEX)
     end
   else
     device.log.error(string.format("Failed to delete code slot %s", deleted_code_slot))
@@ -167,17 +155,18 @@ local function set_credential_response_handler(driver, device, ib, response)
     return
   end
   local code_slot = tostring(credential_index)
-  local status = elements.status
-  if status.value == DoorLock.types.DlStatus.SUCCESS then
+  local status = elements.status.value
+  if status == DoorLock.types.DlStatus.SUCCESS then
     local event = capabilities.lockCodes.codeChanged("", {state_change = true})
-    local max_codes = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME)
-    local code_name = (credential_index == max_codes and lock_utils.COTA_CODE_NAME) or lock_utils.get_code_name(device, code_slot)
+    local cota_cred_index = device:get_field(lock_utils.COTA_CRED_INDEX)
+    local code_name = (credential_index == cota_cred_index and lock_utils.COTA_CODE_NAME) or
+      lock_utils.get_code_name(device, code_slot)
     event.data = {codeName = code_name}
     event.value = lock_utils.get_change_type(device, tostring(code_slot))
     local lock_codes = lock_utils.get_lock_codes(device)
     lock_codes[code_slot] = event.data.codeName
     device:emit_event(event)
-    if credential_index == max_codes then
+    if credential_index == cota_cred_index then
       device:emit_event(
         capabilities.lockCodes.codeChanged(
           code_slot .. " renamed", {state_change = true}
@@ -186,10 +175,39 @@ local function set_credential_response_handler(driver, device, ib, response)
     end
     lock_utils.lock_codes_event(device, lock_codes)
     lock_utils.reset_code_state(device, code_slot)
+    if device:get_field(lock_utils.NONFUNCTIONAL) and cota_cred_index == credential_index then
+      device.log.info("Successfully set COTA credential after being non-functional")
+      device:set_field(lock_utils.NONFUNCTIONAL, false, {persist = true})
+      device:try_update_metadata({profile = "base-lock", provisioning_state = "PROVISIONED"})
+    end
+  elseif device:get_field(lock_utils.COTA_CRED) and credential_index == device:get_field(lock_utils.COTA_CRED_INDEX) then
+    -- Handle failure to set a COTA credential
+    if status == DoorLock.types.DlStatus.OCCUPIED and elements.next_credential_index.value ~= nil then
+      --This credential index is unavailable, but there is another available
+      set_cota_credential(device, elements.next_credential_index.value)
+    elseif status == DoorLock.types.DlStatus.OCCUPIED and
+        elements.next_credential_index.value == nil and
+        credential_index == INITIAL_COTA_INDEX then
+      --There are no credential indices available on the device
+      device.log.error("Device requires COTA credential, but has no credential indexes available!")
+      device.log.error("Lock and Unlock commands will no longer work!!")
+      device:try_update_metadata({profile = "nonfunctional-lock", provisioning_state = "NONFUNCTIONAL"})
+      device:set_field(lock_utils.NONFUNCTIONAL, true, {persist = true})
+    elseif status == DoorLock.types.DlStatus.OCCUPIED and elements.next_credential_index.value == nil then
+      --There are no credential indices available, but we must ensure we search all indices.
+      set_cota_credential(device, INITIAL_COTA_INDEX)
+    elseif status == DoorLock.types.DlStatus.DUPLICATE then
+      --The credential we randomly generated already exists
+      generate_cota_cred_for_device(device)
+      --delay 0 needed for unit test verification of random value
+      device.thread:call_with_delay(0, function(t) set_cota_credential(device, credential_index) end)
+    elseif status == DoorLock.types.DlStatus.INVALID_FIELD then
+      device.log.error("Invalid SetCredential command sent to set a COTA credential. This is a bug.")
+    end
   else
     device.log.error(
       string.format(
-        "Failed to set code for device, SetCredential status received: %s", status
+        "Failed to set user code for device, SetCredential status received: %s", elements.status
       )
     )
   end
@@ -211,8 +229,8 @@ local function get_credential_status_response_handler(driver, device, ib, respon
 
   local event = capabilities.lockCodes.codeChanged("", {state_change = true})
   local code_slot = tostring(cred_index)
-  local max_codes = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME)
-  local code_name = (cred_index == max_codes and lock_utils.COTA_CODE_NAME) or lock_utils.get_code_name(device, code_slot)
+  local cota_cred_index = device:get_field(lock_utils.COTA_CRED_INDEX)
+  local code_name = (cred_index == cota_cred_index and lock_utils.COTA_CODE_NAME) or lock_utils.get_code_name(device, code_slot)
   event.data = {codeName = code_name}
   if credential_exists then
     -- Code slot is occupied
@@ -227,7 +245,7 @@ local function get_credential_status_response_handler(driver, device, ib, respon
     if (lock_utils.get_lock_codes(device)[code_slot] ~= nil) then
       -- Code has been deleted
       lock_utils.lock_codes_event(device, lock_utils.code_deleted(device, code_slot))
-      if cred_index == max_codes then --make sure cota credential exists if it was deleted
+      if cred_index == cota_cred_index then --make sure cota credential exists if it was deleted
         set_cota_credential(device)
       end
     else
@@ -238,28 +256,29 @@ local function get_credential_status_response_handler(driver, device, ib, respon
   end
   device:set_field(lock_utils.CHECKING_CREDENTIAL, nil)
 
-  if (cred_index == device:get_field(lock_utils.CHECKING_CODE)) then
-    -- the code we're checking has arrived
-    if (next_credential_index == nil) then
-      device:emit_event(
-        capabilities.lockCodes.scanCodes(
-          "Complete", {visibility = {displayed = false}}
-        )
+  local is_scanning = device:get_latest_state(
+      "main", capabilities.lockCodes.ID, capabilities.lockCodes.scanCodes.NAME
+    ) == "Scanning"
+  if not is_scanning then
+    return
+  end
+  if (next_credential_index == nil) then
+    device:emit_event(
+      capabilities.lockCodes.scanCodes(
+        "Complete", {visibility = {displayed = false}}
       )
-      local lock_codes = lock_utils.get_lock_codes(device)
-      lock_utils.lock_codes_event(device, lock_codes)
-      device:set_field(lock_utils.CHECKING_CODE, nil)
-    elseif next_credential_index ~= nil then
-      device:set_field(lock_utils.CHECKING_CODE, next_credential_index)
-      device:set_field(lock_utils.CHECKING_CREDENTIAL, next_credential_index)
-      device:send(
-        DoorLock.server.commands.GetCredentialStatus(
-          device,
-          ib.info_block.endpoint_id,
-          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = device:get_field(lock_utils.CHECKING_CREDENTIAL)}
-        )
+    )
+    local lock_codes = lock_utils.get_lock_codes(device)
+    lock_utils.lock_codes_event(device, lock_codes)
+  elseif next_credential_index ~= nil then
+    device:set_field(lock_utils.CHECKING_CREDENTIAL, next_credential_index)
+    device:send(
+      DoorLock.server.commands.GetCredentialStatus(
+        device,
+        ib.info_block.endpoint_id,
+        {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = device:get_field(lock_utils.CHECKING_CREDENTIAL)}
       )
-    end
+    )
   end
 end
 
@@ -290,7 +309,7 @@ local function lock_user_change_event_handler(driver, device, ib, response)
   local operation_type = elements.data_operation_type.value
   local user_index = elements.user_index.value
   local data_index = elements.data_index and elements.data_index.value
-  local max_codes = device:get_latest_state("main", capabilities.lockCodes.ID, capabilities.lockCodes.maxCodes.NAME)
+  local cota_cred_index = device:get_field(lock_utils.COTA_CRED_INDEX)
 
   if data_type_changed == DoorLock.types.DlLockDataType.PIN then -- pin added or removed
     local code_slot = data_index and tostring(data_index) or nil
@@ -298,7 +317,7 @@ local function lock_user_change_event_handler(driver, device, ib, response)
       == DoorLock.types.DlDataOperationType.MODIFY) and code_slot ~= nil then
       local change_type = lock_utils.get_change_type(device, code_slot)
       event.value = change_type
-      local code_name = (data_index == max_codes and lock_utils.COTA_CODE_NAME) or lock_utils.get_code_name(device, code_slot)
+      local code_name = (data_index == cota_cred_index and lock_utils.COTA_CODE_NAME) or lock_utils.get_code_name(device, code_slot)
       event.data = {codeName = code_name}
       device:emit_event(event)
       if string.match(change_type, "%d+ set") ~= nil then
@@ -308,8 +327,9 @@ local function lock_user_change_event_handler(driver, device, ib, response)
       end
     elseif operation_type == DoorLock.types.DlDataOperationType.CLEAR and code_slot ~= nil then
       lock_utils.lock_codes_event(device, lock_utils.code_deleted(device, tostring(code_slot)))
-      if data_index == max_codes then --make sure cota credential exists if something deletes it
-        set_cota_credential(device)
+      --make sure cota credential is created if the user deletes it or a space is made for it
+      if data_index == cota_cred_index or device:get_field(lock_utils.NONFUNCTIONAL) then
+        set_cota_credential(device, cota_cred_index or INITIAL_COTA_INDEX)
       end
     else -- invalid event because no credential index
       device.log.error(
@@ -328,9 +348,8 @@ local function lock_user_change_event_handler(driver, device, ib, response)
     else
       device.log.info("Not handling LockUserChange event")
     end
-    -- TODO Handle single user deletion. Do we need to bookkeep all the credential indexes
-    -- associated with a single user so we can delete their ST code slot, or will PIN
-    -- events be generated for the deleted credentials?
+    -- Note when a Lock User is deleted, the credentials associated with that user are also deleted.
+    -- Change events are created for each credential as well as the user.
   else
     device.log.info(
       string.format(
@@ -380,15 +399,18 @@ local function handle_delete_code(driver, device, command)
 end
 
 local function handle_reload_all_codes(driver, device, command)
-  if (device:get_field(lock_utils.CHECKING_CODE) == nil) then
-    device:set_field(lock_utils.CHECKING_CODE, 1)
+  if (device:get_field(lock_utils.CHECKING_CREDENTIAL) == nil) then
+    device:set_field(lock_utils.CHECKING_CREDENTIAL, 1)
+  else
+    device.log.info(string.format("Delaying scanning since currently checking credential %d", device:get_field(lock_utils.CHECKING_CREDENTIAL)))
+    device.thread:call_with_delay(2, function(t) handle_reload_all_codes(driver, device, command) end)
+    return
   end
   device:emit_event(capabilities.lockCodes.scanCodes("Scanning"))
-  device:set_field(lock_utils.CHECKING_CREDENTIAL, device:get_field(lock_utils.CHECKING_CODE))
   device:send(
     clusters.DoorLock.server.commands.GetCredentialStatus(
       device, device:component_to_endpoint(command.component),
-      {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = device:get_field(lock_utils.CHECKING_CODE)}
+      {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = device:get_field(lock_utils.CHECKING_CREDENTIAL)}
     )
   )
 end

--- a/drivers/SmartThings/matter-lock/src/lock_utils.lua
+++ b/drivers/SmartThings/matter-lock/src/lock_utils.lua
@@ -16,14 +16,15 @@ local lock_utils = {
   -- Lock device field names
   LOCK_CODES = "lockCodes",
   CHECKING_CREDENTIAL = "checkingCredential",
-  CHECKING_CODE = "checkingUser",
   CODE_STATE = "codeState",
   DELETING_CODE = "deletingCode",
   CREDENTIALS_PER_USER = "credsPerUser",
   TOTAL_PIN_USERS = "totalPinUsers",
   SET_CREDENTIAL = "setCredential",
   COTA_CRED = "cotaCred",
-  COTA_CODE_NAME = "ST Remote Operation Code"
+  COTA_CODE_NAME = "ST Remote Operation Code",
+  COTA_CRED_INDEX = "cotaCredIndex",
+  NONFUNCTIONAL = "nonFunctional"
 }
 local capabilities = require "st.capabilities"
 local json = require "st.json"

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -53,33 +53,6 @@ local mock_device_record = {
 }
 local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
 
-local mock_cota_device_record = {
-  profile = t_utils.get_profile_definition("base-lock.yml"),
-  manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
-  endpoints = {
-    {
-      endpoint_id = 1,
-      clusters = {
-        {
-          cluster_id = DoorLock.ID,
-          cluster_type = "SERVER",
-          feature_map = 0x0181, -- PIN & USR & COTA
-        },
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
-      },
-    },
-  },
-}
-local mock_cota_device = test.mock_device.build_test_matter_device(mock_cota_device_record)
-
-local function test_init_cota()
-  local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_cota_device)
-  subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_cota_device))
-  subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_cota_device))
-  test.socket["matter"]:__expect_send({mock_cota_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_cota_device)
-end
-
 local function test_init()
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
@@ -249,82 +222,6 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, req})
     expect_reload_all_codes_messages(mock_device)
   end
-)
-
-test.register_coroutine_test(
-  "Configure should set cota cred for device that supports the feature", function()
-    test.socket.matter:__set_channel_ordering("relaxed")
-    test.socket.device_lifecycle:__queue_receive({ mock_cota_device.id, "added" })
-    test.socket.capability:__expect_send(
-      mock_cota_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
-    )
-    local req = DoorLock.attributes.MaxPINCodeLength:read(mock_cota_device, 1)
-    req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_cota_device, 1))
-    req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_cota_device, 1))
-    req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(mock_cota_device, 1))
-    test.socket.matter:__expect_send({mock_cota_device.id, req})
-    expect_reload_all_codes_messages(mock_cota_device)
-    test.wait_for_events()
-
-    test.socket.capability:__expect_send(mock_cota_device:generate_test_message("main", capabilities.lockCodes.maxCodes(16, {visibility = {displayed = false}})))
-    test.socket.matter:__queue_receive({
-      mock_cota_device.id,
-      DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(mock_cota_device, 1, 16),
-    })
-
-    -- The creation of advance timers, advancing time, and waiting for events
-    -- is done to ensure a correct order of operations and allow for all the
-    -- `call_with_delay(0, ...)` calls to execute at the correct time.
-    test.wait_for_events()
-    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
-
-    test.socket.matter:__queue_receive(
-      {
-        mock_cota_device.id,
-        DoorLock.attributes.RequirePINforRemoteOperation:build_test_report_data(
-          mock_cota_device, 1, true
-        ),
-      }
-    )
-    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
-    test.mock_time.advance_time(1) --trigger remote pin handling
-    test.wait_for_events()
-    mock_cota_device:set_field("cotaCred", "12345678", {persist = true}) --overwrite random cred for test expectation
-    test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
-    test.timer.__create_and_queue_test_time_advance_timer(5, "oneshot")
-    test.mock_time.advance_time(1) --trigger set cota cred function delay,
-    test.wait_for_events()
-    test.socket.matter:__expect_send({
-      mock_cota_device.id,
-      DoorLock.server.commands.ClearCredential(
-        mock_cota_device,
-        1,
-        {credential_type = types.DlCredentialType.PIN, credential_index = 16} --max codes
-      )
-    })
-    test.mock_time.advance_time(2)
-    test.wait_for_events()
-
-
-    test.socket.matter:__expect_send(
-      {
-        mock_cota_device.id,
-        DoorLock.server.commands.SetCredential(
-          mock_cota_device, 1, -- endpoint
-          DoorLock.types.DlDataOperationType.ADD, -- operation_type
-          DoorLock.types.DlCredential(
-            {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 16}
-          ), -- credential
-          "12345678", -- credential_data
-          nil, -- user_index
-          DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
-          DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
-        ),
-      }
-    )
-    test.mock_time.advance_time(2)
-  end,
-  {test_init = test_init_cota}
 )
 
 local credential = DoorLock.types.DlCredential(

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -1,0 +1,575 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- Mock out globals
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local t_utils = require "integration_test.utils"
+local json = require "st.json"
+local clusters = require "st.matter.clusters"
+local DoorLock = clusters.DoorLock
+local types = DoorLock.types
+local data_types = require "st.matter.data_types"
+
+local mock_device_record = {
+  profile = t_utils.get_profile_definition("base-lock.yml"),
+  manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
+  endpoints = {
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = DoorLock.ID,
+          cluster_type = "SERVER",
+          feature_map = 0x0181, -- PIN & USR & COTA
+        },
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+      },
+    },
+  },
+}
+local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
+
+local function test_init()
+  local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
+  subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
+  subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device))
+  test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+end
+
+test.set_test_init_function(test_init)
+
+local expect_reload_all_codes_messages = function(dev)
+  local credential = types.DlCredential({credential_type = types.DlCredentialType.PIN, credential_index = 1})
+  test.socket.capability:__expect_send(
+    dev:generate_test_message(
+      "main", capabilities.lockCodes.scanCodes("Scanning")
+    )
+  )
+  test.socket.matter:__expect_send(
+    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 1, credential)}
+  )
+  test.wait_for_events()
+end
+
+local test_credential_data = "12345678"
+
+local function expect_kick_off_cota_process(device)
+  test.socket.device_lifecycle:__queue_receive({ device.id, "added" })
+  test.socket.capability:__expect_send(
+    device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+  )
+  local req = DoorLock.attributes.MaxPINCodeLength:read(device, 1)
+  req:merge(DoorLock.attributes.MinPINCodeLength:read(device, 1))
+  req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(device, 1))
+  req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(device, 1))
+  test.socket.matter:__expect_send({device.id, req})
+  expect_reload_all_codes_messages(device)
+  test.wait_for_events()
+
+  test.socket.capability:__expect_send(device:generate_test_message("main", capabilities.lockCodes.maxCodes(16, {visibility = {displayed = false}})))
+  test.socket.matter:__queue_receive({
+    device.id,
+    DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(device, 1, 16),
+  })
+
+  -- The creation of advance timers, advancing time, and waiting for events
+  -- is done to ensure a correct order of operations and allow for all the
+  -- `call_with_delay(0, ...)` calls to execute at the correct time.
+  test.wait_for_events()
+  test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+
+  test.socket.matter:__queue_receive(
+    {
+      device.id,
+      DoorLock.attributes.RequirePINforRemoteOperation:build_test_report_data(
+        device, 1, true
+      ),
+    }
+  )
+  test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+  test.mock_time.advance_time(1) --trigger remote pin handling
+  test.wait_for_events()
+  device:set_field("cotaCred", test_credential_data, {persist = true}) --overwrite random cred for test expectation
+  test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
+
+  test.socket.matter:__expect_send(
+    {
+      device.id,
+      DoorLock.server.commands.SetCredential(
+        device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      ),
+    }
+  )
+  test.mock_time.advance_time(1) --trigger set_cota_credential
+  test.wait_for_events()
+end
+
+test.register_coroutine_test(
+  "Added should kick off cota cred process", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for OCCUPIED credential index requests next_credential_index", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for OCCUPIED credential index no space on device", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = data_types.Null()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1,  -- user_index
+        nil -- next_redential_index
+      ),
+    })
+    mock_device:expect_metadata_update({
+      profile = "nonfunctional-lock",
+      provisioning_state = "NONFUNCTIONAL"
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "User creates space for COTA credential on a nonfunctional lock", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = data_types.Null()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1,  -- user_index
+        nil -- next_redential_index
+      ),
+    })
+    mock_device:expect_metadata_update({
+      profile = "nonfunctional-lock",
+      provisioning_state = "NONFUNCTIONAL"
+    })
+    test.wait_for_events()
+
+    test.socket.capability:__queue_receive(
+      {mock_device.id, {capability = capabilities.lockCodes.ID, command = "deleteCode", args = {1}}}
+    )
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.ClearCredential(
+        mock_device,
+        1,
+        {credential_type = types.DlCredentialType.PIN, credential_index = 1}
+      )
+    })
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        DoorLock.server.commands.ClearCredential:build_test_command_response(mock_device, 1),
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .codeChanged("1 deleted", {data = {codeName = "Code 1"}, state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+          capabilities.lockCodes.lockCodes(json.encode({}), {visibility = {displayed = false}})
+      )
+    )
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.SUCCESS,
+        1,  -- user_index
+        nil -- next_redential_index
+      ),
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes.codeChanged(
+          1 .. " set", {data = {codeName = "ST Remote Operation Code"}, state_change = true}
+        )
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes.codeChanged("1 renamed", {state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .lockCodes(json.encode({["1"] = "ST Remote Operation Code"}), {visibility = {displayed = false}})
+      )
+    )
+    mock_device:expect_metadata_update({
+      profile = "base-lock",
+      provisioning_state = "PROVISIONED"
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "External user creates space for COTA credential on a nonfunctional lock", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = data_types.Null()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1,  -- user_index
+        nil -- next_redential_index
+      ),
+    })
+    mock_device:expect_metadata_update({
+      profile = "nonfunctional-lock",
+      provisioning_state = "NONFUNCTIONAL"
+    })
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        DoorLock.server.events.LockUserChange:build_test_event_report(
+          mock_device, 1, -- endpoint
+          {
+            lock_data_type = types.DlLockDataType.PIN,
+            data_operation_type = types.DlDataOperationType.CLEAR,
+            operation_source = types.DlOperationSource.KEYPAD,
+            user_index = 0x1,
+            data_index = 0x1, -- corresponds to credential_index
+          }
+        ),
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .codeChanged("1 deleted", {data = {codeName = "Code 1"}, state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+          capabilities.lockCodes.lockCodes(json.encode({}), {visibility = {displayed = false}})
+      )
+    )
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.SUCCESS,
+        1,  -- user_index
+        nil -- next_redential_index
+      ),
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes.codeChanged(
+          1 .. " set", {data = {codeName = "ST Remote Operation Code"}, state_change = true}
+        )
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes.codeChanged("1 renamed", {state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .lockCodes(json.encode({["1"] = "ST Remote Operation Code"}), {visibility = {displayed = false}})
+      )
+    )
+    mock_device:expect_metadata_update({
+      profile = "base-lock",
+      provisioning_state = "PROVISIONED"
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for OCCUPIED credential index no space, but need full search", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1,  --user_index
+        nil --next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for DUPLICATE credential index generates new credential and retries", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+    test.timer.__create_and_queue_test_time_advance_timer(4, "oneshot")
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.DUPLICATE,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.wait_for_events()
+    local new_credential_data = "87654321"
+    mock_device:set_field("cotaCred", new_credential_data, {persist = true})
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        new_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+    test.mock_time.advance_time(2)
+  end
+)
+
+
+test.register_coroutine_test(
+  "Deleted COTA cred is recreated", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 1,
+        DoorLock.types.DlStatus.SUCCESS,
+        1, --user_index
+        4
+      ),
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .codeChanged("1 set", {data = {codeName = "ST Remote Operation Code"}, state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes.codeChanged("1 renamed", {state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .lockCodes(json.encode({["1"] = "ST Remote Operation Code"}), {visibility = {displayed = false}})
+      )
+    )
+    test.wait_for_events()
+
+    test.socket.capability:__queue_receive(
+      {mock_device.id, {capability = capabilities.lockCodes.ID, command = "deleteCode", args = {1}}}
+    )
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.ClearCredential(
+        mock_device,
+        1,
+        {credential_type = types.DlCredentialType.PIN, credential_index = 1}
+      )
+    })
+    test.wait_for_events()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.server.commands.ClearCredential:build_test_command_response(mock_device, 1),
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.lockCodes
+          .codeChanged("1 deleted", {data = {codeName = "ST Remote Operation Code"}, state_change = true})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+          capabilities.lockCodes.lockCodes(json.encode({}), {visibility = {displayed = false}})
+      )
+    )
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 1, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+  end
+)
+
+
+test.run_registered_tests()


### PR DESCRIPTION
When a lock is added to the driver, and we receive a RequirePINforRemoteOperation report set to true, we kick off the process of setting a COTA credential. First we SetCredential at index 1, if it fails because that slot is occupied we retry with the next available index which is reported in the SetCredentialResponse. Edge cases that are detected:
* The generated credential is a duplicate of a PIN that already exists
* We cannot set a credential because there is no space left on the device
* The user deletes the COTA credential

Work to be done:
- [x] Unit tests for set COTA credential cases
- [x] Add profile switching for situation where the COTA cred cannot be set
- [x] ~~Attempt to clear the COTA credential on device remove event.~~ Sending interactions from the removed handler does not work because the device is already being removed from the fabric by the time the driver gets the removed event. The impact of this is that eventually, after removing and re-adding the lock many times to our platform, we will no longer be able to set a COTA credential. This is an unlikely scenario, and the user would be able to clear the lock codes with our app if it is joined.
