### PR TITLE
Add missing zwave fan fingerprint

### DIFF
--- a/drivers/SmartThings/zwave-fan/fingerprints.yml
+++ b/drivers/SmartThings/zwave-fan/fingerprints.yml
@@ -11,6 +11,12 @@ zwaveManufacturer:
     productType: 0x4944
     productId: 0x3131
     deviceProfileName: fan-3speed
+  - id: "GE/0063/4944/3337"
+    deviceLabel: GE Fan
+    manufacturerId: 0x0063
+    productType: 0x4944
+    productId: 0x3337
+    deviceProfileName: fan-3speed
   - id: "Honeywell/0039/4944/3131"
     deviceLabel: Honeywell Fan
     manufacturerId: 0x0039


### PR DESCRIPTION
This device was actually matching a zwave switch [fingerprint](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/5f908dd06f7031e1dae2e6b6518af90eaeb60d87/drivers/SmartThings/zwave-switch/fingerprints.yml#L25-L29) because that fingerprint omitted the ProductId.

Here is the actual device: https://products.z-wavealliance.org/products/3928?selectedFrequencyId=2