### PR TITLE
Port HSV < - > xy math from the Protocol Handler

### DIFF
--- a/drivers/SmartThings/philips-hue/src/hue/cie_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/cie_utils.lua
@@ -1,0 +1,189 @@
+local st_utils = require "st.utils"
+local CieUtils = {}
+
+local DefaultGamut = {
+  red = {x = 0.6915, y = 0.3083},
+  green = {x = 0.17, y = 0.7},
+  blue = {x = 0.1532, y = 0.0475}
+}
+
+local function _apply_gamma_correct(val)
+  if val > 0.04045 then
+    return ((val + 0.055) / (1.0 + 0.055)) ^ (2.4)
+  else
+    return val / 12.92
+  end
+end
+
+local function _invert_gamma_correct(val)
+  if val <= 0.0031308 then
+    return val * 12.92
+  else
+    return (1.055) * (val ^ (1/2.4)) - 0.055
+  end
+end
+
+local function _vec_cross_product(a, b)
+  return (a.x * b.y) - (b.x * a.y)
+end
+
+local function _xy_in_gamut_triangle(xy, gamut)
+  local red = gamut.red
+  local green = gamut.green
+  local blue = gamut.blue
+
+  local v1 = {}
+  local v2 = {}
+  local q = {}
+
+  v1.x = green.x - red.x;
+  v1.y = green.y - red.y;
+  v2.x = blue.x - red.x;
+  v2.y = blue.y - red.y;
+
+  q.x = xy.x - red.x;
+  q.y = xy.y - red.y;
+
+  local s = _vec_cross_product(q, v2) / _vec_cross_product(v1, v2);
+  local t = _vec_cross_product(v1, q) / _vec_cross_product(v1, v2);
+
+  return (s >= 0) and (t >= 0) and (s + t < 1)
+end
+
+local function _closest_point_on_line(point, line_segment_start, line_segment_end)
+  local AP = {}
+  local AB = {}
+  AP.x = point.x - line_segment_start.x
+  AP.y = point.y - line_segment_start.y
+  AB.x = line_segment_end.x - line_segment_start.x
+  AB.y = line_segment_end.y - line_segment_start.y
+
+  local ab2 = AB.x * AB.x + AB.y * AB.y
+  local ap_ab = AP.x * AB.x + AP.y * AB.y
+  local t = st_utils.clamp_value(ap_ab / ab2, 0, 1)
+
+  return {
+    x = line_segment_start.x + AB.x * t,
+    y = line_segment_start.y + AB.y * t
+  }
+end
+
+local function _distance_between_points(a, b)
+  local dx = a.x - b.x
+  local dy = a.y - b.y
+  return math.sqrt(dx * dx + dy * dy)
+end
+
+local function _closest_point_in_gamut_triangle(xy, gamut)
+  local redGreenCorner = _closest_point_on_line(xy, gamut.red, gamut.green)
+  local blueRedCorner = _closest_point_on_line(xy, gamut.blue, gamut.red)
+  local greenBlueCorner = _closest_point_on_line(xy, gamut.green, gamut.blue)
+
+  local distanceToRedGreen = _distance_between_points(xy, redGreenCorner)
+  local distanceToBlueRed = _distance_between_points(xy, blueRedCorner)
+  local distanceToGreenBlue = _distance_between_points(xy, greenBlueCorner)
+
+  local smallestDistance = distanceToRedGreen
+  local closestPoint = redGreenCorner
+  if distanceToBlueRed < smallestDistance then
+    smallestDistance = distanceToBlueRed
+    closestPoint = blueRedCorner
+  end
+
+  if distanceToGreenBlue < smallestDistance then
+    closestPoint = greenBlueCorner
+  end
+
+  return closestPoint
+end
+
+function CieUtils.safe_rgb_to_xy(red, green, blue, gamut)
+  if gamut == nil then gamut = DefaultGamut end
+  red = _apply_gamma_correct(red)
+  green = _apply_gamma_correct(green)
+  blue = _apply_gamma_correct(blue)
+
+  local x = red * 0.664511 + green * 0.154324 + blue * 0.162028;
+  local y = red * 0.283881 + green * 0.668433 + blue * 0.047685;
+  local z = red * 0.000088 + green * 0.072310 + blue * 0.986039;
+
+  local xy = {}
+  xy.x = (x / (x + y + z))
+  xy.y = (y / (x + y + z))
+
+  -- Portable way to detect NaN in Lua: https://stackoverflow.com/a/37759548/411216
+  -- Leverages the fact that NaN is not equal to any value, including itself.
+  if xy.x ~= xy.x then xy.x = 0 end
+  if xy.y ~= xy.y then xy.y = 0 end
+
+  if not _xy_in_gamut_triangle(xy, gamut) then
+    xy = _closest_point_in_gamut_triangle(xy, gamut)
+  end
+
+  return xy
+end
+
+function CieUtils.safe_xy_to_rgb(xy, gamut)
+  if gamut == nil then gamut = DefaultGamut end
+  if not _xy_in_gamut_triangle(xy, gamut) then
+    xy = _closest_point_in_gamut_triangle(xy, gamut)
+  end
+
+  local x = xy.x
+  local y = xy.y
+  local z = 1.0 - x - y
+  local y2 = 1.0
+  local x2 = (y2 / y) * x
+  local z2 = (y2 / y) * z
+  -- sRGB D65 conversion
+  local r = x2 * 1.656492 - y2 * 0.354851 - z2 * 0.255038
+  local g = -x2 * 0.707196 + y2 * 1.655397 + z2 * 0.036152
+  local b = x2 * 0.051713 - y2 * 0.121364 + z2 * 1.011530
+
+  if (r > b) and (r > g) and (r > 1) then
+    g = g / r
+    b = b / r
+    r = 1
+  elseif (g > b) and (g > r) and (g > 1) then
+    r = r / g
+    b = b / g
+    g = 1
+  elseif (b > r) and (b > g) and (b > 1) then
+    r = r / b
+    g = g / b
+    b = 1
+  end
+
+  -- apply gamma correction
+  r = _invert_gamma_correct(r)
+  g = _invert_gamma_correct(g)
+  b = _invert_gamma_correct(b)
+
+  if (r > b) and (r > g) then
+    if r > 1 then
+      g = g / r
+      b = b / r
+      r = 1.0
+    end
+  elseif (g > b) and (g > r) then
+    if g > 1 then
+      r = r / g
+      b = b / g
+      g = 1.0
+    end
+  elseif (b > r) and (b > g) then
+    if b > 1 then
+      r = r / b
+      g = g / b
+      b = 1.0
+    end
+  end
+
+  r = st_utils.clamp_value(r, 0, 1)
+  g = st_utils.clamp_value(g, 0, 1)
+  b = st_utils.clamp_value(b, 0, 1)
+
+  return r, g, b
+end
+
+return CieUtils

--- a/drivers/SmartThings/philips-hue/src/hue/fields.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/fields.lua
@@ -20,6 +20,7 @@ local Fields = {
   BRIDGE_SW_VERSION = "swversion",
   DEVICE_TYPE = "devicetype",
   EVENT_SOURCE = "eventsource",
+  GAMUT = "gamut",
   HUE_DEVICE_ID = "hue_device_id",
   IPV4 = "ipv4",
   MIN_DIMMING = "mindim",


### PR DESCRIPTION
When this driver was originally published it used the HSV < - > CIE 1931 XY math in `st.utils` which is based on the math from `zll-rgbw-bulb` but it turns out that the transform for Hue isn't actually the same.

This PR introduces the same color conversion math that was used in the Protocol Handler for Hue, making the edge driver behave more like existing Hue integrations.