### PR TITLE
Fix PR number in duplicate profile comment workflow

### DIFF
--- a/.github/workflows/duplicate-profiles-comment.yml
+++ b/.github/workflows/duplicate-profiles-comment.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           body-includes: Duplicate profile check
           comment-author: 'github-actions[bot]'
-          issue-number: ${{ github.event.number }}
+          issue-number: ${{ env.pr_number }}
 
       - name: Post comment
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
I missed this little change, but I hope this is the last thing needed for this to run smoothly.