### PR TITLE
zwave-switch: changed child thermostat profile category to Thermostat

### DIFF
--- a/drivers/SmartThings/zwave-switch/profiles/child-temperature.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/child-temperature.yml
@@ -7,4 +7,4 @@ components:
       - id: refresh
         version: 1
     categories:
-      - name: GenericSensor
+      - name: Thermostat


### PR DESCRIPTION
The child temperature sensor was showing a generic category in the app, so category got changed to Thermostat.