### PR TITLE
fix: Check DNI + parent assigned key for strays

### DIFF
--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -1121,7 +1121,7 @@ cosock.spawn(function()
             for stray_dni, stray_light in pairs(stray_lights) do
               local matching_v1_id = stray_light.data and stray_light.data.bulbId and
                   stray_light.data.bulbId == device_data.id_v1:gsub("/lights/", "")
-              local matching_uuid = stray_light.device_network_id == svc_info.rid or
+              local matching_uuid = stray_light.parent_assigned_child_key == svc_info.rid or
                   stray_light.device_network_id == svc_info.rid
 
               if matching_v1_id or matching_uuid then


### PR DESCRIPTION
This is a result of a workaround for a pre-release defect that was present during pre-release testing and has been fixed but we need to continue to support devices that may have encountered it.

For some devices the service ID will be captured in the DNI instead of the parent assigned child key and so we should check both, but due to an oversight we are only looking at the DNI currently.

This could assist in some rare situations where the v1 ID may not be stable, but I don't have any evidence that this bug is actually impacting any users.