### PR TITLE
Add WALLHERO Switch (#895)

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -2110,6 +2110,12 @@ zigbeeManufacturer:
     model: ROB_200-011-0
     deviceLabel: ROBB SMARRT Zigbee dimmer 2-wire
     deviceProfileName: light-level-power-energy
+  # Wall Hero
+  - id: "WALL HERO/M4T2828A-ZB"
+    deviceLabel: 八键开关 1 (普通开关)
+    manufacturer: WALL HERO
+    model: M4T2828A-ZB
+    deviceProfileName: basic-switch
 zigbeeGeneric:
   - id: "genericSwitch"
     deviceLabel: Zigbee Switch

--- a/drivers/SmartThings/zigbee-switch/profiles/button.yml
+++ b/drivers/SmartThings/zigbee-switch/profiles/button.yml
@@ -1,0 +1,12 @@
+name: button
+components:
+- id: main
+  capabilities:
+  - id: button
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: RemoteController

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -103,7 +103,8 @@ local zigbee_switch_driver_template = {
     require("zigbee-switch-power"),
     require("ge-link-bulb"),
     require("bad_on_off_data_type"),
-    require("robb")
+    require("robb"),
+    require("wallhero")
   },
   lifecycle_handlers = {
     init = device_init,

--- a/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
@@ -1,0 +1,572 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Mock out globals
+local clusters = require "st.zigbee.zcl.clusters"
+local capabilities = require "st.capabilities"
+local frameCtrl = require "st.zigbee.zcl.frame_ctrl"
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local zigbee_test_utils = require "integration_test.zigbee_test_utils"
+
+local OnOff = clusters.OnOff
+local Scenes = clusters.Scenes
+
+local common_switch_profile_def = t_utils.get_profile_definition("basic-switch.yml")
+local scene_switch_profile_def = t_utils.get_profile_definition("button.yml")
+
+local mock_base_device = test.mock_device.build_test_zigbee_device(
+    {
+      label = "八键开关 1 (普通开关)",
+      profile = common_switch_profile_def,
+      zigbee_endpoints = {
+        [1] = {
+          id = 1,
+          manufacturer = "WALL HERO",
+          model = "M4T2828A-ZB",
+          server_clusters = { 0003,0004,0005,0006 }
+        }
+      },
+      fingerprinted_endpoint_id = 0x01
+    }
+)
+
+local mock_parent_device = test.mock_device.build_test_zigbee_device(
+  {
+    profile = common_switch_profile_def,
+    zigbee_endpoints = {
+      [1] = {
+        id = 1,
+        manufacturer = "WALL HERO",
+        model = "M4T2828A-ZB",
+        server_clusters = { 0003,0004,0005,0006 }
+      }
+    },
+    fingerprinted_endpoint_id = 0x01
+  }
+)
+
+-- Switch 2 (Common Switch)
+local mock_first_child = test.mock_device.build_test_child_device(
+  {
+    profile = common_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 2),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 2)
+  }
+)
+
+-- Switch 3 (Common Switch)
+local mock_second_child = test.mock_device.build_test_child_device(
+  {
+    profile = common_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 3),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 3)
+  }
+)
+
+-- Switch 4 (Common Switch)
+local mock_third_child = test.mock_device.build_test_child_device(
+  {
+    profile = common_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 4),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 4)
+  }
+)
+
+-- Switch 5 (Scene Control Button)
+local mock_fourth_child = test.mock_device.build_test_child_device(
+  {
+    profile = scene_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 5),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 5)
+  }
+)
+
+-- Switch 6 (Scene Control Button)
+local mock_fifth_child = test.mock_device.build_test_child_device(
+  {
+    profile = scene_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 6),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 6)
+  }
+)
+
+-- Switch 7 (Scene Control Button)
+local mock_sixth_child = test.mock_device.build_test_child_device(
+  {
+    profile = scene_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 7),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 7)
+  }
+)
+
+-- Switch 8 (Scene Control Button)
+local mock_seventh_child = test.mock_device.build_test_child_device(
+  {
+    profile = scene_switch_profile_def,
+    device_network_id = string.format("%04X:%02X", mock_parent_device:get_short_address(), 8),
+    parent_device_id = mock_parent_device.id,
+    parent_assigned_child_key = string.format("%02X", 8)
+  }
+)
+
+zigbee_test_utils.prepare_zigbee_env_info()
+
+local function test_init()
+  test.mock_device.add_test_device(mock_base_device)
+  test.mock_device.add_test_device(mock_parent_device)
+  test.mock_device.add_test_device(mock_first_child)
+  test.mock_device.add_test_device(mock_second_child)
+  test.mock_device.add_test_device(mock_third_child)
+  test.mock_device.add_test_device(mock_fourth_child)
+  test.mock_device.add_test_device(mock_fifth_child)
+  test.mock_device.add_test_device(mock_sixth_child)
+  test.mock_device.add_test_device(mock_seventh_child)
+  zigbee_test_utils.init_noop_health_check_timer()
+end
+
+test.set_test_init_function(test_init)
+
+-- 4 Common Switch Tests
+test.register_message_test(
+    "Reported on off status should be handled by parent device: on",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_parent_device.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+            true)                               :from_endpoint(0x01) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.on())
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled by first child device: on",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_first_child.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+            true)                             :from_endpoint(0x02) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_first_child:generate_test_message("main", capabilities.switch.switch.on())
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled by Second child device: on",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_second_child.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+            true)                              :from_endpoint(0x03) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_second_child:generate_test_message("main", capabilities.switch.switch.on())
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled by third child device: on",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_third_child.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+            true)                              :from_endpoint(0x04) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_third_child:generate_test_message("main", capabilities.switch.switch.on())
+      }
+    }
+)
+
+test.register_message_test(
+    "reported on off status should be handled by parent device: off",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_parent_device.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+            false)                               :from_endpoint(0x01) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.off())
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled by first child device: off",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_first_child.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+        false)                             :from_endpoint(0x02) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_first_child:generate_test_message("main", capabilities.switch.switch.off())
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled by Second child device: off",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_second_child.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+        false)                              :from_endpoint(0x03) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_second_child:generate_test_message("main", capabilities.switch.switch.off())
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled by third child device: off",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_third_child.id, OnOff.attributes.OnOff:build_test_attr_report(mock_parent_device,
+        false)                              :from_endpoint(0x04) }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_third_child:generate_test_message("main", capabilities.switch.switch.off())
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability on command switch on should be handled : parent device",
+    {
+      {
+        channel = "device_lifecycle",
+        direction = "receive",
+        message = { mock_parent_device.id, "init" }
+      },
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_parent_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x01) }
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability on command switch on should be handled : first child device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_first_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x02) }
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability on command switch on should be handled : second child device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_second_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x03) }
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability on command switch on should be handled : third child device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_third_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x04) }
+      }
+    }
+)
+
+
+test.register_message_test(
+    "Capability off command switch off should be handled : parent device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_parent_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x01) }
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability off command switch off should be handled : first child device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_first_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x02) }
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability off command switch off should be handled : second child device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_second_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x03) }
+      }
+    }
+)
+
+test.register_message_test(
+    "Capability off command switch off should be handled : third child device",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_third_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "zigbee",
+        direction = "send",
+        message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x04) }
+      }
+    }
+)
+
+-- 4 Scene Control Switch (Actually the key)
+test.register_coroutine_test(
+    "RecallScene command should be handled",
+    function()
+      local scenes_command = Scenes.server.commands.RecallScene.build_test_rx(mock_fourth_child, 0xF0F0, 0x05)
+      local frm_ctrl = frameCtrl(0x11)
+      scenes_command.body.zcl_header.frame_ctrl = frm_ctrl
+      test.socket.zigbee:__queue_receive({ mock_parent_device.id, scenes_command })
+      test.socket.capability:__expect_send(mock_fourth_child:generate_test_message("main", capabilities.button.button.pushed(
+                                            { state_change = true }
+                                            )))
+    end
+)
+
+test.register_coroutine_test(
+    "RecallScene command should be handled",
+    function()
+      local scenes_command = Scenes.server.commands.RecallScene.build_test_rx(mock_fifth_child, 0xF0F0, 0x06)
+      local frm_ctrl = frameCtrl(0x11)
+      scenes_command.body.zcl_header.frame_ctrl = frm_ctrl
+      test.socket.zigbee:__queue_receive({ mock_parent_device.id, scenes_command })
+      test.socket.capability:__expect_send(mock_fifth_child:generate_test_message("main", capabilities.button.button.pushed(
+                                            { state_change = true }
+                                            )))
+    end
+)
+
+test.register_coroutine_test(
+    "RecallScene command should be handled",
+    function()
+      local scenes_command = Scenes.server.commands.RecallScene.build_test_rx(mock_sixth_child, 0xF0F0, 0x07)
+      local frm_ctrl = frameCtrl(0x11)
+      scenes_command.body.zcl_header.frame_ctrl = frm_ctrl
+      test.socket.zigbee:__queue_receive({ mock_parent_device.id, scenes_command })
+      test.socket.capability:__expect_send(mock_sixth_child:generate_test_message("main", capabilities.button.button.pushed(
+                                            { state_change = true }
+                                            )))
+    end
+)
+
+test.register_coroutine_test(
+    "RecallScene command should be handled",
+    function()
+      local scenes_command = Scenes.server.commands.RecallScene.build_test_rx(mock_seventh_child, 0xF0F0, 0x08)
+      local frm_ctrl = frameCtrl(0x11)
+      scenes_command.body.zcl_header.frame_ctrl = frm_ctrl
+      test.socket.zigbee:__queue_receive({ mock_parent_device.id, scenes_command })
+      test.socket.capability:__expect_send(mock_seventh_child:generate_test_message("main", capabilities.button.button.pushed(
+                                            { state_change = true }
+                                            )))
+    end
+)
+
+test.register_coroutine_test(
+    "added lifecycle event should create children in parent device",
+    function()
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+      test.socket.device_lifecycle:__queue_receive({ mock_base_device.id, "added" })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 2 (普通开关)",
+        profile = "basic-switch",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "02"
+      })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 3 (普通开关)",
+        profile = "basic-switch",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "03"
+      })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 4 (普通开关)",
+        profile = "basic-switch",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "04"
+      })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 5 (场景开关)",
+        profile = "button",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "05"
+      })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 6 (场景开关)",
+        profile = "button",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "06"
+      })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 7 (场景开关)",
+        profile = "button",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "07"
+      })
+      mock_base_device:expect_device_create({
+        type = "EDGE_CHILD",
+        label = "八键开关 8 (场景开关)",
+        profile = "button",
+        parent_device_id = mock_base_device.id,
+        parent_assigned_child_key = "08"
+      })
+      test.socket.zigbee:__expect_send({
+        mock_base_device.id,
+        OnOff.attributes.OnOff:read(mock_base_device):to_endpoint(0x01)
+      })
+    end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
@@ -1,0 +1,118 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local log = require "log"
+local stDevice = require "st.device"
+local zcl_clusters = require "st.zigbee.zcl.clusters"
+
+local Scenes = zcl_clusters.Scenes
+
+local FINGERPRINTS = {
+  { mfr = "WALL HERO", model = "M4T2828A-ZB", switches = 4, buttons = 4 }
+}
+
+local function can_handle_wallhero_switch(opts, driver, device, ...)
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true
+    end
+  end
+  return false
+end
+
+local function get_children_info(device)
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_model() == fingerprint.model then
+      return fingerprint.switches, fingerprint.buttons
+    end
+  end
+end
+
+local function find_child(parent, ep_id)
+  return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
+end
+
+local function create_child_devices(driver, device)
+  local switch_amount, button_amount = get_children_info(device)
+  local base_name = device.label:sub(1, device.label:find(" "))
+  -- Create Switch 2-4
+  for i = 2, switch_amount, 1 do
+    if find_child(device, i) == nil then
+      local metadata = {
+        type = "EDGE_CHILD",
+        parent_assigned_child_key = string.format("%02X", i),
+        label = base_name .. i .. " (普通开关)",
+        profile = "basic-switch",
+        parent_device_id = device.id,
+        vendor_provided_label = base_name .. i .. " (普通开关)",
+      }
+      driver:try_create_device(metadata)
+    end
+  end
+  -- Create Button if necessary
+  for i = switch_amount+1, switch_amount+button_amount, 1 do
+    if find_child(device, i) == nil then
+      local metadata = {
+        type = "EDGE_CHILD",
+        parent_assigned_child_key = string.format("%02X", i),
+        label = base_name .. i .. " (场景开关)",
+        profile = "button",
+        parent_device_id = device.id,
+        vendor_provided_label = base_name .. i .. " (场景开关)",
+      }
+      driver:try_create_device(metadata)
+    end
+  end
+  device:refresh()
+end
+
+local function device_added(driver, device)
+  if device.network_type ~= stDevice.NETWORK_TYPE_CHILD then
+    create_child_devices(driver, device)
+  end
+  -- Set Button Capabilities for scene switches
+  if device:supports_capability_by_id(capabilities.button.ID) then
+    device:emit_event(capabilities.button.numberOfButtons({ value = 1 }, { visibility = { displayed = false } }))
+    device:emit_event(capabilities.button.supportedButtonValues({ "pushed" }, {visibility = {displayed = false } }))
+  end
+end
+
+local function device_init(driver, device, event)
+  device:set_find_child(find_child)
+end
+
+local function scenes_cluster_handler(driver, device, zb_rx)
+  log.info("Enter scenes_cluster_handler")
+  device:emit_event_for_endpoint(zb_rx.address_header.src_endpoint.value,
+    capabilities.button.button.pushed({ state_change = true }))
+end
+
+local wallheroswitch = {
+  NAME = "Zigbee Wall Hero Switch",
+  lifecycle_handlers = {
+    added = device_added,
+    init = device_init
+  },
+  zigbee_handlers = {
+    cluster = {
+      [Scenes.ID] = {
+        [Scenes.server.commands.RecallScene.ID] = scenes_cluster_handler,
+      }
+    }
+  },
+  can_handle = can_handle_wallhero_switch
+}
+
+return wallheroswitch


### PR DESCRIPTION
* WALLHERO: Add 8-Way Switch EdgeDriver



* Remove 4-way Switch



* Minor Fix

1. Rename wallhero-scene-switch to button.
2. Replace child_device:emit_event with device:emit_event_for_endpoint.
3. Only set button capabilities for scene switch.



---------