### PR TITLE
BUG-7236 Fixes typo leading to less-sensitive Centralite multi-sensors

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/multi-sensor/centralite-multi/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/multi-sensor/centralite-multi/init.lua
@@ -44,7 +44,7 @@ end
 
 local do_configure = function(self, device)
   device:configure()
-  device:send(multi_utils.custom_write_attribute(device, multi_utils.MOTION_THRESHOLD_MULTIPLIER_ATTR, data_types.Uint8, 0x20, CENTRALITE_MFG))
+  device:send(multi_utils.custom_write_attribute(device, multi_utils.MOTION_THRESHOLD_MULTIPLIER_ATTR, data_types.Uint8, 0x02, CENTRALITE_MFG))
   multi_utils.send_common_configuration(self, device, CENTRALITE_MFG)
 end
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_centralite_multi_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_centralite_multi_sensor.lua
@@ -260,7 +260,7 @@ test.register_coroutine_test(
     })
     test.socket.zigbee:__expect_send({
       mock_device.id,
-      build_write_attr_msg(0xFC02, 0x0000, data_types.Uint8, 0x20, 0x104E)
+      build_write_attr_msg(0xFC02, 0x0000, data_types.Uint8, 0x02, 0x104E)
     })
     test.socket.zigbee:__expect_send({
       mock_device.id,


### PR DESCRIPTION
Original DTH was setting this value at 0x02 whereas the driver was configuring it to 20, leading to an order of magnitude-higher acceleration threshold.