### PR TITLE
Wemo dimmers are unreliably reported

### DIFF
--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -35,7 +35,7 @@ local utils = require "st.utils"
 local profiles = {
   ["Insight"] = "wemo.mini-smart-plug.v1",
   ["Socket"] = "wemo.mini-smart-plug.v1",
-  ["Dimmer"] = "wemo.dimmer-switch.v1",
+  ["Dimmer"] = "wemo.mini-smart-plug.v1",
   ["Motion"] = "wemo.motion-sensor.v1",
   ["Lightswitch"] = "wemo.light-switch.v1",
 }


### PR DESCRIPTION
Consider all dimmers as regular smart switches.
Some Wemo switches erroneously report that they are dimmers, so the change prevents switchLevel capability from being added to all wemo devices. Note this is the same as current DTH behavior and is not a loss of functionality on the platform.