### PR TITLE
fix: Fix behavior of dimmer capability at the bottom of the range

### DIFF
--- a/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: colorControl
     version: 1
   - id: colorTemperature

--- a/drivers/SmartThings/philips-hue/profiles/white.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -183,10 +183,9 @@ function PhilipsHueApi:set_light_on_state(id, on)
   return do_put(self, url, payload)
 end
 
-function PhilipsHueApi:set_light_level(id, level, min_dim)
+function PhilipsHueApi:set_light_level(id, level)
   if type(level) == "number" then
     local url = string.format("/clip/v2/resource/light/%s", id)
-    level = math.floor(st_utils.clamp_value(level, min_dim, 100))
     local payload_table = { dimming = { brightness = level } }
 
     return do_put(self, url, json.encode(payload_table))

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -69,7 +69,8 @@ local function emit_light_status_events(light_device, light)
     end
 
     if light.dimming then
-      light_device:emit_event(capabilities.switchLevel.level(math.floor(light.dimming.brightness)))
+      local adjusted_level = st_utils.clamp_value(light.dimming.brightness, 1, 100)
+      light_device:emit_event(capabilities.switchLevel.level(st_utils.round(adjusted_level)))
     end
 
     if light.color_temperature then


### PR DESCRIPTION
Hue has per-product dimming values, and it would be nice to accomodate those. But
there are two problems. The first is that Hue allows for fractional values,
the second is that the min-dimming is often < 1. The DTH simply treated all hue
devices as having a minimum dimming value of 1. So we do that here to maintain
behavior parity with the DTH.

We also update the profiles to have ranges on switch level.

Fixes: Chad-10099
Depends-On: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/475