### PR TITLE
HCS-4016 Enable tamper detection for Aeon Multi 6/7

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
@@ -18,6 +18,9 @@ local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
 
+local TIMER = "timed_clear"
+local TAMPER_CLEAR_TIME = 10
+
 local AEOTEC_MULTISENSOR_FINGERPRINTS = {
   { manufacturerId = 0x0086, productId = 0x0064 }, -- MultiSensor 6
   { manufacturerId = 0x0371, productId = 0x0018 }, -- MultiSensor 7
@@ -39,6 +42,25 @@ local function notification_report_handler(self, device, cmd)
       event = capabilities.powerSource.powerSource.battery()
     elseif cmd.args.event == Notification.event.power_management.AC_MAINS_RE_CONNECTED then
       event = capabilities.powerSource.powerSource.dc()
+    end
+  elseif cmd.args.notification_type == Notification.notification_type.HOME_SECURITY then
+    if cmd.args.event == Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED or
+      cmd.args.event == Notification.event.home_security.TAMPERING_PRODUCT_MOVED then
+      event = capabilities.tamperAlert.tamper.detected()
+      local timer = device:get_field(TIMER)
+      if timer ~= nil then --received a new event before the clear fired
+        device.thread:cancel_timer(timer)
+      end
+      timer = device.thread:call_with_delay(TAMPER_CLEAR_TIME, function(d)
+        device:emit_event(capabilities.tamperAlert.tamper.clear())
+        device:set_field(TIMER, nil)
+      end)
+      device:set_field(TIMER, timer)
+    elseif cmd.args.event == Notification.event.home_security.STATE_IDLE then
+      device:emit_event(capabilities.motionSensor.motion.inactive())
+      event = capabilities.tamperAlert.tamper.clear()
+    elseif cmd.args.event == Notification.event.home_security.MOTION_DETECTION then
+      event = capabilities.motionSensor.motion.active()
     end
   end
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
@@ -119,9 +119,9 @@ test.register_coroutine_test(
     end
 )
 
-test.register_coroutine_test(                                                    
-    "Receiving Wakeup command should generate the correct commands",                
-    function ()                                                                  
+test.register_coroutine_test(
+    "Receiving Wakeup command should generate the correct commands",
+    function ()
       test.socket.zwave:__set_channel_ordering("relaxed")
       test.socket.zwave:__queue_receive(
         {
@@ -130,8 +130,8 @@ test.register_coroutine_test(
         }
       )
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-          mock_sensor,                                                           
-          Configuration:Get({parameter_number = 9})                             
+          mock_sensor,
+          Configuration:Get({parameter_number = 9})
       ))
 
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
@@ -158,10 +158,10 @@ test.register_coroutine_test(
           mock_sensor,
           SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.ULTRAVIOLET})
       ))
-                                                                       
-                                                                                 
-      end                                                                        
-) 
+
+
+      end
+)
 test.register_coroutine_test(
     "Configuration value should be updated and device refreshed, when wakeup notification received",
     function()
@@ -219,96 +219,190 @@ test.register_coroutine_test(
           mock_sensor,
           SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.ULTRAVIOLET})
       ))
-      
+
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-          mock_sensor,                                                           
-          Configuration:Get({parameter_number = 9})                             
+          mock_sensor,
+          Configuration:Get({parameter_number = 9})
       ))
-      
 
     end
 )
 
 test.register_message_test(
   "SensorMultilevel report ultraviolet type should be handled as ultravioletIndex",
+  {
     {
-      {
-        channel = "zwave",
-        direction = "receive",
-        message = { mock_sensor.id, zw_test_utils.zwave_test_build_receive_command(SensorMultilevel:Report({
-          sensor_type = SensorMultilevel.sensor_type.ULTRAVIOLET,
-          sensor_value = 10
-        })) }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_sensor:generate_test_message("main", capabilities.ultravioletIndex.ultravioletIndex({value = 10}))
-      }
+      channel = "zwave",
+      direction = "receive",
+      message = { mock_sensor.id, zw_test_utils.zwave_test_build_receive_command(SensorMultilevel:Report({
+        sensor_type = SensorMultilevel.sensor_type.ULTRAVIOLET,
+        sensor_value = 10
+      })) }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_sensor:generate_test_message("main", capabilities.ultravioletIndex.ultravioletIndex({value = 10}))
     }
+  }
 )
 
 test.register_message_test(
-    "Notification reports about power management should be handled",
+  "Notification reports about power management should be handled",
+  {
     {
-      {
-        channel = "zwave",
-        direction = "receive",
-        message = {
-          mock_sensor.id,
-          Notification:Report({notification_type = Notification.notification_type.POWER_MANAGEMENT, event = Notification.event.power_management.AC_MAINS_DISCONNECTED})
-        }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.battery())
-      },
-      {
-        channel = "zwave",
-        direction = "receive",
-        message = {
-          mock_sensor.id,
-          Notification:Report({notification_type = Notification.notification_type.POWER_MANAGEMENT, event = Notification.event.power_management.AC_MAINS_RE_CONNECTED})
-        }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.dc())
+      channel = "zwave",
+      direction = "receive",
+      message = {
+        mock_sensor.id,
+        Notification:Report({notification_type = Notification.notification_type.POWER_MANAGEMENT, event = Notification.event.power_management.AC_MAINS_DISCONNECTED})
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.battery())
+    },
+    {
+      channel = "zwave",
+      direction = "receive",
+      message = {
+        mock_sensor.id,
+        Notification:Report({notification_type = Notification.notification_type.POWER_MANAGEMENT, event = Notification.event.power_management.AC_MAINS_RE_CONNECTED})
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.dc())
     }
+  }
 )
 
 test.register_message_test(
-    "Configuration reports about power management should be handled",
+  "Configuration reports about power management should be handled",
+  {
     {
-      {
-        channel = "zwave",
-        direction = "receive",
-        message = {
-          mock_sensor.id,
-          Configuration:Report({parameter_number = 9, configuration_value = 0})
-        }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.dc())
-      },
-      {
-        channel = "zwave",
-        direction = "receive",
-        message = {
-          mock_sensor.id,
-          Configuration:Report({parameter_number = 9, configuration_value = 256})
-        }
-      },
-      {
-        channel = "capability",
-        direction = "send",
-        message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.battery())
+      channel = "zwave",
+      direction = "receive",
+      message = {
+        mock_sensor.id,
+        Configuration:Report({parameter_number = 9, configuration_value = 0})
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.dc())
+    },
+    {
+      channel = "zwave",
+      direction = "receive",
+      message = {
+        mock_sensor.id,
+        Configuration:Report({parameter_number = 9, configuration_value = 256})
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_sensor:generate_test_message("main", capabilities.powerSource.powerSource.battery())
     }
+  }
 )
+
+test.register_message_test(
+  "Notification reports about tamper should be handled",
+  {
+    {
+      channel = "zwave",
+      direction = "receive",
+      message = {
+        mock_sensor.id,
+        Notification:Report({notification_type = Notification.notification_type.HOME_SECURITY, event = Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED})
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.detected())
+    }
+  }
+)
+
+test.register_coroutine_test(
+  "Tampers should clear after 10 seconds",
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(10, "oneshot")
+    test.socket.zwave:__queue_receive({
+      mock_sensor.id,
+      Notification:Report({
+        notification_type = Notification.notification_type.HOME_SECURITY,
+        event = Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED
+      })
+    })
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.detected())
+    )
+    test.mock_time.advance_time(10)
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Subsequent tampers should only clear 10 seconds after the most recent",
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(5, "oneshot")
+    test.timer.__create_and_queue_test_time_advance_timer(10, "oneshot")
+    test.socket.zwave:__queue_receive({
+      mock_sensor.id,
+      Notification:Report({
+        notification_type = Notification.notification_type.HOME_SECURITY,
+        event = Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED
+      })
+    })
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.detected())
+    )
+    test.mock_time.advance_time(5)
+    test.socket.zwave:__queue_receive({
+      mock_sensor.id,
+      Notification:Report({
+        notification_type = Notification.notification_type.HOME_SECURITY,
+        event = Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED
+      })
+    })
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.detected())
+    )
+    test.mock_time.advance_time(10)
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Tamper clears from the device should also send a no motion event",
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(10, "oneshot")
+    test.socket.zwave:__queue_receive({
+      mock_sensor.id,
+      Notification:Report({
+        notification_type = Notification.notification_type.HOME_SECURITY,
+        event = Notification.event.home_security.STATE_IDLE
+      })
+    })
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.motionSensor.motion.inactive())
+    )
+    test.mock_time.advance_time(10)
+    test.socket.capability:__expect_send(
+      mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+    )
+  end
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
Notification report handler overwrote defaults without redefining handling of tamper. Also re-added some handling of other events from the DTH that were missing here.