### PR TITLE
CHAD-10232 Handle overlap of 0/360 degrees in HSV color space

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -92,6 +92,10 @@ end
 ---@param device HueChildDevice
 local function do_color_action(driver, device, args)
   local hue, sat = (args.args.color.hue / 100), (args.args.color.saturation / 100)
+  if hue == 1 then -- 0 and 360 degrees are equivalent in HSV, but not in our conversion function
+    hue = 0
+    device:set_field(Fields.WRAPPED_HUE, true)
+  end
   local bridge_device = driver:get_device_info(device:get_field(Fields.PARENT_DEVICE_ID))
 
   if not bridge_device then

--- a/drivers/SmartThings/philips-hue/src/hue/fields.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/fields.lua
@@ -27,7 +27,8 @@ local Fields = {
   MIN_KELVIN = "mintemp",
   MODEL_ID = "modelid",
   PARENT_DEVICE_ID = "parent_device_id_local",
-  RESOURCE_ID = "rid"
+  RESOURCE_ID = "rid",
+  WRAPPED_HUE = "_wrapped_hue"
 }
 
 return Fields

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -90,6 +90,11 @@ local function emit_light_status_events(light_device, light)
       light_device:set_field(Fields.GAMUT, light.color.gamut, { persist = true })
       local r, g, b = HueColorUtils.safe_xy_to_rgb(light.color.xy, light.color.gamut)
       local hue, sat, _ = st_utils.rgb_to_hsv(r, g, b)
+      -- We sent a command where hue == 100 and wrapped the value to 0, reverse that here
+      if light_device:get_field(Fields.WRAPPED_HUE) == true and (hue + .05 >= 1 or hue - .05 <= 0) then
+        hue = 1
+        light_device:set_field(Fields.WRAPPED_HUE, false)
+      end
 
       light_device:emit_event(capabilities.colorControl.hue(st_utils.round(hue * 100)))
       light_device:emit_event(capabilities.colorControl.saturation(st_utils.round(sat * 100)))


### PR DESCRIPTION
Our color conversions don't properly wrap the value of 100% hue (360 degrees) around to be equivalent to 0% hue (0 degrees). This workaround does that wrapping, and reverses it when we receive a device update.