### PR TITLE
Samsung-audio: Add search-parameters to driver

### DIFF
--- a/drivers/SmartThings/samsung-audio/search-parameters.yml
+++ b/drivers/SmartThings/samsung-audio/search-parameters.yml
@@ -1,0 +1,2 @@
+ssdp:
+  - searchTerm: urn:samsung.com:device:RemoteControlReceiver:1


### PR DESCRIPTION
This change adds the search-parameters.yml file to the samsung audio driver.

https://smartthings.atlassian.net/browse/CHAD-10634