### PR TITLE
[Aqara] Update a doConfigure handler in the zigbee-window-treatment driver

### DIFF
--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
@@ -7,6 +7,7 @@ local aqara_utils = require "aqara/aqara_utils"
 local Basic = clusters.Basic
 local WindowCovering = clusters.WindowCovering
 local AnalogOutput = clusters.AnalogOutput
+local Groups = clusters.Groups
 
 local deviceInitialization = capabilities["stse.deviceInitialization"]
 local reverseCurtainDirection = capabilities["stse.reverseCurtainDirection"]
@@ -160,6 +161,7 @@ end
 local function do_configure(self, device)
   device:configure()
   device:send(Basic.attributes.ApplicationVersion:read(device))
+  device:send(Groups.server.commands.RemoveAllGroups(device))
   do_refresh(self, device)
 end
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
@@ -27,6 +27,7 @@ test.add_package_capability("deviceInitialization.yaml")
 local Basic = clusters.Basic
 local WindowCovering = clusters.WindowCovering
 local AnalogOutput = clusters.AnalogOutput
+local Groups = clusters.Groups
 
 local PRIVATE_CLUSTER_ID = 0xFCC0
 local PRIVATE_ATTRIBUTE_ID = 0x0009
@@ -135,6 +136,10 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({
       mock_device.id,
       Basic.attributes.ApplicationVersion:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      Groups.server.commands.RemoveAllGroups(mock_device)
     })
     test.socket.zigbee:__expect_send({
       mock_device.id,

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
@@ -31,6 +31,7 @@ test.add_package_capability("shadeRotateState.yaml")
 local Basic = clusters.Basic
 local WindowCovering = clusters.WindowCovering
 local AnalogOutput = clusters.AnalogOutput
+local Groups = clusters.Groups
 
 local SHADE_LEVEL = "shadeLevel"
 
@@ -113,6 +114,10 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({
       mock_device.id,
       Basic.attributes.ApplicationVersion:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      Groups.server.commands.RemoveAllGroups(mock_device)
     })
     test.socket.zigbee:__expect_send({
       mock_device.id,


### PR DESCRIPTION
Added code to send a command to the device to be not member of the group.

```lua
local function do_configure(self, device)
  ...
  device:send(Groups.server.commands.RemoveAllGroups(device))
  ...
end
```