### PR TITLE
BUG-6885 Change sub-driver handling of ThermostatRunningMode

### DIFF
--- a/drivers/SmartThings/zigbee-thermostat/src/fidure/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/fidure/init.lua
@@ -17,16 +17,12 @@ local device_management = require "st.zigbee.device_management"
 local clusters                      = require "st.zigbee.zcl.clusters"
 local Thermostat                    = clusters.Thermostat
 
-local capabilities              = require "st.capabilities"
-local ThermostatMode            = capabilities.thermostatMode
-
 local do_configure = function(self, device)
   device:send(device_management.build_bind_request(device, Thermostat.ID, self.environment_info.hub_zigbee_eui))
   device:send(Thermostat.attributes.LocalTemperature:configure_reporting(device, 20, 300, 20)) -- report temperature changes over 0.2°C
   device:send(Thermostat.attributes.OccupiedCoolingSetpoint:configure_reporting(device, 10, 320, 50))
   device:send(Thermostat.attributes.OccupiedHeatingSetpoint:configure_reporting(device, 10, 320, 50))
   device:send(Thermostat.attributes.SystemMode:configure_reporting(device, 10, 305))
-  device:send(Thermostat.attributes.ThermostatRunningMode:configure_reporting(device, 10, 315))
   device:send(Thermostat.attributes.ThermostatRunningState:configure_reporting(device, 10, 325))
 end
 
@@ -34,6 +30,13 @@ local fidure_thermostat = {
   NAME = "Fidure Thermostat Handler",
   lifecycle_handlers = {
     doConfigure = do_configure,
+  },
+  zigbee_handlers = {
+    attr = {
+      [Thermostat.ID] = {
+        [Thermostat.attributes.ThermostatRunningMode.ID] = function() end
+      }
+    }
   },
   can_handle = function(opts, driver, device, ...)
     return device:get_manufacturer() == "Fidure" and device:get_model() == "A1732R3"

--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -204,7 +204,6 @@ local do_refresh = function(self, device)
     Thermostat.attributes.LocalTemperature,
     Thermostat.attributes.ControlSequenceOfOperation,
     Thermostat.attributes.ThermostatRunningState,
-    Thermostat.attributes.ThermostatRunningMode,
     Thermostat.attributes.SystemMode,
     FanControl.attributes.FanModeSequence,
     FanControl.attributes.FanMode,

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_fidure_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_fidure_thermostat.lua
@@ -16,7 +16,6 @@ local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"
 local Thermostat = clusters.Thermostat
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
-local base64 = require "st.base64"
 local t_utils = require "integration_test.utils"
 
 local mock_device = test.mock_device.build_test_zigbee_device(
@@ -71,15 +70,23 @@ test.register_coroutine_test(
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
-                                         Thermostat.attributes.ThermostatRunningMode:configure_reporting(mock_device, 10, 315)
-                                       })
-      test.socket.zigbee:__expect_send({
-                                         mock_device.id,
                                          Thermostat.attributes.ThermostatRunningState:configure_reporting(mock_device, 10, 325)
                                        })
 
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end
+)
+
+test.register_message_test(
+    "Thermostat running mode reports are NOT handled",
+    {
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_device.id, Thermostat.attributes.ThermostatRunningMode:build_test_attr_report(mock_device,
+                                                                                                        3), }
+      }
+    }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
@@ -193,10 +193,6 @@ test.register_coroutine_test(
       })
       test.socket.zigbee:__expect_send({
         mock_device.id,
-        Thermostat.attributes.ThermostatRunningMode:configure_reporting(mock_device, 5, 300)
-      })
-      test.socket.zigbee:__expect_send({
-        mock_device.id,
         Thermostat.attributes.ThermostatRunningState:configure_reporting(mock_device, 5, 300)
       })
       test.socket.zigbee:__expect_send({
@@ -253,10 +249,6 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({
         mock_device.id,
         Thermostat.attributes.SystemMode:configure_reporting(mock_device, 5, 300)
-      })
-      test.socket.zigbee:__expect_send({
-        mock_device.id,
-        Thermostat.attributes.ThermostatRunningMode:configure_reporting(mock_device, 5, 300)
       })
       test.socket.zigbee:__expect_send({
         mock_device.id,
@@ -457,6 +449,18 @@ test.register_coroutine_test(
     test.mock_time.advance_time(2)
     test.wait_for_events()
   end
+)
+
+test.register_message_test(
+    "Thermostat running mode reports are NOT handled",
+    {
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_device.id, Thermostat.attributes.ThermostatRunningMode:build_test_attr_report(mock_device,
+                                                                                                        3), }
+      }
+    }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -550,14 +550,6 @@ test.register_message_test(
         direction = "send",
         message = {
           mock_device.id,
-          Thermostat.attributes.ThermostatRunningMode:read(mock_device)
-        }
-      },
-      {
-        channel = "zigbee",
-        direction = "send",
-        message = {
-          mock_device.id,
           Thermostat.attributes.SystemMode:read(mock_device)
         }
       },
@@ -649,14 +641,6 @@ test.register_message_test(
         direction = "send",
         message = {
           mock_device.id,
-          Thermostat.attributes.ThermostatRunningMode:read(mock_device)
-        }
-      },
-      {
-        channel = "zigbee",
-        direction = "send",
-        message = {
-          mock_device.id,
           Thermostat.attributes.SystemMode:read(mock_device)
         }
       },
@@ -692,6 +676,23 @@ test.register_message_test(
           PowerConfiguration.attributes.BatteryAlarmState:read(mock_device)
         }
       },
+    }
+)
+
+test.register_message_test(
+    "Thermostat running mode reports are handled",
+    {
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_device.id, Thermostat.attributes.ThermostatRunningMode:build_test_attr_report(mock_device,
+                                                                                                        3), }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode("cool"))
+      }
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/zenwithin/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/zenwithin/init.lua
@@ -67,7 +67,6 @@ local do_configure = function(self, device)
   device:send(Thermostat.attributes.OccupiedCoolingSetpoint:configure_reporting(device, 5, 300, 50))
   device:send(Thermostat.attributes.OccupiedHeatingSetpoint:configure_reporting(device, 5, 300, 50))
   device:send(Thermostat.attributes.SystemMode:configure_reporting(device, 5, 300))
-  device:send(Thermostat.attributes.ThermostatRunningMode:configure_reporting(device, 5, 300))
   device:send(Thermostat.attributes.ThermostatRunningState:configure_reporting(device, 5, 300))
   device:send(FanControl.attributes.FanMode:configure_reporting(device, 5, 300))
   device:send(PowerConfiguration.attributes.BatteryVoltage:configure_reporting(device, 30, 21600, 1))
@@ -194,6 +193,7 @@ local zenwithin_thermostat = {
         [Thermostat.attributes.MaxHeatSetpointLimit.ID] = setpoint_limit_handler(MAX_HEAT_LIMIT),
         [Thermostat.attributes.MinCoolSetpointLimit.ID] = setpoint_limit_handler(MIN_COOL_LIMIT),
         [Thermostat.attributes.MaxCoolSetpointLimit.ID] = setpoint_limit_handler(MAX_COOL_LIMIT),
+        [Thermostat.attributes.ThermostatRunningMode.ID] = function() end
       },
       [PowerConfiguration.ID] = {
         [PowerConfiguration.attributes.BatteryVoltage.ID] = battery_defaults.battery_volt_attr_handler


### PR DESCRIPTION
The DTHs for the fidure and Zen zigbee thermostats were reporting a custom event when they received ThermostatRunningMode attribute reports, while the zigbee thermostat DTH maps them to mode events.

Also, the zigbee thermostat base driver included a read of the attribute that was not present in the DTH.