### PR TITLE
CHAD-10802 Fibaro Single Switch: Handle reports from all endpoints

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/fibaro-single-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/fibaro-single-switch/init.lua
@@ -41,25 +41,19 @@ local function can_handle_fibaro_single_switch(opts, driver, device, ...)
 end
 
 local function central_scene_notification_handler(self, device, cmd)
-  if cmd.src_channel == nil or cmd.src_channel == 0 then
-    ButtonDefaults.zwave_handlers[cc.CENTRAL_SCENE][CentralScene.NOTIFICATION](self, device, cmd)
-  end
+  ButtonDefaults.zwave_handlers[cc.CENTRAL_SCENE][CentralScene.NOTIFICATION](self, device, cmd)
 end
 
 local function meter_report_handler(self, device, cmd)
-  if cmd.src_channel == nil or cmd.src_channel == 0 then
-    if cmd.args.scale == Meter.scale.electric_meter.KILOWATT_HOURS then
-      EnergyMeterDefaults.zwave_handlers[cc.METER][Meter.REPORT](self, device, cmd)
-    elseif cmd.args.scale == Meter.scale.electric_meter.WATTS then
-      PowerMeterDefaults.zwave_handlers[cc.METER][Meter.REPORT](self, device, cmd)
-    end
+  if cmd.args.scale == Meter.scale.electric_meter.KILOWATT_HOURS then
+    EnergyMeterDefaults.zwave_handlers[cc.METER][Meter.REPORT](self, device, cmd)
+  elseif cmd.args.scale == Meter.scale.electric_meter.WATTS then
+    PowerMeterDefaults.zwave_handlers[cc.METER][Meter.REPORT](self, device, cmd)
   end
 end
 
 local function switch_binary_report_handler(self, device, cmd)
-  if cmd.src_channel == nil or cmd.src_channel == 0 then
-    SwitchDefaults.zwave_handlers[cc.SWITCH_BINARY][SwitchBinary.REPORT](self, device, cmd)
-  end
+  SwitchDefaults.zwave_handlers[cc.SWITCH_BINARY][SwitchBinary.REPORT](self, device, cmd)
 end
 
 local fibaro_single_switch = {

--- a/drivers/SmartThings/zwave-switch/src/fibaro-single-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/fibaro-single-switch/init.lua
@@ -12,16 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-local ButtonDefaults = require "st.zwave.defaults.button"
-local EnergyMeterDefaults = require "st.zwave.defaults.energyMeter"
-local PowerMeterDefaults = require "st.zwave.defaults.powerMeter"
-local SwitchDefaults = require "st.zwave.defaults.switch"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
---- @type st.zwave.CommandClass.CentralScene
-local CentralScene = (require "st.zwave.CommandClass.CentralScene")({ version=1 })
---- @type st.zwave.CommandClass.Meter
-local Meter = (require "st.zwave.CommandClass.Meter")({ version=3 })
+local SwitchDefaults = require "st.zwave.defaults.switch"
 --- @type st.zwave.CommandClass.SwitchBinary
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({ version = 2 })
 
@@ -30,6 +23,14 @@ local FIBARO_SINGLE_SWITCH_FINGERPRINTS = {
   {mfr = 0x010F, prod = 0x0403, model = 0x2000}, -- Fibaro Switch
   {mfr = 0x010F, prod = 0x0403, model = 0x3000} -- Fibaro Switch
 }
+
+local function endpoint_to_component(device, ep)
+  return "main"
+end
+
+local function switch_binary_report_handler(self, device, cmd)
+  SwitchDefaults.zwave_handlers[cc.SWITCH_BINARY][SwitchBinary.REPORT](self, device, cmd)
+end
 
 local function can_handle_fibaro_single_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(FIBARO_SINGLE_SWITCH_FINGERPRINTS) do
@@ -40,31 +41,16 @@ local function can_handle_fibaro_single_switch(opts, driver, device, ...)
   return false
 end
 
-local function central_scene_notification_handler(self, device, cmd)
-  ButtonDefaults.zwave_handlers[cc.CENTRAL_SCENE][CentralScene.NOTIFICATION](self, device, cmd)
-end
-
-local function meter_report_handler(self, device, cmd)
-  if cmd.args.scale == Meter.scale.electric_meter.KILOWATT_HOURS then
-    EnergyMeterDefaults.zwave_handlers[cc.METER][Meter.REPORT](self, device, cmd)
-  elseif cmd.args.scale == Meter.scale.electric_meter.WATTS then
-    PowerMeterDefaults.zwave_handlers[cc.METER][Meter.REPORT](self, device, cmd)
-  end
-end
-
-local function switch_binary_report_handler(self, device, cmd)
-  SwitchDefaults.zwave_handlers[cc.SWITCH_BINARY][SwitchBinary.REPORT](self, device, cmd)
+local function device_init(driver, device)
+  device:set_endpoint_to_component_fn(endpoint_to_component)
 end
 
 local fibaro_single_switch = {
   NAME = "fibaro single switch",
+  lifecycle_handlers = {
+    init = device_init
+  },
   zwave_handlers = {
-    [cc.CENTRAL_SCENE] = {
-      [CentralScene.NOTIFICATION] = central_scene_notification_handler
-    },
-    [cc.METER] = {
-      [Meter.REPORT] = meter_report_handler
-    },
     [cc.SWITCH_BINARY] = {
       [SwitchBinary.REPORT] = switch_binary_report_handler
     }

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_single_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_single_switch.lua
@@ -79,7 +79,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Switch Binary report ON_ENABLE from source channel 2 should be discarded",
+  "Switch Binary report ON_ENABLE from source channel 2 should be treated as from main",
   {
     {
       channel = "device_lifecycle",
@@ -104,6 +104,11 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     }
   }
 )
@@ -139,7 +144,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Switch Binary report OFF_DISABLE from source channel 2 should be discarded",
+  "Switch Binary report OFF_DISABLE from source channel 2 should be treated as from main",
   {
     {
       channel = "device_lifecycle",
@@ -164,6 +169,11 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
     }
   }
 )
@@ -196,7 +206,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Central Scene notification KEY_PRESSED_1_TIME attribute from source channel 2 should be discared",
+  "Central Scene notification KEY_PRESSED_1_TIME attribute from source channel 2 should treated as from main",
   {
     {
       channel = "zwave",
@@ -217,6 +227,12 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.button.button.pushed({
+        state_change = true }))
     }
   }
 )
@@ -242,7 +258,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Central Scene notification KEY_RELEASED attribute from source channel 2 should be discared",
+  "Central Scene notification KEY_RELEASED attribute from source channel 2 should be treated as from main",
   {
     {
       channel = "zwave",
@@ -263,6 +279,12 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.button.button.held({
+        state_change = true }))
     }
   }
 )
@@ -288,7 +310,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Central Scene notification KEY_HELD_DOWN attribute from source channel 2 should be discared",
+  "Central Scene notification KEY_HELD_DOWN attribute from source channel 2 should be treated as from main",
   {
     {
       channel = "zwave",
@@ -309,6 +331,12 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.button.button.down_hold({
+        state_change = true }))
     }
   }
 )
@@ -334,7 +362,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Central Scene notification KEY_PRESSED_2_TIMES attribute from source channel 2 should be discared",
+  "Central Scene notification KEY_PRESSED_2_TIMES attribute from source channel 2 should be treated as from main",
   {
     {
       channel = "zwave",
@@ -355,6 +383,12 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.button.button.double({
+        state_change = true }))
     }
   }
 )
@@ -380,7 +414,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Central Scene notification KEY_PRESSED_3_TIMES attribute from source channel 2 should be discared",
+  "Central Scene notification KEY_PRESSED_3_TIMES attribute from source channel 2 should be treated as from main",
   {
     {
       channel = "zwave",
@@ -401,6 +435,12 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.button.button.pushed_3x({
+        state_change = true }))
     }
   }
 )
@@ -425,7 +465,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Energy meter report  from source channel 2 should be discarded",
+  "Energy meter report  from source channel 2 should be treated as from main",
   {
     {
       channel = "zwave",
@@ -447,6 +487,11 @@ test.register_message_test(
         )
       }
     },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 5, unit = "kWh" }))
+    }
   }
 )
 
@@ -470,7 +515,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Power meter report  from source channel 2 should be discarded",
+  "Power meter report  from source channel 2 should be treated as from main",
   {
     {
       channel = "zwave",
@@ -491,6 +536,11 @@ test.register_message_test(
           )
         )
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 5, unit = "W" }))
     }
   }
 )


### PR DESCRIPTION
Users have reported that the DTH behavior is incorrect, and reports from endpoints other than 1 should be handled.