### PR TITLE
Feature/wemo improvements

### DIFF
--- a/drivers/SmartThings/wemo/src/discovery.lua
+++ b/drivers/SmartThings/wemo/src/discovery.lua
@@ -4,8 +4,46 @@ local http = cosock.asyncify "socket.http"
 local ltn12 = require "ltn12"
 local log = require "log"
 local tablefind = require "util".tablefind
+local utils = require "st.utils"
 local xml2lua = require "xml2lua"
 local xml_handler = require "xmlhandler.tree"
+
+local ControlMessageTypes = {
+  Scan = "scan",
+  FindDevice = "findDevice",
+}
+
+local ControlMessageBuilders = {
+  Scan = function(reply_tx) return { type = ControlMessageTypes.Scan, reply_tx = reply_tx } end,
+  FindDevice = function(device_id, reply_tx)
+    return { type = ControlMessageTypes.FindDevice, device_id = device_id, reply_tx = reply_tx }
+  end,
+}
+
+local Discovery = {}
+
+local function send_disco_request()
+  local listen_ip = "0.0.0.0"
+  local listen_port = 0
+  local multicast_ip = "239.255.255.250"
+  local multicast_port = 1900
+  local multicast_msg = table.concat(
+    {
+      'M-SEARCH * HTTP/1.1',
+      'HOST: 239.255.255.250:1900',
+      'MAN: "ssdp:discover"', -- yes, there are really supposed to be quotes in this one
+      'MX: 4',
+      'ST: urn:Belkin:device:*',
+      '\r\n'
+    },
+    "\r\n"
+  )
+  local sock = assert(socket.udp(), "create discovery socket")
+  assert(sock:setsockname(listen_ip, listen_port), "disco| socket setsockname")
+  local timeouttime = socket.gettime() + 5 -- 5 second timeout, `MX` + 1 for network delay
+  assert(sock:sendto(multicast_msg, multicast_ip, multicast_port))
+  return sock, timeouttime
+end
 
 local function process_response(val)
   local info = {}
@@ -26,18 +64,15 @@ local function fetch_device_metadata(url)
 
   local response = table.concat(responsechunks)
 
-  log.trace("metadata response status", body, status, headers)
-
-  -- vvvvvvvvvvvvvvvv TODO: errors are coming back as literal string "[string "socket"]:1239: closed"
+  -- errors are coming back as literal string "[string "socket"]:1239: closed"
   -- instead of just "closed", so do a `find` for the error
   if string.find(status, "closed") then
-    -- ^^^^^^^^^^^^^^^^
-    log.debug("socket closed unexpectedly, this is usually due to bug in wemo's server, try parsing anyway")
+    log.debug("disco| ignoring unexpected socket close during metadata fetch, try parsing anyway")
     -- this workaround is required because wemo doesn't send the required zero-length chunk
     -- at the end of it `Text-Encoding: Chunked` HTTP message, it just closes the socket,
     -- so ignore closed errors
   elseif status ~= 200 then
-    log.error("metadata request failed (" .. tostring(status) .. ")\n" .. response)
+    log.error("disco| metadata request failed (" .. tostring(status) .. ")\n" .. response)
     return nil, "request failed: " .. tostring(status)
   end
 
@@ -46,7 +81,7 @@ local function fetch_device_metadata(url)
   xml_parser:parse(response)
 
   if not handler.root then
-    log.error("unable to parse device metadata as xml")
+    log.error("disco| unable to parse device metadata as xml")
     return nil, "xml parse error"
   end
 
@@ -64,97 +99,148 @@ local function fetch_device_metadata(url)
   }
 end
 
-local function find(deviceid, callback)
-  log.info("making discovery request", deviceid)
+function Discovery.run_discovery_task()
+  local ctrl_tx, ctrl_rx = cosock.channel.new()
+  Discovery._ctrl_tx = ctrl_tx
 
-  local s = assert(socket.udp(), "create discovery socket")
-
-  local listen_ip = "0.0.0.0"
-  local listen_port = 0
-
-  local multicast_ip = "239.255.255.250"
-  local multicast_port = 1900
-  local multicast_msg = table.concat(
-    {
-      'M-SEARCH * HTTP/1.1',
-      'HOST: 239.255.255.250:1900',
-      'MAN: "ssdp:discover"', -- yes, there are really supposed to be quotes in this one
-      'MX: 2',
-      'ST: urn:Belkin:device:*',
-      '\r\n'
-    },
-    "\r\n"
-  )
-
-  log.trace("discovery request:\n" .. multicast_msg)
-
-  -- bind local ip and port
-  -- device will unicast back to this ip and port
-  assert(s:setsockname(listen_ip, listen_port), "discovery socket setsockname")
-  local timeouttime = socket.gettime() + 3 -- 3 second timeout, `MX` + 1 for network delay
-
-  local ids_found = {} -- used to filter duplicates
+  local sock
+  local search_ids = { }
+  local infos_found = {} -- used to filter duplicates
   local number_found = 0
-
-  assert(s:sendto(multicast_msg, multicast_ip, multicast_port))
-  while true do
-    local time_remaining = math.max(0, timeouttime - socket.gettime())
-    s:settimeout(time_remaining)
-    local val, rip, _ = s:receivefrom()
-    if val then
-      local headers = process_response(val)
-      local ip, port = headers["location"]:match("http://([^,/]+):([^/]+)")
-      -- local id = headers["usn"]  --instead of usn, we need to use mac as id (to handle migration scenario)
-      local meta = fetch_device_metadata(headers["location"])
-      --TODO need to verify ip and id are found
-      if not meta then --TODO this seems like an error
-        meta = {}
+  local timeout = 1 --give controllers 1 second initially to send multiple requests
+  local timeout_epoch
+  cosock.spawn(function()
+    while true do
+      local recv, _, err = socket.select({ctrl_rx, sock}, nil, timeout)
+      if err == "timeout" and sock == nil then
+        log.trace("disco| done waiting for search ids, sending ssdp discovery message")
+        if sock == nil and #search_ids > 0 then
+          sock, timeout_epoch = send_disco_request()
+          timeout = math.max(0, timeout_epoch - socket.gettime())
+        else
+          log.warn("disco| ending without sending request because no search ids requested")
+          break
+        end
+      elseif err == "timeout" and socket ~= nil then
+        break
       end
-      local id = meta.mac
 
-      log.trace("discovery response from:", rip, headers["usn"], id)
-
-      if rip ~= ip then
-        log.warn("recieved discovery response with reported & source IP mismatch, ignoring")
-        log.debug(rip, "!=", ip)
-      elseif ip and port and id and not ids_found[id] then
-        ids_found[id] = true
-        number_found = number_found + 1
-
-        -- local meta = fetch_device_metadata(headers["location"])
-        -- TODO: what?
-        -- if not meta then
-        --  meta = {}
-        -- end
-
-        -- the ID in the response is a substring of the search ID, check if they match (if search ID set)
-        local is_correct_responder = deviceid and string.find(deviceid, id, nil, "plaintext")
-
-        if (not deviceid) or is_correct_responder then
-          callback({ id = id,
-            ip = ip,
-            port = port,
-            raw = headers,
-            name = meta.name,
-            model = meta.model
-          })
-
-          if deviceid then
-            -- just looking for a single device
-            break
+      --Handle the ctrl channel messages first
+      if recv and (recv[1] == ctrl_rx or recv[2] == ctrl_rx) then
+        local msg, err = ctrl_rx:receive()
+        if msg and msg.type and msg.reply_tx then
+          if msg.type == ControlMessageTypes.Scan then
+            log.trace("disco| inserting search id:", "scan")
+            table.insert(search_ids, {id = "scan", reply_tx = msg.reply_tx})
           end
+          if msg.type == ControlMessageTypes.FindDevice then
+            log.trace("disco| inserting search id:", msg.device_id)
+            table.insert(search_ids, {id = msg.device_id, reply_tx = msg.reply_tx})
+            for id, info in pairs(infos_found) do
+              if id == msg.device_id then
+                log.trace("disco| searching for previously discovered device:", msg.device_id)
+                msg.reply_tx:send(info)
+              end
+            end
+          end
+        else
+          log.warn(utils.stringify_table(msg or err, "Unexpected Message/Err on Discovery Control Channel", false))
+        end
+
+        goto continue
+      end
+
+      if recv and (recv[1] == sock or recv[2] == sock) then
+        local val, rip, _ = sock:receivefrom()
+        timeout = math.max(0, timeout_epoch - socket.gettime())
+        -- sock:settimeout(timeout)
+        if val then
+          local headers = process_response(val)
+          local ip, port = headers["location"]:match("http://([^,/]+):([^/]+)")
+          if rip ~= ip then
+            log.warn("recieved discovery response with reported & source IP mismatch, ignoring")
+            log.debug(rip, "!=", ip)
+            goto continue
+          end
+          local meta = fetch_device_metadata(headers["location"])
+          if not meta or not meta.mac or not ip then
+            log.warn("disco| failed to get ip or mac for discovered device, not adding")
+            goto continue
+          end
+          local id = meta.mac
+
+          if ip and port and id and not infos_found[id] then
+            infos_found[id] = {
+              id = id,
+              ip = ip,
+              port = port,
+              raw = headers,
+              name = meta.name,
+              model = meta.model,
+            }
+            number_found = number_found + 1
+            log.trace("disco| found device:", ip, port, id)
+            for _, search_id in ipairs(search_ids) do
+              if search_id.id == "scan" or search_id.id == id then
+                search_id.reply_tx:send(infos_found[id])
+              end
+            end
+          end
+        else
+          error(string.format("error receving discovery replies: %s", rip))
         end
       end
-    elseif rip == "timeout" then
-      break
-    else
-      error(string.format("error receving discovery replies: %s", rip))
+      ::continue::
     end
-  end
-  s:close()
-  log.info_with({hub_logs=true}, string.format("discovery response window ended, %s found", number_found))
+    for _, search_id in ipairs(search_ids) do
+      if search_id.id == "scan" or infos_found[search_id.id] == nil then
+        search_id.reply_tx:close()
+      end
+    end
+    if sock then sock:close() end
+    if ctrl_rx then ctrl_rx:close() end
+    Discovery._ctrl_tx:close()
+    Discovery._ctrl_tx = nil
+    log.info_with({hub_logs=true}, string.format("disco| response window ended, %s found", number_found))
+
+    --prepare return values for requested scan ids
+
+  end, "disco task")
 end
 
-return {
-  find = find,
-}
+--This function should only be sending on tx ctrl channel
+-- to discovery task to add a deviceID to the disco search
+function Discovery.find(deviceid, callback)
+  if Discovery._ctrl_tx == nil then
+    log.trace("disco| starting discovery cosock task")
+    Discovery.run_discovery_task()
+  end
+
+  local tx, rx = cosock.channel.new()
+  if deviceid then
+    Discovery._ctrl_tx:send(ControlMessageBuilders.FindDevice(deviceid, tx))
+    local info = rx:receive()
+    if not info then
+      log.warn("disco| failed to discover the device " .. deviceid)
+    end
+    callback(info)
+    rx:close()
+  else
+    Discovery._ctrl_tx:send(ControlMessageBuilders.Scan(tx))
+    while true do
+      local info, err = rx:receive()
+      if err == "closed" then
+        log.trace("disco| finished scan")
+        rx:close()
+        break
+      end
+      if info ~= nil and info.ip ~= nil and info.id ~= nil then
+        callback(info)
+      else
+        log.warn(string.format("disco| unexpected nil info due to %s", err))
+      end
+    end
+  end
+end
+
+return Discovery

--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -119,10 +119,13 @@ local function device_init(driver, device)
     return
   end
 
-  device:online() -- Mark device as being online
+  device:online()
  
-  device:set_field("ip", info.ip)
-  device:set_field("port", info.port)
+  --ip and port are persisted since sometimes wemo just stop responding to ssdp even though
+  --they are connected to the network. In this case we want them to continue to function
+  --across driver restarts.
+  device:set_field("ip", info.ip, {persist = true})
+  device:set_field("port", info.port, {persist = true})
   device:set_field("serial_num", info.serial_num, {persist = true})
 
   --TODO maybe we should call_on_schedule with the device thread, and the polling.

--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -34,7 +34,7 @@ local devices = _envlibrequire "devices"
 
 -- maps model name to profile name
 local profiles = {
-  ["Insight"] = "wemo.insight-smart-plug.v1",
+  ["Insight"] = "wemo.mini-smart-plug.v1",
   ["Socket"] = "wemo.mini-smart-plug.v1",
   ["Dimmer"] = "wemo.dimmer-switch.v1",
   ["Motion"] = "wemo.motion-sensor.v1",

--- a/drivers/SmartThings/wemo/src/util.lua
+++ b/drivers/SmartThings/wemo/src/util.lua
@@ -13,4 +13,15 @@ function util.tablefind(t, path)
   return item
 end
 
+--- This alternate determination of MAC addrs being equal is
+--- needed since wemo devices usually have a MAC on the network
+--- one greater than what is reported by the device. Migrated
+--- devices use the real network MAC, and devices joined to the
+--- driver use the device reported MAC.
+function util.mac_equal(m1, m2)
+  local v1 = tonumber(m1, 16)
+  local v2 = tonumber(m2, 16)
+  return math.abs(v1 - v2) <= 1
+end
+
 return util


### PR DESCRIPTION
This provides a few changes initially to make development easier, and then the main change is to refactor the discovery module to be a cosock task that can handle multiple discovery requests at once rather than spinning up a discovery loop for each request.

Other issues I have identified in the wemo driver that will be taken care of in separate PRs are:
* Device subscriptions not being setup properly where the listening server is getting updates
* Devices being rediscovered after failed communication if necessary (i.e. ip addr changes).
* Migration issue where DTHs have different macs than what is reported by the device explained more [here](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/483#issuecomment-1402773011). Fixed by #505