### PR TITLE
CHAD-10664 Workaround for Aeotec Smart Switch 6

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/aeotec-smart-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/aeotec-smart-switch/init.lua
@@ -1,0 +1,48 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
+local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({ version=1 })
+
+local AEOTEC_SWITCH_6 = {
+  mfr = 0x0086,
+  prodId = 0x0060
+}
+
+local function can_handle(opts, driver, device, ...)
+  return device:id_match(AEOTEC_SWITCH_6.mfr, nil, AEOTEC_SWITCH_6.prodId)
+end
+
+-- Despite the NIF indicating that this device supports the Switch Multilevel
+-- command class, the device will not respond to multilevel commands
+local function on_off_factory(onOff)
+  return function(driver, device, cmd)
+    device:send(Basic:Set({value=onOff}))
+    device.thread:call_with_delay(3, function() device:send(SwitchBinary:Get({})) end)
+  end
+end
+
+local aeotec_smart_switch = {
+  NAME = "Aeotec Smart Switch 6",
+  capability_handlers = {
+    [capabilities.switch.ID] = {
+      [capabilities.switch.commands.on.NAME] = on_off_factory(0xFF),
+      [capabilities.switch.commands.off.NAME] = on_off_factory(0x00)
+    }
+  },
+  can_handle = can_handle
+}
+
+return aeotec_smart_switch

--- a/drivers/SmartThings/zwave-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/init.lua
@@ -147,7 +147,8 @@ local driver_template = {
     require("ecolink-switch"),
     require("multi-metering-switch"),
     require("zooz-zen-30-dimmer-relay"),
-    require("multichannel-device")
+    require("multichannel-device"),
+    require("aeotec-smart-switch")
   },
   lifecycle_handlers = {
     init = device_init,

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch.lua
@@ -1,0 +1,102 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local zw = require "st.zwave"
+local zw_test_utils = require "integration_test.zwave_test_utils"
+
+local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({ version=2 })
+local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
+
+local aeotec_smart_switch_endpoints = {
+  {
+    command_classes = {
+      { value = zw.BASIC },
+      { value = zw.SWITCH_BINARY },
+      { value = zw.SWITCH_MULTILEVEL },
+      { value = zw.METER },
+    }
+  }
+}
+
+local mock_device = test.mock_device.build_test_zwave_device({
+  profile = t_utils.get_profile_definition("metering-switch.yml"),
+  zwave_endpoints = aeotec_smart_switch_endpoints,
+  zwave_manufacturer_id = 0x0086,
+  zwave_product_type = 0x0003,
+  zwave_product_id = 0x0060
+})
+
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
+end
+
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+  "Device should use Basic SETs and GETs despite supporting Switch Multilevel (on)",
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "switch", command = "on", args = {}}
+    })
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        Basic:Set({
+          value = 0xFF
+        })
+      )
+    )
+    test.wait_for_events()
+    test.mock_time.advance_time(3)
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        SwitchBinary:Get({})
+      )
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Device should use Basic SETs and GETs despite supporting Switch Multilevel (off)",
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "switch", command = "off", args = {}}
+    })
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        Basic:Set({
+          value = 0x00
+        })
+      )
+    )
+    test.wait_for_events()
+    test.mock_time.advance_time(3)
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        SwitchBinary:Get({})
+      )
+    )
+  end
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
It was discovered that, with the reordering of default switch on commands, that the Aeotec Smart Switch 6 reports Switch Multilevel support, but does not respond to Switch Multilevel commands. This workaround reverts it to using the same commands as the DTH.