### PR TITLE
Fix label for Matter temperature and humidity sensor

### DIFF
--- a/drivers/SmartThings/matter-sensor/fingerprints.yml
+++ b/drivers/SmartThings/matter-sensor/fingerprints.yml
@@ -20,7 +20,7 @@ matterGeneric:
       - id: 0x0307 # Humidity Sensor
     deviceProfileName: humidity-battery
   - id: "matter/temperature-humidity/sensor"
-    deviceLabel: Matter Humidity Sensor
+    deviceLabel: Matter Temp/Humidity Sensor
     deviceTypes:
       - id: 0x0307 # Humidity Sensor
       - id: 0x0302 # Temperature Sensor


### PR DESCRIPTION
Minor fix to the label to include temperature short-form for a fingerprint that includes both device types, since this gets used as a default label in the app post onboarding.