### PR TITLE
BUG-8069 Z-Wave Switch: fix generic fingerprint ranking

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -923,6 +923,13 @@ zwaveGeneric:
     deviceLabel: Dimmer Switch
     genericType: 0x11 # GENERIC_TYPE_SWITCH_MULTILEVEL
     deviceProfileName: switch-level
+  - id: "GenericDimmerSwitch/3"
+    deviceLabel: Dimmer Switch
+    commandClasses:
+      supported:
+        - 0x25 # binary switch
+        - 0x26 # switch multilevel
+    deviceProfileName: switch-level
   - id: "GenericMultiChannelDevice/1"
     deviceLabel: Z-Wave Device Multichannel
     commandClasses:


### PR DESCRIPTION
Because we had two fingerprints with only one command class each, a device that supported both command classes would match to both with equal 'match score'. I've added a third fingerprint such that devices that support both binary and multilevel switch ccs will match to a multilevel profile