### PR TITLE
Hue bug fixes for event emit and initialization

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -230,7 +230,9 @@ local function do_refresh_light(driver, light_device)
       else
         for _, light_info in ipairs(light_resp.data) do
           if light_info.id == light_resource_id then
-            light_device:set_field(Fields.GAMUT, light_info.color.gamut_type, { persist = true })
+            if light_info.color ~= nil and light_info.color.gamut then
+              light_device:set_field(Fields.GAMUT, light_info.color.gamut_type, { persist = true })
+            end
             driver.emit_light_status_events(light_device, light_info)
             success = true
           end

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -425,7 +425,9 @@ light_added = function(driver, device, parent_device_id, resource_id)
 
   -- persistent fields
   device:set_field(Fields.DEVICE_TYPE, "light", { persist = true })
-  device:set_field(Fields.GAMUT, light_info.color.gamut, { persist = true })
+  if light_info.color ~= nil and light_info.color.gamut then
+    device:set_field(Fields.GAMUT, light_info.color.gamut, { persist = true })
+  end
   device:set_field(Fields.HUE_DEVICE_ID, light_info.hue_device_id, { persist = true })
   device:set_field(Fields.MIN_DIMMING, minimum_dimming, { persist = true })
   device:set_field(Fields.PARENT_DEVICE_ID, light_info.parent_device_id, { persist = true })

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -435,6 +435,8 @@ light_added = function(driver, device, parent_device_id, resource_id)
   device:set_field(Fields._ADDED, true, { persist = true })
 
   driver.light_id_to_device[device_light_resource_id] = device
+  -- the refresh handler adds lights that don't have a fully initialized bridge to a queue.
+  handlers.refresh_handler(driver, device)
 end
 
 ---@param driver HueDriver


### PR DESCRIPTION
This PR fixes two small issues that manifested in several small bugs:

1. We found a few more places where the new color gamut logic wasn't hardened and could allow for nil index errors
2. At some point we removed synthetic event emit on init, but never added a synthetic event emit on add to make up for it.