### PR TITLE
DuraGreen Light: Build specific command

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
@@ -1,0 +1,175 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local clusters = require "st.zigbee.zcl.clusters"
+local zigbee_test_utils = require "integration_test.zigbee_test_utils"
+
+local OnOff = clusters.OnOff
+local Level = clusters.Level
+local ColorControl = clusters.ColorControl
+
+local mock_device = test.mock_device.build_test_zigbee_device(
+  { profile = t_utils.get_profile_definition("color-temp-bulb.yml"),
+    fingerprinted_endpoint_id = 0x01,
+    zigbee_endpoints = {
+      [1] = {
+        id = 1,
+        manufacturer = "DURAGREEN",
+        model = "DG-CCT-01",
+        server_clusters = {0x0000, 0x0003, 0x0004, 0x0005, 0x0006, 0x0008, 0x0300}
+      }
+    }
+  }
+)
+
+zigbee_test_utils.prepare_zigbee_env_info()
+
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
+end
+
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
+)
+
+test.register_message_test(
+  "Refresh should read all necessary attributes",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {mock_device.id, {capability = "refresh", component = "main", command = "refresh", args = {}}}
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        OnOff.attributes.OnOff:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        Level.attributes.CurrentLevel:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:read(mock_device)
+      }
+    }
+  },
+  {
+    inner_block_ordering = "relaxed"
+  }
+)
+
+test.register_coroutine_test(
+  "Set Color Temperature command test",
+  function()
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.socket.capability:__queue_receive({mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = { 200 } } })
+
+    local temp_in_mired = math.floor(1000000 / 200)
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.commands.On(mock_device)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.commands.MoveToColorTemperature(mock_device, temp_in_mired, 0x0000)
+      }
+    )
+
+    test.wait_for_events()
+
+    test.mock_time.advance_time(1)
+    test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
+  end
+)
+
+test.register_coroutine_test(
+  "Set SwitchLevel command test",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = {50} } })
+
+    local command = Level.server.commands.MoveToLevelWithOnOff(mock_device, math.floor(50 / 100.0 * 254), 0xFFFF)
+    command.body.zcl_body.options_mask = nil
+    command.body.zcl_body.options_override = nil
+    test.socket.zigbee:__expect_send(
+      {
+         mock_device.id,
+         command
+      }
+    )
+  end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/duragreen/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/duragreen/init.lua
@@ -1,0 +1,52 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local clusters = require "st.zigbee.zcl.clusters"
+
+local Level = clusters.Level
+
+local DURAGREEN_BULB_FINGERPRINTS = {
+  ["DURAGREEN"] = {
+    ["DG-CW-02"] = true,
+    ["DG-CW-01"] = true,
+    ["DG-CCT-01"] = true
+  },
+}
+
+local function can_handle_duragreen_bulb(opts, driver, device)
+  return (DURAGREEN_BULB_FINGERPRINTS[device:get_manufacturer()] or {})[device:get_model()] or false
+end
+
+local function handle_set_level(driver, device, cmd)
+  local level = math.floor(cmd.args.level/100.0 * 254)
+  local transtition_time = cmd.args.rate or 0xFFFF
+  local command = Level.server.commands.MoveToLevelWithOnOff(device, level, transtition_time)
+
+  command.body.zcl_body.options_mask = nil
+  command.body.zcl_body.options_override = nil
+  device:send(command)
+end
+
+local duragreen_color_temp_bulb = {
+  NAME = "DuraGreen Color Temp Bulb",
+  capability_handlers = {
+    [capabilities.switchLevel.ID] = {
+      [capabilities.switchLevel.commands.setLevel.NAME] = handle_set_level
+    }
+  },
+  can_handle = can_handle_duragreen_bulb
+}
+
+return duragreen_color_temp_bulb

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/init.lua
@@ -134,6 +134,9 @@ local white_color_temp_bulb = {
       [capabilities.colorTemperature.commands.setColorTemperature.NAME] = set_color_temperature_handler
     }
   },
+  sub_drivers = {
+    require("white-color-temp-bulb.duragreen"),
+  },
   can_handle = can_handle_white_color_temp_bulb
 }
 


### PR DESCRIPTION
DuraGreen is not compatible with current default switchlevel api,
It can't process options_mask and options_override.

Build specific command as a workaround.