### PR TITLE
Fix multiple comments from duplicate profile script

### DIFF
--- a/.github/scripts/check_duplicates.py
+++ b/.github/scripts/check_duplicates.py
@@ -119,8 +119,8 @@ with open(str(Path.home()) + '/files.csv', 'r') as csvfile:
 
 with open("profile-comment-body.md", "w") as f:
     if duplicate_pairs:
-        f.write("Duplicate profile(s) detected:\n")
+        f.write("Duplicate profile check: Warning - duplicate profiles detected.\n")
         for duplicate in duplicate_pairs:
             f.write("%s == %s\n" % (duplicate[0], duplicate [1]))
     else:
-        f.write("No duplicate profiles detected.")
+        f.write("Duplicate profile check: Passed - no duplicate profiles detected.")

--- a/.github/workflows/duplicate-profiles.yml
+++ b/.github/workflows/duplicate-profiles.yml
@@ -34,7 +34,7 @@ jobs:
         uses: peter-evans/find-comment@v2
         id: fc
         with:
-          body-includes: Duplicate profile(s) detected
+          body-includes: Duplicate profile check
           comment-author: 'github-actions[bot]'
           issue-number: ${{ github.event.number }}
 


### PR DESCRIPTION
Fixes an issue where multiple "No duplicate profiles detected." messages would be posted on PR's. The script will now edit the same comment everytime it is run.