### PR TITLE
Matter-thermostat add support for mains powered thermostats

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-nobattery.yml
@@ -1,0 +1,16 @@
+name: thermostat-cooling-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-nobattery.yml
@@ -1,0 +1,18 @@
+name: thermostat-fan-cooling-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-nobattery.yml
@@ -1,0 +1,18 @@
+name: thermostat-fan-heating-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-nobattery.yml
@@ -1,0 +1,20 @@
+name: thermostat-fan-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-nobattery.yml
@@ -1,0 +1,16 @@
+name: thermostat-heating-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-nobattery.yml
@@ -1,0 +1,18 @@
+name: thermostat-humidity-cooling-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate-nobattery.yml
@@ -1,0 +1,20 @@
+name: thermostat-humidity-fan-cooling-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-nobattery.yml
@@ -1,0 +1,20 @@
+name: thermostat-humidity-fan-heating-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-nobattery.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-fan-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-nobattery.yml
@@ -1,0 +1,18 @@
+name: thermostat-humidity-heating-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-nobattery.yml
@@ -1,0 +1,20 @@
+name: thermostat-humidity-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-nobattery.yml
@@ -1,0 +1,18 @@
+name: thermostat-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -43,7 +43,51 @@ local setpoint_limit_device_field = {
   MIN_DEADBAND = "MIN_DEADBAND",
 }
 
+local subscribed_attributes = {
+  [capabilities.temperatureMeasurement.ID] = {
+    clusters.Thermostat.attributes.LocalTemperature,
+    clusters.TemperatureMeasurement.attributes.MeasuredValue
+  },
+  [capabilities.relativeHumidityMeasurement.ID] = {
+    clusters.RelativeHumidityMeasurement.attributes.MeasuredValue
+  },
+  [capabilities.thermostatMode.ID] = {
+    clusters.Thermostat.attributes.SystemMode,
+    clusters.Thermostat.attributes.ControlSequenceOfOperation
+  },
+  [capabilities.thermostatOperatingState.ID] = {
+    clusters.Thermostat.attributes.ThermostatRunningState
+  },
+  [capabilities.thermostatFanMode.ID] = {
+    clusters.FanControl.attributes.FanModeSequence,
+    clusters.FanControl.attributes.FanMode
+  },
+  [capabilities.thermostatCoolingSetpoint.ID] = {
+    clusters.Thermostat.attributes.OccupiedCoolingSetpoint
+  },
+  [capabilities.thermostatHeatingSetpoint.ID] = {
+    clusters.Thermostat.attributes.OccupiedHeatingSetpoint
+  },
+  [capabilities.battery.ID] = {
+    clusters.PowerSource.attributes.BatPercentRemaining
+  }
+}
+
 local function device_init(driver, device)
+  device:subscribe()
+end
+
+local function info_changed(driver, device, event, args)
+  --Note this is needed because device:subscribe() does not recalculate
+  -- the subscribed attributes each time it is run, that only happens at init.
+  -- This will change in the 0.48.x release of the lua libs.
+  for cap_id, attributes in pairs(subscribed_attributes) do
+    if device:supports_capability_by_id(cap_id) then
+      for _, attr in ipairs(attributes) do
+        device:add_subscribed_attribute(attr)
+      end
+    end
+  end
   device:subscribe()
 end
 
@@ -54,6 +98,7 @@ local function do_configure(driver, device)
   local thermo_eps = device:get_endpoints(clusters.Thermostat.ID)
   local fan_eps = device:get_endpoints(clusters.FanControl.ID)
   local humidity_eps = device:get_endpoints(clusters.RelativeHumidityMeasurement.ID)
+  local battery_eps = device:get_endpoints(clusters.PowerSource.ID)
   local profile_name = "thermostat"
   --Note: we have not encountered thermostats with multiple endpoints that support the Thermostat cluster
   if #thermo_eps == 1 then
@@ -76,7 +121,12 @@ local function do_configure(driver, device)
 
     -- TODO remove this in favor of reading Thermostat clusters AttributeList attribute
     -- to determine support for ThermostatRunningState
+    -- Add nobattery profiles if updated
     profile_name = profile_name .. "-nostate"
+
+    if #battery_eps == 0 then
+      profile_name = profile_name .. "-nobattery"
+    end
 
     log.info_with({hub_logs=true}, string.format("Updating device profile to %s.", profile_name))
     device:try_update_metadata({profile = profile_name})
@@ -329,6 +379,7 @@ local matter_driver_template = {
     init = device_init,
     added = device_added,
     doConfigure = do_configure,
+    infoChanged = info_changed,
   },
   matter_handlers = {
     attr = {
@@ -360,35 +411,7 @@ local matter_driver_template = {
       }
     }
   },
-  subscribed_attributes = {
-    [capabilities.temperatureMeasurement.ID] = {
-      clusters.Thermostat.attributes.LocalTemperature,
-      clusters.TemperatureMeasurement.attributes.MeasuredValue
-    },
-    [capabilities.relativeHumidityMeasurement.ID] = {
-      clusters.RelativeHumidityMeasurement.attributes.MeasuredValue
-    },
-    [capabilities.thermostatMode.ID] = {
-      clusters.Thermostat.attributes.SystemMode,
-      clusters.Thermostat.attributes.ControlSequenceOfOperation
-    },
-    [capabilities.thermostatOperatingState.ID] = {
-      clusters.Thermostat.attributes.ThermostatRunningState
-    },
-    [capabilities.thermostatFanMode.ID] = {
-      clusters.FanControl.attributes.FanModeSequence,
-      clusters.FanControl.attributes.FanMode
-    },
-    [capabilities.thermostatCoolingSetpoint.ID] = {
-      clusters.Thermostat.attributes.OccupiedCoolingSetpoint
-    },
-    [capabilities.thermostatHeatingSetpoint.ID] = {
-      clusters.Thermostat.attributes.OccupiedHeatingSetpoint
-    },
-    [capabilities.battery.ID] = {
-      clusters.PowerSource.attributes.BatPercentRemaining
-    }
-  },
+  subscribed_attributes = subscribed_attributes,
   capability_handlers = {
     [capabilities.thermostatMode.ID] = {
       [capabilities.thermostatMode.commands.setThermostatMode.NAME] = set_thermostat_mode,

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -37,6 +37,7 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = 1,
       clusters = {
         {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
         {
           cluster_id = clusters.Thermostat.ID,
           cluster_revision=5,
@@ -69,6 +70,7 @@ local mock_device_simple = test.mock_device.build_test_matter_device({
     {
       endpoint_id = 1,
       clusters = {
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
         {
           cluster_id = clusters.Thermostat.ID,
           cluster_revision=5,
@@ -81,31 +83,74 @@ local mock_device_simple = test.mock_device.build_test_matter_device({
   }
 })
 
-local function test_init()
-  local cluster_subscribe_list = {
-    clusters.Thermostat.attributes.LocalTemperature,
-    clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
-    clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
-    clusters.Thermostat.attributes.SystemMode,
-    clusters.Thermostat.attributes.ThermostatRunningState,
-    clusters.Thermostat.attributes.ControlSequenceOfOperation,
-    clusters.Thermostat.attributes.LocalTemperature,
-    clusters.TemperatureMeasurement.attributes.MeasuredValue,
-    clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
-    clusters.FanControl.attributes.FanMode,
-    clusters.FanControl.attributes.FanModeSequence,
+local mock_device_no_battery = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("thermostat.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = clusters.Thermostat.ID,
+          cluster_revision=5,
+          cluster_type="SERVER",
+          feature_map=2, -- Cool feature only.
+        },
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
+      }
+    }
   }
-  local cluster_subscribe_list_simple = {
-    clusters.Thermostat.attributes.LocalTemperature,
-    clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
-    clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
-    clusters.Thermostat.attributes.SystemMode,
-    clusters.Thermostat.attributes.ThermostatRunningState,
-    clusters.Thermostat.attributes.ControlSequenceOfOperation,
-    clusters.Thermostat.attributes.LocalTemperature,
-    clusters.TemperatureMeasurement.attributes.MeasuredValue,
-  }
+})
 
+local cluster_subscribe_list = {
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+  clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+  clusters.Thermostat.attributes.SystemMode,
+  clusters.Thermostat.attributes.ThermostatRunningState,
+  clusters.Thermostat.attributes.ControlSequenceOfOperation,
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.TemperatureMeasurement.attributes.MeasuredValue,
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+  clusters.FanControl.attributes.FanMode,
+  clusters.FanControl.attributes.FanModeSequence,
+  clusters.PowerSource.attributes.BatPercentRemaining,
+}
+local cluster_subscribe_list_simple = {
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+  clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+  clusters.Thermostat.attributes.SystemMode,
+  clusters.Thermostat.attributes.ThermostatRunningState,
+  clusters.Thermostat.attributes.ControlSequenceOfOperation,
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.TemperatureMeasurement.attributes.MeasuredValue,
+  clusters.PowerSource.attributes.BatPercentRemaining,
+}
+local cluster_subscribe_list_no_battery = {
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+  clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+  clusters.Thermostat.attributes.SystemMode,
+  clusters.Thermostat.attributes.ThermostatRunningState,
+  clusters.Thermostat.attributes.ControlSequenceOfOperation,
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.TemperatureMeasurement.attributes.MeasuredValue,
+}
+
+local function test_init()
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
@@ -119,10 +164,18 @@ local function test_init()
       subscribe_request_simple:merge(cluster:subscribe(mock_device_simple))
     end
   end
+  local subscribe_request_no_battery = cluster_subscribe_list_no_battery[1]:subscribe(mock_device_no_battery)
+  for i, cluster in ipairs(cluster_subscribe_list_no_battery) do
+    if i > 1 then
+      subscribe_request_no_battery:merge(cluster:subscribe(mock_device_no_battery))
+    end
+  end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.socket.matter:__expect_send({mock_device_simple.id, subscribe_request_simple})
+  test.socket.matter:__expect_send({mock_device_no_battery.id, subscribe_request_no_battery})
   test.mock_device.add_test_device(mock_device)
   test.mock_device.add_test_device(mock_device_simple)
+  test.mock_device.add_test_device(mock_device_no_battery)
 end
 test.set_test_init_function(test_init)
 
@@ -130,12 +183,27 @@ test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event due to cluster feature map",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  local read_limits = clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:read()
-  read_limits:merge(clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:read())
-  test.socket.matter:__expect_send({mock_device.id, read_limits})
+    local read_limits = clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:read()
+    read_limits:merge(clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:read())
+    test.socket.matter:__expect_send({mock_device.id, read_limits})
     --TODO why does provisiong state get added in the do configure event handle, but not the refres?
     mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only-nostate" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+end
+)
+
+test.register_coroutine_test(
+  "Profile change on doConfigure lifecycle event due to cluster feature map",
+  function()
+    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+    for i, cluster in ipairs(cluster_subscribe_list) do
+      if i > 1 then
+        subscribe_request:merge(cluster:subscribe(mock_device))
+      end
+    end
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
+    test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed({}))
 end
 )
 
@@ -148,6 +216,18 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device_simple.id, read_limits})
     mock_device_simple:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
     mock_device_simple:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+end
+)
+
+test.register_coroutine_test(
+  "Profile change on doConfigure lifecycle event no battery support",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_no_battery.id, "doConfigure" })
+    local read_limits = clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:read()
+    read_limits:merge(clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:read())
+    test.socket.matter:__expect_send({mock_device_no_battery.id, read_limits})
+    mock_device_no_battery:expect_metadata_update({ profile = "thermostat-cooling-only-nostate-nobattery" })
+    mock_device_no_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -42,6 +42,7 @@ local mock_device = test.mock_device.build_test_matter_device({
           cluster_type="SERVER",
           feature_map=35, -- Heat, Cool, and Auto features.
         },
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
       }
     }
   }
@@ -56,6 +57,7 @@ local function test_init()
     clusters.Thermostat.attributes.ThermostatRunningState,
     clusters.Thermostat.attributes.ControlSequenceOfOperation,
     clusters.Thermostat.attributes.LocalTemperature,
+    clusters.PowerSource.attributes.BatPercentRemaining,
   }
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)


### PR DESCRIPTION
I only added profiles for the nostate profiles since currently all thermostats are joined using those profiles.