### PR TITLE
Update matter-sensor temperature sensor device category

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/humidity-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/humidity-battery.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: HumiditySensor
+  - name: GenericSensor
 preferences:
   - preferenceId: humidityOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/humidity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/humidity.yml
@@ -9,7 +9,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: HumiditySensor
+  - name: GenericSensor
 preferences:
   - preferenceId: humidityOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-battery.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: GenericSensor
+  - name: Thermostat
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
@@ -13,7 +13,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: GenericSensor
+  - name: Thermostat
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: GenericSensor
+  - name: Thermostat
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature.yml
@@ -9,7 +9,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: GenericSensor
+  - name: Thermostat
 preferences:
   - preferenceId: tempOffset
     explicit: true


### PR DESCRIPTION
Use Thermostat category because it results in a better icon than the GenericSensor category.