### PR TITLE
deploy: Add search-parameters to driver package

### DIFF
--- a/.github/workflows/upload-driver-packages.yml
+++ b/.github/workflows/upload-driver-packages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Package the driver
         working-directory: ${{ matrix.driver }}
         run: |
-          zip -v ${{env.package_key}}.zip config.yml fingerprints.yml $(find profiles -name "*.y*ml") $(find . -name "*.lua") -x "*test*"
+          zip -v ${{env.package_key}}.zip config.yml fingerprints.yml search-parameters.y*ml $(find profiles -name "*.y*ml") $(find . -name "*.lua") -x "*test*"
       - name: Upload packaged driver artifact
         uses: actions/upload-artifact@v3
         with:

--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -93,7 +93,7 @@ for partner in partners:
       retries = 0
       while not os.path.exists(driver+".zip") and retries < 5:
         try:
-          subprocess.run(["zip -r ../"+driver+".zip config.yml fingerprints.yml $(find profiles -name \"*.y*ml\") $(find . -name \"*.lua\") -x \"*test*\""], cwd=driver, shell=True, capture_output=True, check=True)
+          subprocess.run(["zip -r ../"+driver+".zip config.yml fingerprints.yml search-parameters.y*ml $(find profiles -name \"*.y*ml\") $(find . -name \"*.lua\") -x \"*test*\""], cwd=driver, shell=True, capture_output=True, check=True)
         except subprocess.CalledProcessError as error:
           print(error.stderr)
         retries += 1


### PR DESCRIPTION
Previous changes that added search-parameters files to some drivers didn't include changes to the deploy script to include those files so they were never included in the driver package. This change updates the deploy script to include them.