### PR TITLE
Change switch on/off default commands to reflect v47

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
@@ -301,9 +301,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.ON_ENABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0xFF,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,
@@ -366,9 +366,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.OFF_DISABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0x00,
+          duration = "default"
         },
           {
             encap = zw.ENCAP.AUTO,

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
@@ -325,9 +325,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.ON_ENABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0xFF,
+          duration = "default"
         },
           {
             encap = zw.ENCAP.AUTO,
@@ -390,9 +390,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.OFF_DISABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0x00,
+          duration = "default"
         },
           {
             encap = zw.ENCAP.AUTO,

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_double_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_double_switch.lua
@@ -18,6 +18,7 @@ local zw = require "st.zwave"
 local zw_test_utils = require "integration_test.zwave_test_utils"
 local t_utils = require "integration_test.utils"
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({ version = 2 })
+local SwitchMultilevel = (require "st.zwave.CommandClass.SwitchMultilevel")({ version = 4 })
 local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1, strict = true })
 local Meter = (require "st.zwave.CommandClass.Meter")({ version = 3 })
 local CentralScene = (require "st.zwave.CommandClass.CentralScene")({ version = 1 })
@@ -300,9 +301,9 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Set({
-                target_value = SwitchBinary.value.ON_ENABLE,
-                duration = 0
+              SwitchMultilevel:Set({
+                value = 0xFF,
+                duration = "default"
               },
                   {
                     encap = zw.ENCAP.AUTO,
@@ -316,7 +317,7 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Get({},
+              SwitchMultilevel:Get({},
                   {
                     encap = zw.ENCAP.AUTO,
                     src_channel = 0,
@@ -338,9 +339,9 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Set({
-                target_value = SwitchBinary.value.ON_ENABLE,
-                duration = 0
+              SwitchMultilevel:Set({
+                value = 0xFF,
+                duration = "default"
               },
                   {
                     encap = zw.ENCAP.AUTO,
@@ -354,7 +355,7 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Get({},
+              SwitchMultilevel:Get({},
                   {
                     encap = zw.ENCAP.AUTO,
                     src_channel = 0,
@@ -376,9 +377,9 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Set({
-                target_value = SwitchBinary.value.OFF_DISABLE,
-                duration = 0
+              SwitchMultilevel:Set({
+                value = 0x00,
+                duration = "default"
               },
                   {
                     encap = zw.ENCAP.AUTO,
@@ -392,7 +393,7 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Get({},
+              SwitchMultilevel:Get({},
                   {
                     encap = zw.ENCAP.AUTO,
                     src_channel = 0,
@@ -414,9 +415,9 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Set({
-                target_value = SwitchBinary.value.OFF_DISABLE,
-                duration = 0
+              SwitchMultilevel:Set({
+                value = 0x00,
+                duration = "default"
               },
                   {
                     encap = zw.ENCAP.AUTO,
@@ -430,7 +431,7 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
-              SwitchBinary:Get({},
+              SwitchMultilevel:Get({},
                   {
                     encap = zw.ENCAP.AUTO,
                     src_channel = 0,

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
@@ -341,9 +341,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.ON_ENABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0xFF,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,
@@ -406,9 +406,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.OFF_DISABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0x00,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
@@ -330,9 +330,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.ON_ENABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0xFF,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,
@@ -395,9 +395,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.OFF_DISABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0x00,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
@@ -233,9 +233,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.ON_ENABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0xFF,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,
@@ -297,9 +297,9 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
-        SwitchBinary:Set({
-          target_value = SwitchBinary.value.OFF_DISABLE,
-          duration = 0
+        SwitchMultilevel:Set({
+          value = 0x00,
+          duration = "default"
         },
         {
           encap = zw.ENCAP.AUTO,


### PR DESCRIPTION
The preference order for the default on/off command was changed in v47 because of the differences in functionality between binary switch on and switch multilevel on. Namely, switch multilvel on returns to the most recent on value, which was viewed as preferred.