### PR TITLE
fix(sonos): Properly remove FF and Rewind.

### DIFF
--- a/drivers/SmartThings/sonos/profiles/sonos-player.yml
+++ b/drivers/SmartThings/sonos/profiles/sonos-player.yml
@@ -6,11 +6,16 @@ components:
     version: 1
     config:
       values:
-        - key: "{{enumCommands}}"
+        - key: "playbackStatus.value"
           enabledValues:
             - 'playing'
             - 'paused'
             - 'stopped'
+        - key: "{{enumCommands}}"
+          enabledValues:
+            - 'play'
+            - 'pause'
+            - 'stop'
   - id: mediaGroup
     version: 1
   - id: mediaPresets


### PR DESCRIPTION
We disabled the enum commands, but did not fully
disable the playbackStatus capability command values.

Fixes: CHAD-10815