### PR TITLE
Fix status/status report handling for smartsense multi

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
@@ -97,14 +97,14 @@ end
 
 local function status_handler(driver, device, zb_rx)
   -- This is a custom cluster command for the kickstarter multi.  It contains 2 fields
-  -- a temp field and a status field
+  -- a 16-bit temp field and an 8-bit status field
   -- The status fields is further broken up into 3 bit values:
   --   bit 0 is 1 if acceleration is active otherwise 0.
   --   bit 1 is 1 if the contact sensor is open otherwise 0
   --   bit 2-7 is a 6 bit battery voltage value in tenths of a volt
   local batteryDivisor = 10
-  local temperature = zb_rx.body.zcl_body.body_bytes:byte(1)
-  local status = zb_rx.body.zcl_body.body_bytes:byte(2)
+  local temperature = zb_rx.body.zcl_body.body_bytes:byte(1) | (zb_rx.body.zcl_body.body_bytes:byte(2) << 8)
+  local status = zb_rx.body.zcl_body.body_bytes:byte(3)
   local acceleration = status & ACCELERATION_MASK
   local contact = (status & CONTACT_MASK) >> 1
   local battery = (status >> 2) / batteryDivisor
@@ -116,16 +116,16 @@ end
 
 local function status_report_handler(driver, device, zb_rx)
   -- This is a custom cluster command for the kickstarter multi.  It contains 3 fields
-  -- a temp field, a status field and a battery voltage field (this field is battery voltage * 40).
+  -- a 16-bit temp field, an 8-bit status field and an 8-bit battery voltage field (this field is battery voltage * 40).
   -- The status fields is further broken up into 2 bit values:
   --   bit 0 is 1 if acceleration is active otherwise 0.
   --   bit 1 is 1 if the contact sensor is open otherwise 0
   local batteryDivisor = 40
-  local temperature = zb_rx.body.zcl_body.body_bytes:byte(1)
-  local status = zb_rx.body.zcl_body.body_bytes:byte(2)
+  local temperature = zb_rx.body.zcl_body.body_bytes:byte(1) | (zb_rx.body.zcl_body.body_bytes:byte(2) << 8)
+  local status = zb_rx.body.zcl_body.body_bytes:byte(3)
   local acceleration = status & ACCELERATION_MASK
   local contact = (status & CONTACT_MASK) >> 1
-  local battery = zb_rx.body.zcl_body.body_bytes:byte(3) / batteryDivisor
+  local battery = zb_rx.body.zcl_body.body_bytes:byte(4) / batteryDivisor
   multi_utils.handle_acceleration_report(device, acceleration)
   contact_handler(device, contact)
   battery_handler(device, battery, zb_rx)

--- a/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
@@ -130,7 +130,7 @@ test.register_coroutine_test(
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_multi_status_message(mock_device, "\xFF\x4B")
+        build_multi_status_message(mock_device, "\xFF\x00\x4B")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -145,7 +145,7 @@ test.register_coroutine_test(
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_multi_status_message(mock_device, "\xFF\x4A")
+        build_multi_status_message(mock_device, "\xFF\x00\x4A")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -160,7 +160,7 @@ test.register_coroutine_test(
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_multi_status_message(mock_device, "\xFF\x49")
+        build_multi_status_message(mock_device, "\xFF\x00\x49")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -175,7 +175,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_multi_status_message(mock_device, "\xFF\x48")
+      build_multi_status_message(mock_device, "\xFF\x00\x48")
     })
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -186,11 +186,26 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Report from cluster 0xFC03, command 0x00 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - open, battery(60%)",
+  "Report from cluster 0xFC03, command 0x07 should be handled as: Temperature (26.0 C), Acceleration - inactive, Contact - closed, battery(60%)",
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_multi_status_report_message(mock_device, "\xFF\x03\x48")
+      build_multi_status_message(mock_device, "\x04\x01\x48")
+    })
+    test.socket.capability:__set_channel_ordering("relaxed")
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 26.0, unit = "C" })))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.inactive()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.contactSensor.contact.closed()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
+  end
+)
+
+test.register_coroutine_test(
+  "Report from cluster 0xFC03, command 0x09 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - open, battery(60%)",
+  function()
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      build_multi_status_report_message(mock_device, "\xFF\x00\x03\x48")
     })
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -201,11 +216,11 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Report from cluster 0xFC03, command 0x00 should be handled as: Temperature (25.5 C), Acceleration - inactive, Contact - open, battery(60%)",
+  "Report from cluster 0xFC03, command 0x09 should be handled as: Temperature (25.5 C), Acceleration - inactive, Contact - open, battery(60%)",
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_multi_status_report_message(mock_device, "\xFF\x02\x48")
+      build_multi_status_report_message(mock_device, "\xFF\x00\x02\x48")
     })
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -216,11 +231,11 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Report from cluster 0xFC03, command 0x00 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - closed, battery(60%)",
+  "Report from cluster 0xFC03, command 0x09 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - closed, battery(60%)",
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_multi_status_report_message(mock_device, "\xFF\x01\x48")
+      build_multi_status_report_message(mock_device, "\xFF\x00\x01\x48")
     })
     test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
@@ -231,11 +246,11 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-    "KK - Report from cluster 0xFC03, command 0x00 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - closed, battery(97%)",
+    "KK - Report from cluster 0xFC03, command 0x09 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - closed, battery(97%)",
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_multi_status_report_message(mock_device, "\x88\x00\x74")
+        build_multi_status_report_message(mock_device, "\x88\x00\x00\x74")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 13.60, unit = "C" })))
@@ -246,14 +261,29 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-    "Report from cluster 0xFC03, command 0x00 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - closed, battery(60%)",
+    "Report from cluster 0xFC03, command 0x09 should be handled as: Temperature (25.5 C), Acceleration - active, Contact - closed, battery(60%)",
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_multi_status_report_message(mock_device, "\xFF\x00\x48")
+        build_multi_status_report_message(mock_device, "\xFF\x00\x00\x48")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.5, unit = "C" })))
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.inactive()))
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.contactSensor.contact.closed()))
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
+    end
+)
+
+test.register_coroutine_test(
+    "Report from cluster 0xFC03, command 0x09 should be handled as: Temperature (26.0 C), Acceleration - active, Contact - closed, battery(60%)",
+    function()
+      test.socket.zigbee:__queue_receive({
+        mock_device.id,
+        build_multi_status_report_message(mock_device, "\x04\x01\x00\x48")
+      })
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 26.0, unit = "C" })))
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.inactive()))
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.contactSensor.contact.closed()))
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))


### PR DESCRIPTION
When this device reports its status, it sends a 16-bit temperature value as a part of the report. This was being incorrectly handled as an 8-bit value. This fix ensures the status handlers properly handle the temperature value as a uint16.