### PR TITLE
fix: Responsive attr. emit after handling commands

### DIFF
--- a/drivers/SmartThings/philips-hue/src/hue/fields.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/fields.lua
@@ -19,6 +19,7 @@ local Fields = {
   BRIDGE_ID = "bridgeid",
   BRIDGE_SW_VERSION = "swversion",
   DEVICE_TYPE = "devicetype",
+  EMIT_CACHE = "emitted",
   EVENT_SOURCE = "eventsource",
   GAMUT = "gamut",
   HUE_DEVICE_ID = "hue_device_id",


### PR DESCRIPTION
Previously we relied on the eventual update from the SSE stream to emit capability attribute updates that result from command handling. This is subject to latency spikes and responsiveness jitter due to encapsulation and rate limiting on the Hue bridge itself that it uses to conserve its own resources.

This change adopts a pattern found in other drivers where the endpoint provides an ACK which we use as a signal that we can emit and update that attribute update that matches the args to command we just sent. We then cache that attribute update, and we check against that for similarity before performing any additional attribute event emissions for that capability.