### PR TITLE
Handle non-sequential matter endpoints in matter-switch

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -28,10 +28,26 @@ local function convert_huesat_st_to_matter(val)
   return math.floor((val * 0xFE) / 100.0 + 0.5)
 end
 
+--- component_to_endpoint helper function to handle situations where
+--- device does not have endpoint ids in sequential order from 1
+--- In this case the function returns the lowest endpoint value that isn't 0
+local function find_default_endpoint(device, component)
+  local res = device.MATTER_DEFAULT_ENDPOINT
+  local eps = device:get_endpoints(nil)
+  table.sort(eps)
+  for _, v in ipairs(eps) do
+    if v ~= 0 then --0 is the matter RootNode endpoint
+      res = v
+      break
+    end
+  end
+  return res
+end
+
 local function component_to_endpoint(device, component_id)
   -- Assumes matter endpoint layout is sequentional starting at 1.
   local ep_num = component_id:match("switch(%d)")
-  return ep_num and tonumber(ep_num) or device.MATTER_DEFAULT_ENDPOINT
+  return ep_num and tonumber(ep_num) or find_default_endpoint(device, component_id)
 end
 
 local function endpoint_to_component(device, ep)


### PR DESCRIPTION
This functionality will be in the lua libs in 0.48 but only for devices that dont override the component_to_endpoint function.