### PR TITLE
Hue bugfix bridge offline every driver restart

### DIFF
--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -701,6 +701,8 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
       log.info_with({ hub_logs = true },
         string.format("Event Source Connection for Hue Bridge \"%s\" established, marking online", device.label))
       device:online()
+      --TODO should we do a refresh of all child devices when we first connect?
+      --handlers.refresh_handlers(driver, device)
     end
 
     eventsource.onerror = function()

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -701,7 +701,9 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
       log.info_with({ hub_logs = true },
         string.format("Event Source Connection for Hue Bridge \"%s\" established, marking online", device.label))
       device:online()
-      --We do a refresh of all child devices when we first connect, to determine which are still online.
+      --We do a refresh of all child devices when we first connect to emit events for all child devices
+      -- after the bridge is online, this will cause ST to mark the children online.
+      --TODO use the actual zigbee service to get the actual child device connectivity
       handlers.refresh_handler(driver, device)
     end
 

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -701,8 +701,8 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
       log.info_with({ hub_logs = true },
         string.format("Event Source Connection for Hue Bridge \"%s\" established, marking online", device.label))
       device:online()
-      --TODO should we do a refresh of all child devices when we first connect?
-      --handlers.refresh_handlers(driver, device)
+      --We do a refresh of all child devices when we first connect, to determine which are still online.
+      handlers.refresh_handler(driver, device)
     end
 
     eventsource.onerror = function()

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -54,8 +54,10 @@ local function emit_light_status_events(light_device, light)
   if light_device ~= nil then
     if light.status then
       if light.status == "connected" then
+        light_device.log.info_with({hub_logs=true}, "Light status event, marking device online")
         light_device:online()
       elseif light.status == "connectivity_issue" then
+        light_device.log.info_with({hub_logs=true}, "Light status event, marking device offline")
         light_device:offline()
         return
       end
@@ -688,7 +690,6 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
   if not device:get_field(Fields.EVENT_SOURCE) then
     log.info_with({ hub_logs = true }, "Creating SSE EventSource for bridge " ..
       (device.label or device.device_network_id or device.id or "unknown bridge"))
-    device:offline()
     local url_table = lunchbox_util.force_url_table(bridge_url .. "/eventstream/clip/v2")
     local eventsource = EventSource.new(
       url_table,


### PR DESCRIPTION
Whenever a driver is restarted, a bridge will temporarily be marked offline while the event source connection is created. This seems to be affecting the online/offline state of children incorrectly post 0.49.x FW.