### PR TITLE
CHAD-10633: Wemo search parameters

### DIFF
--- a/drivers/SmartThings/wemo/search-parameters.yml
+++ b/drivers/SmartThings/wemo/search-parameters.yml
@@ -1,0 +1,2 @@
+ssdp:
+  - searchTerm: urn:Belkin:device:*


### PR DESCRIPTION
This change adds search parameters to the wemo driver.

https://smartthings.atlassian.net/browse/CHAD-10633