### PR TITLE
Refactor migration to avoid over-spawning tasks

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -325,13 +325,15 @@ process_discovered_light = function(driver, bridge_id, resource_id, device_info,
     }
 
     HueDiscovery.light_state_disco_cache[light.id] = {
+      id = light.id,
       on = light.on,
       color = light.color,
       dimming = light.dimming,
       color_temp = light.color_temperature,
       mode = light.mode,
       parent_device_id = bridge_device.id,
-      hue_device_id = light.owner.rid
+      hue_device_id = light.owner.rid,
+      hue_device_data = device_info
     }
 
     local count = try_create_count[create_device_msg.label] or 0

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -25,7 +25,16 @@ local function do_switch_action(driver, device, args)
   local hue_api = bridge_device:get_field(Fields.BRIDGE_API)
 
   if not (light_id or hue_api) then
-    log.warn_with({ hub_logs = true }, "Could not get a proper light resource ID or API instance for ", device.label)
+    log.warn_with({ hub_logs = true },
+      string.format(
+        "Could not get a proper light resource ID or API instance for %s" ..
+        "\n\tLight Resource ID: %s" ..
+        "\n\tHue API nil? %s",
+        (device.label or device.id or "unknown device"),
+        light_id,
+        (hue_api == nil)
+      )
+    )
     return
   end
 
@@ -59,7 +68,16 @@ local function do_switch_level_action(driver, device, args)
   local hue_api = bridge_device:get_field(Fields.BRIDGE_API)
 
   if not (light_id or hue_api) then
-    log.warn_with({ hub_logs = true }, "Could not get a proper light resource ID or API instance for ", device.label)
+    log.warn_with({ hub_logs = true },
+      string.format(
+        "Could not get a proper light resource ID or API instance for %s" ..
+        "\n\tLight Resource ID: %s" ..
+        "\n\tHue API nil? %s",
+        (device.label or device.id or "unknown device"),
+        light_id,
+        (hue_api == nil)
+      )
+    )
     return
   end
 
@@ -112,7 +130,16 @@ local function do_color_action(driver, device, args)
   local hue_api = bridge_device:get_field(Fields.BRIDGE_API)
 
   if not (light_id or hue_api) then
-    log.warn_with({ hub_logs = true }, "Could not get a proper light resource ID or API instance for ", device.label)
+    log.warn_with({ hub_logs = true },
+      string.format(
+        "Could not get a proper light resource ID or API instance for %s" ..
+        "\n\tLight Resource ID: %s" ..
+        "\n\tHue API nil? %s",
+        (device.label or device.id or "unknown device"),
+        light_id,
+        (hue_api == nil)
+      )
+    )
     return
   end
 
@@ -152,7 +179,16 @@ local function do_color_temp_action(driver, device, args)
   local hue_api = bridge_device:get_field(Fields.BRIDGE_API)
 
   if not (light_id or hue_api) then
-    log.warn_with({ hub_logs = true }, "Could not get a proper light resource ID or API instance for ", device.label)
+    log.warn_with({ hub_logs = true },
+      string.format(
+        "Could not get a proper light resource ID or API instance for %s" ..
+        "\n\tLight Resource ID: %s" ..
+        "\n\tHue API nil? %s",
+        (device.label or device.id or "unknown device"),
+        light_id,
+        (hue_api == nil)
+      )
+    )
     return
   end
 

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -45,7 +45,7 @@ local StrayDeviceMessageTypes = {
 local DEFAULT_MIREK = 153
 
 -- "forward declare" some functions
-local logged_light_added, logged_bridge_added, _initialize, bridge_added, light_added, init_light, logged_init_light
+local logged_light_added, logged_bridge_added, _initialize, bridge_added, light_added, init_light, logged_init_light, init_bridge, logged_init_bridge
 
 ---@param light_device HueChildDevice
 ---@param light table
@@ -165,7 +165,14 @@ local function migrate_bridge(driver, device)
           device:try_update_metadata(new_metadata)
           log.info_with({ hub_logs = true },
             string.format("Bridge %s Migrated, re-adding", (device.label or device.id or "unknown device")))
+          log.info_with({hub_logs = true}, string.format(
+            "Re-requesting added handler for %s after migrating", (device.label or device.id or "unknown device")
+          ))
           logged_bridge_added(hue_driver, device)
+          log.info_with({hub_logs = true}, string.format(
+              "Re-requesting init handler for %s after migrating", (device.label or device.id or "unknown device")
+          ))
+          logged_init_bridge(hue_driver, device)
           bridge_found = true
         end)
         if bridge_found then return end
@@ -693,7 +700,7 @@ end
 
 ---@param driver HueDriver
 ---@param device HueBridgeDevice
-local function init_bridge(driver, device)
+init_bridge = function (driver, device)
   log.info_with({ hub_logs = true },
     string.format("Init Bridge for device %s", (device.label or device.id or "unknown device")))
   local device_bridge_id = device:get_field(Fields.BRIDGE_ID)
@@ -812,10 +819,10 @@ init_light = function(driver, device)
   end
 end
 
-local logged_init_bridge = utils.log_func_wrapper(init_bridge, "init_bridge")
 local logged_migrate_bridge = utils.log_func_wrapper(migrate_bridge, "migrate_bridge")
 local logged_migrate_light = utils.log_func_wrapper(migrate_light, "migrate_light")
 
+logged_init_bridge = utils.log_func_wrapper(init_bridge, "init_bridge")
 logged_init_light = utils.log_func_wrapper(init_light, "init_light")
 logged_light_added = utils.log_func_wrapper(light_added, "light_added")
 logged_bridge_added = utils.log_func_wrapper(bridge_added, "bridge_added")

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -36,24 +36,6 @@ local st_utils = require "st.utils"
 local syncCapabilityId = "samsungim.hueSyncMode"
 local hueSyncMode = capabilities[syncCapabilityId]
 
-local Device = require "st.device".Device
-local old_get_field = Device.get_field
-Device.get_field = utils.log_func_wrapper(
-  function(device, field)
-    local ret = old_get_field(device, field)
-    if ret == nil then
-      log.info_with({ hub_logs = true }, string.format(
-        "Requested field %s from device %s but found nil. Device data store: %s",
-        field,
-        (device.label or device.id or "unknown device"),
-        st_utils.stringify_table({ device.transient_store, device.persistent_store })
-      ))
-    end
-    return ret
-  end,
-  "Device:get_field"
-)
-
 local StrayDeviceMessageTypes = {
   FoundBridge = "FOUND_BRIDGE",
   NewStrayLight = "NEW_STRAY_LIGHT",

--- a/drivers/SmartThings/philips-hue/src/utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils.lua
@@ -39,6 +39,31 @@ function utils.is_dth_light(device)
       and device.data.username ~= nil
 end
 
+-- build a exponential backoff time value generator
+--
+-- max: the maximum wait interval (not including `rand factor`)
+-- inc: the rate at which to exponentially back off
+-- rand: a randomization range of (-rand, rand) to be added to each interval
+function utils.backoff_builder(max, inc, rand)
+  local count = 0
+  inc = inc or 1
+  return function()
+    local randval = 0
+    if rand then
+      randval = math.random() * rand * 2 - rand
+    end
+
+    local base = inc * (2 ^ count - 1)
+    count = count + 1
+
+    -- ensure base backoff (not including random factor) is less than max
+    if max then base = math.min(base, max) end
+
+    -- ensure total backoff is >= 0
+    return math.max(base + randval, 0)
+  end
+end
+
 function utils.log_func_wrapper(func, func_name, log_level)
   local log = require "log"
   local st_utils = require "st.utils"

--- a/drivers/SmartThings/philips-hue/src/utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils.lua
@@ -45,14 +45,22 @@ function utils.log_func_wrapper(func, func_name, log_level)
   log_level = log_level or log.LOG_LEVEL_INFO
   local wrapped_f = function(...)
     local args = {...}
-    local log_str = "call to " .. func_name .. ": "
+    local log_str = "call to " .. func_name .. ": \n"
     for i, a in ipairs(args) do
-      local arg_string = st_utils.stringify_table(a)
-      -- Truncate extremely long args except for TRACE log level
-      if #arg_string > 25 and log_level ~= log.LOG_LEVEL_TRACE then
-        arg_string = string.sub(arg_string, 1, 26)
+      local arg_string = "    "
+      if type(a) == "table" and a.pretty_print ~= nil then
+        arg_string = arg_string .. a:pretty_print()
+      elseif type(a) == "table" and a.NAME then
+        arg_string = arg_string .. "table NAME: "..a.NAME
+      else
+        arg_string = arg_string .. st_utils.stringify_table(a)
       end
-      log_str = log_str .. arg_string
+
+      -- Truncate extremely long args except for TRACE log level
+      if #arg_string > 100 and log_level ~= log.LOG_LEVEL_TRACE then
+        arg_string = string.sub(arg_string, 1, 101)
+      end
+      log_str = log_str .. arg_string .. "\n"
     end
     log.log({hub_logs = true}, log_level, log_str)
     return func(table.unpack(args))


### PR DESCRIPTION
We introduced some accidentally quadratic behavior that was leading
to a massive amount of cosock tasks getting spawned.

We had to refactor the data flow a little bit in order to achieve this,
so the behavior may appear to have a changed a bit more than preferred.
However, the savings on CPU/Memory/network overhead are appreciable.