### PR TITLE
Remove supportedTrackControlCommands when playing radio source

### DIFF
--- a/drivers/SmartThings/bose/src/listener.lua
+++ b/drivers/SmartThings/bose/src/listener.lua
@@ -61,6 +61,23 @@ function Listener:now_playing_update(info)
     trackdata.album = bose_utils.sanitize_field(info.album)
     trackdata.albumArtUrl = bose_utils.sanitize_field(info.art_url)
     trackdata.mediaSource = bose_utils.sanitize_field(info.source)
+    if trackdata.mediaSource ~= nil then
+      local cached_track_control_cmds = self.device:get_latest_state(
+        "main", capabilities.mediaTrackControl.ID,
+        capabilities.mediaTrackControl.supportedTrackControlCommands.NAME
+      )
+      if trackdata.mediaSource == "TUNEIN" and
+        (cached_track_control_cmds == nil or utils.table_size(cached_track_control_cmds) > 0) then
+        -- Switching to radio source which disables track controls
+        self.device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({ }))
+      elseif trackdata.mediaSource ~= "TUNEIN" and
+        (cached_track_control_cmds == nil or utils.table_size(cached_track_control_cmds) == 0) then
+        self.device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
+          capabilities.mediaTrackControl.commands.nextTrack.NAME,
+          capabilities.mediaTrackControl.commands.previousTrack.NAME,
+        }))
+      end
+    end
     trackdata.title = bose_utils.sanitize_field(info.track) or
       bose_utils.sanitize_field(info.station) or
       (info.source == "AUX" and "Auxiliary input") or

--- a/drivers/SmartThings/sonos/src/api/event_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/event_handlers.lua
@@ -83,6 +83,22 @@ function CapEventHandlers.handle_playback_metadata_update(device, metadata_statu
     elseif is_linein or is_station or is_show or is_radio_tracklist then
       audio_track_data.mediaSource = metadata_status_body.container.name
     end
+
+    local cached_track_control_cmds = device:get_latest_state(
+      "main", capabilities.mediaTrackControl.ID,
+      capabilities.mediaTrackControl.supportedTrackControlCommands.NAME
+    )
+    -- If this is a radio source, disable track controls
+    if is_radio_tracklist and
+      (cached_track_control_cmds == nil or st_utils.table_size(cached_track_control_cmds) > 0) then
+      device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({ }))
+    elseif not is_radio_tracklist and
+      ((cached_track_control_cmds == nil or st_utils.table_size(cached_track_control_cmds) == 0) ) then
+        device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
+          capabilities.mediaTrackControl.commands.nextTrack.NAME,
+          capabilities.mediaTrackControl.commands.previousTrack.NAME,
+        }))
+    end
   end
 
   local track_info = nil


### PR DESCRIPTION
This un-reverts commit 5f5947952c1b32711a6d8406a8a923d618461797 for Bose and adds the same functionality to Sonos.