### PR TITLE
fix: Perform explicit MAC lookup at discovery

### DIFF
--- a/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
@@ -6,8 +6,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorTemperature
     version: 1
+    config:
+      values:
+        - key: "colorTemperature.value"
+          range: [ 2200, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
@@ -6,10 +6,18 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorControl
     version: 1
   - id: colorTemperature
     version: 1
+    config:
+      values:
+        - key: "colorTemperature.value"
+          range: [ 2000, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/profiles/white.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -33,12 +33,17 @@ function HueDiscovery.discover(driver, _, should_continue)
 
   while should_continue() do
     local known_dni_to_device_map = {}
+    local computed_mac_addresses = {}
     for _, device in ipairs(driver:get_devices()) do
       local dni = device.device_network_id
       known_dni_to_device_map[dni] = device
+      local ipv4 = device:get_field(Fields.IPV4);
+      if ipv4 then
+        computed_mac_addresses[ipv4] = device.device_network_id
+      end
     end
 
-    HueDiscovery.search_for_bridges(driver, function(hue_driver, bridge_ip, bridge_id)
+    HueDiscovery.search_for_bridges(driver, computed_mac_addresses, function(hue_driver, bridge_ip, bridge_id)
       discovered_bridge_callback(hue_driver, bridge_ip, bridge_id, known_dni_to_device_map)
     end)
 
@@ -51,8 +56,9 @@ end
 
 ---comment
 ---@param driver HueDriver
+---@param computed_mac_addresses table<string,string>
 ---@param callback fun(driver: HueDriver, ip: string, id: string)
-function HueDiscovery.search_for_bridges(driver, callback)
+function HueDiscovery.search_for_bridges(driver, computed_mac_addresses, callback)
   local mdns_responses, err = mdns.discover(SERVICE_TYPE, DOMAIN)
 
   if err ~= nil then
@@ -79,12 +85,28 @@ function HueDiscovery.search_for_bridges(driver, callback)
       goto continue
     end
 
-    -- the Hue Bridge hostname is the Bridge ID, which is stable.
-    local bridge_id = string.upper(info.host_info.name:sub(1, -(#("." .. DOMAIN) + 1)));
     local ip_addr = info.host_info.address;
 
+    if not computed_mac_addresses[ip_addr] then
+      -- Hue *typically* formats the BridgeID as the uppercase MAC address, minus separators.
+      -- However, it can be user overriden, set by a user, and may not be unique, so we want
+      -- to stick to that format but make sure it's actually the mac address. Instead of pulling
+      -- the bridge id out of the bridge info, we'll extract the MAC address and apply the above mentioned
+      -- formatting rules. We also prefer the MAC because it makes for a good Device Network ID.
+      local bridge_info, rest_err, _ = HueApi.get_bridge_info(ip_addr)
+      if rest_err ~= nil or not bridge_info then
+        log.error("Error querying bridge info: ", rest_err)
+        goto continue
+      end
+
+      -- '-' and ':' or '::' are the accepted separators used for MAC address segments, so
+      -- we strip thoes out and make the string uppercase
+      local bridge_id = bridge_info.mac:gsub("-", ""):gsub(":", ""):upper()
+      computed_mac_addresses[ip_addr] = bridge_id
+    end
+
     if type(callback) == "function" then
-      callback(driver, ip_addr, bridge_id)
+      callback(driver, ip_addr, computed_mac_addresses[ip_addr])
     else
       log.warn(
         "Argument passed in `callback` position for "

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -4,7 +4,7 @@ local HueApi = require "hue.api"
 local log = require "log"
 
 local capabilities = require "st.capabilities"
-local utils = require "st.utils"
+local st_utils = require "st.utils"
 
 local handlers = {}
 
@@ -44,7 +44,7 @@ end
 ---@param driver HueDriver
 ---@param device HueDevice
 local function do_switch_level_action(driver, device, args)
-  local level = args.args.level
+  local level = st_utils.clamp_value(args.args.level, 1, 100)
   local bridge_device = driver:get_device_info(device:get_field(Fields.PARENT_DEVICE_ID))
 
   if not bridge_device then
@@ -60,9 +60,23 @@ local function do_switch_level_action(driver, device, args)
     return
   end
 
-  local min_dim = (device:get_field(Fields.MIN_DIMMING) or 2.0)
-  local resp, err = hue_api:set_light_level(light_id, level, min_dim)
+  local is_off = device:get_latest_state(
+    "main", capabilities.switch.ID, capabilities.switch.switch.NAME) == "off"
 
+  if is_off then
+    local resp, err = hue_api:set_light_on_state(light_id, true)
+    if not resp or (resp.errors and #resp.errors == 0) then
+      if err ~= nil then
+        log.error("Error performing on/off action: " .. err)
+      elseif resp and #resp.errors > 0 then
+        for _, error in ipairs(resp.errors) do
+          log.error("Error returned in Hue response: " .. error.description)
+        end
+      end
+    end
+  end
+
+  local resp, err = hue_api:set_light_level(light_id, level)
   if not resp or (resp.errors and #resp.errors == 0) then
     if err ~= nil then
       log.error("Error performing switch level action: " .. err)
@@ -93,7 +107,7 @@ local function do_color_action(driver, device, args)
     return
   end
 
-  local x, y, _ = utils.safe_hsv_to_xy(hue, sat)
+  local x, y, _ = st_utils.safe_hsv_to_xy(hue, sat)
 
   x = x / 65536 -- safe_hsv_to_xy uses values from 0x0000 to 0xFFFF, Hue wants [0, 1]
   y = y / 65536 -- safe_hsv_to_xy uses values from 0x0000 to 0xFFFF, Hue wants [0, 1]
@@ -134,7 +148,7 @@ local function do_color_temp_action(driver, device, args)
     return
   end
 
-  local clamped_kelvin = utils.clamp_value(
+  local clamped_kelvin = st_utils.clamp_value(
     kelvin, HueApi.MIN_TEMP_KELVIN, HueApi.MAX_TEMP_KELVIN
   )
   local mirek = math.floor(handlers.kelvin_to_mirek(clamped_kelvin))

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -183,10 +183,9 @@ function PhilipsHueApi:set_light_on_state(id, on)
   return do_put(self, url, payload)
 end
 
-function PhilipsHueApi:set_light_level(id, level, min_dim)
+function PhilipsHueApi:set_light_level(id, level)
   if type(level) == "number" then
     local url = string.format("/clip/v2/resource/light/%s", id)
-    level = math.floor(st_utils.clamp_value(level, min_dim, 100))
     local payload_table = { dimming = { brightness = level } }
 
     return do_put(self, url, json.encode(payload_table))

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -69,7 +69,8 @@ local function emit_light_status_events(light_device, light)
     end
 
     if light.dimming then
-      light_device:emit_event(capabilities.switchLevel.level(math.floor(light.dimming.brightness)))
+      local adjusted_level = st_utils.clamp_value(light.dimming.brightness, 1, 100)
+      light_device:emit_event(capabilities.switchLevel.level(st_utils.round(adjusted_level)))
     end
 
     if light.color_temperature then


### PR DESCRIPTION
Some bridges won't use their MAC-based Bridge ID as the hostname when responding
to mDNS queries. We were relying on that functionality in our discovery loop so
we fix that by querying the bridge config info, which is an endpoint that does
not require auth and that has the MAC address as an explicitly reported field.

Fixes: CHAD-10160
