### PR TITLE
Feature/wemo power energy

### DIFF
--- a/drivers/SmartThings/wemo/src/command_handlers.lua
+++ b/drivers/SmartThings/wemo/src/command_handlers.lua
@@ -22,7 +22,7 @@ function command_handlers.handle_refresh(driver, device)
 end
 
 function command_handlers.handle_reset_energy_meter(driver, device)
-  device:set_field("DAILY_ENERGY_REPORT", true)
+  device.log.warn("Wemo has no documented api to reset energy meter")
 end
 
 return command_handlers

--- a/drivers/SmartThings/wemo/src/command_handlers.lua
+++ b/drivers/SmartThings/wemo/src/command_handlers.lua
@@ -21,4 +21,8 @@ function command_handlers.handle_refresh(driver, device)
   end
 end
 
+function command_handlers.handle_reset_energy_meter(driver, device)
+  device:set_field("DAILY_ENERGY_REPORT", true)
+end
+
 return command_handlers

--- a/drivers/SmartThings/wemo/src/init.lua
+++ b/drivers/SmartThings/wemo/src/init.lua
@@ -113,12 +113,6 @@ local function device_init(driver, device)
     function() protocol.poll(device) end,
     device.id .. "poll"
   )
-  if device:supports_capability_by_id("energyMeter") then
-    local f = function(dev) dev:set_field("DAILY_ENERGY_REPORT", true) end
-    f(device)
-    device.thread:call_on_schedule(86400, f, device.id .. "energyreport")
-  end
-
 
   --Rediscovery task. Needs task because if device init doesn't return, no events are handled
   -- on the device thread.

--- a/drivers/SmartThings/wemo/src/parser.lua
+++ b/drivers/SmartThings/wemo/src/parser.lua
@@ -74,10 +74,11 @@ local function handle_binary_state(device, value)
   if result.current_power_mW ~= nil and result.energy_today_Wh ~= nil and
     device:supports_capability_by_id("powerMeter") and device:supports_capability_by_id("energyMeter") then
     device:emit_event(capabilities.powerMeter.power(result.current_power_mW / 1000)) --ST uses watts by default
-    --Report energy
-    if device:get_field("DAILY_ENERGY_REPORT") then
+    --Sometimes total energy reported is way off, in that case use the daily energy reported
+    if result.energy_today_Wh > result.energy_total_Wh then
       device:emit_event(capabilities.energyMeter.energy({value = result.energy_today_Wh, unit = "Wh"}))
-      device:set_field("DAILY_ENERGY_REPORT", false)
+    else
+      device:emit_event(capabilities.energyMeter.energy({value = result.energy_total_Wh, unit = "Wh"}))
     end
   end
 end

--- a/drivers/SmartThings/wemo/src/parser.lua
+++ b/drivers/SmartThings/wemo/src/parser.lua
@@ -30,13 +30,28 @@ end
 
 local function handle_binary_state(device, value)
   -- parses wemo insight style ("8|1611850428|58|...") state, works just fine for a single value too
-  local vals = string.gmatch(value, "%d+")
-  -- map all values to numbers
-  -- note: this really does need `or nil`, `tonumber()` is an error, `tonumber(nil)` returns nil
-  local numvals = function() return tonumber(vals() or 0) end
+  local result = {}
+  local lut = {
+      "state",
+      "last_changed_timestamp",
+      "last_on_for_s",
+      "on_today_s",
+      "on_total_s",
+      "timespan_s",
+      "avg_power_W",
+      "current_power_mW",
+      "energy_today_Wh",
+      "energy_total_Wh",
+      "standby_limit_mW",
+  }
+  -- Parse the data and insert into the result_table
+  local iter = value:gmatch("([^|]+)")
+  for _, name in ipairs(lut) do
+      result[name] = tonumber(iter() or 0)
+  end
 
   -- power state
-  local state = numvals()
+  local state = result.state
   if state == 0 then
     if device:supports_capability_by_id("switch") then
       device:emit_event(capabilities.switch.switch("off"))
@@ -55,7 +70,16 @@ local function handle_binary_state(device, value)
       log.warn("parse| BinaryState event on device that supports neither `switch` nor `motionSensor`")
     end
   end
-  -- TODO: there's a bunch more values from insight plugs, what do they mean?
+
+  if result.current_power_mW ~= nil and result.energy_today_Wh ~= nil and
+    device:supports_capability_by_id("powerMeter") and device:supports_capability_by_id("energyMeter") then
+    device:emit_event(capabilities.powerMeter.power(result.current_power_mW / 1000)) --ST uses watts by default
+    --Report energy
+    if device:get_field("DAILY_ENERGY_REPORT") then
+      device:emit_event(capabilities.energyMeter.energy({value = result.energy_today_Wh, unit = "Wh"}))
+      device:set_field("DAILY_ENERGY_REPORT", false)
+    end
+  end
 end
 
 local function handle_brightness(device, value)
@@ -110,6 +134,12 @@ function parser.parse_get_state_resp_xml(device, xml)
   if brightness then
     log.trace("parse| brightness", brightness)
     handle_brightness(device, brightness)
+  end
+
+  local insight = tablefind(parsed_xml, "s:Envelope.s:Body.u:GetInsightParamsResponse.InsightParams")
+  if insight then
+    log.trace("parse| insight_params", insight)
+    handle_binary_state(device, insight)
   end
 end
 


### PR DESCRIPTION
Im not convinced in the energy meter reporting of this device at all, in fact it may be worthwhile to only report powerMeter capabilities for the device since it is very inconsistent in its values for energy reports (total energy fluctuates a lot including negative values, and it seems very high)

This implementation is based off the way device report payloads are interpreted [here](https://github.com/tigoe/WeMoExamples/tree/master) and [here](https://github.com/SmartThingsUle/Wemo/blob/4f5236c3fb1aa14834cd11d3173495edfff6d1a4/WeMo%20Insight%20Switch.groovy#L110)