### PR TITLE
Add special handling for fractional endpoints

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/src/test/test_aeotec_radiator_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_aeotec_radiator_thermostat.lua
@@ -222,7 +222,9 @@ test.register_coroutine_test(
               mock_device,
               ThermostatSetpoint:Set({
                                        setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
-                                       value = 21.5
+                                       value = 21.5,
+                                       precision = 1,
+                                       size = 2
                                      })
           )
       )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
@@ -363,7 +363,9 @@ test.register_coroutine_test(
               mock_device,
               ThermostatSetpoint:Set({
                                        setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
-                                       value = 21.5
+                                       value = 21.5,
+                                       precision = 1,
+                                       size = 2
                                      })
           )
       )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
@@ -392,7 +392,9 @@ test.register_coroutine_test(
         mock_device,
         ThermostatSetpoint:Set({
           setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
-          value = 21.5
+          value = 21.5,
+          precision = 1,
+          size = 2
         })
       )
     )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
@@ -514,7 +514,9 @@ test.register_coroutine_test(
         mock_device,
         ThermostatSetpoint:Set({
                                 setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
-                                value = 21.5
+                                value = 21.5,
+                                precision = 1,
+                                size = 2
                               })
       )
     )


### PR DESCRIPTION
This is a workaround for handling fractional setpoint in zwave thermostats while a more permanent fix is added to the lua libs. Fractional values such as 21.5 are expected to be represented with an int value and a corresponding precision value such that the temperature = value * 10^(-precision).