### PR TITLE
Bug fix:  avoid indexing a nil object

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/init.lua
@@ -51,16 +51,18 @@ end
 local function added_handler(self, device)
   local config = supported_values.get_device_parameters(device)
   for _, component in pairs(device.profile.components) do
-    local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
     if config ~= nil then
+      local number_of_buttons = component.id == "main" and config.NUMBER_OF_BUTTONS or 1
       device:emit_component_event(component,
         capabilities.button.supportedButtonValues(config.SUPPORTED_BUTTON_VALUES, { visibility = { displayed = false } }))
+      device:emit_component_event(component,
+        capabilities.button.numberOfButtons({ value = number_of_buttons }, { visibility = { displayed = false } }))
     else
       device:emit_component_event(component,
         capabilities.button.supportedButtonValues({ "pushed", "held" }, { visibility = { displayed = false } }))
+      device:emit_component_event(component,
+        capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } }))
     end
-    device:emit_component_event(component,
-      capabilities.button.numberOfButtons({ value = number_of_buttons }, { visibility = { displayed = false } }))
   end
   -- device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end


### PR DESCRIPTION
It's possible that config is nil.
We should not use it without checking, otherwise we will hit nid index error.
