### PR TITLE
Fix FF and RW in Automation for Post Mig

### DIFF
--- a/drivers/SmartThings/samsung-audio/profiles/samsung-audio.yml
+++ b/drivers/SmartThings/samsung-audio/profiles/samsung-audio.yml
@@ -4,6 +4,18 @@ components:
   capabilities:
   - id: mediaPlayback
     version: 1
+    config:
+      values:
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - 'play'
+            - 'pause'
+            - 'stop'
+        - key: "playbackStatus.value"
+          enabledValues:
+            - 'playing'
+            - 'paused'
+            - 'stopped'
   - id: mediaTrackControl
     version: 1
   - id: audioMute


### PR DESCRIPTION
Fix Issues for https://smartthings.atlassian.net/browse/CHAD-10342 (POST mig: "Fast forward" and "Rewind" options appear in automation trigger)