### PR TITLE
fix(sonos): Don't onboard non-primary bonded devices.

### DIFF
--- a/drivers/SmartThings/sonos/src/disco.lua
+++ b/drivers/SmartThings/sonos/src/disco.lua
@@ -37,18 +37,16 @@ end
 
 function Discovery.discover(driver, _, should_continue)
   log.info("Starting Sonos discovery")
-  local known_devices_dnis = {}
-  local found_ip_addrs = {}
-
-  local device_list = driver:get_devices()
-  for _, device in ipairs(device_list) do
-    local id = device.device_network_id
-    known_devices_dnis[id] = true
-  end
-
-  driver.found_ips = found_ip_addrs
+  driver.found_ips = {}
 
   while should_continue() do
+    local known_devices_dnis = {}
+    local device_list = driver:get_devices()
+    for _, device in ipairs(device_list) do
+      local id = device.device_network_id
+      known_devices_dnis[id] = true
+    end
+
     ssdp.search(SONOS_SSDP_SEARCH_TERM, function(group_info)
       ssdp_discovery_callback(driver, group_info, known_devices_dnis, driver.found_ips)
     end)

--- a/drivers/SmartThings/sonos/src/ssdp.lua
+++ b/drivers/SmartThings/sonos/src/ssdp.lua
@@ -73,7 +73,19 @@ function SSDP.search(search_term, callback)
           log.debug(rip, "!=", ip)
         elseif ip and is_group_coordinator and group_id and
             group_name and household_id and wss_url then
-          callback(group_info)
+          if #group_id == 0 then
+            log.debug(string.format(
+            "Received SSDP response for non-primary Sonos device in a bonded set, skipping; SSDP Response: %s\n",
+            st_utils.stringify_table(group_info, nil, false)))
+          elseif callback ~= nil then
+            if type(callback) == "function" then
+              callback(group_info)
+            else
+              log.warn(string.format(
+              "Expected a function in callback argument position for `SSDP.search`, found argument of type %s",
+              type(callback)))
+            end
+          end
         else
           log.warn(
             "Received incomplete Sonos SSDP M-SEARCH Reply, retrying search")


### PR DESCRIPTION
If a device is part of a bonded set it would not be onboarded by the DTH. But there was a bug in the edge driver that would bring these devices over after migration and join them fresh during discovery when using the Edge Driver.

This fix gets us back to parity with the DTH by excluding bonded devices that are not the primary device.

Fixes: CHAD-10888