### PR TITLE
Refresh of lock with codes causes too many events

### DIFF
--- a/drivers/SmartThings/zwave-lock/src/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/init.lua
@@ -105,6 +105,11 @@ local init_handler = function(driver, device, event)
   populate_state_from_data(device)
 end
 
+local do_refresh = function(self, device)
+  device:send(DoorLock:OperationGet({}))
+  device:send(Battery:Get({}))
+end
+
 --- @param driver st.zwave.Driver
 --- @param device st.zwave.Device
 --- @param cmd table
@@ -165,6 +170,9 @@ local driver_template = {
   capability_handlers = {
     [capabilities.lockCodes.ID] = {
       [capabilities.lockCodes.commands.updateCodes.NAME] = update_codes
+    },
+    [capabilities.refresh.ID] = {
+      [capabilities.refresh.commands.refresh.NAME] = do_refresh
     }
   },
   zwave_handlers = {

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock.lua
@@ -35,7 +35,7 @@ local zwave_lock_endpoints = {
   {
     command_classes = {
       {value = zw.BATTERY},
-      {value = DoorLock},
+      {value = zw.DOOR_LOCK},
       {value = zw.USER_CODE},
       {value = zw.NOTIFICATION}
     }
@@ -728,6 +728,26 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
             capabilities.lockCodes.codeChanged("1 set", { data = { codeName = "test"}, state_change = true  }))
     )
+  end
+)
+
+test.register_coroutine_test(
+  "When the device is added it should be set up and start reading codes",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        DoorLock:OperationGet({})
+      )
+    )
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        Battery:Get({})
+      )
+    )
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
@@ -37,7 +37,7 @@ local zwave_lock_endpoints = {
   {
     command_classes = {
       { value = zw.BATTERY },
-      { value = DoorLock },
+      { value = zw.DOOR_LOCK },
       { value = zw.USER_CODE },
       { value = zw.NOTIFICATION }
     }


### PR DESCRIPTION
This brings behavior back in line with the DTH.