### PR TITLE
Bugfix sonos listener receives message for unknown household

### DIFF
--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -225,7 +225,7 @@ function SonosConnection.new(driver, device)
         if body.version ~= favorites_version then
           favorites_version = body.version
 
-          local household = self.driver.sonos:get_household(header.householdId)
+          local household = self.driver.sonos:get_household(header.householdId) or { groups = {} }
 
           for group_id, group in pairs(household.groups) do
             local coordinator_id = self.driver.sonos:get_coordinator_for_group(header.householdId, group_id)


### PR DESCRIPTION
This is mainly just a mitigation to unblock internal users experiencing crashes while testing other features. Im not sure when this would happen, but it seems like something in the device initialization failed to collect household info for the device. Ill try to get some more logs to investigate why this is happening.