### PR TITLE
String data type handling for frequency duration in Aqara Motion Sensor 

### DIFF
--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/aqara_utils.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/aqara_utils.lua
@@ -24,6 +24,10 @@ local function motion_detected(device)
   end
 
   local detect_duration = device:get_field(PREF_FREQUENCY_KEY) or PREF_FREQUENCY_VALUE_DEFAULT
+  if type(detect_duration) == "string"  then
+    detect_duration = tonumber(detect_duration)
+  end
+
   local inactive_state = function()
     device:emit_event(capabilities.motionSensor.motion.inactive())
   end


### PR DESCRIPTION
Fix for the error:
2023-02-09_11:45:27.134 | E | edi        | <Aqara motion Sensor (0cf7d3b5)> 동작센서 thread encountered error: [string "st/dispatcher.lua"]:233: Error encountered while processing event for <ZigbeeDevice: 6de00bca-*-*-*-dbe918c4937c [0x2B86] (동작센서)>:
[string "init.lua"]:46: Timer delay must be a number