### PR TITLE
Icon of aeotec-multipurpose-6 sensor was wrong.

### DIFF
--- a/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/aeotec-multisensor-6.yml
@@ -35,7 +35,7 @@ components:
             - battery
             - mains
   categories:
-  - name: MultiFunctionalSensor
+  - name: MotionSensor
 preferences:
   - name: "motionDelayTime"
     title: "Motion Sensor Delay Time"


### PR DESCRIPTION
Icon of aeotec-multipurpose-6 sensor was wrong.

should be displayed as MotionSensor

https://aeotec.com/products/aeotec-multi-sensor-6

![esp7rizr](https://user-images.githubusercontent.com/34559415/235032898-6632c364-245c-407e-bd9d-fdfe1cd41b2f.png)
