### PR TITLE
[Sonos] Add preference for the load faves queue behavior

### DIFF
--- a/drivers/SmartThings/sonos/profiles/sonos-player.yml
+++ b/drivers/SmartThings/sonos/profiles/sonos-player.yml
@@ -29,3 +29,16 @@ components:
     version: 1
   categories:
   - name: Speaker
+preferences:
+- name: "queueAction"
+  title: "\"Load Favorites\" Queuing Action"
+  description: Determines the playback behavior when a Favorite is loaded while content is already queued on the speaker.
+  required: false
+  preferenceType: enumeration
+  definition:
+    options:
+      Append: "Add to End of Queue"
+      Insert: "Play Now"
+      Insert_Next: "Play Next"
+      Replace: "Replace Queue"
+    default: Append

--- a/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
@@ -9,6 +9,8 @@ local st_utils = require "st.utils"
 --- https://developer.sonos.com/reference/control-api-examples-lan/
 local CapCommandHandlers = {}
 
+local QUEUE_ACTION_PREF = "queueAction"
+
 local function _do_send(device, payload)
   local conn = device:get_field(PlayerFields.CONNECTION)
   if conn and conn:is_running() then
@@ -151,7 +153,8 @@ function CapCommandHandlers.handle_play_preset(driver, device, cmd)
     { namespace = "favorites", command = "loadFavorite" },
     {
       favoriteId = cmd.args.presetId,
-      playOnCompletion = true
+      playOnCompletion = true,
+      action = (device.preferences[QUEUE_ACTION_PREF] or "APPEND")
     }
   }
   _do_send_to_group(driver, device, payload)


### PR DESCRIPTION
This is a PR to address a separate community PR that wanted to shore up behavior for loading favorites to a Sonos queue: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/577

The linked PR definitely presents a better take on what the default behavior should be, however, the existing integration we provide uses the speaker's default behavior which is equivalent to the `Append` preference in this PR.

cc @TheMegamind