### PR TITLE
Refresh matter devices on device added event

### DIFF
--- a/drivers/SmartThings/matter-button/src/init.lua
+++ b/drivers/SmartThings/matter-button/src/init.lua
@@ -139,6 +139,7 @@ local function device_added(driver, device)
 
   device:emit_event(capabilities.button.numberOfButtons({value=1}, {visibility = {displayed = false}})) --number of buttons
 
+  device:refresh()
 end
 
 --end of lifecyle handlers

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -507,6 +507,8 @@ local function device_added(driver, device)
     end
     device:send(req)
   end
+
+  handle_refresh()
 end
 
 local matter_lock_driver = {

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -159,6 +159,8 @@ end
 local function device_added(driver, device)
   device:send(clusters.Thermostat.attributes.ControlSequenceOfOperation:read(device))
   device:send(clusters.FanControl.attributes.FanModeSequence:read(device))
+
+  device:refresh()
 end
 
 local function temp_event_handler(attribute)

--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -29,6 +29,8 @@ local function device_added(driver, device)
   device:emit_event(
     capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"})
   )
+
+  device:refresh()
 end
 
 local function device_removed(driver, device) log.info("device removed") end


### PR DESCRIPTION
This change adds a device refresh to matter drivers that have a non-default added handler. There is another PR to change the default behavior for matter devices so that a refresh is done by default on device add.