### PR TITLE
CHAD-10712 Multi metering switch fixes

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch.lua
@@ -27,11 +27,6 @@ local WYFY_PRODUCT_ID = 0x5102
 local profile = t_utils.get_profile_definition("switch-binary.yml")
 
 local WYFY_multicomponent_endpoints = {
-  { -- ep 0
-    command_classes = {
-      { value = zw.SWITCH_BINARY }
-    }
-  },
   { -- ep 1
     command_classes = {
       { value = zw.SWITCH_BINARY }


### PR DESCRIPTION
- Fixes the method used for calculating the number of child devices
- Triggers a refresh when the root node sends updates, otherwise ignores them