### PR TITLE
Fix for Hue devices that migrated in to an incomplete state with stale IP data.

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -334,17 +334,17 @@ function HueDiscovery.do_mdns_scan(driver)
   end
 
   for _, info in ipairs(mdns_responses.found) do
-    if not net_utils.validate_ipv4_string(info.host_info.address) then   -- we only care about the ipV4 types here.
+    if not net_utils.validate_ipv4_string(info.host_info.address) then -- we only care about the ipV4 types here.
       log.trace("Invalid IPv4 address: " .. info.host_info.address)
       return
     end
 
-    if info.service_info.service_type ~= HueDiscovery.ServiceType then   -- response for a different service type. Shouldn't happen.
+    if info.service_info.service_type ~= HueDiscovery.ServiceType then -- response for a different service type. Shouldn't happen.
       log.warn("Unexpected service type response: " .. info.service_info.service_type)
       return
     end
 
-    if info.service_info.domain ~= HueDiscovery.Domain then   -- response for a different domain. Shouldn't happen.
+    if info.service_info.domain ~= HueDiscovery.Domain then -- response for a different domain. Shouldn't happen.
       log.warn("Unexpected domain response: " .. info.service_info.domain)
       return
     end
@@ -396,7 +396,7 @@ function HueDiscovery.do_mdns_scan(driver)
       update_needed = true
     end
 
-      if driver.joined_bridges[bridge_id] and not driver.ignored_bridges[bridge_id] then
+    if driver.joined_bridges[bridge_id] and not driver.ignored_bridges[bridge_id] then
       local bridge_device = driver:get_device_by_dni(bridge_id, true)
       update_needed = update_needed or (bridge_device:get_field(Fields.IPV4) ~= bridge_info.ip)
       if update_needed then

--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -390,9 +390,16 @@ function HueDiscovery.do_mdns_scan(driver)
       end
     end
 
+    local update_needed = false
     if not utils.deep_table_eq((bridge_netinfo[bridge_id] or {}), bridge_info) then
       bridge_netinfo[bridge_id] = bridge_info
+      update_needed = true
+    end
+
       if driver.joined_bridges[bridge_id] and not driver.ignored_bridges[bridge_id] then
+      local bridge_device = driver:get_device_by_dni(bridge_id, true)
+      update_needed = update_needed or (bridge_device:get_field(Fields.IPV4) ~= bridge_info.ip)
+      if update_needed then
         driver:update_bridge_netinfo(bridge_id, bridge_info)
       end
     end

--- a/drivers/SmartThings/philips-hue/src/hue/types.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/types.lua
@@ -22,10 +22,13 @@
 --- @field public api_key_to_bridge_id table<string,string>
 --- @field public update_bridge_netinfo fun(self: HueDriver, bridge_id: string, bridge_info: HueBridgeInfo)
 --- @field public emit_light_status_events fun(light_device: HueChildDevice, light: table)
+--- @field public get_device_by_dni fun(self: HueDriver, device_network_id: string, force_refresh?: boolean): HueDevice|nil
 --- @field private _lights_pending_refresh table<string,HueChildDevice>
 
 --- @class HueDevice:st.Device
 --- @field public label string
+--- @field public id string
+--- @field public device_network_id string
 --- @field public data table|nil migration data for a migrated device
 --- @field public get_field fun(self: HueDevice, key: string):any
 --- @field public set_field fun(self: HueDevice, key: string, value: any, args?: table)


### PR DESCRIPTION
In the specific situation where a Hue topology gets migrated with a stale IP
address, we can get in to a situation where the change detection happens
before the `[joined_bridges]` map is populated, meaning that subsequent scans
won't know that an update needs to happen.

The DTH Protocol Handler is wise enough to find a Hue Bridge after its IP has changed and make sure its connecting properly but it doesn't *appear* that it updates the `ip` field on its device data reliably, so if a device migrates any time after its IP has changed it's likely that we'll receive the incorrect IP out of the gate, which would put us in this situation.

We rectify that by also factoring in the stored IP in the device's fields
when determining if a change has occurred.