### PR TITLE
Play and Volume Delay Fix

### DIFF
--- a/drivers/SmartThings/samsung-audio/src/handlers.lua
+++ b/drivers/SmartThings/samsung-audio/src/handlers.lua
@@ -16,6 +16,7 @@ local command = require "command"
 local log = require "log"
 local utils = require "st.utils"
 local capabilities = require "st.capabilities"
+local VOL_STEP = 5
 
 --- @module Samsung-audio.CapabilityHandlers
 local CapabilityHandlers = {}
@@ -106,7 +107,7 @@ function CapabilityHandlers.handle_volume_up(driver, device, cmd)
   local ip = device:get_field("ip")
   local vol = command.volume(ip)
   if vol then
-    local set_vol = command.set_volume(ip, tonumber(vol.volume) + 5)
+    local set_vol = command.set_volume(ip, tonumber(vol.volume) + VOL_STEP)
     if set_vol then
       device:emit_event(capabilities.audioVolume.volume(tonumber(set_vol.volume)))
       device:emit_event(capabilities.audioMute.mute.unmuted())
@@ -118,7 +119,7 @@ function CapabilityHandlers.handle_volume_down(driver, device, cmd)
   local ip = device:get_field("ip")
   local vol = command.volume(ip)
   if vol then
-    local set_vol = command.set_volume(ip, tonumber(vol.volume) - 5)
+    local set_vol = command.set_volume(ip, tonumber(vol.volume) - VOL_STEP)
     if set_vol then
       device:emit_event(capabilities.audioVolume.volume(tonumber(set_vol.volume)))
       device:emit_event(capabilities.audioMute.mute.unmuted())

--- a/drivers/SmartThings/samsung-audio/src/handlers.lua
+++ b/drivers/SmartThings/samsung-audio/src/handlers.lua
@@ -39,7 +39,7 @@ end
 
 function CapabilityHandlers.handle_play(driver, device, cmd)
   local ip = device:get_field("ip")
-  CapabilityHandlers.handle_on(driver, device, nil) --turn on if device is off
+  -- CapabilityHandlers.handle_on(driver, device, nil) --on/off is not working for samsung-audio (same issue with cloud DTH)
   local ret = command.play(ip)
   if ret then
    device:emit_event(capabilities.mediaPlayback.playbackStatus.playing())
@@ -106,7 +106,10 @@ end
 
 function CapabilityHandlers.handle_set_volume(driver, device, cmd)
   local ip = device:get_field("ip")
-  command.set_volume(ip, cmd.args.volume)
+  local vol = command.set_volume(ip, cmd.args.volume)
+  if vol then
+    device:emit_event(capabilities.audioVolume.volume(tonumber(vol.volume)))
+  end
 end
 
 return CapabilityHandlers

--- a/drivers/SmartThings/samsung-audio/src/handlers.lua
+++ b/drivers/SmartThings/samsung-audio/src/handlers.lua
@@ -80,19 +80,37 @@ end
 
 function CapabilityHandlers.handle_mute(driver, device, cmd)
   local ip = device:get_field("ip")
-  command.mute(ip)
+  local muteStatus = command.mute(ip)
+  if muteStatus then
+    if muteStatus.muted ~= "off" then
+      device:emit_event(capabilities.audioMute.mute.muted())
+    else
+      device:emit_event(capabilities.audioMute.mute.unmuted())
+    end
+  end
 end
 
 function CapabilityHandlers.handle_unmute(driver, device, cmd)
   local ip = device:get_field("ip")
-  command.unmute(ip)
+  local muteStatus = command.unmute(ip)
+  if muteStatus then
+    if muteStatus.muted ~= "off" then
+      device:emit_event(capabilities.audioMute.mute.muted())
+    else
+      device:emit_event(capabilities.audioMute.mute.unmuted())
+    end
+  end
 end
 
 function CapabilityHandlers.handle_volume_up(driver, device, cmd)
   local ip = device:get_field("ip")
   local vol = command.volume(ip)
   if vol then
-    command.set_volume(ip, vol.volume + 5)
+    local set_vol = command.set_volume(ip, tonumber(vol.volume) + 5)
+    if set_vol then
+      device:emit_event(capabilities.audioVolume.volume(tonumber(set_vol.volume)))
+      device:emit_event(capabilities.audioMute.mute.unmuted())
+    end
   end
 end
 
@@ -100,7 +118,11 @@ function CapabilityHandlers.handle_volume_down(driver, device, cmd)
   local ip = device:get_field("ip")
   local vol = command.volume(ip)
   if vol then
-    command.set_volume(ip, vol.volume - 5)
+    local set_vol = command.set_volume(ip, tonumber(vol.volume) - 5)
+    if set_vol then
+      device:emit_event(capabilities.audioVolume.volume(tonumber(set_vol.volume)))
+      device:emit_event(capabilities.audioMute.mute.unmuted())
+    end
   end
 end
 
@@ -109,6 +131,7 @@ function CapabilityHandlers.handle_set_volume(driver, device, cmd)
   local vol = command.set_volume(ip, cmd.args.volume)
   if vol then
     device:emit_event(capabilities.audioVolume.volume(tonumber(vol.volume)))
+    device:emit_event(capabilities.audioMute.mute.unmuted())
   end
 end
 


### PR DESCRIPTION
"https://smartthings.atlassian.net/browse/CHAD-10011" -> Fix for delay in Play and Volume command.

Power On/Off command is not responsive for samsung-audio (known issue with cloud DTH case too).
Play is using power command which is causing delay in command execution. So, commented the power command.

For Volume setting, now emitting the new set volume (received in device response) back to ST app. 