### PR TITLE
Bose discovery hardening

### DIFF
--- a/drivers/SmartThings/bose/src/disco.lua
+++ b/drivers/SmartThings/bose/src/disco.lua
@@ -9,95 +9,193 @@
 --  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
 --  either express or implied. See the License for the specific language governing permissions
 --  and limitations under the License.
---
 
 local cosock = require "cosock"
 local socket = require "cosock.socket"
-local http = cosock.asyncify "socket.http" -- TODO use luncheon instead
-local ltn12 = require "ltn12"
 local log = require "log"
-local xml2lua = require "xml2lua"
-local xml_handler = require "xmlhandler.tree"
 local utils = require "st.utils"
-local command = require "command"
 
---- @module bose.Disco
-local Disco = {}
+local ControlMessageTypes = {
+  Scan = "scan",
+  FindDevice = "findDevice",
+}
+
+local ControlMessageBuilders = {
+  Scan = function(reply_tx) return { type = ControlMessageTypes.Scan, reply_tx = reply_tx } end,
+  FindDevice = function(device_id, reply_tx)
+    return { type = ControlMessageTypes.FindDevice, device_id = device_id, reply_tx = reply_tx }
+  end,
+}
+
+local Discovery = {}
+
+local function send_disco_request()
+  local listen_ip = "0.0.0.0"
+  local listen_port = 0
+  local multicast_ip = "239.255.255.250"
+  local multicast_port = 1900
+  local multicast_msg = table.concat(
+    {
+      'M-SEARCH * HTTP/1.1',
+      'HOST: 239.255.255.250:1900',
+      'MAN: "ssdp:discover"', -- yes, there are really supposed to be quotes in this one
+      'MX: 2',
+      'ST: urn:schemas-upnp-org:device:MediaRenderer:1',
+      '\r\n'
+    },
+    "\r\n"
+  )
+  local sock = assert(socket.udp(), "create discovery socket")
+  assert(sock:setsockname(listen_ip, listen_port), "disco| socket setsockname")
+  local timeouttime = socket.gettime() + 3 -- 3 second timeout, `MX` + 1 for network delay
+  assert(sock:sendto(multicast_msg, multicast_ip, multicast_port))
+  return sock, timeouttime
+end
 
 local function process_response(val)
   local info = {}
   val = string.gsub(val, "HTTP/1.1 200 OK\r\n", "", 1)
-  for k, v in string.gmatch(val, "([%g]+): ([%g ]*)\r\n") do info[string.lower(k)] = v end
+  for k, v in string.gmatch(val, "([%w_-]+): *([%g ]*)\r\n") do
+    info[string.lower(k)] = v
+  end
   return info
 end
 
-function Disco.find(deviceid, callback)
-  local s = assert(socket.udp(), "create discovery socket")
+function Discovery.run_discovery_task()
+  local ctrl_tx, ctrl_rx = cosock.channel.new()
+  Discovery._ctrl_tx = ctrl_tx
 
-  local listen_ip = "0.0.0.0"
-  local listen_port = 0
-
-  local multicast_ip = "239.255.255.250"
-  local multicast_port = 1900
-  local multicast_msg = table.concat({
-    "M-SEARCH * HTTP/1.1", "HOST: 239.255.255.250:1900",
-    "MAN: \"ssdp:discover\"", -- yes, there are really supposed to be quotes in this one
-    "MX: 2", "ST: urn:schemas-upnp-org:device:MediaRenderer:1", "\r\n",
-  }, "\r\n")
-
-  -- bind local ip and port
-  -- device will unicast back to this ip and port
-  assert(s:setsockname(listen_ip, listen_port), "discovery socket setsockname")
-  local timeouttime = socket.gettime() + 3 -- 3 second timeout, `MX` + 1 for network delay
-
-  local ids_found = {} -- used to filter duplicates
+  local sock
+  local search_ids = {}
+  local infos_found = {} -- used to filter duplicates
   local number_found = 0
+  local timeout = 1 --give controllers 1 second initially to send multiple requests
+  local timeout_epoch
+  cosock.spawn(function()
+    while true do
+      local recv, _, err = socket.select({ ctrl_rx, sock }, nil, timeout)
+      if err == "timeout" and sock == nil then
+        log.trace("disco| done waiting for search ids, sending ssdp discovery message")
+        if sock == nil and #search_ids > 0 then
+          sock, timeout_epoch = send_disco_request()
+          timeout = math.max(0, timeout_epoch - socket.gettime())
+        else
+          log.warn("disco| ending without sending request because no search ids requested")
+          break
+        end
+      elseif err == "timeout" and socket ~= nil then
+        break
+      end
 
-  log.debug("sending discovery multicast request")
-  assert(s:sendto(multicast_msg, multicast_ip, multicast_port))
-  while true do
-    local time_remaining = math.max(0, timeouttime - socket.gettime())
-    s:settimeout(time_remaining)
-    local val, rip, _ = s:receivefrom()
-    if val then
-      local headers = process_response(val)
-      if headers["location"] ~= nil then
-        local ip, port, id = headers["location"]:match(
-                               "http://([^,/]+):([^/]+)/%a+/BO5EBO5E%-F00D%-F00D%-FEED%-([%g-]+).xml")
+      --Handle the ctrl channel messages first
+      if recv and (recv[1] == ctrl_rx or recv[2] == ctrl_rx) then
+        local msg, err = ctrl_rx:receive()
+        if msg and msg.type and msg.reply_tx then
+          if msg.type == ControlMessageTypes.Scan then
+            log.trace("disco| inserting search id:", "scan")
+            table.insert(search_ids, { id = "scan", reply_tx = msg.reply_tx })
+          end
+          if msg.type == ControlMessageTypes.FindDevice then
+            log.trace("disco| inserting search id:", msg.device_id)
+            table.insert(search_ids, { id = msg.device_id, reply_tx = msg.reply_tx })
+            for id, info in pairs(infos_found) do
+              if id == msg.device_id then
+                log.trace("disco| searching for previously discovered device:", msg.device_id)
+                msg.reply_tx:send(info)
+              end
+            end
+          end
+        else
+          log.warn(utils.stringify_table(msg or err, "Unexpected Message/Err on Discovery Control Channel", false))
+        end
 
-        -- TODO how do I know the device that responded is actually a bose device
-        -- potentially will need to make a request to the endpoint
-        -- fetch_device_metadata()
-        if rip ~= ip then
-          log.warn(string.format(
-                     "[%s]recieved discovery response with reported (%s) & source IP (%s) mismatch, ignoring",
-                     deviceid, rip, ip))
-          log.debug(rip, "!=", ip)
-        elseif ip and id then
-          if deviceid then
-            -- check if the speaker we just found was the one we were looking for
-            if deviceid == id then
-              callback({id = id, ip = ip, raw = val})
-              break
+        goto continue
+      end
+
+      if recv and (recv[1] == sock or recv[2] == sock) then
+        local val, rip, _ = sock:receivefrom()
+        timeout = math.max(0, timeout_epoch - socket.gettime())
+        --timeout managed via select
+        -- sock:settimeout(timeout)
+        if val then
+          local headers = process_response(val)
+          if headers["location"] ~= nil then
+            local ip, port, id = headers["location"]:match(
+                                   "http://([^,/]+):([^/]+)/%a+/BO5EBO5E%-F00D%-F00D%-FEED%-([%g-]+).xml")
+
+            if rip ~= ip and ip ~= nil then
+              log.warn(string.format(
+                         "disco| recieved response with reported (%s) & source IP (%s) mismatch, ignoring",
+                         rip, ip))
+            elseif ip and id then
+              log.trace("disco| found device:", ip, port, id)
+              infos_found[id] = {id = id, ip = ip, raw = val}
+              number_found = number_found + 1
+              for _, search_id in ipairs(search_ids) do
+                if search_id.id == "scan" or search_id.id == id then
+                  search_id.reply_tx:send(infos_found[id])
+                end
+              end
+            else
+              log.debug(string.format("disco| response from %s isnt a bose device: %s", headers["location"], headers["server"]))
             end
           else
-            callback({id = id, ip = ip, raw = val})
+            log.warn_with({hub_logs = true},
+              string.format("disco| response from %s doesn't contain a location header: %s", rip, val))
           end
+        else
+          error(string.format("error receving discovery replies: %s", rip))
         end
-      else
-        log.error_with({hub_logs = true},
-          string.format("disco response received from %s doesn't contain location header: %s", rip, val))
       end
-    elseif rip == "timeout" then
-      if deviceid then
-        log.warn_with({hub_logs=true}, string.format("Timed out searching for device %s", deviceid))
-      end
-      break
-    else
-      error(string.format("[%s]error receving discovery replies: %s", deviceid, rip))
+      ::continue::
     end
-  end
-  s:close()
+    for _, search_id in ipairs(search_ids) do
+      if search_id.id == "scan" or infos_found[search_id.id] == nil then
+        search_id.reply_tx:close()
+      end
+    end
+    if sock then sock:close() end
+    if ctrl_rx then ctrl_rx:close() end
+    log.info_with({ hub_logs = true },
+      string.format("disco| response window ended, %s found", number_found))
+    Discovery._ctrl_tx:close()
+    Discovery._ctrl_tx = nil
+  end, "disco task")
 end
 
-return Disco
+--This function should only be sending on tx ctrl channel
+-- to discovery task to add a deviceID to the disco search
+function Discovery.find(deviceid, callback)
+  if Discovery._ctrl_tx == nil then
+    log.trace("disco| starting discovery cosock task")
+    Discovery.run_discovery_task()
+  end
+
+  local tx, rx = cosock.channel.new()
+  if deviceid then
+    Discovery._ctrl_tx:send(ControlMessageBuilders.FindDevice(deviceid, tx))
+    local info = rx:receive()
+    if not info then
+      log.warn("disco| failed to discover the device " .. deviceid)
+    end
+    callback(info)
+    rx:close()
+  else
+    Discovery._ctrl_tx:send(ControlMessageBuilders.Scan(tx))
+    while true do
+      local info, err = rx:receive()
+      if err == "closed" then
+        log.trace("disco| finished scan")
+        rx:close()
+        break
+      end
+      if info ~= nil and info.ip ~= nil and info.id ~= nil then
+        callback(info)
+      else
+        log.warn(string.format("disco| unexpected nil info due to %s", err))
+      end
+    end
+  end
+end
+
+return Discovery

--- a/drivers/SmartThings/bose/src/init.lua
+++ b/drivers/SmartThings/bose/src/init.lua
@@ -31,6 +31,7 @@ local utils = require "st.utils"
 local bose_utils = require "utils"
 local command = require "command"
 local socket = require "cosock.socket"
+local cosock = require "cosock"
 
 local Listener = require "listener"
 local discovery = require "disco"
@@ -51,7 +52,6 @@ local function discovery_handler(driver, _, should_continue)
     discovery.find(nil, function(device) -- This is called after finding a device
       local id = device.id
       local ip = device.ip
-      log.info_with({hub_logs=true}, string.format("Found a device. ip: %s, id: %s", device.ip, device.id))
       if not known_devices[id] and not found_devices[id] then
         local dev_info, err = command.info(ip)
         if not dev_info then
@@ -77,11 +77,12 @@ local function discovery_handler(driver, _, should_continue)
           model = dev_info.model or "unknown soundtouch",
           vendor_provided_label = "SoundTouch",
         }
-        log.debug("Create device with:", utils.stringify_table(create_device_msg))
+        log.info_with({hub_logs = true},
+          string.format("Create device with: %s", utils.stringify_table(create_device_msg)))
         assert(driver:try_create_device(create_device_msg))
         found_devices[id] = true
       else
-        log.info("Discovered already known device")
+        log.info(string.format("Discovered already known device %s", id))
       end
     end)
   end
@@ -92,7 +93,7 @@ local function do_refresh(driver, device, cmd)
   -- get speaker playback state
   local info, err = command.now_playing(device:get_field("ip"))
   if not info then
-    log.error(string.format("failed to get speaker state: %s", err))
+    device.log.error(string.format("failed to get speaker state: %s", err))
   elseif info.source == "STANDBY" then
     device:emit_event(capabilities.switch.switch.off())
     device:emit_event(capabilities.mediaPlayback.playbackStatus.stopped())
@@ -138,7 +139,7 @@ local function do_refresh(driver, device, cmd)
   -- get volume
   local vol, err = command.volume(device:get_field("ip"))
   if not vol then
-    log.error(string.format("failed to get initial volume: %s", err))
+    device.log.error(string.format("failed to get initial volume: %s", err))
   else
     device:emit_event(capabilities.audioVolume.volume(vol.actual))
     if vol.muted then device:emit_event(capabilities.audioMute.mute.muted()) end
@@ -147,71 +148,73 @@ local function do_refresh(driver, device, cmd)
   -- get presets
   local presets, err = command.presets(device:get_field("ip"))
   if not presets then
-    log.error(string.format("failed to get presets: %s", err))
+    device.log.error(string.format("failed to get presets: %s", err))
   else
     device:emit_event(capabilities.mediaPresets.presets(presets))
   end
-end
 
--- build a exponential backoff time value generator
---
--- max: the maximum wait interval (not including `rand factor`)
--- inc: the rate at which to exponentially back off
--- rand: a randomization range of (-rand, rand) to be added to each interval
-local function backoff_builder(max, inc, rand)
-  local count = 0
-  inc = inc or 1
-  return function()
-    local randval = 0
-    if rand then
-      -- random value in range (-rand, rand)
-      randval = math.random() * rand * 2 - rand
+  -- restart listener if needed
+  local listener = device:get_field("listener")
+  local success = false
+  if listener and (listener:is_stopped() or listener.websocket == nil)then
+    device.log.info("Restarting listening websocket client for device updates")
+    listener:stop()
+    socket.sleep(1) --give time for Lustre to close the websocket
+    if not listener:start() then
+      device.log.warn_with({hub_logs = true}, "Failed to restart listening websocket client for device updates")
     end
-
-    local base = inc * (2 ^ count - 1)
-    count = count + 1
-
-    -- ensure base backoff (not including random factor) is less than max
-    if max then base = math.min(base, max) end
-
-    -- ensure total backoff is >= 0
-    return math.max(base + randval, 0)
   end
 end
 
 local function device_init(driver, device)
-  local backoff = backoff_builder(60, 1, 0.1)
-  local serial_number = bose_utils.get_serial_number(device)
-  local dev_info
-  while true do -- todo should we limit this? I think this will just spin forever if the device goes down
-    discovery.find(serial_number, function(found) dev_info = found end)
-    if dev_info then break end
-    socket.sleep(backoff())
-  end
-
-  if not dev_info or not dev_info.ip then
-    log.warn_with({hub_logs=true}, "device not found on network")
+  -- at the time of authoring, there is a bug with LAN Edge Drivers where `init`
+  -- may not be called on every device that gets added to the driver
+  if device:get_field("init_started") then
     return
   end
+  device:set_field("init_started", true)
+  device.log.info_with({ hub_logs = true }, "initializing device")
+  local serial_number = bose_utils.get_serial_number(device)
 
-  device:set_field("ip", dev_info.ip, {persist = true})
+  cosock.spawn(function()
+    local backoff = utils.backoff_builder(300, 1, 0.25)
+    local dev_info
+    while true do
+      discovery.find(serial_number, function(found) dev_info = found end)
+      if dev_info then break end
+      local tm = backoff()
+      device.log.info_with({ hub_logs = true }, string.format("Failed to initialize device, retrying after delay: %.1f", tm))
+      socket.sleep(tm)
+    end
+    if not dev_info or not dev_info.ip then
+      device.log.warn_with({hub_logs=true}, "device not found on network")
+      return
+    end
+    device.log.info_with({ hub_logs = true }, string.format("Device init re-discovered device on the lan: %s", dev_info.ip))
+    device:set_field("ip", dev_info.ip, {persist = true})
 
-  device:emit_event(capabilities.mediaPlayback.supportedPlaybackCommands({
-    capabilities.mediaPlayback.commands.play.NAME,
-    capabilities.mediaPlayback.commands.pause.NAME,
-    capabilities.mediaPlayback.commands.stop.NAME,
-  }))
-  do_refresh(driver, device)
+    device:emit_event(capabilities.mediaPlayback.supportedPlaybackCommands({
+      capabilities.mediaPlayback.commands.play.NAME,
+      capabilities.mediaPlayback.commands.pause.NAME,
+      capabilities.mediaPlayback.commands.stop.NAME,
+    }))
+    do_refresh(driver, device)
 
-  local listener = Listener.create_device_event_listener(driver, device)
-  if listener then
-    device:set_field("listener", listener)
-    listener:start()
-  end
+    backoff = utils.backoff_builder(300, 1, 0.25)
+    while true do
+      local listener = Listener.create_device_event_listener(driver, device)
+      device:set_field("listener", listener)
+      if listener:start() then break end
+      local tm = backoff()
+      device.log.info_with({ hub_logs = true },
+        string.format("Failed to initialize device websocket listener, retrying after delay: %.1f", tm))
+      socket.sleep(tm)
+    end
+  end, device.id .. " init_disco")
 end
 
 local function device_removed(driver, device)
-  log.info("handling device removed...")
+  device.log.info("handling device removed...")
   local listener = device:get_field("listener")
   if listener then listener:stop() end
 end
@@ -220,9 +223,9 @@ local function info_changed(driver, device, event, args)
   if device.label ~= args.old_st_store.label then
     local ip = device:get_field("ip")
     if not ip then
-      log.warn("failed to get device ip to update the speakers name")
+      device.log.warn("failed to get device ip to update the speakers name")
       local err = command.set_name(device.label)
-      if err then log.error("failed to set device name") end
+      if err then device.log.error("failed to set device name") end
     end
   end
 end
@@ -233,6 +236,7 @@ local bose = Driver("bose", {
     init = device_init,
     removed = device_removed,
     infoChanged = info_changed,
+    added = device_init,
   },
   capability_handlers = {
     [capabilities.switch.ID] = {

--- a/drivers/SmartThings/bose/src/listener.lua
+++ b/drivers/SmartThings/bose/src/listener.lua
@@ -286,4 +286,8 @@ function Listener:stop()
   end
 end
 
+function Listener:is_stopped()
+  return self._stopped
+end
+
 return Listener


### PR DESCRIPTION
Harden the SSDP header regex to handle more valid HTTP headers. Also provide more explicit logging for the various discovery conditions.

Spawn device init as a cosock task in case it takes a long time, so the device thread is not blocked.

Device added and device init result in initialization code running once to account for existing lan bugs where sometimes init is not run when newly joined devices are added.

Make disco loop more robust to avoid overuse of sockets when multiple devices are being discovered/migrated at one time. This will follow the pattern I used for Wemo where the disco loop can service multiple discovery requests from the driver (due to init or scan nearby) with a single multicast discovery request.

Refresh should restart the websocket listener if it needs to be. This is a defensive change that might help users resolve state update issues if they are occurring, but I have yet to see it be needed in the field.