### PR TITLE
Fix motion threshold on SmartThings multisensor

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/multi-sensor/smartthings-multi/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/multi-sensor/smartthings-multi/init.lua
@@ -60,7 +60,8 @@ end
 local function do_configure(self, device)
   device:configure()
   device:send(multi_utils.custom_write_attribute(device, multi_utils.MOTION_THRESHOLD_MULTIPLIER_ATTR, data_types.Uint8, 0x01, SMARTTHINGS_MFG))
-  device:send(multi_utils.custom_write_attribute(device, multi_utils.MOTION_THRESHOLD_ATTR, data_types.Uint16, 0x0276, SMARTTHINGS_MFG))
+  -- This value should be "0x0276", but it is passed as little-endian as a bug-workaround (see DVCSMP-4739)
+  device:send(multi_utils.custom_write_attribute(device, multi_utils.MOTION_THRESHOLD_ATTR, data_types.Uint16, 0x7602, SMARTTHINGS_MFG))
   multi_utils.send_common_configuration(self, device, SMARTTHINGS_MFG)
 end
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_smartthings_multi_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_smartthings_multi_sensor.lua
@@ -322,7 +322,7 @@ test.register_coroutine_test(
     })
     test.socket.zigbee:__expect_send({
       mock_device.id,
-      build_write_attr_msg(0xFC02, 0x0002, data_types.Uint16, 0x0276, 0x110A)
+      build_write_attr_msg(0xFC02, 0x0002, data_types.Uint16, 0x7602, 0x110A)
     })
     test.socket.zigbee:__expect_send({
       mock_device.id,


### PR DESCRIPTION
The motion threshold was being passed with incorrect endianess, causing the threshold for motion detection to be higher than expected.

Check here for more info on the bug: https://smartthings.atlassian.net/browse/DVCSMP-4739