### PR TITLE
BUG-7952: Aeotec Multi 6: fixes powerSource reports

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
@@ -34,7 +34,7 @@ end
 local function configuration_report_handler(self, device, cmd)
   local power_source
   if cmd.args.parameter_number == PREFERENCE_NUM then
-    if cmd.args.configuration_value == 0 then
+    if cmd.args.configuration_value & 0x100 == 0 then
       power_source = capabilities.powerSource.powerSource.dc()
     else
       power_source = capabilities.powerSource.powerSource.battery()

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
@@ -287,7 +287,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_sensor.id,
-        Configuration:Report({parameter_number = 9, configuration_value = 0})
+        Configuration:Report({parameter_number = 9, configuration_value = 2}) -- device docs report this should be zero, but actual devices report 2
       }
     },
     {


### PR DESCRIPTION
Change is based on both reports from devices as well as closer inspection of DTH code.