### PR TITLE
Eve: Update deviceLabel

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,22 +1,22 @@
 matterManufacturer:
 #Eve
   - id: "Eve/Energy/US"
-    deviceLabel: Eve Energy US
+    deviceLabel: Eve Energy
     vendorId: 0x130A
     productId: 0x53
     deviceProfileName: plug-binary
   - id: "Eve/Energy/Europe"
-    deviceLabel: Eve Energy Europe
+    deviceLabel: Eve Energy
     vendorId: 0x130A
     productId: 0x50
     deviceProfileName: plug-binary
   - id: "Eve/Energy/U.K."
-    deviceLabel: Eve Energy U.K.
+    deviceLabel: Eve Energy
     vendorId: 0x130A
     productId: 0x54
     deviceProfileName: plug-binary
   - id: "Eve/Energy/Australia"
-    deviceLabel: Eve Energy Australia
+    deviceLabel: Eve Energy
     vendorId: 0x130A
     productId: 0x5E
     deviceProfileName: plug-binary


### PR DESCRIPTION
We would like to use "Eve Energy” without the country information for all end-user-facing strings. This commit updates the deviceLabel string in the fingerprints to remove the country information.