### PR TITLE
Wemo MAC differences on migrated devices

### DIFF
--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -119,10 +119,13 @@ local function device_init(driver, device)
     return
   end
 
-  device:online() -- Mark device as being online
+  device:online()
  
-  device:set_field("ip", info.ip)
-  device:set_field("port", info.port)
+  --ip and port are persisted since sometimes wemo just stop responding to ssdp even though
+  --they are connected to the network. In this case we want them to continue to function
+  --across driver restarts.
+  device:set_field("ip", info.ip, {persist = true})
+  device:set_field("port", info.port, {persist = true})
   device:set_field("serial_num", info.serial_num, {persist = true})
 
   --TODO maybe we should call_on_schedule with the device thread, and the polling.

--- a/drivers/SmartThings/wemo/src/util.lua
+++ b/drivers/SmartThings/wemo/src/util.lua
@@ -13,4 +13,15 @@ function util.tablefind(t, path)
   return item
 end
 
+--- This alternate determination of MAC addrs being equal is
+--- needed since wemo devices usually have a MAC on the network
+--- one greater than what is reported by the device. Migrated
+--- devices use the real network MAC, and devices joined to the
+--- driver use the device reported MAC.
+function util.mac_equal(m1, m2)
+  local v1 = tonumber(m1, 16)
+  local v2 = tonumber(m2, 16)
+  return math.abs(v1 - v2) <= 1
+end
+
 return util


### PR DESCRIPTION
The MAC printed on the device and advertised in device metadata is used for the access point that the wemo device sets up for onboarding, and the MAC that is used once on the homes network is one more than what is advertised in metadata. The DTH got the actual MAC because its discovery pulls this info from the network; the driver queries the device for this info because it is not available on the socket that we have in drivers. This change will consider MAC addrs that are off by one as equal when discovering devices on the LAN.

An alternative approach would be to "calculate" the actual mac address from what is reported from the device, but there is no guarantee that all wemo devices will actually being doing this MAC change. Documentation is very limited.