### PR TITLE
Revert "Wemo dimmers are unreliably reported"

### DIFF
--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -34,7 +34,7 @@ local utils = require "st.utils"
 local profiles = {
   ["Insight"] = "wemo.mini-smart-plug.v1",
   ["Socket"] = "wemo.mini-smart-plug.v1",
-  ["Dimmer"] = "wemo.mini-smart-plug.v1",
+  ["Dimmer"] = "wemo.dimmer-switch.v1",
   ["Motion"] = "wemo.motion-sensor.v1",
   ["Lightswitch"] = "wemo.light-switch.v1",
 }


### PR DESCRIPTION
This reverts commit 2690e669d0e6063f64a89992845f28eeb97befcf.

This will not affect migration from DTHs (non of which include the switch level capability). The original reason for the change was because our testing encounter a device that reported dimmer funcitonality via ssdp discovery but didn't actually support it, so the capability was on the device but non functional. There are wemo dimmers that do work properly so we should keep this functionality for those devices.