### PR TITLE
zigbee-contact: Fix vibration/3-axis reporting for original SmartThings multi sensor

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
@@ -25,6 +25,11 @@ local SMARTSENSE_MULTI_XYZ_CMD = 0x05
 local SMARTSENSE_MULTI_STATUS_CMD = 0x07
 local SMARTSENSE_MULTI_STATUS_REPORT_CMD = 0x09
 
+local SMARTSENSE_MULTI_FINGERPRINTS = {
+  { mfr = "SmartThings", model = "PGC313" },
+  { mfr = "SmartThings", model = "PGC313EU" }
+}
+
 local function acceleration_handler(driver, device, zb_rx)
   -- This is a custom cluster command for the kickstarter multi.
   -- This has no body but is sent everytime the accelerometer transitions from an unmoving state to a moving one.
@@ -147,8 +152,12 @@ local smartsense_multi = {
     }
   },
   can_handle = function(opts, driver, device, ...)
-    local sp = device:supports_server_cluster(SMARTSENSE_MULTI_CLUSTER, 1)
-    return sp
+    for _, fingerprint in ipairs(SMARTSENSE_MULTI_FINGERPRINTS) do
+      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+        return true
+      end
+    end
+    return false
   end
 }
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
@@ -33,6 +33,8 @@ local mock_device = test.mock_device.build_test_zigbee_device(
     zigbee_endpoints = {
       [1] = {
         id = 1,
+        manufacturer = "SmartThings",
+        model = "PGC313",
         server_clusters = {SMARTSENSE_MULTI_CLUSTER}
       }
     }


### PR DESCRIPTION
The original `can_handle` function was not working, so anytime one of the original SmartThings multi sensors would join, it would not correctly map to the smartsense-multi subdriver. This is due to the fact that the multisensors don't report that they support the cluster 0xFC03 (custom smartsense multi cluster), so the previous `can_handle` implementation would never return true. Now, we just check the manufacturer and the model in the `can_handle` function to ensure that the function returns true for the appropriate sensors.