### PR TITLE
HCS-3681 add fingerprint for kickstarter motion sensor

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
@@ -24,11 +24,22 @@ local SMARTSENSE_MULTI_ACC_CMD = 0x00
 local SMARTSENSE_MULTI_XYZ_CMD = 0x05
 local SMARTSENSE_MULTI_STATUS_CMD = 0x07
 local SMARTSENSE_MULTI_STATUS_REPORT_CMD = 0x09
+local SMARTSENSE_PROFILE_ID = 0xFC01
 
 local SMARTSENSE_MULTI_FINGERPRINTS = {
   { mfr = "SmartThings", model = "PGC313" },
   { mfr = "SmartThings", model = "PGC313EU" }
 }
+
+local function can_handle(opts, driver, device, ...)
+  for _, fingerprint in ipairs(SMARTSENSE_MULTI_FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true
+    end
+  end
+  if device.zigbee_endpoints[1].profileId == SMARTSENSE_PROFILE_ID then return true end
+  return false
+end
 
 local function acceleration_handler(driver, device, zb_rx)
   -- This is a custom cluster command for the kickstarter multi.
@@ -151,14 +162,7 @@ local smartsense_multi = {
       }
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    for _, fingerprint in ipairs(SMARTSENSE_MULTI_FINGERPRINTS) do
-      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-        return true
-      end
-    end
-    return false
-  end
+  can_handle = can_handle
 }
 
 return smartsense_multi

--- a/drivers/SmartThings/zigbee-motion-sensor/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-motion-sensor/fingerprints.yml
@@ -189,3 +189,11 @@ zigbeeManufacturer:
     manufacturer: THIRDREALITY
     model: 3RMS16BZ
     deviceProfileName: motion-battery
+zigbeeGeneric:
+  - id: kickstarter/motion/1
+    deviceLabel: SmartThings Motion Sensor
+    zigbeeProfiles:
+      - 0xFC01
+    deviceIdentifiers:
+      - 0x013A
+    deviceProfileName: smartsense-motion

--- a/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/init.lua
@@ -23,7 +23,6 @@ local SMARTSENSE_MODEL = "PGC314"
 local SMARTSENSE_PROFILE_ID = 0xFC01
 local SMARTSENSE_MOTION_CLUSTER = 0xFC04
 local SMARTSENSE_MOTION_STATUS_CMD = 0x00
-local SMARTSENSE_MOTION_STATUS_REPORT_CMD = 0x02
 local MOTION_MASK = 0x02
 local POWER_SOURCE_MASK = 0x01
 local battery_table = {
@@ -43,6 +42,14 @@ local battery_table = {
   [15] = 0,
   [0] = 0
 }
+
+local function can_handle(opts, driver, device, ...)
+  if (device:get_manufacturer() == SMARTSENSE_MFR and device:get_model() == SMARTSENSE_MODEL) or
+    device.zigbee_endpoints[1].profileId == SMARTSENSE_PROFILE_ID then
+    return true
+  end
+  return false
+end
 
 local function device_added(driver, device)
   -- device:emit_event(motion.inactive())
@@ -88,9 +95,7 @@ local smartsense_motion = {
   lifecycle_handlers = {
     added = device_added
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == SMARTSENSE_MFR and device:get_model() == SMARTSENSE_MODEL
-  end
+  can_handle = can_handle
 }
 
 return smartsense_motion

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
@@ -22,7 +22,6 @@ local SMARTSENSE_PROFILE_ID = 0xFC01
 local MFG_CODE = 0x110A
 local SMARTSENSE_MOTION_CLUSTER = 0xFC04
 local SMARTSENSE_MOTION_STATUS_CMD = 0x00
-local SMARTSENSE_MOTION_STATUS_REPORT_CMD = 0x02
 local FRAME_CTRL = 0x1D
 local ENDPOINT = 0x02
 
@@ -34,6 +33,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         id = 1,
         manufacturer = "SmartThings",
         model = "PGC314",
+        profileId = 0xFC01,
         server_clusters = {}
       }
     }


### PR DESCRIPTION
Kickstarter motion sensors don't report a mfr/model, so a different method needs to be used to fingerprint them and appropriately route messages.