### PR TITLE
Add generic fingerprint for matter bridges

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -21,7 +21,51 @@ matterManufacturer:
     productId: 0x5E
     deviceProfileName: plug-binary
 
+#Bridge devices need manufacturer specific fingerprints until
+#bridge support is released to all hubs. This is because of the way generic
+#fingerprints work for bridges joined prior to hubs being able to support them
+  - id: "Aqara/m2/hub"
+    deviceLabel: Matter Bridge
+    vendorId: 0x115F
+    productId: 0x0802
+    deviceProfileName: matter-bridge
+  - id: "Ubisys/G1"
+    deviceLabel: Matter Bridge
+    vendorId: 0x10F2
+    productId: 0x6100
+    deviceProfileName: matter-bridge
+  - id: "Feibit/Matter/Gateway"
+    deviceLabel: Matter Bridge
+    vendorId: 0x117E
+    productId: 0xFB01
+    deviceProfileName: matter-bridge
+  - id: "Yeelight/Pro/Gateway"
+    deviceLabel: Matter Bridge
+    vendorId: 0x1312
+    productId: 0x0002
+    deviceProfileName: matter-bridge
+  - id: "QBEDFMB3/Gateway"
+    deviceLabel: Matter Bridge
+    vendorId: 0x131E
+    productId: 0x0001
+    deviceProfileName: matter-bridge
+  - id: "Philips/Hue/Bridge"
+    deviceLabel: Matter Bridge
+    vendorId: 0x100B
+    productId: 0x0002
+    deviceProfileName: matter-bridge
+  - id: "Switchbot/hub2"
+    deviceLabel: Matter Bridge
+    vendorId: 0x1397
+    productId: 0x07E7
+    deviceProfileName: matter-bridge
+
 matterGeneric:
+  - id: "matter/bridge"
+    deviceLabel: Matter Bridge
+    deviceTypes:
+      - id: 0x000E # Aggregator
+    deviceProfileName: matter-bridge
   - id: "matter/on-off/light"
     deviceLabel: Matter OnOff Light
     deviceTypes:

--- a/drivers/SmartThings/matter-switch/profiles/matter-bridge.yml
+++ b/drivers/SmartThings/matter-switch/profiles/matter-bridge.yml
@@ -1,0 +1,8 @@
+name: matter-bridge
+components:
+- id: main
+  capabilities:
+  - id: refresh
+    version: 1
+  categories:
+  - name: Bridges


### PR DESCRIPTION
This maps to the matter-thing fingerprint since the platform does not yet support matter bridges.