### PR TITLE
fix: Fixes a place where a key rename was missed.

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -230,7 +230,7 @@ local function do_refresh_light(driver, light_device)
       else
         for _, light_info in ipairs(light_resp.data) do
           if light_info.id == light_resource_id then
-            light_device:set_field(Fields.COLOR_GAMUT, light_info.color.gamut_type, { persist = true })
+            light_device:set_field(Fields.GAMUT, light_info.color.gamut_type, { persist = true })
             driver.emit_light_status_events(light_device, light_info)
             success = true
           end


### PR DESCRIPTION
When we refactored COLOR_GAMUT -> GAMUT, we missed a spot. This can cause refresh actions to fail for color lights.