### PR TITLE
fix(Sonos): Streamline device initialization process

### DIFF
--- a/drivers/SmartThings/sonos/src/disco.lua
+++ b/drivers/SmartThings/sonos/src/disco.lua
@@ -37,18 +37,17 @@ end
 
 function Discovery.discover(driver, _, should_continue)
   log.info("Starting Sonos discovery")
-  local known_devices_dnis = {}
-  local found_ip_addrs = {}
-
-  local device_list = driver:get_devices()
-  for _, device in ipairs(device_list) do
-    local id = device.device_network_id
-    known_devices_dnis[id] = true
-  end
-
-  driver.found_ips = found_ip_addrs
+  driver.found_ips = {}
 
   while should_continue() do
+    local known_devices_dnis = {}
+
+    local device_list = driver:get_devices()
+    for _, device in ipairs(device_list) do
+      local id = device.device_network_id
+      known_devices_dnis[id] = true
+    end
+
     ssdp.search(SONOS_SSDP_SEARCH_TERM, function(group_info)
       ssdp_discovery_callback(driver, group_info, known_devices_dnis, driver.found_ips)
     end)

--- a/drivers/SmartThings/sonos/src/types.lua
+++ b/drivers/SmartThings/sonos/src/types.lua
@@ -113,6 +113,7 @@ Types.SonosCapabilities = {
 --- Sonos systems local state
 --- @class SonosState
 --- @field public get_household fun(self: SonosState, id: HouseholdId): SonosHousehold
+--- @field public is_household_known fun(self: SonosState, id: HouseholdId): boolean
 --- @field public update_household_info fun(self: SonosState, id: HouseholdId, groups_event: SonosGroupsResponseBody, device: SonosDevice|nil)
 --- @field public update_household_favorites fun(self: SonosState, id: HouseholdId, favorites: SonosFavorites)
 --- @field public get_group_for_player fun(self: SonosState, household_id: HouseholdId, player_id: PlayerId): GroupId
@@ -161,6 +162,12 @@ function SonosState.new()
 
   --- @param self SonosState
   --- @param id HouseholdId
+  ret.is_household_known = function(self, id)
+    return private.households[id] ~= nil and private.households[id].mapped_once
+  end
+
+  --- @param self SonosState
+  --- @param id HouseholdId
   --- @param groups_event SonosGroupsResponseBody
   --- @param device SonosDevice|nil
   ret.update_household_info = function(self, id, groups_event, device)
@@ -195,6 +202,7 @@ function SonosState.new()
     end
 
     private.households[id] = household
+    private.households[id].mapped_once = true
 
     -- emit group info update [groupId, groupRole, groupPrimaryDeviceId]
     if device ~= nil then


### PR DESCRIPTION
The initialization routine opted for a pretty heavy-weight eventual consistency model with a bunch of repeated/duplicated checks on speakers as they onboarded. It was also doing an extra round or two of re-scanning.

This tightens up some of the checks to prevent doing a bunch of un-needed work and introducing a bunch of un-needed network traffic.