### PR TITLE
Fix Sonos issues related to capability mismatches from DTH to Edge Driver

### DIFF
--- a/drivers/SmartThings/sonos/profiles/sonos-player.yml
+++ b/drivers/SmartThings/sonos/profiles/sonos-player.yml
@@ -19,6 +19,8 @@ components:
     version: 1
   - id: audioMute
     version: 1
+  - id: audioNotification
+    version: 1
   - id: audioTrackData
     version: 1
   - id: audioVolume

--- a/drivers/SmartThings/sonos/profiles/sonos-player.yml
+++ b/drivers/SmartThings/sonos/profiles/sonos-player.yml
@@ -11,6 +11,8 @@ components:
             - 'playing'
             - 'paused'
             - 'stopped'
+  - id: mediaGroup
+    version: 1
   - id: mediaPresets
     version: 1
   - id: mediaTrackControl

--- a/drivers/SmartThings/sonos/profiles/sonos-player.yml
+++ b/drivers/SmartThings/sonos/profiles/sonos-player.yml
@@ -4,6 +4,13 @@ components:
   capabilities:
   - id: mediaPlayback
     version: 1
+    config:
+      values:
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - 'playing'
+            - 'paused'
+            - 'stopped'
   - id: mediaPresets
     version: 1
   - id: mediaTrackControl

--- a/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
@@ -157,4 +157,20 @@ function CapCommandHandlers.handle_play_preset(driver, device, cmd)
   _do_send_to_group(driver, device, payload)
 end
 
+function CapCommandHandlers.handle_audio_notification(driver, device, cmd)
+  local payload = {
+    { namespace = "audioClip", command = "loadAudioClip" },
+    {
+      appId = "edge.smartthings.com",
+      name = "SmartThings Audio Notification",
+      streamUrl = cmd.args.uri,
+    }
+  }
+
+  if type(cmd.args.level) == 'number' then
+    payload[2].volume = cmd.args.level
+  end
+  _do_send_to_self(driver, device, payload)
+end
+
 return CapCommandHandlers

--- a/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
@@ -26,6 +26,14 @@ local function _do_send_to_group(driver, device, payload)
   _do_send(device, payload)
 end
 
+local function _do_send_to_self(driver, device, payload)
+  local household_id, player_id = driver.sonos:get_player_for_device(device)
+  payload[1].householdId = household_id
+  payload[1].playerId = player_id
+
+  _do_send(device, payload)
+end
+
 function CapCommandHandlers.handle_play(driver, device, _cmd)
   local payload = {
     { namespace = "playback", command = "play" }, {}
@@ -65,13 +73,55 @@ end
 function CapCommandHandlers.handle_set_mute(driver, device, cmd)
   local set_mute = (cmd.args and cmd.args.state == "muted")
   local payload = {
+    { namespace = "playerVolume", command = "setMute" },
+    { muted = set_mute }
+  }
+  _do_send_to_self(driver, device, payload)
+end
+
+function CapCommandHandlers.handle_volume_up(driver, device, cmd)
+  local payload = {
+    { namespace = "playerVolume", command = "setRelativeVolume" },
+    { volumeDelta = 5 }
+  }
+  _do_send_to_self(driver, device, payload)
+end
+
+function CapCommandHandlers.handle_volume_down(driver, device, cmd)
+  local payload = {
+    { namespace = "playerVolume", command = "setRelativeVolume" },
+    { volumeDelta = -5 }
+  }
+  _do_send_to_self(driver, device, payload)
+end
+
+function CapCommandHandlers.handle_set_volume(driver, device, cmd)
+  local new_volume = st_utils.clamp_value(cmd.args.volume, 0, 100)
+  local payload = {
+    { namespace = "playerVolume", command = "setVolume" },
+    { volume = new_volume }
+  }
+  _do_send_to_self(driver, device, payload)
+end
+
+function CapCommandHandlers.handle_group_mute(driver, device, _cmd)
+  CapCommandHandlers.handle_group_set_mute(driver, device, { args = { state = "muted" } })
+end
+
+function CapCommandHandlers.handle_group_unmute(driver, device, _cmd)
+  CapCommandHandlers.handle_group_set_mute(driver, device, { args = { state = "unmuted" } })
+end
+
+function CapCommandHandlers.handle_group_set_mute(driver, device, cmd)
+  local set_mute = (cmd.args and cmd.args.state == "muted")
+  local payload = {
     { namespace = "groupVolume", command = "setMute" },
     { muted = set_mute }
   }
   _do_send_to_group(driver, device, payload)
 end
 
-function CapCommandHandlers.handle_volume_up(driver, device, cmd)
+function CapCommandHandlers.handle_group_volume_up(driver, device, cmd)
   local payload = {
     { namespace = "groupVolume", command = "setRelativeVolume" },
     { volumeDelta = 5 }
@@ -79,7 +129,7 @@ function CapCommandHandlers.handle_volume_up(driver, device, cmd)
   _do_send_to_group(driver, device, payload)
 end
 
-function CapCommandHandlers.handle_volume_down(driver, device, cmd)
+function CapCommandHandlers.handle_group_volume_down(driver, device, cmd)
   local payload = {
     { namespace = "groupVolume", command = "setRelativeVolume" },
     { volumeDelta = -5 }
@@ -87,7 +137,7 @@ function CapCommandHandlers.handle_volume_down(driver, device, cmd)
   _do_send_to_group(driver, device, payload)
 end
 
-function CapCommandHandlers.handle_set_volume(driver, device, cmd)
+function CapCommandHandlers.handle_group_set_volume(driver, device, cmd)
   local new_volume = st_utils.clamp_value(cmd.args.volume, 0, 100)
   local payload = {
     { namespace = "groupVolume", command = "setVolume" },

--- a/drivers/SmartThings/sonos/src/api/event_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/event_handlers.lua
@@ -1,4 +1,7 @@
 local capabilities = require "st.capabilities"
+local log = require "log"
+
+local st_utils = require "st.utils"
 
 local CapEventHandlers = {}
 
@@ -33,6 +36,17 @@ function CapEventHandlers.handle_group_update(device, group_info)
   device:emit_event(capabilities.mediaGroup.groupPrimaryDeviceId(groupPrimaryDeviceId))
   device:emit_event(capabilities.mediaGroup.groupId(groupId))
 end
+
+function CapEventHandlers.handle_audio_clip_status(device, clips)
+  for _, clip in ipairs(clips) do
+    if clip.status == "ACTIVE" then
+      log.debug(st_utils.stringify_table(clip, "Playing Audio Clip: ", false))
+    elseif clip.status == "DONE" then
+      log.debug(st_utils.stringify_table(clip, "Completed Playing Audio Clip: ", false))
+    end
+  end
+end
+
 function CapEventHandlers.handle_playback_status(device, playback_state)
   if playback_state == CapEventHandlers.PlaybackStatus.Playing then
     device:emit_event(capabilities.mediaPlayback.playbackStatus.playing())

--- a/drivers/SmartThings/sonos/src/api/event_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/event_handlers.lua
@@ -18,6 +18,21 @@ function CapEventHandlers.handle_player_volume(device, new_volume, is_muted)
   end
 end
 
+function CapEventHandlers.handle_group_volume(device, new_volume, is_muted)
+  device:emit_event(capabilities.mediaGroup.groupVolume(new_volume))
+  if is_muted then
+    device:emit_event(capabilities.mediaGroup.groupMute.muted())
+  else
+    device:emit_event(capabilities.mediaGroup.groupMute.unmuted())
+  end
+end
+
+function CapEventHandlers.handle_group_update(device, group_info)
+  local groupRole, groupPrimaryDeviceId, groupId = table.unpack(group_info)
+  device:emit_event(capabilities.mediaGroup.groupRole(groupRole))
+  device:emit_event(capabilities.mediaGroup.groupPrimaryDeviceId(groupPrimaryDeviceId))
+  device:emit_event(capabilities.mediaGroup.groupId(groupId))
+end
 function CapEventHandlers.handle_playback_status(device, playback_state)
   if playback_state == CapEventHandlers.PlaybackStatus.Playing then
     device:emit_event(capabilities.mediaPlayback.playbackStatus.playing())

--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -28,7 +28,7 @@ local SonosRestApi = require "api.rest"
 local SonosConnection = {}
 SonosConnection.__index = SonosConnection
 
-local self_subscriptions = { "groups", "playerVolume" }
+local self_subscriptions = { "groups", "playerVolume", "audioClip" }
 local coordinator_subscriptions = { "groupVolume", "playback", "favorites", "playbackMetadata" }
 local favorites_version = ""
 
@@ -157,6 +157,11 @@ function SonosConnection.new(driver, device)
         local player_id = self.device:get_field(PlayerFields.PLAYER_ID)
         if player_id == header.playerId and body.volume and (body.muted ~= nil) then
           EventHandlers.handle_player_volume(self.device, body.volume, body.muted)
+        end
+      elseif header.type == "audioClipStatus" then
+        local player_id = self.device:get_field(PlayerFields.PLAYER_ID)
+        if player_id == header.playerId then
+          EventHandlers.handle_audio_clip_status(self.device, body.audioClips)
         end
       elseif header.type == "groupVolume" then
         if body.volume and (body.muted ~= nil) then

--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -141,7 +141,7 @@ function SonosConnection.new(driver, device)
       if header.type == "groups" then
         local household_id, current_coordinator = self.driver.sonos:get_coordinator_for_device(self.device)
         local _, player_id = self.driver.sonos:get_player_for_device(self.device)
-        self.driver.sonos:update_household_info(header.householdId, body)
+        self.driver.sonos:update_household_info(header.householdId, body, self.device)
         local _, updated_coordinator = self.driver.sonos:get_coordinator_for_device(self.device)
 
         Router.cleanup_unused_sockets(self.driver)
@@ -167,7 +167,7 @@ function SonosConnection.new(driver, device)
             --- is being deleted so we check for the presence of emit event as a proxy for
             --- whether or not this device is currently capable of emitting events.
             if device_for_player and device_for_player.emit_event then
-              EventHandlers.handle_player_volume(device_for_player, body.volume, body.muted)
+              EventHandlers.handle_group_volume(device_for_player, body.volume, body.muted)
             end
           end
         end

--- a/drivers/SmartThings/sonos/src/api/sonos_websocket_router.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_websocket_router.lua
@@ -19,7 +19,6 @@ local SonosWebSocketRouter = {}
 local control_tx, control_rx = channel.new()
 control_rx:settimeout(0.5)
 
----@alias PlayerId string
 ---@alias WsId string|number
 ---@alias chan_tx table
 ---@alias chan_rx table
@@ -80,6 +79,14 @@ cosock.spawn(function()
             end
           end
         elseif err == "closed" and recv.id then -- closed websocket
+          log.trace(string.format("Websocket %s closed", tostring(recv.id)))
+          local still_open_sockets = {}
+          for player_id, wss in pairs(websockets) do
+            if wss.id ~= recv.id then
+              still_open_sockets[player_id] = wss
+            end
+          end
+          websockets = still_open_sockets
           for _, uuid in ipairs(listener_ids_for_socket[recv.id]) do
             local listener = listeners[uuid]
 
@@ -115,36 +122,35 @@ cosock.spawn(function()
   end
 end)
 
---- @param player_id PlayerId
 --- @param url_table table
 --- @return WebSocket|nil
 --- @return nil|string error
 local function _make_websocket(url_table)
   local sock, err = socket.tcp()
+  if not sock or err ~= nil then return nil, "Could not open TCP socket: " .. err end
+  local _, err = sock:settimeout(3)
+  if err ~= nil then return nil, "Could not set TCP socket timeout: " .. err end
 
-  if sock then
-    sock:settimeout(3)
-    log.trace(string.format(
-      "Opening up websocket connection for host/port %s %s",
-      url_table.host, url_table.port))
-    _, err = sock:connect(url_table.host, url_table.port)
-    if not err then
-      sock:setoption("keepalive", true)
+  log.trace(string.format(
+    "Opening up websocket connection for host/port %s %s",
+    url_table.host, url_table.port))
 
-      sock, err = ssl.wrap(sock, {
-        mode = "client",
-        protocol = "any",
-        verify = "none",
-        options = "all"
-      })
+  _, err = sock:connect(url_table.host, url_table.port)
+  if err ~= nil then return nil, "Socket connect error: " .. err end
 
-      if err then return nil, "SSL Wrap error: " .. err end
+  _, err = sock:setoption("keepalive", true)
+  if err ~= nil then return nil, "Socket set keepalive error: " .. err end
 
-      sock:dohandshake()
-    end
-  else
-    return nil, "Could not open TCP socket: " .. err
-  end
+  sock, err = ssl.wrap(sock, {
+    mode = "client",
+    protocol = "any",
+    verify = "none",
+    options = "all"
+  })
+  if err ~= nil then return nil, "SSL Wrap error: " .. err end
+
+  _, err = sock:dohandshake()
+  if err ~= nil then return nil, "SSL Handhsake error: " .. err end
 
   --- SONOS_API_KEY is a Global added to the environment in the root init.lua.
   --- This API key is injected in to the driver at deploy time for production.
@@ -154,23 +160,21 @@ local function _make_websocket(url_table)
                                        :protocol("v1.api.smartspeaker.audio")
 
   local wss = WebSocket.client(sock, url_table.path, config)
-
   _, err = wss:client_handshake_and_start(url_table.host, url_table.port)
-
-  if err ~= nil then
-    return nil, "Error starting websocket: " .. err
-  end
+  if err ~= nil then return nil, "Error starting websocket: " .. err end
 
   return wss
 end
 
 function SonosWebSocketRouter.is_connected(player_id)
-  return websockets[player_id] ~= nil
+  local wss = websockets[player_id]
+  return wss ~= nil and wss.state ~= nil and wss.state == "Active"
 end
 
 function SonosWebSocketRouter.register_listener_for_socket(listener,
                                                            player_id_for_socket)
   local ws = websockets[player_id_for_socket]
+  ws._player_id = player_id_for_socket
 
   if ws ~= nil then
     local uuid = st_utils.generate_uuid_v4()

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -27,7 +27,7 @@ local function find_player_for_device(driver, device, should_continue)
     local attempts = 0
     should_continue = function()
       attempts = attempts + 1
-      return attempts <= 20
+      return attempts <= 10
     end
   end
 
@@ -63,10 +63,12 @@ local function _initialize_device(driver, device)
       log.debug("Rescanning for player with DNI " .. device.device_network_id)
       local success = find_player_for_device(driver, device)
       if not success then
-        error(string.format(
-          "Received event for device DNI [%s] but could not find matching player on local network",
-          device.device_network_id
+        device:offline()
+        log.error(string.format(
+          "Could not initialize Sonos Player [%s], it does not appear to be on the network",
+          device.label
         ))
+        return
       end
     end
 

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -211,15 +211,6 @@ local driver = Driver("Sonos", {
     [capabilities.refresh.ID] = {
       [capabilities.refresh.commands.refresh.NAME] = do_refresh,
     },
-    [capabilities.mediaPlayback.ID] = {
-      [capabilities.mediaPlayback.commands.play.NAME] = CmdHandlers.handle_play,
-      [capabilities.mediaPlayback.commands.pause.NAME] = CmdHandlers.handle_pause,
-      [capabilities.mediaPlayback.commands.stop.NAME] = CmdHandlers.handle_pause,
-    },
-    [capabilities.mediaTrackControl.ID] = {
-      [capabilities.mediaTrackControl.commands.nextTrack.NAME] = CmdHandlers.handle_next_track,
-      [capabilities.mediaTrackControl.commands.previousTrack.NAME] = CmdHandlers.handle_previous_track,
-    },
     [capabilities.audioMute.ID] = {
       [capabilities.audioMute.commands.mute.NAME] = CmdHandlers.handle_mute,
       [capabilities.audioMute.commands.unmute.NAME] = CmdHandlers.handle_unmute,
@@ -230,9 +221,26 @@ local driver = Driver("Sonos", {
       [capabilities.audioVolume.commands.volumeDown.NAME] = CmdHandlers.handle_volume_down,
       [capabilities.audioVolume.commands.setVolume.NAME] = CmdHandlers.handle_set_volume,
     },
+    [capabilities.mediaGroup.ID] = {
+      [capabilities.mediaGroup.commands.groupVolumeUp.NAME] = CmdHandlers.handle_mute,
+      [capabilities.mediaGroup.commands.groupVolumeDown.NAME] = CmdHandlers.handle_unmute,
+      [capabilities.mediaGroup.commands.setGroupVolume.NAME] = CmdHandlers.handle_set_mute,
+      [capabilities.mediaGroup.commands.muteGroup.NAME] = CmdHandlers.handle_volume_up,
+      [capabilities.mediaGroup.commands.unmuteGroup.NAME] = CmdHandlers.handle_volume_down,
+      [capabilities.mediaGroup.commands.setGroupMute.NAME] = CmdHandlers.handle_set_volume,
+    },
+    [capabilities.mediaPlayback.ID] = {
+      [capabilities.mediaPlayback.commands.play.NAME] = CmdHandlers.handle_play,
+      [capabilities.mediaPlayback.commands.pause.NAME] = CmdHandlers.handle_pause,
+      [capabilities.mediaPlayback.commands.stop.NAME] = CmdHandlers.handle_pause,
+    },
     [capabilities.mediaPresets.ID] = {
       [capabilities.mediaPresets.commands.playPreset.NAME] = CmdHandlers.handle_play_preset,
     },
+    [capabilities.mediaTrackControl.ID] = {
+      [capabilities.mediaTrackControl.commands.nextTrack.NAME] = CmdHandlers.handle_next_track,
+      [capabilities.mediaTrackControl.commands.previousTrack.NAME] = CmdHandlers.handle_previous_track,
+    }
   },
   sonos = SonosState.new(),
   update_group_state = update_group_state,

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -216,6 +216,11 @@ local driver = Driver("Sonos", {
       [capabilities.audioMute.commands.unmute.NAME] = CmdHandlers.handle_unmute,
       [capabilities.audioMute.commands.setMute.NAME] = CmdHandlers.handle_set_mute,
     },
+    [capabilities.audioNotification.ID] = {
+      [capabilities.audioNotification.commands.playTrack.NAME] = CmdHandlers.handle_audio_notification,
+      [capabilities.audioNotification.commands.playTrackAndResume.NAME] = CmdHandlers.handle_audio_notification,
+      [capabilities.audioNotification.commands.playTrackAndRestore.NAME] = CmdHandlers.handle_audio_notification,
+    },
     [capabilities.audioVolume.ID] = {
       [capabilities.audioVolume.commands.volumeUp.NAME] = CmdHandlers.handle_volume_up,
       [capabilities.audioVolume.commands.volumeDown.NAME] = CmdHandlers.handle_volume_down,

--- a/drivers/SmartThings/sonos/src/lunchbox/rest.lua
+++ b/drivers/SmartThings/sonos/src/lunchbox/rest.lua
@@ -63,6 +63,7 @@ local function send_request(client, request)
   local payload = request:serialize()
 
   local bytes, err, idx = nil, nil, 0
+  if client.socket == nil then return nil, "closed", nil end
 
   repeat bytes, err, idx = client.socket:send(payload, idx + 1, #payload) until (bytes == #payload)
       or (err ~= nil)

--- a/drivers/SmartThings/sonos/src/types.lua
+++ b/drivers/SmartThings/sonos/src/types.lua
@@ -1,5 +1,7 @@
+local handlers = require "api.event_handlers"
 local log = require "log"
 local PlayerFields = require "fields".SonosPlayerFields
+
 --- @module 'sonos.types'
 local Types = {}
 
@@ -111,7 +113,7 @@ Types.SonosCapabilities = {
 --- Sonos systems local state
 --- @class SonosState
 --- @field public get_household fun(self: SonosState, id: HouseholdId): SonosHousehold
---- @field public update_household_info fun(self: SonosState, id: HouseholdId, groups_event: SonosGroupsResponseBody)
+--- @field public update_household_info fun(self: SonosState, id: HouseholdId, groups_event: SonosGroupsResponseBody, device: SonosDevice|nil)
 --- @field public update_household_favorites fun(self: SonosState, id: HouseholdId, favorites: SonosFavorites)
 --- @field public get_group_for_player fun(self: SonosState, household_id: HouseholdId, player_id: PlayerId): GroupId
 --- @field public get_coordinator_for_player fun(self: SonosState, household_id: HouseholdId, player_id: PlayerId): PlayerId
@@ -160,7 +162,8 @@ function SonosState.new()
   --- @param self SonosState
   --- @param id HouseholdId
   --- @param groups_event SonosGroupsResponseBody
-  ret.update_household_info = function(self, id, groups_event)
+  --- @param device SonosDevice|nil
+  ret.update_household_info = function(self, id, groups_event, device)
     local household = private.households[id] or {}
     local groups, players = groups_event.groups, groups_event.players
 
@@ -192,6 +195,26 @@ function SonosState.new()
     end
 
     private.households[id] = household
+
+    -- emit group info update [groupId, groupRole, groupPrimaryDeviceId]
+    if device ~= nil then
+      local device_player_id = device:get_field(PlayerFields.PLAYER_ID)
+      local group_id = self:get_group_for_player(id, device_player_id)
+      local coordinator_id = self:get_coordinator_for_player(id, device_player_id)
+
+      local role = ""
+      if device_player_id == coordinator_id then
+        if #household.groups[group_id].playerIds > 1 then
+          role = "primary"
+        else
+          role = "ungrouped"
+        end
+      else
+        role = "auxilary"
+      end
+
+      handlers.handle_group_update(device, {role, coordinator_id, group_id})
+    end
   end
 
   --- @param self SonosState


### PR DESCRIPTION
## [Fix CHAD-10316 with embedded device config](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/commit/a6c48c4cabd91f6ee93ff44a0e78271c70c0a4d0)

Remove the `Rewind` and `Fast Forward` capabilities because not everything in the plugin is respecting the supported command event emission.

Fixes: CHAD-10316

## [Fix: disconnect detection bugs](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/commit/c485252110aea0f94cce83e2213e585925300854)

No ticket, just some issues that were found during development that would result in crashes sometimes during disconnect.

## [Fix: Restore `mediaGroup` capability functionality](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/commit/c1a314d9349ea142034825f084a3bbd0b5788ef5)

Add the `mediaGroup` capability and its handlers/emissions back to Sonos. Erroneously dropped when porting.

Fixes: CHAD-10310

## [Fix: restore `audioNotification` capability](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/commit/2c3d8a02e46de21f238b160c3110602ea40b0050)

Add the `audioNotification` and its handlers back to Sonos. Erroneously dropped when porting.

Fixes: CHAD-10289