### PR TITLE
CHAD-10123 Round fahrenheit values before sending them to z-wave ther…

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/src/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/init.lua
@@ -48,6 +48,11 @@ local function convert_to_device_temp(command_temp, device_scale)
   elseif (command_temp >= 40 and (device_scale == ThermostatSetpoint.scale.CELSIUS or device_scale == nil)) then
     command_temp = utils.f_to_c(command_temp)
   end
+
+  -- Lots of devices don't like being sent fractional F values, so let's just round them
+  if command_temp >= 40 and (device_scale == ThermostatSetpoint.scale.FAHRENHEIT) then
+    command_temp = utils.round(command_temp)
+  end
   return command_temp
 end
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_stelpro_ki_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_stelpro_ki_thermostat.lua
@@ -62,7 +62,7 @@ test.register_coroutine_test(
           ThermostatSetpoint:Set({
             setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
             scale = 1,
-            value = 84.2
+            value = 84
           })
       )
     )


### PR DESCRIPTION
…mostats

Occasionally the UI will send us fractional values which we were sending along dutifully, but thermostats will often ignore these.