### PR TITLE
Send WakeUpIntervalGet once when device wakes up

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
@@ -27,6 +27,12 @@ local function can_handle_multisensor_6(opts, self, device, ...)
 end
 
 local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   device:send(Configuration:Get({parameter_number = PREFERENCE_NUM}))
   device:refresh()
 end

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
@@ -27,6 +27,12 @@ local function can_handle_multisensor_7(opts, self, device, ...)
 end
 
 local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   device:send(Configuration:Get({parameter_number = PREFERENCE_NUM}))
   device:refresh()
 end

--- a/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
@@ -27,6 +27,12 @@ local function can_handle_enerwave_motion_sensor(opts, driver, device, cmd, ...)
 end
 
 local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   local current_motion_status = device:get_latest_state("main", capabilities.motionSensor.ID, capabilities.motionSensor.motion.NAME)
   if current_motion_status == nil then
     device:send(Association:Set({grouping_identifier = 1, node_ids = {driver.environment_info.hub_zwave_id}}))

--- a/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
@@ -57,6 +57,12 @@ local function update_preferences(self, device, args)
 end
 
 local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   local get_temp = SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE}, {dst_channels = {3}})
   device:send(get_temp)
   local get_luminance = SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.LUMINANCE}, {dst_channels = {2}})

--- a/drivers/SmartThings/zwave-sensor/src/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/init.lua
@@ -21,6 +21,8 @@ local ZwaveDriver = require "st.zwave.driver"
 local defaults = require "st.zwave.defaults"
 --- @type st.zwave.CommandClass.Basic
 local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
+--- @type st.zwave.CommandClass.WakeUp
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local preferences = require "preferences"
 local configurations = require "configurations"
@@ -57,6 +59,16 @@ local function basic_set_handler(driver, device, cmd)
       device:emit_event_for_endpoint(cmd.src_channel, capabilities.motionSensor.motion.inactive())
     end
   end
+end
+
+local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
+  device:refresh()
 end
 
 local function do_configure(driver, device)
@@ -137,6 +149,9 @@ local driver_template = {
   zwave_handlers = {
     [cc.BASIC] = {
       [Basic.SET] = basic_set_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
 }

--- a/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
@@ -48,6 +48,12 @@ local function do_configure(driver, device)
 end
 
 local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   if device:get_field(CONFIG_REPORT_RECEIVED) ~= true then
     device:send(Configuration:Get({ parameter_number = LEAKAGE_ALARM_PARAM }))
   end

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
@@ -131,6 +131,10 @@ test.register_coroutine_test(
       )
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
           Configuration:Get({parameter_number = 9})
       ))
 
@@ -183,6 +187,10 @@ test.register_coroutine_test(
           WakeUp:Notification({})
         }
       )
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
           Configuration:Set({parameter_number = 3, size = 2, configuration_value = 120})

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_7.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_7.lua
@@ -132,6 +132,10 @@ test.register_coroutine_test(
         }
       )
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+        mock_sensor,
+        WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
           Configuration:Get({parameter_number = 10})
       ))
@@ -187,7 +191,10 @@ test.register_coroutine_test(
           mock_sensor,
           Configuration:Get({parameter_number = 10})
       ))
-
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+        mock_sensor,
+        WakeUp:IntervalGet({})
+      ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
           Configuration:Set({parameter_number = 3, size = 2, configuration_value = 120})

--- a/drivers/SmartThings/zwave-sensor/src/test/test_enerwave_motion_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_enerwave_motion_sensor.lua
@@ -65,7 +65,12 @@ test.register_coroutine_test(
 test.register_coroutine_test(
     "At a WakeUp, Assocation:Set should be sent when there wasn't a motion status event",
     function()
+      test.socket.zwave:__set_channel_ordering("relaxed")
       test.socket.zwave:__queue_receive({mock_sensor.id, WakeUp:Notification({}) })
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
           Association:Set({grouping_identifier = 1, node_ids = {}})
@@ -80,12 +85,18 @@ test.register_coroutine_test(
 test.register_coroutine_test(
     "At a WakeUp, Assocation:Set shouldn't be sent when there was a motion status event",
     function()
+      test.socket.zwave:__set_channel_ordering("relaxed")
       mock_sensor.wrapped_device.state_cache = {["main"] = {["motionSensor"] = {["motion"] = {["value"] = "inactive"}}}}
       test.socket.zwave:__queue_receive({mock_sensor.id, WakeUp:Notification({}) })
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
           Battery:Get({})
       ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
+
     end
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everpsring_sp817.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everpsring_sp817.lua
@@ -82,6 +82,10 @@ test.register_coroutine_test(
         }
       )
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
         mock_sensor,
         Configuration:Set({configuration_value = 360, parameter_number = 4, size = 2})
       ))

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_PIR_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_PIR_sensor.lua
@@ -174,6 +174,10 @@ test.register_coroutine_test(
       )
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
           Configuration:Set({parameter_number = 1, size = 2, configuration_value = 1000})
       ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_2.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_2.lua
@@ -213,6 +213,10 @@ test.register_coroutine_test(
       )
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
           mock_fibaro_door_window_sensor,
+          WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+          mock_fibaro_door_window_sensor,
           Configuration:Set({parameter_number = 1, size = 1, configuration_value = 1})
       ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
@@ -313,6 +317,10 @@ test.register_coroutine_test(
           WakeUp:Notification({})
         }
       )
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+        mock_fibaro_door_window_sensor,
+        WakeUp:IntervalGet({})
+      ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         WakeUp:IntervalSet({node_id = 0x00, seconds = 10 * 3600})

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
@@ -273,6 +273,10 @@ test.register_coroutine_test(
     )
     test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
       mock_fibaro_door_window_sensor,
+      WakeUp:IntervalGet({})
+    ))
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_fibaro_door_window_sensor,
       Battery:Get({})
     ))
     test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor_zw5.lua
@@ -68,6 +68,11 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
         zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(
+        zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
           Configuration:Set({parameter_number = 1, size = 2, configuration_value = 600})
       ))
       test.socket.zwave:__expect_send(

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor_zw5.lua
@@ -121,6 +121,11 @@ test.register_coroutine_test(
       test.socket.zwave:__expect_send(
         zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
+          WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(
+        zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
           Configuration:Set({parameter_number = 2, size = 1, configuration_value = 3})
       ))
       test.socket.zwave:__expect_send(

--- a/drivers/SmartThings/zwave-sensor/src/test/test_homeseer_multi_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_homeseer_multi_sensor.lua
@@ -122,6 +122,10 @@ test.register_coroutine_test(
       ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
         mock_sensor,
+        WakeUp:IntervalGet({})
+      ))
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+        mock_sensor,
         Battery:Get({})
       ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
@@ -144,6 +148,10 @@ test.register_coroutine_test(
           WakeUp:Notification({})
         }
       )
+      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+        mock_sensor,
+        WakeUp:IntervalGet({})
+      ))
       test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
         mock_sensor,
         SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE}, {dst_channels={3}})

--- a/drivers/SmartThings/zwave-sensor/src/test/test_no_wakeup_poll.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_no_wakeup_poll.lua
@@ -75,6 +75,14 @@ test.register_message_test(
     },
     {
       channel = "zwave",
+      direction = "send",
+      message = zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        WakeUp:IntervalGet({ })
+      )
+    },
+    {
+      channel = "zwave",
       direction = "receive",
       message = { mock_device.id, zw_test_utils.zwave_test_build_receive_command( SensorBinary:Report({
         sensor_type = SensorBinary.sensor_type.DOOR_WINDOW,
@@ -99,6 +107,9 @@ test.register_message_test(
         Battery:Get({ })
       )
     },
+  },
+  {
+    inner_block_ordering = "relaxed"
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
@@ -83,10 +83,15 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Wakeup Notification should prompt a configuration get until a report is received",
   function ()
+    test.socket.zwave:__set_channel_ordering("relaxed")
     test.socket.zwave:__queue_receive({mock_sensor.id, WakeUp:Notification({})})
     test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
       mock_sensor,
       Configuration:Get({ parameter_number = 12})
+    ))
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_sensor,
+      WakeUp:IntervalGet({})
     ))
     test.socket.zwave:__queue_receive({mock_sensor.id, Configuration:Report( { configuration_value = 0x00, parameter_number = 12 } )})
     mock_sensor:expect_metadata_update({ profile = "illuminance-temperature" })

--- a/drivers/SmartThings/zwave-sensor/src/test/test_vision_motion_detector.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_vision_motion_detector.lua
@@ -147,9 +147,20 @@ test.register_message_test(
         direction = "send",
         message = zw_test_utils.zwave_test_build_send_command(
           mock_sensor,
+          WakeUp:IntervalGet({})
+        )
+      },
+      {
+        channel = "zwave",
+        direction = "send",
+        message = zw_test_utils.zwave_test_build_send_command(
+          mock_sensor,
           SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
         )
       }
+    },
+    {
+      inner_block_ordering = "relaxed"
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_light_sensor.lua
@@ -247,7 +247,15 @@ test.register_message_test(
           mock_device,
           SensorBinary:Get({ sensor_type = SensorBinary.sensor_type.MOTION })
         )
-      }
+      },
+      {
+        channel = "zwave",
+        direction = "send",
+        message = zw_test_utils.zwave_test_build_send_command(
+          mock_device,
+          WakeUp:IntervalGet({})
+        )
+      },
     },
     {
       inner_block_ordering = "relaxed"

--- a/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
@@ -29,6 +29,12 @@ end
 
 -- Nortek open/closed sensors _always_ respond with "open" when polled, and they are polled after wakeup
 local function wakeup_notification(driver, device, cmd)
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   if device:get_latest_state("main", capabilities.contactSensor.ID, capabilities.contactSensor.contact.NAME) == nil then
     device:send(SensorBinary:Get({sensor_type = SensorBinary.sensor_type.DOOR_WINDOW}))
   end

--- a/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
@@ -55,6 +55,12 @@ local function device_added(self, device)
 end
 
 local function wakeup_notification_handler(self, device, cmd)
+    --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+    --This is done to help the hub correctly set the checkInterval for migrated devices.
+    if not device:get_field("__wakeup_interval_get_sent") then
+      device:send(WakeUp:IntervalGetV1({}))
+      device:set_field("__wakeup_interval_get_sent", true)
+    end
   device:emit_event(capabilities.smokeDetector.smoke.clear())
   device:send(Battery:Get({}))
   device:send(SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE}))

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
@@ -92,6 +92,13 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
+        WakeUp:IntervalGet({})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
         Configuration:Set({parameter_number=1, size=1, configuration_value=0})
       )
     )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_thermostat_heating_battery.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_thermostat_heating_battery.lua
@@ -142,6 +142,11 @@ test.register_coroutine_test(
                 zw_test_utilities.zwave_test_build_receive_command(
                         WakeUp:Notification({}))
             })
+            test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
         end
 )
 
@@ -173,6 +178,11 @@ test.register_coroutine_test(
                 zw_test_utilities.zwave_test_build_receive_command(
                         WakeUp:Notification({}))
             })
+            test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
             -- expect nothing since time is not exceed 24 hours
 
             test.wait_for_events()
@@ -370,6 +380,13 @@ test.register_coroutine_test(
             test.socket.zwave:__queue_receive({
                 mock_device.id, zw_test_utilities.zwave_test_build_receive_command(WakeUp:Notification({}))
             })
+
+            test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
+
             -- Celsius 25 should be converted to Fahrenheit 77, since devices use Fahrenheit scale.
             test.socket.zwave:__expect_send(
                     zw_test_utilities.zwave_test_build_send_command(
@@ -457,6 +474,12 @@ test.register_coroutine_test(
                 mock_device.id, zw_test_utilities.zwave_test_build_receive_command(WakeUp:Notification({}))
             })
 
+            test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
+
             -- Celsius 25
             test.socket.zwave:__expect_send(
                     zw_test_utilities.zwave_test_build_send_command(
@@ -528,6 +551,12 @@ test.register_coroutine_test(
             test.socket.zwave:__queue_receive(
                     {mock_device.id, zw_test_utilities.zwave_test_build_receive_command(WakeUp:Notification({}))}
             )
+
+            test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
 
             test.socket.zwave:__expect_send(
                     zw_test_utilities.zwave_test_build_send_command(
@@ -621,6 +650,12 @@ test.register_coroutine_test(
             )
 
             test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
+
+            test.socket.zwave:__expect_send(
                     zw_test_utilities.zwave_test_build_send_command(
                             mock_device,
                             ThermostatSetpoint:Set({
@@ -692,6 +727,11 @@ test.register_coroutine_test(
                             seconds = new_reportingInterval*60
                         })
                 ))
+        test.socket.zwave:__expect_send(
+            zw_test_utilities.zwave_test_build_send_command(
+              mock_device,
+              WakeUp:IntervalGet({})
+        ))
     end
 )
 
@@ -723,6 +763,12 @@ test.register_coroutine_test(
                                 local_protection_state = Protection.protection_state.NO_OPERATION_POSSIBLE,
                             })
                     ))
+            test.socket.zwave:__expect_send(
+                zw_test_utilities.zwave_test_build_send_command(
+                  mock_device,
+                  WakeUp:IntervalGet({})
+            ))
+
         end
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/init.lua
@@ -210,6 +210,12 @@ local function set_heating_setpoint(driver, device, command)
 end
 
 local function wakeup_notification_handler(self, device, cmd)
+    --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+    --This is done to help the hub correctly set the checkInterval for migrated devices.
+    if not device:get_field("__wakeup_interval_get_sent") then
+      device:send(WakeUp:IntervalGetV1({}))
+      device:set_field("__wakeup_interval_get_sent", true)
+    end
     check_and_send_cached_setpoint(device)
     check_and_send_battery_get(device)
     check_and_send_clock_set(device)


### PR DESCRIPTION
This helps the hubs device health implementation work better for migrated devices by ensuring a WakeUpIntervalReport is received post migration. Note this will be done by default in the lua libs post 0.49.x hub FW release.