### PR TITLE
Add Leviton dimmer switch fingerprints

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -603,6 +603,13 @@ zwaveManufacturer:
     deviceLabel: Leviton Dimmer Switch
     manufacturerId: 0x001D
     productId: 0x0001
+    productType: 0x3301
+    deviceProfileName: switch-level
+  - id: 001D/3201/0001
+    deviceLabel: Leviton Dimmer Switch
+    manufacturerId: 0x001D
+    productId: 0x0001
+    productType: 0x3201
     deviceProfileName: switch-level
   - id: 001D/1B03/0334
     deviceLabel: Leviton Dimmer Switch


### PR DESCRIPTION
Adds fingerprints specifically for the 3301/3201 Leviton products. Without this change, the fingerprint was too permissive and was causing the Levition 3601 product to incorrectly match the same switch level profile as the 3301/3201 products. The 3601 product should now correctly match the right generic fingerprint.