### PR TITLE
add Sengled W41-N13 bulb

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -128,6 +128,11 @@ matterGeneric:
     deviceTypes:
       - id: 0x0105 # Color Dimmer Switch
     deviceProfileName: switch-color-level
+  - id: "sengled/W41-N13"
+    deviceLabel: Matter Color Temperature Light
+    deviceTypes:
+      - id: 0x010D # Extended Color Light
+    deviceProfileName: light-level-colorTemperature-color
 
 matterThing:
   - id: SmartThings/MatterThing

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -20,6 +20,11 @@ matterManufacturer:
     vendorId: 0x130A
     productId: 0x5E
     deviceProfileName: plug-binary
+  - id: "Sengled/Light/Matter"
+    deviceLabel: Sengled Bulbs W41-N13
+    vendorId: 0x1160
+    productId: 0x9001
+    deviceProfileName: light-level-colorTemperature-color
 
 #Bridge devices need manufacturer specific fingerprints until
 #bridge support is released to all hubs. This is because of the way generic
@@ -128,7 +133,7 @@ matterGeneric:
     deviceTypes:
       - id: 0x0105 # Color Dimmer Switch
     deviceProfileName: switch-color-level
-  - id: "sengled/W41-N13"
+  - id: "matter/temp/color/light"
     deviceLabel: Matter Color Temperature Light
     deviceTypes:
       - id: 0x010D # Extended Color Light

--- a/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-color.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-color.yml
@@ -1,0 +1,21 @@
+name: light-level-colorTemperature-color
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: switchLevel
+    version: 1
+  - id: colorTemperature
+    version: 1
+  - id: colorControl
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Light
+metadata:
+  mnmn: SmartThingsEdge
+  vid: generic-rgbw-color-bulb-2000K-6500K


### PR DESCRIPTION
    1. Add the light-level-colorTemperature-color.yml file to the path SmartThingsEdgeDrivers/drivers/SmartThings/matter-switch/profiles/
    2. Modified  SmartThingsEdgeDrivers/drivers/SmartThings/matter-switch/fingerprints.yml  file, a new device id is added.