### PR TITLE
Fix CHAD-10235: Address issues when coordinator speaker isn't joined

### DIFF
--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -51,8 +51,7 @@ _update_subscriptions_helper = function(sonos_conn, householdId, playerId, group
       {}
     }
     local payload = json.encode(payload_table)
-    local dni = sonos_conn.driver.sonos:get_dni_for_player_id(playerId)
-    Router.send_message_to_player(dni, payload)
+    Router.send_message_to_player(playerId, payload)
   end
 end
 
@@ -80,7 +79,7 @@ end
 ---@param household_id HouseholdId
 ---@param self_player_id PlayerId
 local function _open_coordinator_socket(sonos_conn, household_id, self_player_id)
-  log.trace("Open coordinator socket: " .. household_id .. ":" .. self_player_id)
+  log.trace("Open coordinator socket for: " .. sonos_conn.device.label)
   local _, coordinator_id, err = sonos_conn.driver.sonos:get_coordinator_for_device(sonos_conn.device)
   if err ~= nil then
     log.error(
@@ -92,9 +91,8 @@ local function _open_coordinator_socket(sonos_conn, household_id, self_player_id
 
   if coordinator_id ~= self_player_id then
     local coordinator = sonos_conn.driver.sonos:get_household(household_id).players[coordinator_id]
-    local coordinator_dni = sonos_conn.driver.sonos:get_dni_for_player_id(coordinator_id)
     local _, err =
-    Router.open_socket_for_player(coordinator_dni, coordinator.websocketUrl)
+    Router.open_socket_for_player(coordinator_id, coordinator.websocketUrl)
 
     if err ~= nil then
       log.error(
@@ -104,7 +102,7 @@ local function _open_coordinator_socket(sonos_conn, household_id, self_player_id
       )
     end
 
-    listener_id, err = Router.register_listener_for_socket(sonos_conn, coordinator_dni)
+    listener_id, err = Router.register_listener_for_socket(sonos_conn, coordinator_id)
     if err ~= nil or not listener_id then
       log.error(err)
     else
@@ -149,18 +147,36 @@ function SonosConnection.new(driver, device)
         if body.volume and (body.muted ~= nil) then
           local group = self.driver.sonos:get_household(header.householdId).groups[header.groupId] or { playerIds = {} }
           for _, player_id in ipairs(group.playerIds) do
-            EventHandlers.handle_player_volume(self.driver._dni_to_device[device.device_network_id], body.volume, body.muted)
+            local device_for_player = self.driver._player_id_to_device[player_id]
+            --- we've seen situations where these messages can be processed while a device
+            --- is being deleted so we check for the presence of emit event as a proxy for
+            --- whether or not this device is currently capable of emitting events.
+            if device_for_player and device_for_player.emit_event then
+              EventHandlers.handle_player_volume(device_for_player, body.volume, body.muted)
+            end
           end
         end
       elseif header.type == "playbackStatus" then
         local group = self.driver.sonos:get_household(header.householdId).groups[header.groupId] or { playerIds = {} }
         for _, player_id in ipairs(group.playerIds) do
-          EventHandlers.handle_playback_status(self.driver._dni_to_device[device.device_network_id], body.playbackState)
+          local device_for_player = self.driver._player_id_to_device[player_id]
+          --- we've seen situations where these messages can be processed while a device
+          --- is being deleted so we check for the presence of emit event as a proxy for
+          --- whether or not this device is currently capable of emitting events.
+          if device_for_player and device_for_player.emit_event then
+            EventHandlers.handle_playback_status(device_for_player, body.playbackState)
+          end
         end
       elseif header.type == "metadataStatus" then
         local group = self.driver.sonos:get_household(header.householdId).groups[header.groupId] or { playerIds = {} }
         for _, player_id in ipairs(group.playerIds) do
-          EventHandlers.handle_playback_metadata_update(self.driver._dni_to_device[device.device_network_id], body)
+          local device_for_player = self.driver._player_id_to_device[player_id]
+          --- we've seen situations where these messages can be processed while a device
+          --- is being deleted so we check for the presence of emit event as a proxy for
+          --- whether or not this device is currently capable of emitting events.
+          if device_for_player and device_for_player.emit_event then
+            EventHandlers.handle_playback_metadata_update(device_for_player, body)
+          end
         end
       elseif header.namespace == "favorites" and header.type == "versionChanged" then
         if body.version ~= favorites_version then
@@ -190,7 +206,13 @@ function SonosConnection.new(driver, device)
               self.driver.sonos:update_household_favorites(header.householdId, new_favorites)
 
               for _, player_id in ipairs(group.playerIds) do
-                EventHandlers.update_favorites(self.driver._dni_to_device[device.device_network_id], new_favorites)
+                local device_for_player = self.driver._player_id_to_device[player_id]
+                --- we've seen situations where these messages can be processed while a device
+                --- is being deleted so we check for the presence of emit event as a proxy for
+                --- whether or not this device is currently capable of emitting events.
+                if device_for_player and device_for_player.emit_event then
+                  EventHandlers.update_favorites(device_for_player, new_favorites)
+                end
               end
             end
           end
@@ -200,6 +222,7 @@ function SonosConnection.new(driver, device)
   end
 
   self.on_error = function(uuid, err)
+    log.error(err or ("unknown websocket error for " .. (self.device.label or "unknown device")))
   end
 
   self.on_close = function(uuid)
@@ -209,18 +232,23 @@ function SonosConnection.new(driver, device)
   return self
 end
 
---- Whether or not the connection has a live websocket connection
+--- Whether or not the connection has all of the live websocket connections it needs to function
 --- @return boolean
 function SonosConnection:is_running()
-  return not err and Router.is_connected(self.device.device_network_id) and self._initialized
+  return self:self_running() and self:coordinator_running()
 end
 
 --- Whether or not the connection has a live websocket connection
 --- @return boolean
+function SonosConnection:self_running()
+  return Router.is_connected(self.device:get_field(PlayerFields.PLAYER_ID)) and self._initialized
+end
+
+--- Whether or not the connection has a live websocket connection to its coordinator
+--- @return boolean
 function SonosConnection:coordinator_running()
   local _, coordinator_id = self.driver.sonos:get_coordinator_for_device(self.device)
-  local coordinator_dni = self.driver.sonos:get_dni_for_player_id(coordinator_id)
-  return not err and Router.is_connected(coordinator_dni) and self._initialized
+  return Router.is_connected(coordinator_id) and self._initialized
 end
 
 function SonosConnection:refresh_subscriptions()
@@ -234,13 +262,12 @@ end
 function SonosConnection:send_command(cmd)
   log.trace("Sending command over websocket channel for device " .. self.device.label)
   local _, coordinator_id = self.driver.sonos:get_coordinator_for_device(self.device)
-  local coordinator_dni = self.driver.sonos:get_dni_for_player_id(coordinator_id)
   local json_payload, err = json.encode(cmd)
 
   if err or not json_payload then
     log.error("Json encoding error: " .. err)
   else
-    Router.send_message_to_player(coordinator_dni, json_payload)
+    Router.send_message_to_player(coordinator_id, json_payload)
   end
 end
 
@@ -255,21 +282,24 @@ function SonosConnection:start()
     return false
   end
 
-  local url = self.device:get_field(PlayerFields.WSS_URL) or {}
   local household_id = self.device:get_field(PlayerFields.HOUSEHOULD_ID)
   local player_id = self.device:get_field(PlayerFields.PLAYER_ID)
 
-  local _, err = Router.open_socket_for_player(self.device.device_network_id, url)
-  if err ~= nil then
-    log.error(err)
-    return false
-  end
+  if not self:self_running() then
+    local url = self.device:get_field(PlayerFields.WSS_URL) or {}
 
-  local listener_id, err = Router.register_listener_for_socket(self, self.device.device_network_id)
-  if err ~= nil or not listener_id then
-    log.error(err)
-  else
-    self._self_listener_uuid = listener_id
+    local _, err = Router.open_socket_for_player(player_id, url)
+    if err ~= nil then
+      log.error(err)
+      return false
+    end
+
+    local listener_id, err = Router.register_listener_for_socket(self, player_id)
+    if err ~= nil or not listener_id then
+      log.error(err)
+    else
+      self._self_listener_uuid = listener_id
+    end
   end
 
   if not self:coordinator_running() then
@@ -277,9 +307,14 @@ function SonosConnection:start()
   end
 
   self:refresh_subscriptions()
-  self.device:online()
-  self._initialized = true
-  return true
+  local coordinator_id = self.driver.sonos:get_coordinator_for_player(household_id, player_id)
+  if Router.is_connected(player_id) and Router.is_connected(coordinator_id) then
+    self.device:online()
+    self._initialized = true
+    return true
+  end
+
+  return false
 end
 
 --- Stop the websocket processing loop and close the connection
@@ -287,24 +322,11 @@ function SonosConnection:stop()
   self._initialized = false
   log.info("Stopping Sonos connection for " .. self.device.label)
   local _, player_id = self.driver.sonos:get_player_for_device(self.device)
+  local household_id, group_id = self.driver.sonos:get_group_for_device(self.device)
+  local coordinator_id = self.driver.sonos:get_coordinator_for_group(household_id, group_id)
 
-  local known_devices = self.driver:get_devices()
-  local is_socket_in_use = false
-
-  local dni_equal = self.driver.is_same_mac_address
-  for _, device in ipairs(known_devices) do
-    if dni_equal(device.device_network_id, self.device.device_network_id) then
-      local _, coordinator_id = self.driver.sonos:get_coordinator_for_device(device)
-
-      if player_id == coordinator_id then
-        is_socket_in_use = true
-        break
-      end
-    end
-  end
-
-  if not is_socket_in_use then
-    Router.close_socket_for_player(self.device.device_network_id)
+  if not player_id == coordinator_id then
+    Router.close_socket_for_player(player_id)
   end
 end
 

--- a/drivers/SmartThings/sonos/src/types.lua
+++ b/drivers/SmartThings/sonos/src/types.lua
@@ -119,9 +119,8 @@ Types.SonosCapabilities = {
 --- @field public get_player_for_device fun(self: SonosState, device: SonosDevice): HouseholdId,PlayerId,string
 --- @field public get_coordinator_for_device fun(self: SonosState, device: SonosDevice): HouseholdId,PlayerId,string
 --- @field public get_group_for_device fun(self: SonosState, device: SonosDevice): HouseholdId,GroupId,string
---- @field public get_dni_for_player_id fun(self: SonosState, player_id: PlayerId): DNI,nil|string
---- @field public mark_player_as_joined fun(self: SonosState, dni: DNI, player_id: PlayerId)
---- @field public mark_player_as_removed fun(self: SonosState, dni: DNI, player_id: PlayerId)
+--- @field public mark_player_as_joined fun(self: SonosState, player_id: PlayerId)
+--- @field public mark_player_as_removed fun(self: SonosState, player_id: PlayerId)
 --- @field public is_player_joined fun(self: SonosState, household_id_or_dni: HouseholdId|string, player_id?: PlayerId): boolean
 local SonosState = {}
 SonosState.__index = SonosState
@@ -131,25 +130,15 @@ function SonosState.new()
 
   local private = {
     households = {},
-    joined_players = {},
-    player_id_to_dni = {},
+    joined_players = {}
   }
 
-  ret.mark_player_as_joined = function(self, dni, player_id)
-    private.joined_players[dni] = true
-    private.player_id_to_dni[player_id] = dni
+  ret.mark_player_as_joined = function(self, player_id)
+    private.joined_players[player_id] = true
   end
 
-  ret.mark_player_as_removed = function(self, dni, player_id)
-    if dni == private.player_id_to_dni[player_id] then private.player_id_to_dni[player_id] = nil end
-    private.joined_players[dni] = false
-  end
-
-  ret.get_dni_for_player_id = function(self, player_id)
-    local ret = private.player_id_to_dni[player_id]
-    local err = nil
-    if not ret then err = string.format("No mapping from %s to DNI", player_id) end
-    return ret, err
+  ret.mark_player_as_removed = function(self, player_id)
+    private.joined_players[player_id] = false
   end
 
   ret.is_player_joined = function(self, dni)
@@ -301,7 +290,7 @@ Types.SonosState = SonosState
 --- Sonos Edge Driver extensions
 --- @class SonosDriver : Driver
 --- @field public sonos SonosState Local state related to the sonos systems
---- @field private _dni_to_device table<string,SonosDevice>
+--- @field private _player_id_to_device table<string,SonosDevice>
 --- @field public update_group_state fun(self: SonosDriver, header: SonosResponseHeader, body: SonosGroupsResponseBody)
 --- @field public handle_ssdp_discovery fun(self: SonosDriver, ssdp_group_info: SonosSSDPInfo, callback?: DiscoCallback)
 --- @field public is_same_mac_address fun(dni: string, other: string): boolean


### PR DESCRIPTION
If a speaker is in a group but its coordinator isn't on the platform
we still want to be able to work with the speaker. The driver actually
worked like this originally but migration readiness broke this.

This fix restores that functionality. It also adds explicit reconnect logic
instead of waiting for an eventual reconnect based on group status
changes.

Fixes: CHAD-10235, CHAD-10136, CHAD-10005