### PR TITLE
fixed incorrect profile assignment for AduroSmart Eria device

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -1567,7 +1567,7 @@ zigbeeManufacturer:
     deviceLabel: Eria Switch
     manufacturer: AduroSmart Eria
     model: BDP3001
-    deviceProfileName: switch-power
+    deviceProfileName: switch-level
   - id: "AduroSmart Eria/ZLL-DimmableLight"
     deviceLabel: Eria Light
     manufacturer: AduroSmart Eria


### PR DESCRIPTION
The following device had the incorrect profile assignment looking at the DTH, it should have moved to a profile with the switch level capability. 
manufacturer: AduroSmart Eria    model: BDP3001