### PR TITLE
Bugfix matter color control error on XY values of (0, 0)

### DIFF
--- a/drivers/SmartThings/matter-switch/src/color_utils.lua
+++ b/drivers/SmartThings/matter-switch/src/color_utils.lua
@@ -1,0 +1,64 @@
+--TODO remove the usage of these color utils once 0.48.x has been distributed
+-- to all hubs.
+local color_utils = {}
+local utils = require "st.utils"
+
+local function color_gamma_revert(value)
+  return value <= 0.0031308 and 12.92 * value or (1.0 + 0.055) * (value ^ (1.0 / 2.4)) - 0.055
+end
+
+--- Convert from x/y/Y to Red/Green/Blue
+---
+--- @param x number x axis non-negative value
+--- @param y number y axis non-negative value
+--- @param Y number Y tristimulus value
+--- @returns number, number, number equivalent red, green, blue vector with each color in the range [0,1]
+color_utils.xy_to_rgb = function(x, y, Y)
+  local subexpr = y ~= 0 and (Y / y) or 0
+  local X = subexpr * x
+  local Z = subexpr * (1.0 - x - y)
+
+  local M = {
+    {  3.2404542, -1.5371385, -0.4985314 },
+    { -0.9692660,  1.8760108,  0.0415560 },
+    {  0.0556434, -0.2040259,  1.0572252 }
+  }
+
+  local r = X * M[1][1] + Y * M[1][2] + Z * M[1][3]
+  local g = X * M[2][1] + Y * M[2][2] + Z * M[2][3]
+  local b = X * M[3][1] + Y * M[3][2] + Z * M[3][3]
+
+  r = r < 0 and 0 or r
+  r = r > 1 and 1 or r
+  g = g < 0 and 0 or g
+  g = g > 1 and 1 or g
+  b = b < 0 and 0 or b
+  b = b > 1 and 1 or b
+
+  local max_rgb = math.max(r, g, b)
+  r = color_gamma_revert(r / max_rgb)
+  g = color_gamma_revert(g / max_rgb)
+  b = color_gamma_revert(b / max_rgb)
+
+  return r, g, b
+end
+
+--- Convert from x/y/Y to Hue/Saturation
+--- If every value is missing then [x, y, Y] = [0, 0, 1]
+---
+--- @param x number red in range [0x0000, 0xFFFF]
+--- @param y number green in range [0x0000, 0xFFFF]
+--- @param Y number blue in range [0x0000, 0xFFFF]
+--- @returns number, number equivalent hue, saturation, level each in range [0,100]%
+color_utils.safe_xy_to_hsv = function(x, y, Y)
+  local safe_x = x ~= nil and x / 65536 or 0
+  local safe_y = y ~= nil and y / 65536 or 0
+  local safe_Y = Y ~= nil and Y or 1
+
+  local r, g, b = color_utils.xy_to_rgb(safe_x, safe_y, safe_Y)
+  local h, s, v = utils.rgb_to_hsv(r, g, b)
+
+  return utils.round(h * 100), utils.round(s * 100), utils.round(v * 100)
+end
+
+return color_utils

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -213,6 +213,8 @@ local function temp_attr_handler(driver, device, ib, response)
   end
 end
 
+local color_utils = require "color_utils"
+
 local function x_attr_handler(driver, device, ib, response)
   local y = device:get_field(RECEIVED_Y)
   --TODO it is likely that both x and y attributes are in the response (not guaranteed though)
@@ -221,7 +223,7 @@ local function x_attr_handler(driver, device, ib, response)
     device:set_field(RECEIVED_X, ib.data.value)
   else
     local x = ib.data.value
-    local h, s, _ = utils.safe_xy_to_hsv(x, y)
+    local h, s, _ = color_utils.safe_xy_to_hsv(x, y)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.hue(h))
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.saturation(s))
     device:set_field(RECEIVED_Y, nil)
@@ -234,7 +236,7 @@ local function y_attr_handler(driver, device, ib, response)
     device:set_field(RECEIVED_Y, ib.data.value)
   else
     local y = ib.data.value
-    local h, s, _ = utils.safe_xy_to_hsv(x, y)
+    local h, s, _ = color_utils.safe_xy_to_hsv(x, y)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.hue(h))
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.saturation(s))
     device:set_field(RECEIVED_X, nil)

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -465,6 +465,39 @@ test.register_message_test(
 )
 
 test.register_message_test(
+  "X and Y color values have 0 value",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(33))
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(100))
+    }
+  }
+)
+
+
+test.register_message_test(
   "Y and X color values should report hue and saturation once both have been received",
   {
     {


### PR DESCRIPTION
The lua libs utils function returns NAN for these inputs which results failed capability event serialization when they are reported by a device. The utils function itself will be fixed in hub FW 0.48.x

- [x] Test with the device to see that these values are actually making sense for the user in this case.