### PR TITLE
fix: Addresses several issues with the Hue driver discovered in beta testing

### DIFF
--- a/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
@@ -8,6 +8,10 @@ components:
     version: 1
   - id: colorTemperature
     version: 1
+    config:
+      values:
+        - key: "colorTemperature.value"
+          range: [ 2200, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
@@ -10,6 +10,10 @@ components:
     version: 1
   - id: colorTemperature
     version: 1
+    config:
+      values:
+        - key: "colorTemperature.value"
+          range: [ 2000, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorControl
     version: 1
   - id: colorTemperature

--- a/drivers/SmartThings/philips-hue/profiles/white.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -33,12 +33,17 @@ function HueDiscovery.discover(driver, _, should_continue)
 
   while should_continue() do
     local known_dni_to_device_map = {}
+    local computed_mac_addresses = {}
     for _, device in ipairs(driver:get_devices()) do
       local dni = device.device_network_id
       known_dni_to_device_map[dni] = device
+      local ipv4 = device:get_field(Fields.IPV4);
+      if ipv4 then
+        computed_mac_addresses[ipv4] = device.device_network_id
+      end
     end
 
-    HueDiscovery.search_for_bridges(driver, function(hue_driver, bridge_ip, bridge_id)
+    HueDiscovery.search_for_bridges(driver, computed_mac_addresses, function(hue_driver, bridge_ip, bridge_id)
       discovered_bridge_callback(hue_driver, bridge_ip, bridge_id, known_dni_to_device_map)
     end)
 
@@ -51,8 +56,9 @@ end
 
 ---comment
 ---@param driver HueDriver
+---@param computed_mac_addresses table<string,string>
 ---@param callback fun(driver: HueDriver, ip: string, id: string)
-function HueDiscovery.search_for_bridges(driver, callback)
+function HueDiscovery.search_for_bridges(driver, computed_mac_addresses, callback)
   local mdns_responses, err = mdns.discover(SERVICE_TYPE, DOMAIN)
 
   if err ~= nil then
@@ -79,12 +85,28 @@ function HueDiscovery.search_for_bridges(driver, callback)
       goto continue
     end
 
-    -- the Hue Bridge hostname is the Bridge ID, which is stable.
-    local bridge_id = string.upper(info.host_info.name:sub(1, -(#("." .. DOMAIN) + 1)));
     local ip_addr = info.host_info.address;
 
+    if not computed_mac_addresses[ip_addr] then
+      -- Hue *typically* formats the BridgeID as the uppercase MAC address, minus separators.
+      -- However, it can be user overriden, set by a user, and may not be unique, so we want
+      -- to stick to that format but make sure it's actually the mac address. Instead of pulling
+      -- the bridge id out of the bridge info, we'll extract the MAC address and apply the above mentioned
+      -- formatting rules. We also prefer the MAC because it makes for a good Device Network ID.
+      local bridge_info, rest_err, _ = HueApi.get_bridge_info(ip_addr)
+      if rest_err ~= nil or not bridge_info then
+        log.error("Error querying bridge info: ", rest_err)
+        goto continue
+      end
+
+      -- '-' and ':' or '::' are the accepted separators used for MAC address segments, so
+      -- we strip thoes out and make the string uppercase
+      local bridge_id = bridge_info.mac:gsub("-", ""):gsub(":", ""):upper()
+      computed_mac_addresses[ip_addr] = bridge_id
+    end
+
     if type(callback) == "function" then
-      callback(driver, ip_addr, bridge_id)
+      callback(driver, ip_addr, computed_mac_addresses[ip_addr])
     else
       log.warn(
         "Argument passed in `callback` position for "

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -60,6 +60,22 @@ local function do_switch_level_action(driver, device, args)
     return
   end
 
+  local is_off = device:get_latest_state(
+    "main", capabilities.switch.ID, capabilities.switch.switch.NAME) == "off"
+
+  if is_off then
+    local resp, err = hue_api:set_light_on_state(light_id, true)
+    if not resp or (resp.errors and #resp.errors == 0) then
+      if err ~= nil then
+        log.error("Error performing switch level action: " .. err)
+      elseif resp and #resp.errors > 0 then
+        for _, error in ipairs(resp.errors) do
+          log.error("Error returned in Hue response: " .. error.description)
+        end
+      end
+    end
+  end
+
   local min_dim = (device:get_field(Fields.MIN_DIMMING) or 2.0)
   local resp, err = hue_api:set_light_level(light_id, level, min_dim)
 

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -4,7 +4,7 @@ local HueApi = require "hue.api"
 local log = require "log"
 
 local capabilities = require "st.capabilities"
-local utils = require "st.utils"
+local st_utils = require "st.utils"
 
 local handlers = {}
 
@@ -44,7 +44,7 @@ end
 ---@param driver HueDriver
 ---@param device HueDevice
 local function do_switch_level_action(driver, device, args)
-  local level = args.args.level
+  local level = st_utils.clamp_value(args.args.level, 1, 100)
   local bridge_device = driver:get_device_info(device:get_field(Fields.PARENT_DEVICE_ID))
 
   if not bridge_device then
@@ -67,7 +67,7 @@ local function do_switch_level_action(driver, device, args)
     local resp, err = hue_api:set_light_on_state(light_id, true)
     if not resp or (resp.errors and #resp.errors == 0) then
       if err ~= nil then
-        log.error("Error performing switch level action: " .. err)
+        log.error("Error performing on/off action: " .. err)
       elseif resp and #resp.errors > 0 then
         for _, error in ipairs(resp.errors) do
           log.error("Error returned in Hue response: " .. error.description)
@@ -76,9 +76,7 @@ local function do_switch_level_action(driver, device, args)
     end
   end
 
-  local min_dim = (device:get_field(Fields.MIN_DIMMING) or 2.0)
-  local resp, err = hue_api:set_light_level(light_id, level, min_dim)
-
+  local resp, err = hue_api:set_light_level(light_id, level)
   if not resp or (resp.errors and #resp.errors == 0) then
     if err ~= nil then
       log.error("Error performing switch level action: " .. err)
@@ -109,7 +107,7 @@ local function do_color_action(driver, device, args)
     return
   end
 
-  local x, y, _ = utils.safe_hsv_to_xy(hue, sat)
+  local x, y, _ = st_utils.safe_hsv_to_xy(hue, sat)
 
   x = x / 65536 -- safe_hsv_to_xy uses values from 0x0000 to 0xFFFF, Hue wants [0, 1]
   y = y / 65536 -- safe_hsv_to_xy uses values from 0x0000 to 0xFFFF, Hue wants [0, 1]
@@ -150,7 +148,7 @@ local function do_color_temp_action(driver, device, args)
     return
   end
 
-  local clamped_kelvin = utils.clamp_value(
+  local clamped_kelvin = st_utils.clamp_value(
     kelvin, HueApi.MIN_TEMP_KELVIN, HueApi.MAX_TEMP_KELVIN
   )
   local mirek = math.floor(handlers.kelvin_to_mirek(clamped_kelvin))

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -183,10 +183,9 @@ function PhilipsHueApi:set_light_on_state(id, on)
   return do_put(self, url, payload)
 end
 
-function PhilipsHueApi:set_light_level(id, level, min_dim)
+function PhilipsHueApi:set_light_level(id, level)
   if type(level) == "number" then
     local url = string.format("/clip/v2/resource/light/%s", id)
-    level = math.floor(st_utils.clamp_value(level, min_dim, 100))
     local payload_table = { dimming = { brightness = level } }
 
     return do_put(self, url, json.encode(payload_table))

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -1,15 +1,44 @@
+local cosock = require "cosock"
+local channel = require "cosock.channel"
+
 local json = require "st.json"
+local log = require "log"
 local RestClient = require "lunchbox.rest"
-local utils = require "st.utils"
+local st_utils = require "st.utils"
 
 local APPLICATION_KEY_HEADER = "hue-application-key"
+
+local ControlMessageTypes = {
+  Shutdown = "shutdown",
+  Get = "get",
+  Put = "put",
+  Update = "update",
+}
+
+local ControlMessageBuilders = {
+  Shutdown = function() return { _type = ControlMessageTypes.Shutdown } end,
+  Get = function(path, reply_tx) return { _type = ControlMessageTypes.Get, path = path, reply_tx = reply_tx } end,
+  Put = function(path, payload, reply_tx)
+    return { _type = ControlMessageTypes.Put, path = path, payload = payload, reply_tx = reply_tx }
+  end,
+  Update = function(base_url, api_key)
+    return { _type = ControlMessageTypes.Update, base_url = base_url, api_key = api_key, }
+  end
+}
 
 --- Phillips Hue REST API Module
 --- @class PhilipsHueApi
 --- @field private client RestClient
 --- @field private headers table<string,string>
+--- @field private _ctrl_tx table
 local PhilipsHueApi = {}
 PhilipsHueApi.__index = PhilipsHueApi
+PhilipsHueApi.__gc = function(self)
+  if self._running then
+    self._ctrl_tx:send(ControlMessageBuilders.Shutdown())
+    self._running = false
+  end
+end
 
 PhilipsHueApi.MIN_CLIP_V2_SWVERSION = 1948086000
 PhilipsHueApi.MIN_TEMP_KELVIN = 2000
@@ -22,20 +51,6 @@ local function retry_fn(retry_attempts)
     count = count + 1
     return count < retry_attempts
   end
-end
-
-function PhilipsHueApi.new_bridge_manager(base_url, api_key, socket_builder)
-  return setmetatable(
-    {
-      headers = { [APPLICATION_KEY_HEADER] = api_key or "" },
-      client = RestClient.new(base_url, socket_builder),
-    }, PhilipsHueApi
-  )
-end
-
-function PhilipsHueApi:update_connection(hub_base_url, api_key)
-  self.client:update_base_url(hub_base_url)
-  self.headers[APPLICATION_KEY_HEADER] = api_key
 end
 
 local function process_rest_response(response, err, partial)
@@ -52,12 +67,77 @@ local function process_rest_response(response, err, partial)
   end
 end
 
-local function do_get(api_instance, path)
-  return process_rest_response(api_instance.client:get(path, api_instance.headers, retry_fn(5)))
+function PhilipsHueApi.new_bridge_manager(base_url, api_key, socket_builder)
+  local control_tx, control_rx = channel.new()
+  local self = setmetatable(
+    {
+      headers = { [APPLICATION_KEY_HEADER] = api_key or "" },
+      client = RestClient.new(base_url, socket_builder),
+      _ctrl_tx = control_tx,
+      _running = true
+    }, PhilipsHueApi
+  )
+
+  cosock.spawn(function()
+    while true do
+      local msg, err = control_rx:receive()
+      if err then
+        log.error("Error receiving on control channel for REST API thread", err)
+        goto continue
+      end
+
+      if msg and msg._type then
+        if msg._type == ControlMessageTypes.Shutdown then
+          log.trace("REST API Control Thread received shutdown message");
+          self._running = false
+          return
+        end
+
+        if msg._type == ControlMessageTypes.Update then
+          self.client:update_base_url(msg.base_url)
+          self.headers[APPLICATION_KEY_HEADER] = msg.api_key
+          goto continue
+        end
+
+        local path, reply_tx = msg.path, msg.reply_tx
+        if msg._type == ControlMessageTypes.Get then
+          reply_tx:send(
+            table.pack(process_rest_response(self.client:get(path, self.headers, retry_fn(5))))
+          )
+        elseif msg._type == ControlMessageTypes.Put then
+          local payload = msg.payload
+          reply_tx:send(
+            table.pack(process_rest_response(self.client:put(path, payload, self.headers, retry_fn(5))))
+          )
+        end
+      else
+        log.warn(st_utils.stringify_table(msg, "Unexpected Message on REST API Control Channel", false))
+      end
+
+      ::continue::
+    end
+  end, string.format("Hue API Thread for %s", base_url))
+
+  return self
 end
 
-local function do_put(api_instance, path, payload)
-  return process_rest_response(api_instance.client:put(path, payload, api_instance.headers, retry_fn(5)))
+function PhilipsHueApi:update_connection(hub_base_url, api_key)
+  local msg = ControlMessageBuilders.Update(hub_base_url, api_key)
+  self._ctrl_tx:send(msg)
+end
+
+local function do_get(instance, path)
+  local reply_tx, reply_rx = channel.new()
+  local msg = ControlMessageBuilders.Get(path, reply_tx);
+  instance._ctrl_tx:send(msg)
+  return table.unpack(reply_rx:receive())
+end
+
+local function do_put(instance, path, payload)
+  local reply_tx, reply_rx = channel.new()
+  local msg = ControlMessageBuilders.Put(path, payload, reply_tx);
+  instance._ctrl_tx:send(msg)
+  return table.unpack(reply_rx:receive())
 end
 
 ---@param bridge_ip string
@@ -72,10 +152,6 @@ function PhilipsHueApi.request_api_key(bridge_ip)
   local body = json.encode { devicetype = "smartthings_edge_driver#" .. bridge_ip, generateclientkey = true }
   return process_rest_response(RestClient.one_shot_post("https://" .. bridge_ip .. "/api", body, nil, nil))
 end
-
--- function PhilipsHueApi:get_configs()
---     return do_get(self, "/api/config")
--- end
 
 function PhilipsHueApi:get_lights() return do_get(self, "/clip/v2/resource/light") end
 
@@ -110,12 +186,13 @@ end
 function PhilipsHueApi:set_light_level(id, level, min_dim)
   if type(level) == "number" then
     local url = string.format("/clip/v2/resource/light/%s", id)
-    level = math.floor(utils.clamp_value(level, min_dim, 100))
+    level = math.floor(st_utils.clamp_value(level, min_dim, 100))
     local payload_table = { dimming = { brightness = level } }
 
     return do_put(self, url, json.encode(payload_table))
   else
-    return nil, string.format("Expected number for light level, received %s", utils.stringify_table(level, nil, false))
+    return nil,
+        string.format("Expected number for light level, received %s", st_utils.stringify_table(level, nil, false))
   end
 end
 
@@ -129,7 +206,7 @@ function PhilipsHueApi:set_light_color_xy(id, xy_table)
     return do_put(self, url, payload)
   else
     return nil,
-        string.format("invalid XY color table for set_light_color_xy: %s", utils.stringify_table(xy_table, nil, false))
+        string.format("invalid XY color table for set_light_color_xy: %s", st_utils.stringify_table(xy_table, nil, false))
   end
 end
 
@@ -141,7 +218,7 @@ function PhilipsHueApi:set_light_color_temp(id, mirek)
     return do_put(self, url, payload)
   else
     return nil,
-        string.format("Expected number for color temp mirek, received %s", utils.stringify_table(mirek, nil, false))
+        string.format("Expected number for color temp mirek, received %s", st_utils.stringify_table(mirek, nil, false))
   end
 end
 

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -69,7 +69,8 @@ local function emit_light_status_events(light_device, light)
     end
 
     if light.dimming then
-      light_device:emit_event(capabilities.switchLevel.level(math.floor(light.dimming.brightness)))
+      local adjusted_level = st_utils.clamp_value(light.dimming.brightness, 1, 100)
+      light_device:emit_event(capabilities.switchLevel.level(st_utils.round(adjusted_level)))
     end
 
     if light.color_temperature then


### PR DESCRIPTION
This PR addresses multiple reported issues from QA, internal testing, and beta testing.

- The first commit addresses coroutine safety on the REST API; If multiple capability commands arrived in quick enough succession, it could cause a crash because multiple callsites would be waiting for a response on the TCP socket at the same time, leading to `select`ing from multiple callsites which cosock will properly and defensively treat as an error condition. This is done by adopting what is basically an actor/handle pattern for the Hue API instances.
- The second commit fixes an issue where certain network topologies or user configurations can mask the bridge's MAC Address at discovery time when processing mDNS responses, so we now always query the bridge directly for this information.
- The third commit fixes a regression from the DTH where dimming commands sent to an "off" bulb would not turn the bulb back on
- The fourth commit adds ranges for color temperature to the profile
- The fifth commit adds ranges to the dimmer profiles and fixes the way switch levels are rounded/clamped to be in line with how the DTH rounded/clamped at the bottom end of the dimming range.

Bugs fixed:
- [x] [CHAD-10182] ]Make the Hue REST API Coroutine Safe
- [x] [CHAD-10160] mDNS discovery assumes that the hostname will always be the bridgeId; we should query the bridge for this instead
- [x] [CHAD-10104] Adjusting the dimmer on a bulb that is "off" does not turn the bulb on 
- [x] [CHAD-10100] Establish ranges on profiles for Color Temperature values 
- [x] [CHAD-10099] Make dimmer capability behave like it did with the DTH 