### PR TITLE
fix: Set bulbs on if off when handling switchLevel

### DIFF
--- a/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
@@ -6,8 +6,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorTemperature
     version: 1
+    config:
+      values:
+        - key: "colorTemperature.value"
+          range: [ 2200, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
@@ -6,10 +6,18 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorControl
     version: 1
   - id: colorTemperature
     version: 1
+    config:
+      values:
+        - key: "colorTemperature.value"
+          range: [ 2000, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/profiles/white.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -60,6 +60,22 @@ local function do_switch_level_action(driver, device, args)
     return
   end
 
+  local is_off = device:get_latest_state(
+    "main", capabilities.switch.ID, capabilities.switch.switch.NAME) == "off"
+
+  if is_off then
+    local resp, err = hue_api:set_light_on_state(light_id, true)
+    if not resp or (resp.errors and #resp.errors == 0) then
+      if err ~= nil then
+        log.error("Error performing on/off action: " .. err)
+      elseif resp and #resp.errors > 0 then
+        for _, error in ipairs(resp.errors) do
+          log.error("Error returned in Hue response: " .. error.description)
+        end
+      end
+    end
+  end
+
   local min_dim = (device:get_field(Fields.MIN_DIMMING) or 2.0)
   local resp, err = hue_api:set_light_level(light_id, level, min_dim)
 

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -183,10 +183,9 @@ function PhilipsHueApi:set_light_on_state(id, on)
   return do_put(self, url, payload)
 end
 
-function PhilipsHueApi:set_light_level(id, level, min_dim)
+function PhilipsHueApi:set_light_level(id, level)
   if type(level) == "number" then
     local url = string.format("/clip/v2/resource/light/%s", id)
-    level = math.floor(st_utils.clamp_value(level, min_dim, 100))
     local payload_table = { dimming = { brightness = level } }
 
     return do_put(self, url, json.encode(payload_table))

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -69,7 +69,8 @@ local function emit_light_status_events(light_device, light)
     end
 
     if light.dimming then
-      light_device:emit_event(capabilities.switchLevel.level(math.floor(light.dimming.brightness)))
+      local adjusted_level = st_utils.clamp_value(light.dimming.brightness, 1, 100)
+      light_device:emit_event(capabilities.switchLevel.level(st_utils.round(adjusted_level)))
     end
 
     if light.color_temperature then


### PR DESCRIPTION
The established behavior for a Hue bulb on our platform is to turn on if it's off
and it receives a dimming event. This fixes that regression.

Fixes: CHAD-10104
Depends-On: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/473