### PR TITLE
Add fingerprint for GE 40amp embrighten switch with metering.

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -778,6 +778,12 @@ zwaveManufacturer:
     productType: 0x4F44
     productId: 0x3031
     deviceProfileName: metering-switch
+  - id: 0063/4F44/3032
+    deviceLabel: GE Switch
+    manufacturerId: 0x0063
+    productType: 0x4F44
+    productId: 0x3032
+    deviceProfileName: metering-switch
   - id: 010F/1801/1000
     deviceLabel: Fibaro Outlet
     manufacturerId: 0x010F


### PR DESCRIPTION
I added a new ge enbrighten 40amp switch to smartthings and noticed the driver choices I had were to either provide switch control or only show metering information. My previous switch I had that migrated shows both the switch control and the metering. I looked at the smartthings adavanced web app and noticed a slight difference in product ID that might be the culprit? 

properly configured device:
![image](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/assets/41752582/1f46bc1d-19bd-4303-aeb9-bab898c32c2a)

new not properly configured:
![image](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/assets/41752582/9d457787-a4c0-4f8b-99de-07585c06f46e)
