### PR TITLE
Add missing wemo model name to profile match

### DIFF
--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -37,6 +37,7 @@ local profiles = {
   ["Dimmer"] = "wemo.dimmer-switch.v1",
   ["Motion"] = "wemo.motion-sensor.v1",
   ["Lightswitch"] = "wemo.light-switch.v1",
+  ["LightSwitch"] = "wemo.light-switch.v1",
 }
 
 local function device_removed(driver, device)


### PR DESCRIPTION
Some users are unable to onboard wemo devices with the LightSwitch model