### PR TITLE
Add periodic mDNS Scanning to Philips Hue Edge Driver

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -1,5 +1,3 @@
-local Fields = require "hue.fields"
-local HueApi = require "hue.api"
 local log = require "log"
 local socket = require "cosock.socket"
 
@@ -7,6 +5,8 @@ local mdns = require "st.mdns"
 local net_utils = require "st.net_utils"
 local st_utils = require "st.utils"
 
+local Fields = require "hue.fields"
+local HueApi = require "hue.api"
 local utils = require "utils"
 
 local SERVICE_TYPE = "_hue._tcp"
@@ -15,7 +15,9 @@ local DOMAIN = "local"
 local HueDiscovery = {
   api_keys = {},
   disco_api_instances = {},
-  light_state_disco_cache = {}
+  light_state_disco_cache = {},
+  ServiceType = SERVICE_TYPE,
+  Domain = DOMAIN,
 }
 
 local supported_resource_types = {
@@ -34,21 +36,23 @@ function HueDiscovery.discover(driver, _, should_continue)
   log.info_with({ hub_logs = true }, "Starting Hue discovery")
 
   while should_continue() do
-    local known_dni_to_device_map = {}
+    local known_identifier_to_device_map = {}
     local computed_mac_addresses = {}
     for _, device in ipairs(driver:get_devices()) do
       -- the bridge won't have a parent assigned key so we give that boolean short circuit preference
       local dni = device.parent_assigned_child_key or device.device_network_id
-      known_dni_to_device_map[dni] = device
+      known_identifier_to_device_map[dni] = device
       local ipv4 = device:get_field(Fields.IPV4);
       if ipv4 then
         computed_mac_addresses[ipv4] = dni
       end
     end
 
+    HueDiscovery.do_mdns_scan(driver)
     HueDiscovery.search_for_bridges(driver, computed_mac_addresses, function(hue_driver, bridge_ip, bridge_id)
-      discovered_bridge_callback(hue_driver, bridge_ip, bridge_id, known_dni_to_device_map)
+      discovered_bridge_callback(hue_driver, bridge_ip, bridge_id, known_identifier_to_device_map)
     end)
+    socket.sleep(1.0)
   end
   log.info_with({ hub_logs = true }, "Ending Hue discovery")
 end
@@ -58,83 +62,27 @@ end
 ---@param computed_mac_addresses table<string,string>
 ---@param callback fun(driver: HueDriver, ip: string, id: string)
 function HueDiscovery.search_for_bridges(driver, computed_mac_addresses, callback)
-  local mdns_responses, err = mdns.discover(SERVICE_TYPE, DOMAIN)
-
-  if err ~= nil then
-    log.error_with({ hub_logs = true }, "Error during service discovery: ", err)
-    return
-  end
-
-  if not (mdns_responses and mdns_responses.found and #mdns_responses.found > 0) then
-    log.warn("No mdns responses for Hue service this attempt, continuing...")
-    return
-  end
-
-  for _, info in ipairs(mdns_responses.found) do
-    if not net_utils.validate_ipv4_string(info.host_info.address) then -- we only care about the ipV4 types here.
-      log.trace("Invalid IPv4 address: " .. info.host_info.address)
-      goto continue
-    end
-    if info.service_info.service_type ~= SERVICE_TYPE then -- response for a different service type. Shouldn't happen.
-      log.warn("Unexpected service type response: " .. info.service_info.service_type)
-      goto continue
-    end
-    if info.service_info.domain ~= DOMAIN then -- response for a different domain. Shouldn't happen.
-      log.warn("Unexpected domain response: " .. info.service_info.domain)
-      goto continue
-    end
-
-    local ip_addr = info.host_info.address;
-
-    if not computed_mac_addresses[ip_addr] then
-      -- Hue *typically* formats the BridgeID as the uppercase MAC address, minus separators.
-      -- However, it can be user overriden, set by a user, and may not be unique, so we want
-      -- to stick to that format but make sure it's actually the mac address. Instead of pulling
-      -- the bridge id out of the bridge info, we'll extract the MAC address and apply the above mentioned
-      -- formatting rules. We also prefer the MAC because it makes for a good Device Network ID.
-      local bridge_info, rest_err, _ = HueApi.get_bridge_info(
-        ip_addr,
-        utils.labeled_socket_builder("[Discovery: " .. ip_addr .. " Bridge Info Request]")
-      )
-      if rest_err ~= nil or not bridge_info then
-        log.error_with({ hub_logs = true }, string.format(
-          "Error querying bridge info for discovered IP address %s: %s",
-          ip_addr,
-          (rest_err or "unexpected nil in error position")
-        )
-        )
-        goto continue
-      end
-
-      -- '-' and ':' or '::' are the accepted separators used for MAC address segments, so
-      -- we strip thoes out and make the string uppercase
-      if bridge_info.mac then
-        local bridge_id = bridge_info.mac:gsub("-", ""):gsub(":", ""):upper()
-        computed_mac_addresses[ip_addr] = bridge_id
-      end
-    end
-
-    if type(callback) == "function" then
-      callback(driver, ip_addr, computed_mac_addresses[ip_addr])
+  local scanned_bridges = driver.datastore.bridge_netinfo or {}
+  for bridge_id, bridge_info in pairs(scanned_bridges) do
+    if type(callback) == "function" and bridge_info ~= nil then
+      callback(driver, bridge_info.ip, bridge_id)
     else
       log.warn(
         "Argument passed in `callback` position for "
         .. "`HueDiscovery.search_for_bridges` is not a function"
       )
     end
-
-    ::continue::
   end
 end
 
 ---@param driver HueDriver
 ---@param bridge_ip string
 ---@param bridge_id string
----@param known_dni_to_device_map table<string,HueDevice>
-discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_dni_to_device_map)
+---@param known_identifier_to_device_map table<string,HueDevice>
+discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_identifier_to_device_map)
   if driver.ignored_bridges[bridge_id] then return end
 
-  local known_bridge_device = known_dni_to_device_map[bridge_id]
+  local known_bridge_device = known_identifier_to_device_map[bridge_id]
   if known_bridge_device and known_bridge_device:get_field(Fields.API_KEY) then
     HueDiscovery.api_keys[bridge_id] = known_bridge_device:get_field(Fields.API_KEY)
   end
@@ -142,7 +90,8 @@ discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_dni_to
   if known_bridge_device ~= nil
       and driver.joined_bridges[bridge_id]
       and HueDiscovery.api_keys[bridge_id]
-      and known_bridge_device:get_field(Fields._INIT) then
+      and known_bridge_device:get_field(Fields._INIT)
+  then
     log.info_with({ hub_logs = true }, string.format("Scanning bridge %s for devices...", bridge_id))
 
     HueDiscovery.disco_api_instances[bridge_id] = HueDiscovery.disco_api_instances[bridge_id]
@@ -154,7 +103,7 @@ discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_dni_to
 
     HueDiscovery.search_bridge_for_supported_devices(driver, HueDiscovery.disco_api_instances[bridge_id],
       function(hue_driver, svc_info, device_info)
-        discovered_device_callback(hue_driver, bridge_id, svc_info, device_info, known_dni_to_device_map)
+        discovered_device_callback(hue_driver, bridge_id, svc_info, device_info, known_identifier_to_device_map)
       end,
       "[Discovery: " ..
       (known_bridge_device.label or bridge_id or known_bridge_device.id or "unknown bridge") .. " bridge scan]"
@@ -162,8 +111,8 @@ discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_dni_to
     return
   end
 
-  local socket_builder = utils.labeled_socket_builder(bridge_id)
   if not HueDiscovery.api_keys[bridge_id] then
+    local socket_builder = utils.labeled_socket_builder(bridge_id)
     local api_key_response, err, _ = HueApi.request_api_key(bridge_ip, socket_builder)
 
     if err ~= nil or not api_key_response then
@@ -193,10 +142,10 @@ discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_dni_to
   end
 
   if HueDiscovery.api_keys[bridge_id] and not driver.joined_bridges[bridge_id] then
-    local bridge_info, err, _ = HueApi.get_bridge_info(bridge_ip, socket_builder)
-    if err ~= nil or not bridge_info then
-      log.error_with({ hub_logs = true }, string.format("Error querying bridge info for %s: %s", bridge_id,
-        (err or "unexpected nil in error position")))
+    local bridge_info = driver.datastore.bridge_netinfo[bridge_id]
+
+    if not bridge_info then
+      log.debug(string.format("Bridge info for %s not yet available", bridge_id))
       return
     end
 
@@ -206,8 +155,7 @@ discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_dni_to
       return
     end
 
-    bridge_info.ip = bridge_ip
-    driver.joined_bridges[bridge_id] = bridge_info
+    driver.joined_bridges[bridge_id] = true
 
     if not known_bridge_device then
       local create_device_msg = {
@@ -272,13 +220,13 @@ end
 ---@param bridge_id string
 ---@param svc_info table
 ---@param device_info table
----@param known_dni_to_device_map table<string,HueDevice>
-discovered_device_callback = function(driver, bridge_id, svc_info, device_info, known_dni_to_device_map)
+---@param known_identifier_to_device_map table<string,HueDevice>
+discovered_device_callback = function(driver, bridge_id, svc_info, device_info, known_identifier_to_device_map)
   local v1_dni = bridge_id .. "/" .. (device_info.id_v1 or "UNKNOWN"):gsub("/lights/", "")
   local edge_dni = svc_info.rid or ""
-  if known_dni_to_device_map[v1_dni] or known_dni_to_device_map[edge_dni] then return end
+  if known_identifier_to_device_map[v1_dni] or known_identifier_to_device_map[edge_dni] then return end
   if svc_info.rtype == "light" then
-    process_discovered_light(driver, bridge_id, svc_info.rid, device_info, known_dni_to_device_map)
+    process_discovered_light(driver, bridge_id, svc_info.rid, device_info, known_identifier_to_device_map)
   end
 end
 
@@ -286,8 +234,8 @@ end
 ---@param bridge_id string
 ---@param resource_id string
 ---@param device_info table
----@param known_dni_to_device_map table<string,boolean>
-process_discovered_light = function(driver, bridge_id, resource_id, device_info, known_dni_to_device_map)
+---@param known_identifier_to_device_map table<string,boolean>
+process_discovered_light = function(driver, bridge_id, resource_id, device_info, known_identifier_to_device_map)
   local api_instance = HueDiscovery.disco_api_instances[bridge_id]
   if not api_instance then
     log.warn("No API instance for bridge_id ", bridge_id)
@@ -334,7 +282,7 @@ process_discovered_light = function(driver, bridge_id, resource_id, device_info,
       goto continue
     end
 
-    local bridge_device = known_dni_to_device_map[bridge_id]
+    local bridge_device = known_identifier_to_device_map[bridge_id]
 
     local create_device_msg = {
       type = "EDGE_CHILD",
@@ -369,6 +317,86 @@ end
 
 is_device_service_supported = function(svc_info)
   return supported_resource_types[svc_info.rtype or ""]
+end
+
+function HueDiscovery.do_mdns_scan(driver)
+  local bridge_netinfo = driver.datastore.bridge_netinfo
+  local mdns_responses, err = mdns.discover(HueDiscovery.ServiceType, HueDiscovery.Domain)
+
+  if err ~= nil then
+    log.error_with({ hub_logs = true }, "Error during service discovery: ", err)
+    return
+  end
+
+  if not (mdns_responses and mdns_responses.found and #mdns_responses.found > 0) then
+    log.warn("No mdns responses for Hue service this attempt, continuing...")
+    return
+  end
+
+  for _, info in ipairs(mdns_responses.found) do
+    if not net_utils.validate_ipv4_string(info.host_info.address) then   -- we only care about the ipV4 types here.
+      log.trace("Invalid IPv4 address: " .. info.host_info.address)
+      return
+    end
+
+    if info.service_info.service_type ~= HueDiscovery.ServiceType then   -- response for a different service type. Shouldn't happen.
+      log.warn("Unexpected service type response: " .. info.service_info.service_type)
+      return
+    end
+
+    if info.service_info.domain ~= HueDiscovery.Domain then   -- response for a different domain. Shouldn't happen.
+      log.warn("Unexpected domain response: " .. info.service_info.domain)
+      return
+    end
+
+    -- Hue *typically* formats the BridgeID as the uppercase MAC address, minus separators.
+    -- However, it can be user overriden, set by a user, and may not be unique, so we want
+    -- to stick to that format but make sure it's actually the mac address. Instead of pulling
+    -- the bridge id out of the bridge info, we'll extract the MAC address and apply the above mentioned
+    -- formatting rules. We also prefer the MAC because it makes for a good Device Network ID.
+    local ip_addr = info.host_info.address;
+    local bridge_info, rest_err, _ = HueApi.get_bridge_info(
+      ip_addr,
+      utils.labeled_socket_builder("[mDNS Scan: " .. ip_addr .. " Bridge Info Request]")
+    )
+    if rest_err ~= nil or not bridge_info then
+      log.error_with({ hub_logs = true },
+        string.format(
+          "Error querying bridge info for discovered IP address %s: %s",
+          ip_addr,
+          (rest_err or "unexpected nil in error position")
+        )
+      )
+      return
+    end
+    -- '-' and ':' or '::' are the accepted separators used for MAC address segments, so
+    -- we strip thoes out and make the string uppercase
+    if not bridge_info.mac then
+      log.warn_with({ hub_logs = true },
+        string.format(
+          "No MAC address in returned Bridge Info for IP %s.", ip_addr
+        )
+      )
+      return
+    end
+
+    bridge_info.ip = ip_addr
+    local bridge_id = bridge_info.mac:gsub("-", ""):gsub(":", ""):upper()
+
+    -- sanitize userdata nulls from JSON decode
+    for k, v in pairs(bridge_info) do
+      if type(v) == "userdata" then
+        bridge_info[k] = nil
+      end
+    end
+
+    if not utils.deep_table_eq((bridge_netinfo[bridge_id] or {}), bridge_info) then
+      bridge_netinfo[bridge_id] = bridge_info
+      if driver.joined_bridges[bridge_id] and not driver.ignored_bridges[bridge_id] then
+        driver:update_bridge_netinfo(bridge_id, bridge_info)
+      end
+    end
+  end
 end
 
 return HueDiscovery

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -86,7 +86,7 @@ local function process_rest_response(response, err, partial, err_callback)
       )
     end
 
-    return table.unpack(json_result)
+    return table.unpack(json_result, 1, json_result.n)
   else
     return nil, "no response or error received"
   end
@@ -185,7 +185,7 @@ local function do_get(instance, path)
     instance.client:close_socket()
     return nil, "cosock error: " .. err
   end
-  return table.unpack(recv)
+  return table.unpack(recv, 1, recv.n)
 end
 
 local function do_put(instance, path, payload)
@@ -198,7 +198,7 @@ local function do_put(instance, path, payload)
     instance.client:close_socket()
     return nil, "cosock error: " .. err
   end
-  return table.unpack(recv)
+  return table.unpack(recv, 1, recv.n)
 end
 
 ---@param bridge_ip string
@@ -220,7 +220,7 @@ function PhilipsHueApi.get_bridge_info(bridge_ip, socket_builder)
   if err ~= nil then
     return nil, "cosock error: " .. err
   end
-  return table.unpack(recv)
+  return table.unpack(recv, 1, recv.n)
 end
 
 ---@param bridge_ip string
@@ -243,7 +243,7 @@ function PhilipsHueApi.request_api_key(bridge_ip, socket_builder)
   if err ~= nil then
     return nil, "cosock error: " .. err
   end
-  return table.unpack(recv)
+  return table.unpack(recv, 1, recv.n)
 end
 
 function PhilipsHueApi:get_lights() return do_get(self, "/clip/v2/resource/light") end

--- a/drivers/SmartThings/philips-hue/src/hue/types.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/types.lua
@@ -10,16 +10,19 @@
 --- @field public replacesbridgeid string|nil
 --- @field public modelid string
 --- @field public starterkitid string
+--- @field public ip string|nil
 
 --- @class HueDriver:Driver
 --- @field public ignored_bridges table<string,boolean>
---- @field public joined_bridges table<string,table>
+--- @field public joined_bridges table<string,boolean>
 --- @field public light_id_to_device table<string,HueChildDevice>
 --- @field public device_rid_to_light_rid table<string,string>
 --- @field public stray_bulb_tx table cosock channel
+--- @field public datastore table persistent store
 --- @field public api_key_to_bridge_id table<string,string>
---- @field private _lights_pending_refresh table<string,HueChildDevice>
+--- @field public update_bridge_netinfo fun(self: HueDriver, bridge_id: string, bridge_info: HueBridgeInfo)
 --- @field public emit_light_status_events fun(light_device: HueChildDevice, light: table)
+--- @field private _lights_pending_refresh table<string,HueChildDevice>
 
 --- @class HueDevice:st.Device
 --- @field public label string

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -726,7 +726,7 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
       if msg and msg.data then
         local json_result = table.pack(pcall(json.decode, msg.data))
         local success = table.remove(json_result, 1)
-        local events, err = table.unpack(json_result)
+        local events, err = table.unpack(json_result, 1, json_result.n)
 
         if not success then
           log.error_with({ hub_logs = true },

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -18,20 +18,21 @@
 --
 --  ===============================================================================================
 local cosock = require "cosock"
+local log = require "log"
+
+local capabilities = require "st.capabilities"
+local Driver = require "st.driver"
+local json = require "st.json"
+local st_utils = require "st.utils"
+
 local Discovery = require "disco"
 local EventSource = require "lunchbox.sse.eventsource"
 local Fields = require "hue.fields"
 local handlers = require "handlers"
 local HueApi = require "hue.api"
 local HueColorUtils = require "hue.cie_utils"
-local log = require "log"
 local lunchbox_util = require "lunchbox.util"
 local utils = require "utils"
-
-local capabilities = require "st.capabilities"
-local Driver = require "st.driver"
-local json = require "st.json"
-local st_utils = require "st.utils"
 
 local syncCapabilityId = "samsungim.hueSyncMode"
 local hueSyncMode = capabilities[syncCapabilityId]
@@ -178,18 +179,11 @@ local function migrate_bridge(driver, device)
               (device.label or device.id or "unknown device")
             )
           )
-          local bridge_info, err, _ = HueApi.get_bridge_info(
-            bridge_ip,
-            utils.labeled_socket_builder(
-              "[Migrate: " .. (device.label or bridge_id or device.id or "unknown bridge") .. " Bridge Info Request"
-            )
-          )
-          if err ~= nil or not bridge_info then
-            log.error_with({ hub_logs = true }, string.format("Error querying bridge info for %s: %s",
-              (device.label or bridge_id or device.id or "unknown bridge"),
-              (err or "unexpected nil in error position")
-            )
-            )
+
+          local bridge_info = driver.datastore.bridge_netinfo[bridge_id]
+
+          if not bridge_info then
+            log.debug(string.format("Bridge info for %s not yet available", bridge_id))
             return
           end
 
@@ -199,9 +193,7 @@ local function migrate_bridge(driver, device)
             return
           end
 
-          bridge_info.ip = bridge_ip
-
-          hue_driver.joined_bridges[bridge_id] = bridge_info
+          hue_driver.joined_bridges[bridge_id] = true
           Discovery.api_keys[bridge_id] = api_key
 
           local new_metadata = {
@@ -251,24 +243,13 @@ local function spawn_bridge_add_api_key_task(driver, device)
     -- 30 seconds is the typical UX for waiting to hit the link button in the Hue ecosystem
     local timeout_time = cosock.socket.gettime() + 30
 
-    local bridge_info = driver.joined_bridges[device_bridge_id]
-    if not bridge_info then
-      device.log.error_with(
-        { hub_logs = true },
-        "Missing bridge info/ip address as well as application key " ..
-        "for LAN Hue Bridge, cannot proceed."
-      )
-      return
-    end
-
-    local bridge_ip = bridge_info.ip
     -- we pre-declare these variables in the outer scope so that our gotos work.
     -- a sad day that we need these gotos.
-    local api_key_response, err, api_key, _
+    local api_key_response, err, api_key, bridge_info, bridge_ip, _
     repeat
       local time_remaining = math.max(0, timeout_time - cosock.socket.gettime())
       if time_remaining == 0 then
-        log.error_with({ hub_logs = true },
+        device.log.error_with({ hub_logs = true },
           string.format(
             "Link button not pressed or API key not received for bridge \"%s\" after 30 seconds, sleeping then trying again in a few minutes.",
             device.label
@@ -278,6 +259,13 @@ local function spawn_bridge_add_api_key_task(driver, device)
         timeout_time = cosock.socket.gettime() + 30 -- refresh timeout time
         goto continue
       end
+
+      if not driver.datastore.bridge_netinfo[device_bridge_id] then
+        goto continue
+      end
+
+      bridge_info = driver.datastore.bridge_netinfo[device_bridge_id]
+      bridge_ip = bridge_info.ip
 
       api_key_response, err, _ = HueApi.request_api_key(
         bridge_ip,
@@ -323,13 +311,15 @@ local function update_bridge_fields_from_info(driver, bridge_info, bridge_device
   end
 
   bridge_device:set_field(Fields.DEVICE_TYPE, "bridge", { persist = true })
-  bridge_device:set_field(Fields.IPV4, bridge_ip, { persist = true })
   bridge_device:set_field(Fields.MODEL_ID, bridge_info.modelid, { persist = true })
   bridge_device:set_field(Fields.BRIDGE_ID, device_bridge_id, { persist = true })
   bridge_device:set_field(Fields.BRIDGE_SW_VERSION, tonumber(bridge_info.swversion or "0", 10), { persist = true })
-  bridge_device:set_field(Fields.API_KEY, Discovery.api_keys[device_bridge_id], { persist = true })
-  bridge_device:set_field(Fields._ADDED, true, { persist = true })
-  driver.api_key_to_bridge_id[Discovery.api_keys[device_bridge_id]] = device_bridge_id
+
+  if Discovery.api_keys[device_bridge_id] then
+    bridge_device:set_field(Fields.API_KEY, Discovery.api_keys[device_bridge_id], { persist = true })
+    driver.api_key_to_bridge_id[Discovery.api_keys[device_bridge_id]] = device_bridge_id
+  end
+  bridge_device:set_field(Fields.IPV4, bridge_ip, { persist = true })
 end
 
 ---@param driver HueDriver
@@ -338,7 +328,7 @@ bridge_added = function(driver, device)
   log.info_with({ hub_logs = true },
     string.format("Bridge Added for device %s", (device.label or device.id or "unknown device")))
   local device_bridge_id = device.device_network_id
-  local bridge_info = driver.joined_bridges[device_bridge_id]
+  local bridge_info = driver.datastore.bridge_netinfo[device_bridge_id]
 
   if not bridge_info then
     local known_macs = {}
@@ -363,18 +353,10 @@ bridge_added = function(driver, device)
               (device.label or device.id or "unknown device")
             )
             )
-            local bridge_info, err, _ = HueApi.get_bridge_info(
-              bridge_ip,
-              utils.labeled_socket_builder(
-                "[Added: " .. (device.label or bridge_id or device.id or "unknown bridge") .. " Bridge Info Request"
-              )
-            )
-            if err ~= nil or not bridge_info then
-              log.error_with({ hub_logs = true }, string.format("Error querying bridge info for %s: %s",
-                (device.label or bridge_id or device.id or "unknown bridge"),
-                (err or "unexpected nil in error position")
-              )
-              )
+            local bridge_info = driver.datastore.bridge_netinfo[bridge_id]
+
+            if not bridge_info then
+              log.debug(string.format("Bridge info for %s not yet available", bridge_id))
               return
             end
 
@@ -384,9 +366,9 @@ bridge_added = function(driver, device)
               return
             end
 
-            bridge_info.ip = bridge_ip
-            driver.joined_bridges[bridge_id] = bridge_info
+            driver.joined_bridges[bridge_id] = true
             update_bridge_fields_from_info(driver, bridge_info, device)
+            device:set_field(Fields._ADDED, true, { persist = true })
             bridge_found = true
           end)
           if bridge_found then return end
@@ -408,6 +390,7 @@ bridge_added = function(driver, device)
     )
   else
     update_bridge_fields_from_info(driver, bridge_info, device)
+    device:set_field(Fields._ADDED, true, { persist = true })
   end
 
   if not Discovery.api_keys[device_bridge_id] then
@@ -441,13 +424,13 @@ local function migrate_light(driver, device, parent_device_id, hue_light_descrip
     )
   )
 
-  local known_dni_to_device_map = {}
+  local known_identifier_to_device_map = {}
   for _, known_device in ipairs(driver:get_devices()) do
     local dni = known_device.device_network_id or known_device.parent_assigned_child_key
-    known_dni_to_device_map[dni] = known_device
+    known_identifier_to_device_map[dni] = known_device
   end
 
-  local bridge_device = known_dni_to_device_map[bridge_id or ""]
+  local bridge_device = known_identifier_to_device_map[bridge_id or ""]
   local api_instance = (bridge_device and bridge_device:get_field(Fields.BRIDGE_API))
       or (bridge_device and Discovery.disco_api_instances[bridge_device.device_network_id])
   local light_resource = hue_light_description or
@@ -858,7 +841,7 @@ init_bridge = function(driver, device)
     ))
     cosock.spawn(
       function()
-        local bridge_info, err
+        local bridge_info
         -- create a very slow backoff
         local backoff_generator = utils.backoff_builder(10, 0.1, 0.1)
         local sleep_time = 0.1
@@ -869,35 +852,24 @@ init_bridge = function(driver, device)
               (device.label or device.id or "unknown device")
             )
           )
-          bridge_info, err = HueApi.get_bridge_info(
-            ip,
-            utils.labeled_socket_builder(
-              "[BridgeInit: " ..
-              (device.label or device.device_network_id or device.id or "unknown bridge") .. " Bridge Info Request"
-            )
-          )
+          bridge_info = driver.datastore.bridge_netinfo[device_bridge_id]
 
-          if err ~= nil or bridge_info == nil then
-            log.error_with({ hub_logs = true }, string.format("Error querying bridge info for %s: %s",
-              (device.label or device.device_network_id or device.id or "unknown bridge"),
-              (err or "unexpected nil in error position")
-            )
-            )
+          if not bridge_info then
+            log.debug(string.format("Bridge info for %s not yet available", device_bridge_id))
             goto continue
-          end
+          else
+            if tonumber(bridge_info.swversion or "0", 10) < HueApi.MIN_CLIP_V2_SWVERSION then
+              log.warn("Found bridge that does not support CLIP v2 API, ignoring")
+              driver.ignored_bridges[device_bridge_id] = true
+              return
+            end
 
-          if tonumber(bridge_info.swversion or "0", 10) < HueApi.MIN_CLIP_V2_SWVERSION then
-            log.warn("Found bridge that does not support CLIP v2 API, ignoring")
-            driver.ignored_bridges[device_bridge_id] = true
-            return
-          end
-
-          if bridge_info ~= nil then
             log.info("Bridge info for %s received, initializing network configuration")
-            driver.joined_bridges[device_bridge_id] = bridge_info
+            driver.joined_bridges[device_bridge_id] = true
             do_bridge_network_init(driver, device, bridge_url, api_key)
             return
           end
+
           ::continue::
           if sleep_time < 10 then
             sleep_time = backoff_generator()
@@ -990,6 +962,14 @@ end
 ---@param driver HueDriver
 ---@param device HueDevice
 _initialize = function(driver, device, event, args, parent_device_id)
+  if not (
+        driver:get_device_by_dni(device.device_network_id)
+        and driver:get_device_by_dni(device.device_network_id).id == device.id
+      )
+  then
+    driver.datastore.dni_to_device_id[device.device_network_id] = device.id
+  end
+
   log.info(
     string.format("_initialize handling event %s for device %s", event, (device.label or device.id or "unknown device")))
   if not device:get_field(Fields._ADDED) then
@@ -1236,11 +1216,18 @@ local switch_level_handler = handlers.switch_level_handler
 local set_color_temp_handler = handlers.set_color_temp_handler
 
 local function remove(driver, device)
+  driver.datastore.dni_to_device_id[device.device_network_id] = nil
   if device:get_field(Fields.DEVICE_TYPE) == "bridge" then
     local api_instance = device:get_field(Fields.BRIDGE_API)
     if api_instance then
       api_instance:shutdown()
       device:set_field(Fields.BRIDGE_API, nil)
+    end
+
+    local event_source = device:get_field(Fields.EVENT_SOURCE)
+    if event_source then
+      event_source:close()
+      device:set_field(Fields.EVENT_SOURCE, nil)
     end
   end
 end
@@ -1322,9 +1309,63 @@ local hue = Driver("hue",
       else
         return false
       end
+    end,
+    update_bridge_netinfo = function(self, bridge_id, bridge_info)
+      if self.joined_bridges[bridge_id] then
+        local bridge_device = self:get_device_by_dni(bridge_id)
+        if not bridge_device then
+          log.warn_with({ hub_logs = true },
+            string.format(
+              "Couldn't locate bridge device for joined bridge with DNI %s",
+              bridge_id
+            )
+          )
+          return
+        end
+
+        if bridge_info.ip ~= bridge_device:get_field(Fields.IPV4) then
+          update_bridge_fields_from_info(self, bridge_info, bridge_device)
+          local maybe_api_client = bridge_device:get_field(Fields.BRIDGE_API)
+          local maybe_api_key = bridge_device:get_field(Fields.API_KEY) or Discovery.api_keys[bridge_id]
+          local maybe_event_source = bridge_device:get_field(Fields.EVENT_SOURCE)
+          local bridge_url = "https://" .. bridge_info.ip
+
+          if maybe_api_key then
+            if maybe_api_client then
+              maybe_api_client:update_connection(bridge_url, maybe_api_key)
+            end
+
+            if maybe_event_source then
+              maybe_event_source:close()
+              bridge_device:set_field(Fields.EVENT_SOURCE, nil)
+              do_bridge_network_init(self, bridge_device, bridge_url, maybe_api_key)
+            end
+          end
+        end
+      end
+    end,
+    get_device_by_dni = function(self, dni)
+      local device_uuid = self.datastore.dni_to_device_id[dni]
+      if not device_uuid then return nil end
+      return self:get_device_info(device_uuid)
     end
   }
 )
+
+if hue.datastore["bridge_netinfo"] == nil then
+  hue.datastore["bridge_netinfo"] = {}
+end
+
+if hue.datastore["dni_to_device_id"] == nil then
+  hue.datastore["dni_to_device_id"] = {}
+end
+
+-- Kick off a scan right away to attempt to populate some information
+hue:call_with_delay(3, Discovery.do_mdns_scan, "Philips Hue mDNS Initial Scan")
+
+-- re-scan every minute
+local MDNS_SCAN_INTERVAL_SECONDS = 60
+hue:call_on_schedule(MDNS_SCAN_INTERVAL_SECONDS, Discovery.do_mdns_scan, "Philips Hue mDNS Scan Task")
 
 log.info("Starting Hue driver")
 hue:run()

--- a/drivers/SmartThings/philips-hue/src/lunchbox/sse/eventsource.lua
+++ b/drivers/SmartThings/philips-hue/src/lunchbox/sse/eventsource.lua
@@ -466,6 +466,11 @@ function EventSource.new(url, extra_headers, sock_builder)
   cosock.spawn(function()
     local st_utils = require "st.utils"
     while true do
+      if source.ready_state == EventSource.ReadyStates.CLOSED and
+          not source._reconnect
+      then
+        return
+      end
       local _, action_err, partial = state_actions[source.ready_state](source)
       if action_err ~= nil then
         if action_err ~= "timeout" or action_err ~= "wantread" then
@@ -485,7 +490,9 @@ end
 --- Close the event source, signalling that a reconnect is not desired
 function EventSource:close()
   self._reconnect = false
-  self._sock:close()
+  if self._sock ~= nil then
+    self._sock:close()
+  end
   self._sock = nil
   self.ready_state = EventSource.ReadyStates.CLOSED
 end

--- a/drivers/SmartThings/philips-hue/src/utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils.lua
@@ -7,6 +7,7 @@ local MAC_ADDRESS_STR_LEN = 12
 function utils.str_starts_with(str, start)
   return str:sub(1, #start) == start
 end
+
 function utils.is_nan(number)
   -- IEEE 754 dictates that NaN compares falsey to everything, including itself.
   if number ~= number then
@@ -23,7 +24,7 @@ function utils.is_nan(number)
 
   -- In the event that something goes wrong with the above two things,
   -- we simply compare the tostring against a known NaN value.
-  return tostring(number) == tostring(0/0)
+  return tostring(number) == tostring(0 / 0)
 end
 
 --- Only checked during `added` callback
@@ -31,7 +32,7 @@ end
 ---@return boolean
 function utils.is_edge_bridge(device)
   return device.device_network_id and #device.device_network_id == MAC_ADDRESS_STR_LEN and
-  not (device.data and device.data.username)
+      not (device.data and device.data.username)
 end
 
 --- Only checked during `added` callback
@@ -39,7 +40,7 @@ end
 ---@return boolean
 function utils.is_edge_light(device)
   return device.parent_assigned_child_key and #device.parent_assigned_child_key > MAC_ADDRESS_STR_LEN and
-  not (device.data and device.data.username and device.data.bulbId)
+      not (device.data and device.data.username and device.data.bulbId)
 end
 
 --- Only checked during `added` callback
@@ -168,6 +169,42 @@ function utils.labeled_socket_builder(label)
     return sock, err
   end
   return make_socket
+end
+
+--- From https://gist.github.com/sapphyrus/fd9aeb871e3ce966cc4b0b969f62f539
+--- MIT licensed
+function utils.deep_table_eq(tbl1, tbl2)
+  if tbl1 == tbl2 then
+    return true
+  elseif type(tbl1) == "table" and type(tbl2) == "table" then
+    for key1, value1 in pairs(tbl1) do
+      local value2 = tbl2[key1]
+
+      if value2 == nil then
+        -- avoid the type call for missing keys in tbl2 by directly comparing with nil
+        return false
+      elseif value1 ~= value2 then
+        if type(value1) == "table" and type(value2) == "table" then
+          if not utils.deep_table_eq(value1, value2) then
+            return false
+          end
+        else
+          return false
+        end
+      end
+    end
+
+    -- check for missing keys in tbl1
+    for key2, _ in pairs(tbl2) do
+      if tbl1[key2] == nil then
+        return false
+      end
+    end
+
+    return true
+  end
+
+  return false
 end
 
 return utils


### PR DESCRIPTION
The main change to the functionality of the driver in this PR is that *all* mDNS operations have been consolidated in to a function that does the requisite REST calls for discovered bridges and updates state on the driver's persistent store by accessing the `driver.datastore` table proxy directly.

I'm not normally in favor of using side-effect oriented flows like this, but in this specific case it actually solves a lot of problems for us:

1. It reduces the number of tasks trying to use the mDNS socket at the same time by removing mDNS operations from `search_for_bridges`
2. It reduces the number of tasks attempting REST network operations by having the various tasks that run during init and migration simply query the datastore cylically instead of querying the network cyclically (in the case of bridge info; we still need to scan known bridges for their lights)
3. The new entrypoint can be called manually/deliberately to force a scan that updates the state, which can be seen in the Discovery flow: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/ca534245610eaa6aaba4f832229b974dbe53b7e9/drivers/SmartThings/philips-hue/src/disco.lua#L51
4. By using the persistent store, it speeds up the driver's orienting of itself and connecting to bridges during start-up without needing a full re-scan if nothing has changed

This was tested in a variety of combinations, including injecting a driver restart in to the system and having the IP address change during restart, a full disconnect/reconnect, and IP changes while the driver is live.

**_Edit:_**
There is one thing I want to call out, which is that we currently *don't* trigger an immediate state update on disconnect. There's no really good way to disambiguate between a disconnect because re-scanning is needed vs, say, the Hue Bridge getting unplugged temporarily. I figured it was probably more beneficial and less risky to just user a relatively "short" poll interval of 60 seconds instead of coming up with heuristics to try and figure out how to re-scan on disconnect without hammering TCP connection attempts, especially since we don't currently have the ability to subscribe to mDNS events that tell us if something is actually offline or not.
