### PR TITLE
Reduce Sonos logging but keep important logs in hub logs

### DIFF
--- a/drivers/SmartThings/sonos/src/api/sonos_websocket_router.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_websocket_router.lua
@@ -1,4 +1,4 @@
-local old_log = require "log"
+local log = require "log"
 local cosock = require "cosock"
 local socket = require "cosock.socket"
 local channel = require "cosock.channel"
@@ -9,15 +9,6 @@ local Message = require "lustre".Message
 local CloseCode = require "lustre.frame.close".CloseCode
 local lb_utils = require "lunchbox.util"
 local st_utils = require "st.utils"
-
-local log = {}
-log.info = old_log.info
-log.warn = old_log.warn
-log.error = old_log.error
-log.debug = old_log.debug
-log.trace = function(...)
-  old_log.info_with({hub_logs = true}, table.concat({"[TRACE->INFO] ", ...}))
-end
 
 --- A "singleton" module that maintains all of the websockets for a
 --- home's Sonos players. A player as modeled in the driver will have

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -1,29 +1,26 @@
 SONOS_API_KEY = require 'app_key'
 local old_log = require "log"
 
--- Forward all debug logs to hubcore info logs.
-old_log.debug = function(...)
-  old_log.info_with({hub_logs = true}, table.concat({"[DEBUG->INFO] ", ...}))
-end
-
--- Print all errors to hubcore for now
+-- Print all errors, warnings, and info to hubcore for now
 old_log.error = function(...)
   old_log.error_with({hub_logs = true}, ...)
 end
 
--- Print all warnings to hubcore for now
 old_log.warn = function(...)
   old_log.warn_with({hub_logs = true}, ...)
 end
 
+old_log.info = function(...)
+  old_log.info_with({hub_logs = true}, ...)
+end
+
 local log = {}
+
 log.warn = old_log.warn
 log.error = old_log.error
 log.debug = old_log.debug
 log.trace = old_log.trace
-log.info = function(...)
-  old_log.info_with({hub_logs = true}, ...)
-end
+log.info = old_log.info
 
 local Driver = require "st.driver"
 
@@ -45,7 +42,7 @@ local utils = require "utils"
 --- @param device SonosDevice
 --- @param should_continue function|nil
 local function find_player_for_device(driver, device, should_continue)
-  log.info(string.format("Looking for Sonos Player on network for device (%s:%s)", device.label, device.device_network_id))
+  device.log.info(string.format("Looking for Sonos Player on network for device (%s)", device.device_network_id))
   local player_found = false
 
   -- Because SSDP is UDP/unreliable, sometimes we can miss a broadcast.
@@ -60,13 +57,13 @@ local function find_player_for_device(driver, device, should_continue)
     --- @param ssdp_group_info SonosSSDPInfo
     SSDP.search(SONOS_SSDP_SEARCH_TERM, function(ssdp_group_info)
       driver:handle_ssdp_discovery(ssdp_group_info, function(dni, _, _, _)
-        log.info(string.format(
+        device.log.info(string.format(
             "Found device for Sonos search query with MAC addr %s, comparing to %s",
             dni, device.device_network_id
           )
         )
         if dni_equal(dni, device.device_network_id) then
-          log.info(string.format("Found Sonos Player match for %s", device.label))
+          device.log.info(string.format("Found Sonos Player match for device"))
           player_found = true
         end
       end)

--- a/drivers/SmartThings/sonos/src/ssdp.lua
+++ b/drivers/SmartThings/sonos/src/ssdp.lua
@@ -76,6 +76,9 @@ function SSDP.search(search_term, callback)
     if val then
       local headers = process_response(val)
 
+      -- log all SSDP responses, even if they don't have proper headers
+      log.debug_with({hub_logs = true}, string.format("Received response for Sonos search with headers [%s], processing details",
+          st_utils.stringify_table(headers)))
       if
           -- we don't explicitly check "st" because we don't index in to the contained
           -- value so the equality check suffices as a nil check as well.
@@ -88,8 +91,6 @@ function SSDP.search(search_term, callback)
             "household.smartspeaker.audio") and
           headers["st"] == search_term and headers["server"]:find("Sonos")
       then
-        log.debug(string.format("Received response for Sonos search with headers [%s], processing details",
-          st_utils.stringify_table(headers)))
         local ip =
             headers["location"]:match("http://([^,/]+):[^/]+/.+%.xml")
 
@@ -116,7 +117,7 @@ function SSDP.search(search_term, callback)
         elseif ip and is_group_coordinator and group_id and
             group_name and household_id and wss_url then
           if #group_id == 0 then
-            log.debug(string.format(
+            log.debug_with({hub_logs = true}, string.format(
               "Received SSDP response for non-primary Sonos device in a bonded set, skipping; SSDP Response: %s\n",
               st_utils.stringify_table(group_info, nil, false)))
           elseif callback ~= nil then

--- a/drivers/SmartThings/sonos/src/utils.lua
+++ b/drivers/SmartThings/sonos/src/utils.lua
@@ -36,7 +36,7 @@ function utils.labeled_socket_builder(label)
   end
 
   local function make_socket(host, port, wrap_ssl)
-    log.info(
+    log.trace(
       string.format(
         "%sCreating TCP socket for REST Connection", label
       )
@@ -47,7 +47,7 @@ function utils.labeled_socket_builder(label)
       return nil, (err or "unknown error creating TCP socket")
     end
 
-    log.info(
+    log.trace(
       string.format(
         "%sSetting TCP socket timeout for REST Connection", label
       )
@@ -57,7 +57,7 @@ function utils.labeled_socket_builder(label)
       return nil, "settimeout error: " .. err
     end
 
-    log.info(
+    log.trace(
       string.format(
         "%sConnecting TCP socket for REST Connection", label
       )
@@ -67,7 +67,7 @@ function utils.labeled_socket_builder(label)
     if err then return nil, err end
 
     if wrap_ssl then
-      log.info(
+      log.trace(
         string.format(
           "%sCreating SSL wrapper for for REST Connection", label
         )
@@ -77,7 +77,7 @@ function utils.labeled_socket_builder(label)
       if err ~= nil then
          return nil, "SSL wrap error: " .. err
       end
-      log.info(
+      log.trace(
         string.format(
           "%sPerforming SSL handshake for for REST Connection", label
         )


### PR DESCRIPTION
This removes all logs below info-level from the hub logs.

Note, a handful of the critical log messages we used for debugging will still be available:
* `Found device for Sonos search query with MAC addr %s, comparing to %s` - for MAC addr.  Will still be in hub logs, but the quantity should be significantly reduced thanks to https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/826
* `Received SSDP response for non-primary Sonos device in a bonded set, skipping; SSDP Response: %s` - for checking number of bonded devices
* `Looking for Sonos Player on network for device (%s:%s)` - for dni
* `Couldn't find Sonos Player [%s] during SSDP scan, trying again shortly` - for finding DNI of devices that are still trying to be matched