### PR TITLE
[Bug] Cync bulb turns off, when brightness level set to "1" in ST App.

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -91,7 +91,7 @@ end
 
 local function handle_set_level(driver, device, cmd)
   local endpoint_id = device:component_to_endpoint(cmd.component)
-  local level = math.floor(cmd.args.level/100.0 * 254)
+  local level = math.floor((cmd.args.level/100.0 * 254) + 0.5)
   local req = clusters.LevelControl.server.commands.MoveToLevelWithOnOff(device, endpoint_id, level, cmd.args.rate or 0, 0 ,0)
   device:send(req)
 end


### PR DESCRIPTION
In case of Apple, Alexa ecosystem, the Cync bulb didn't turn off. 
There is a problem with the level value sent from the edge driver to the device.