### PR TITLE
Sonos: Add Periodic SSDP scan to detect IP changes

### DIFF
--- a/drivers/SmartThings/sonos/src/disco.lua
+++ b/drivers/SmartThings/sonos/src/disco.lua
@@ -61,7 +61,7 @@ function Discovery.discover(driver, _, should_continue)
     ssdp.search(SONOS_SSDP_SEARCH_TERM, function(group_info)
       ssdp_discovery_callback(driver, group_info, known_devices_dnis, driver.found_ips)
     end)
-  cosock.socket.sleep(0.1)
+    cosock.socket.sleep(0.1)
   end
   log.info("Ending Sonos discovery")
 end

--- a/drivers/SmartThings/sonos/src/disco.lua
+++ b/drivers/SmartThings/sonos/src/disco.lua
@@ -13,10 +13,20 @@ local ssdp_discovery_callback = function(driver, ssdp_group_info, known_devices_
   if not found_ip_addrs[ssdp_group_info.ip] then
     found_ip_addrs[ssdp_group_info.ip] = true
 
-    local function add_device_callback(dni, _, player_info, _)
+    local function add_device_callback(dni, inner_ssdp_group_info, player_info, group_info)
       if not known_devices_dnis[dni] then
         local name = player_info.device.name or player_info.device.modelDisplayName or "Unknown Sonos Player"
         local model = player_info.device.modelDisplayName or "Unknown Sonos Model"
+
+        local field_cache = {
+          household_id = inner_ssdp_group_info.household_id,
+          player_id = player_info.playerId,
+          wss_url = player_info.websocketUrl
+        }
+
+        driver._field_cache[dni] = field_cache
+
+        driver.sonos:update_household_info(player_info.householdId, group_info)
 
         local create_device_msg = {
           type = "LAN",

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -3,15 +3,15 @@ local old_log = require "log"
 
 -- Print all errors, warnings, and info to hubcore for now
 old_log.error = function(...)
-  old_log.error_with({hub_logs = true}, ...)
+  old_log.error_with({ hub_logs = true }, ...)
 end
 
 old_log.warn = function(...)
-  old_log.warn_with({hub_logs = true}, ...)
+  old_log.warn_with({ hub_logs = true }, ...)
 end
 
 old_log.info = function(...)
-  old_log.info_with({hub_logs = true}, ...)
+  old_log.info_with({ hub_logs = true }, ...)
 end
 
 local log = {}
@@ -56,7 +56,7 @@ local function find_player_for_device(driver, device, should_continue)
   repeat
     --- @param ssdp_group_info SonosSSDPInfo
     SSDP.search(SONOS_SSDP_SEARCH_TERM, function(ssdp_group_info)
-      driver:handle_ssdp_discovery(ssdp_group_info, function(dni, _, _, _)
+      driver:handle_ssdp_discovery(ssdp_group_info, function(dni, inner_ssdp_group_info, player_info, group_info)
         device.log.info(string.format(
             "Found device for Sonos search query with MAC addr %s, comparing to %s",
             dni, device.device_network_id
@@ -64,6 +64,16 @@ local function find_player_for_device(driver, device, should_continue)
         )
         if dni_equal(dni, device.device_network_id) then
           device.log.info(string.format("Found Sonos Player match for device"))
+
+          local field_cache = {
+            household_id = inner_ssdp_group_info.household_id,
+            player_id = player_info.playerId,
+            wss_url = player_info.websocketUrl
+          }
+
+          driver._field_cache[dni] = field_cache
+
+          driver.sonos:update_household_info(player_info.householdId, group_info)
           player_found = true
         end
       end)
@@ -73,12 +83,91 @@ local function find_player_for_device(driver, device, should_continue)
   return player_found
 end
 
+local function update_fields_from_ssdp_scan(driver, device, fields)
+  local current_player_id = device:get_field(PlayerFields.PLAYER_ID)
+  local current_url = device:get_field(PlayerFields.WSS_URL)
+  local current_household_id = device:get_field(PlayerFields.HOUSEHOULD_ID)
+  local sonos_conn = device:get_field(PlayerFields.CONNECTION) --- @type SonosConnection
+
+  local already_connected = sonos_conn ~= nil
+  local refresh = false
+
+  if current_player_id ~= fields.player_id then
+    if current_player_id ~= nil then
+      driver._player_id_to_device[current_player_id] = nil
+      driver.sonos:mark_player_as_removed(current_player_id)
+      refresh = true
+    end
+    driver._player_id_to_device[fields.player_id] = device -- quickly look up device from player id string
+    driver.sonos:mark_player_as_joined(fields.player_id)
+    device:set_field(PlayerFields.PLAYER_ID, fields.player_id, { persist = true })
+  end
+
+  if current_household_id ~= fields.household_id then
+    if current_household_id ~= nil then
+      refresh = true
+    end
+    device:set_field(PlayerFields.HOUSEHOULD_ID, fields.household_id, { persist = true })
+  end
+
+  if current_url ~= fields.wss_url then
+    if current_url ~= nil and sonos_conn ~= nil then
+      sonos_conn:stop()
+      device:set_field(PlayerFields.CONNECTION, nil)
+      refresh = true
+    end
+    device:set_field(PlayerFields.WSS_URL, fields.wss_url, { persist = true })
+  end
+
+  if refresh and already_connected then
+    if not sonos_conn then
+      sonos_conn = SonosConnection.new(driver, device)
+      device:set_field(PlayerFields.CONNECTION, sonos_conn)
+      -- calls refresh subscriptions for us
+      sonos_conn:start()
+      return
+    end
+
+    sonos_conn:refresh_subscriptions()
+  end
+end
+
+local function scan_for_ssdp_updates(driver)
+  SSDP.search(SONOS_SSDP_SEARCH_TERM, function(ssdp_group_info)
+    driver:handle_ssdp_discovery(ssdp_group_info, function(dni, inner_ssdp_group_info, player_info, group_info)
+      local current_cached_fields = driver._field_cache[dni] or {}
+      local updated_fields = {
+        household_id = inner_ssdp_group_info.household_id,
+        player_id = player_info.playerId,
+        wss_url = player_info.websocketUrl
+      }
+
+      driver._field_cache[dni] = updated_fields
+      driver.sonos:update_household_info(player_info.householdId, group_info)
+
+      if not utils.deep_table_eq(current_cached_fields, updated_fields) then
+        local device = driver:get_device_by_dni(dni)
+        if device then
+          update_fields_from_ssdp_scan(driver, device, updated_fields)
+        end
+      end
+    end)
+  end)
+end
+
 -- We use the same handler for added and init here because at the time of authoring
 -- this driver, there is a bug with LAN Edge Drivers where `init` may not be called
 -- on every device that gets created using `try_create_device`. This makes sure that
 -- a device is fully initialized whether we come from fresh join or restart.
 -- See: https://smartthings.atlassian.net/browse/CHAD-9683
 local function _initialize_device(driver, device)
+  if not (
+        driver:get_device_by_dni(device.device_network_id)
+        and driver:get_device_by_dni(device.device_network_id).id == device.id
+      )
+  then
+    driver.datastore.dni_to_device_id[device.device_network_id] = device.id
+  end
   if not device:get_field(PlayerFields._IS_SCANNING) then
     device:set_field(PlayerFields._IS_SCANNING, true)
     cosock.spawn(
@@ -99,7 +188,7 @@ local function _initialize_device(driver, device)
             while not success do
               success = find_player_for_device(driver, device)
               if not success then
-                device.log.warn_with({hub_logs = true}, string.format(
+                device.log.warn_with({ hub_logs = true }, string.format(
                   "Couldn't find Sonos Player [%s] during SSDP scan, trying again shortly",
                   device.label
                 ))
@@ -108,14 +197,9 @@ local function _initialize_device(driver, device)
             end
           end
 
-          local fields = driver._field_cache[device.device_network_id]
-          driver._player_id_to_device[fields.player_id] = device -- quickly look up device from player id string
-          driver.sonos:mark_player_as_joined(fields.player_id)
-
           log.trace("Setting persistent fields")
-          device:set_field(PlayerFields.WSS_URL, fields.wss_url, { persist = true })
-          device:set_field(PlayerFields.HOUSEHOULD_ID, fields.household_id, { persist = true })
-          device:set_field(PlayerFields.PLAYER_ID, fields.player_id, { persist = true })
+          local fields = driver._field_cache[device.device_network_id]
+          update_fields_from_ssdp_scan(driver, device, fields)
 
           device:set_field(PlayerFields._IS_INIT, true)
         end
@@ -171,6 +255,7 @@ end
 --- @param device SonosDevice
 local function device_removed(driver, device)
   log.trace(string.format("%s device removed", device.label))
+  driver.datastore.dni_to_device_id[device.device_network_id] = nil
   local player_id = device:get_field(PlayerFields.PLAYER_ID)
   local sonos_conn = device:get_field(PlayerFields.CONNECTION)
   if sonos_conn and sonos_conn:is_running() then sonos_conn:stop() end
@@ -229,16 +314,6 @@ local function handle_ssdp_discovery(self, ssdp_group_info, callback)
     local mac_addr, _ = player_info.device.serialNumber:match("(.*):.*"):gsub("-", "")
     local dni = mac_addr
     log.trace(string.format("MAC of %s computed from serial number: %s", player_info.device.name, mac_addr))
-
-    local field_cache = {
-      household_id = ssdp_group_info.household_id,
-      player_id = player_info.playerId,
-      wss_url = player_info.websocketUrl
-    }
-
-    self._field_cache[dni] = field_cache
-
-    self.sonos:update_household_info(player_info.householdId, group_info)
 
     if type(callback) == "function" then
       callback(dni, ssdp_group_info, player_info, group_info)
@@ -304,8 +379,30 @@ local driver = Driver("Sonos", {
     local dni_normalized = dni:gsub("-", ""):gsub(":", ""):lower()
     local other_normalized = other:gsub("-", ""):gsub(":", ""):lower()
     return dni_normalized == other_normalized
+  end,
+  get_device_by_dni = function(self, dni)
+    local device_uuid = self.datastore.dni_to_device_id[dni]
+    if not device_uuid then return nil end
+    return self:get_device_info(device_uuid)
   end
 })
+
+if driver.datastore["_field_cache"] == nil then
+  driver.datastore["_field_cache"] = {}
+end
+
+if driver.datastore["dni_to_device_id"] == nil then
+  driver.datastore["dni_to_device_id"] = {}
+end
+
+driver._field_cache = driver.datastore._field_cache
+
+-- Kick off a scan right away to attempt to populate some information
+driver:call_with_delay(3, scan_for_ssdp_updates, "Sonos SSDP Initial Scan")
+
+-- re-scan every 10 minutes
+local SSDP_SCAN_INTERVAL_SECONDS = 600
+driver:call_on_schedule(SSDP_SCAN_INTERVAL_SECONDS, scan_for_ssdp_updates, "Sonos SSDP Scan Task")
 
 log.info("Starting Sonos run loop")
 driver:run()

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -58,9 +58,9 @@ local function find_player_for_device(driver, device, should_continue)
     SSDP.search(SONOS_SSDP_SEARCH_TERM, function(ssdp_group_info)
       driver:handle_ssdp_discovery(ssdp_group_info, function(dni, inner_ssdp_group_info, player_info, group_info)
         device.log.info(string.format(
-            "Found device for Sonos search query with MAC addr %s, comparing to %s",
-            dni, device.device_network_id
-          )
+          "Found device for Sonos search query with MAC addr %s, comparing to %s",
+          dni, device.device_network_id
+        )
         )
         if dni_equal(dni, device.device_network_id) then
           device.log.info(string.format("Found Sonos Player match for device"))
@@ -87,7 +87,7 @@ local function update_fields_from_ssdp_scan(driver, device, fields)
   local current_player_id = device:get_field(PlayerFields.PLAYER_ID)
   local current_url = device:get_field(PlayerFields.WSS_URL)
   local current_household_id = device:get_field(PlayerFields.HOUSEHOULD_ID)
-  local sonos_conn = device:get_field(PlayerFields.CONNECTION) --- @type SonosConnection
+  local sonos_conn = device:get_field(PlayerFields.CONNECTION) --- @type SonosConnection|nil
 
   local already_connected = sonos_conn ~= nil
   local refresh = false
@@ -113,6 +113,7 @@ local function update_fields_from_ssdp_scan(driver, device, fields)
   if current_url ~= fields.wss_url then
     if current_url ~= nil and sonos_conn ~= nil then
       sonos_conn:stop()
+      sonos_conn = nil
       device:set_field(PlayerFields.CONNECTION, nil)
       refresh = true
     end
@@ -175,8 +176,8 @@ local function _initialize_device(driver, device)
         if not device:get_field(PlayerFields._IS_INIT) then
           log.trace(string.format("%s setting up device", device.label))
           local is_already_found =
-          ((driver.found_ips and driver.found_ips[device.device_network_id])
-              or driver.sonos:is_player_joined(device.device_network_id)) and
+              ((driver.found_ips and driver.found_ips[device.device_network_id])
+                or driver.sonos:is_player_joined(device.device_network_id)) and
               driver._field_cache[device.device_network_id]
 
           if not is_already_found then

--- a/drivers/SmartThings/sonos/src/ssdp.lua
+++ b/drivers/SmartThings/sonos/src/ssdp.lua
@@ -77,11 +77,12 @@ function SSDP.search(search_term, callback)
       local headers = process_response(val)
 
       -- log all SSDP responses, even if they don't have proper headers
-      log.debug_with({hub_logs = true}, string.format("Received response for Sonos search with headers [%s], processing details",
+      log.debug_with({ hub_logs = true },
+        string.format("Received response for Sonos search with headers [%s], processing details",
           st_utils.stringify_table(headers)))
       if
-          -- we don't explicitly check "st" because we don't index in to the contained
-          -- value so the equality check suffices as a nil check as well.
+      -- we don't explicitly check "st" because we don't index in to the contained
+      -- value so the equality check suffices as a nil check as well.
           SSDP.check_headers_contain(
             headers,
             "server",
@@ -117,7 +118,7 @@ function SSDP.search(search_term, callback)
         elseif ip and is_group_coordinator and group_id and
             group_name and household_id and wss_url then
           if #group_id == 0 then
-            log.debug_with({hub_logs = true}, string.format(
+            log.debug_with({ hub_logs = true }, string.format(
               "Received SSDP response for non-primary Sonos device in a bonded set, skipping; SSDP Response: %s\n",
               st_utils.stringify_table(group_info, nil, false)))
           elseif callback ~= nil then

--- a/drivers/SmartThings/sonos/src/types.lua
+++ b/drivers/SmartThings/sonos/src/types.lua
@@ -7,16 +7,16 @@ local Types = {}
 
 --- @enum SonosCapabilities
 Types.SonosCapabilities = {
-  PLAYBACK = "PLAYBACK", --- The player can produce audio. You can target it for playback.
-  CLOUD = "CLOUD", --- The player can send commands and receive events over the internet.
-  HT_PLAYBACK = "HT_PLAYBACK", --- The player is a home theater source. It can reproduce the audio from a home theater system, typically delivered by S/PDIF or HDMI.
-  HT_POWER_STATE = "HT_POWER_STATE", --- The player can control the home theater power state. For example, it can switch a connected TV on or off.
-  AIRPLAY = "AIRPLAY", --- The player can host AirPlay streams. This capability is present when the device is advertising AirPlay support.
-  LINE_IN = "LINE_IN", --- The player has an analog line-in.
-  AUDIO_CLIP = "AUDIO_CLIP", ---  The device is capable of playing audio clip notifications.
-  VOICE = "VOICE", --- The device supports the voice namespace (not yet implemented by Sonos).
+  PLAYBACK = "PLAYBACK",                   --- The player can produce audio. You can target it for playback.
+  CLOUD = "CLOUD",                         --- The player can send commands and receive events over the internet.
+  HT_PLAYBACK = "HT_PLAYBACK",             --- The player is a home theater source. It can reproduce the audio from a home theater system, typically delivered by S/PDIF or HDMI.
+  HT_POWER_STATE = "HT_POWER_STATE",       --- The player can control the home theater power state. For example, it can switch a connected TV on or off.
+  AIRPLAY = "AIRPLAY",                     --- The player can host AirPlay streams. This capability is present when the device is advertising AirPlay support.
+  LINE_IN = "LINE_IN",                     --- The player has an analog line-in.
+  AUDIO_CLIP = "AUDIO_CLIP",               ---  The device is capable of playing audio clip notifications.
+  VOICE = "VOICE",                         --- The device supports the voice namespace (not yet implemented by Sonos).
   SPEAKER_DETECTION = "SPEAKER_DETECTION", --- The component device is capable of detecting connected speaker drivers.
-  FIXED_VOLUME = "FIXED_VOLUME" --- The device supports fixed volume.
+  FIXED_VOLUME = "FIXED_VOLUME"            --- The device supports fixed volume.
 }
 
 --- @alias PlayerId string
@@ -224,11 +224,11 @@ function SonosState.new()
         --info gather since post migration we have seen once that coordinator_id is sometimes a table,
         -- which causes a crash when emitting the mediaGroup.groupPrimaryDeviceId capability event
         local ut = require "st.utils"
-        log.warn(ut.stringify_table({household = household, coordinator_id = coordinator_id},
+        log.warn(ut.stringify_table({ household = household, coordinator_id = coordinator_id },
           "Household update with invalid coordinator_id data:", false
         ))
       end
-      handlers.handle_group_update(device, {role, coordinator_id, group_id})
+      handlers.handle_group_update(device, { role, coordinator_id, group_id })
     end
   end
 
@@ -240,7 +240,7 @@ function SonosState.new()
     local household = private.households[household_id]
     if household == nil then
       local ut = require "st.utils"
-      log.error(ut.stringify_table({household = household}, "Get group for invalid household", false))
+      log.error(ut.stringify_table({ household = household }, "Get group for invalid household", false))
       return
     end
     return household.player_to_group_map[player_id]
@@ -254,7 +254,7 @@ function SonosState.new()
     local household = private.households[household_id]
     if household == nil then
       local ut = require "st.utils"
-      log.error(ut.stringify_table({household = household}, "Get coordinator for invalid household", false))
+      log.error(ut.stringify_table({ household = household }, "Get coordinator for invalid household", false))
       return
     end
     return household.group_to_coordinator_map[group_id]

--- a/drivers/SmartThings/sonos/src/utils.lua
+++ b/drivers/SmartThings/sonos/src/utils.lua
@@ -73,16 +73,16 @@ function utils.labeled_socket_builder(label)
         )
       )
       sock, err =
-        ssl.wrap(sock, {mode = "client", protocol = "any", verify = "none", options = "all"})
+          ssl.wrap(sock, { mode = "client", protocol = "any", verify = "none", options = "all" })
       if err ~= nil then
-         return nil, "SSL wrap error: " .. err
+        return nil, "SSL wrap error: " .. err
       end
       log.trace(
         string.format(
           "%sPerforming SSL handshake for for REST Connection", label
         )
       )
-        _, err = sock:dohandshake()
+      _, err = sock:dohandshake()
       if err ~= nil then
         return nil, "Error with SSL handshake: " .. err
       end

--- a/drivers/SmartThings/sonos/src/utils.lua
+++ b/drivers/SmartThings/sonos/src/utils.lua
@@ -93,4 +93,40 @@ function utils.labeled_socket_builder(label)
   return make_socket
 end
 
+--- From https://gist.github.com/sapphyrus/fd9aeb871e3ce966cc4b0b969f62f539
+--- MIT licensed
+function utils.deep_table_eq(tbl1, tbl2)
+  if tbl1 == tbl2 then
+    return true
+  elseif type(tbl1) == "table" and type(tbl2) == "table" then
+    for key1, value1 in pairs(tbl1) do
+      local value2 = tbl2[key1]
+
+      if value2 == nil then
+        -- avoid the type call for missing keys in tbl2 by directly comparing with nil
+        return false
+      elseif value1 ~= value2 then
+        if type(value1) == "table" and type(value2) == "table" then
+          if not utils.deep_table_eq(value1, value2) then
+            return false
+          end
+        else
+          return false
+        end
+      end
+    end
+
+    -- check for missing keys in tbl1
+    for key2, _ in pairs(tbl2) do
+      if tbl1[key2] == nil then
+        return false
+      end
+    end
+
+    return true
+  end
+
+  return false
+end
+
 return utils


### PR DESCRIPTION
Similarly to Hue, this adds a periodic scan for detecting changes in IP address
at runtime after a device has onboarded.

This refactor isn't as surgical as the Hue one because the Sonos topology is
simpler, so we didn't do a deep gutting of the discovery logic and left it
mostly untouched, so we still actively perform SSDP scans during discovery.

Relaxing this for Sonos is likely best left to a refactor after we move the
SSDP APIs in to hubcore and expose them via the lua libs.

Fixes: [CHAD-11472](https://smartthings.atlassian.net/browse/CHAD-11472)

cc @TheMegamind 