### PR TITLE
fix: Remove unused imports for luacheck.

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
@@ -14,8 +14,6 @@
 
 local capabilities = require "st.capabilities"
 local supported_values = require "zigbee-multi-button.supported_values"
-local log = require "log"
-local utils = require "st.utils"
 
 local ZIGBEE_MULTI_BUTTON_FINGERPRINTS = {
   { mfr = "CentraLite", model = "3450-L" },


### PR DESCRIPTION
There were two unused imports in zigbee button that were making luacheck complain.