### PR TITLE
Fix/hue-join-improvements-and-CHAD-10213

### DIFF
--- a/drivers/SmartThings/philips-hue/profiles/legacy-color.yml
+++ b/drivers/SmartThings/philips-hue/profiles/legacy-color.yml
@@ -1,0 +1,20 @@
+name: legacy-color
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: switchLevel
+    version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [ 1, 100 ]
+  - id: colorControl
+    version: 1
+  - id: samsungim.hueSyncMode
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Light

--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -285,7 +285,11 @@ process_discovered_light = function(driver, bridge_id, resource_id, device_info,
     local profile_ref = nil
 
     if light.color then
-      profile_ref = "white-and-color-ambiance" -- all color light products support `white` (dimming) and `ambiance` (color temp)
+      if light.color_temperature then
+        profile_ref = "white-and-color-ambiance"
+      else
+        profile_ref = "legacy-color"
+      end
     elseif light.color_temperature then
       profile_ref = "white-ambiance" -- all color temp products support `white` (dimming)
     elseif light.dimming then

--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -35,7 +35,8 @@ function HueDiscovery.discover(driver, _, should_continue)
     local known_dni_to_device_map = {}
     local computed_mac_addresses = {}
     for _, device in ipairs(driver:get_devices()) do
-      local dni = device.device_network_id or device.parent_assigned_child_key
+      -- the bridge won't have a parent assigned key so we give that boolean short circuit preference
+      local dni = device.parent_assigned_child_key or device.device_network_id
       known_dni_to_device_map[dni] = device
       local ipv4 = device:get_field(Fields.IPV4);
       if ipv4 then


### PR DESCRIPTION
## [fix CHAD-10213: Legacy color profile](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/525/commits/8952caa2207b2736155cdfb8182ed72961096e88)

Adds a profile for legacy Hue Color devices that support color
control without white/temperature control.

Fixes: CHAD-10213

## [fix: Don't send join message for joined bulbs](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/525/commits/31c489f84ece6c86242dae28f303850646651277)

EDGE_CHILD devices get an auto-assigned UUID DNI so we weren't
using the correct value for child devices when trying to ascertain
already joined devices.

This was leading to a flood of try_create_device messages during
discovery for already joined devices.

## [fix: Eliminate several spurious refreshes](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/525/commits/d09fc6d42a66956f6404bc5ba08fd31c0224616f)

The logic revised in this commit was causing a lot of spurious
events to be emitted, so we revise some things.

First is that we only refresh after init on fresh join, not general init.

Second is that we don't do a forced refresh whenever the SSE stream connects.
This is fine for fresh join because we do a forced refresh anyway, and it's
fine for reconnects because the SSE implementation will request any messages
that it has missed in the interrim whenever it performs a reconnect.