### PR TITLE
Poll bulbs for their Zigbee Connectivity status explicitly when refreshing

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -2,7 +2,9 @@ local Fields = require "hue.fields"
 local HueApi = require "hue.api"
 local HueColorUtils = require "hue.cie_utils"
 local log = require "log"
+local utils = require "utils"
 
+local cosock = require "cosock"
 local capabilities = require "st.capabilities"
 local st_utils = require "st.utils"
 
@@ -245,8 +247,45 @@ end
 
 ---@param driver HueDriver
 ---@param light_device HueChildDevice
-local function do_refresh_light(driver, light_device)
+---@param conn_status_cache table|nil
+---@param light_status_cache table|nil
+local function do_refresh_light(driver, light_device, conn_status_cache, light_status_cache)
   local light_resource_id = light_device:get_field(Fields.RESOURCE_ID)
+  local hue_device_id = light_device:get_field(Fields.HUE_DEVICE_ID)
+
+  local do_zigbee_request = true
+  local do_light_request = true
+  local light_online = true
+
+  if type(conn_status_cache) == "table" then
+    local zigbee_status = conn_status_cache[hue_device_id]
+    if zigbee_status ~= nil then
+      if zigbee_status.status and zigbee_status.status == "connected" then
+        light_device.log.debug(string.format("Zigbee Status for %s is connected", light_device.label))
+        light_device:online()
+        do_zigbee_request = false
+      else
+        light_device.log.debug(string.format("Zigbee Status for %s is not connected", light_device.label))
+        light_device:offline()
+        do_zigbee_request = false
+        light_online = false
+      end
+    end
+  end
+
+  if type(light_status_cache) == "table" then
+    local light_info = light_status_cache[hue_device_id]
+    if light_info ~= nil then
+      if light_info.id == light_resource_id then
+        if light_info.color ~= nil and light_info.color.gamut then
+          light_device:set_field(Fields.GAMUT, light_info.color.gamut_type, { persist = true })
+        end
+        driver.emit_light_status_events(light_device, light_info)
+        do_light_request = false
+      end
+    end
+  end
+
   local bridge_id = light_device.parent_device_id or light_device:get_field(Fields.PARENT_DEVICE_ID)
   local bridge_device = driver:get_device_info(bridge_id)
 
@@ -262,30 +301,106 @@ local function do_refresh_light(driver, light_device)
   end
 
   local hue_api = bridge_device:get_field(Fields.BRIDGE_API)
-  local success = false
+  local success = not (do_light_request or do_zigbee_request)
   local count = 0
   local num_attempts = 3
+  local zigbee_resource_id
+  local rest_resp, rest_err
+  local backoff_generator = utils.backoff_builder(10, 0.1, 0.1)
+  --- this loop is a rate-limit dodge.
+  ---
+  --- One of the various symptoms of hitting the Hue Bridge's rate limit is that you'll get a silent
+  --- failure that takes the form of the bridge returning the last valid response it replied with.
+  --- So we hit the bridge 2-3 times and check the IDs in the responses to verify that we're getting
+  --- the information for the light that we expect to getting the info for.
   repeat
-    local light_resp, err = hue_api:get_light_by_id(light_resource_id)
     count = count + 1
-    if err ~= nil then
-      log.error_with({ hub_logs = true }, err)
-    elseif light_resp ~= nil then
-      if #light_resp.errors > 0 then
-        for _, err in ipairs(light_resp.errors) do
-          log.error_with({ hub_logs = true }, "Error in Hue API response: " .. err.description)
+    if do_zigbee_request then
+      rest_resp, rest_err = hue_api:get_device_by_id(hue_device_id)
+      if rest_err ~= nil then
+        log.error_with({ hub_logs = true }, rest_err)
+        goto continue
+      end
+
+      if rest_resp ~= nil then
+        if #rest_resp.errors > 0 then
+          for _, err in ipairs(rest_resp.errors) do
+            log.error_with({ hub_logs = true }, "Error in Hue API response: " .. err.description)
+          end
+          goto continue
         end
-      else
-        for _, light_info in ipairs(light_resp.data) do
+
+        for _, hue_device in ipairs(rest_resp.data) do
+          for _, svc_info in ipairs(hue_device.services or {}) do
+            if svc_info.rtype == "zigbee_connectivity" then
+              zigbee_resource_id = svc_info.rid
+            end
+          end
+        end
+      end
+
+      if zigbee_resource_id ~= nil then
+        rest_resp, rest_err = hue_api:get_zigbee_connectivity_by_id(zigbee_resource_id)
+        if rest_err ~= nil then
+          log.error_with({ hub_logs = true }, rest_err)
+          goto continue
+        end
+
+        if rest_resp ~= nil then
+          if #rest_resp.errors > 0 then
+            for _, err in ipairs(rest_resp.errors) do
+              log.error_with({ hub_logs = true }, "Error in Hue API response: " .. err.description)
+            end
+            goto continue
+          end
+
+          for _, zigbee_svc in ipairs(rest_resp.data) do
+            if zigbee_svc.owner and zigbee_svc.owner.rid == hue_device_id then
+              if zigbee_svc.status and zigbee_svc.status == "connected" then
+                light_device.log.debug(string.format("Zigbee Status for %s is connected", light_device.label))
+                light_device:online()
+              else
+                light_device.log.debug(string.format("Zigbee Status for %s is not connected", light_device.label))
+                light_device:offline()
+                light_online = false
+              end
+            end
+          end
+        end
+      end
+    end
+
+    if do_light_request then
+      rest_resp, rest_err = hue_api:get_light_by_id(light_resource_id)
+      if rest_err ~= nil then
+        log.error_with({ hub_logs = true }, rest_err)
+        goto continue
+      end
+
+      if rest_resp ~= nil then
+        if #rest_resp.errors > 0 then
+          for _, err in ipairs(rest_resp.errors) do
+            log.error_with({ hub_logs = true }, "Error in Hue API response: " .. err.description)
+          end
+          goto continue
+        end
+
+        for _, light_info in ipairs(rest_resp.data) do
           if light_info.id == light_resource_id then
             if light_info.color ~= nil and light_info.color.gamut then
               light_device:set_field(Fields.GAMUT, light_info.color.gamut_type, { persist = true })
             end
-            driver.emit_light_status_events(light_device, light_info)
+            if light_online then
+              driver.emit_light_status_events(light_device, light_info)
+            end
             success = true
           end
         end
       end
+    end
+    ::continue::
+    if not success then
+      cosock.socket.sleep(backoff_generator())
     end
   until success or count >= num_attempts
 end
@@ -295,26 +410,67 @@ end
 local function do_refresh_all_for_bridge(driver, bridge_device)
   local child_devices = bridge_device:get_child_list() --[=[@as HueChildDevice[]]=]
 
+  if not bridge_device:get_field(Fields._INIT) then
+    log.warn("Bridge for lights not yet initialized, can't refresh yet.")
+    return
+  end
+
+  local hue_api = bridge_device:get_field(Fields.BRIDGE_API) --[[@as PhilipsHueApi]]
+
+  local conn_status, conn_rest_err = hue_api:get_connectivity_status()
+  local light_status, light_rest_err = hue_api:get_lights()
+
+  if conn_rest_err ~= nil or light_rest_err ~= nil then
+    bridge_device.log.error(
+      string.format(
+        "Couldn't refresh devices connected to bridge.\n" ..
+        "get_connectivity_status error? %s\n" ..
+        "get_lights error? %s\n",
+        conn_rest_err,
+        light_rest_err
+      )
+    )
+    return
+  end
+
+  if (not conn_status) or (not light_status) then
+    bridge_device.log.warn(
+      string.format(
+        "Received empty status payloads with no errors while refreshing, aborting refresh handler.\n" ..
+        "Connectivity status nil? %s\n" ..
+        "Light status nil? %s\n",
+        (conn_status == nil),
+        (light_status == nil)
+      )
+    )
+    return
+  end
+
+  if conn_status.errors and #conn_status.errors > 0 then
+    bridge_device.log.error("Errors in connectivity status payload: " .. st_utils.stringify_table(conn_status.errors))
+    return
+  end
+
+  if light_status.errors and #light_status.errors > 0 then
+    bridge_device.log.error("Errors in light status payload: " .. st_utils.stringify_table(light_status.errors))
+    return
+  end
+
+  local conn_status_cache = {}
+  local light_status_cache = {}
+
+  for _, zigbee_status in ipairs(conn_status.data) do
+    conn_status_cache[zigbee_status.owner.rid] = zigbee_status
+  end
+
+  for _, light_status in ipairs(light_status.data) do
+    light_status_cache[light_status.owner.rid] = light_status
+  end
+
   for _, device in ipairs(child_devices) do
-    if device and device.datastore and device.datastore.__devices_store then
-      log.trace(
-        st_utils.stringify_table(
-          (device.datastore.__devices_store[device.id] or { unknown = "no datastore entry" }),
-          string.format(
-            "%s device datastore", (device.label or string.format("unlabeled device with id %s", device.id))
-          ),
-          false
-        )
-      )
-    else
-      log.warn(
-        string.format("Device %s does not have a proper datastore association",
-          (device.label or device.id or "unknown device"))
-      )
-    end
     local device_type = device:get_field(Fields.DEVICE_TYPE)
     if device_type == "light" then
-      do_refresh_light(driver, device)
+      do_refresh_light(driver, device, conn_status_cache, light_status_cache)
     end
   end
 end
@@ -323,7 +479,9 @@ end
 ---@param device HueDevice
 function handlers.refresh_handler(driver, device, cmd)
   if device:get_field(Fields.DEVICE_TYPE) == "bridge" then
-    do_refresh_all_for_bridge(driver, device --[[@as HueBridgeDevice]])
+    cosock.spawn(function()
+      do_refresh_all_for_bridge(driver, device --[[@as HueBridgeDevice]])
+    end, string.format("Refresh All Lights On Hue Bridge [%s] Task", device.label))
   elseif device:get_field(Fields.DEVICE_TYPE) == "light" then
     do_refresh_light(driver, device --[[@as HueChildDevice]])
   end

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -175,6 +175,8 @@ function PhilipsHueApi:update_connection(hub_base_url, api_key)
   self._ctrl_tx:send(msg)
 end
 
+---@return table|nil response REST response, nil if error
+---@return nil|string error nil on success
 local function do_get(instance, path)
   local reply_tx, reply_rx = channel.new()
   reply_rx:settimeout(10)
@@ -188,6 +190,8 @@ local function do_get(instance, path)
   return table.unpack(recv, 1, recv.n)
 end
 
+---@return table|nil response REST response, nil if error
+---@return nil|string error nil on success
 local function do_put(instance, path, payload)
   local reply_tx, reply_rx = channel.new()
   reply_rx:settimeout(10)
@@ -254,8 +258,16 @@ function PhilipsHueApi:get_connectivity_status() return do_get(self, "/clip/v2/r
 
 function PhilipsHueApi:get_rooms() return do_get(self, "/clip/v2/resource/room") end
 
-function PhilipsHueApi:get_light_by_id(id)
-  return do_get(self, string.format("/clip/v2/resource/light/%s", id))
+function PhilipsHueApi:get_light_by_id(light_resource_id)
+  return do_get(self, string.format("/clip/v2/resource/light/%s", light_resource_id))
+end
+
+function PhilipsHueApi:get_device_by_id(hue_device_id)
+  return do_get(self, string.format("/clip/v2/resource/device/%s", hue_device_id))
+end
+
+function PhilipsHueApi:get_zigbee_connectivity_by_id(zigbee_resource_id)
+  return do_get(self, string.format("/clip/v2/resource/zigbee_connectivity/%s", zigbee_resource_id))
 end
 
 function PhilipsHueApi:get_room_by_id(id)

--- a/drivers/SmartThings/philips-hue/src/hue/types.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/types.lua
@@ -30,6 +30,7 @@
 --- @field public id string
 --- @field public device_network_id string
 --- @field public data table|nil migration data for a migrated device
+--- @field public log table device-scoped logging module
 --- @field public get_field fun(self: HueDevice, key: string):any
 --- @field public set_field fun(self: HueDevice, key: string, value: any, args?: table)
 --- @field public emit_event fun(self: HueDevice, event: any)

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -54,8 +54,10 @@ local function emit_light_status_events(light_device, light)
   if light_device ~= nil then
     if light.status then
       if light.status == "connected" then
+        light_device.log.info_with({hub_logs=true}, "Light status event, marking device online")
         light_device:online()
       elseif light.status == "connectivity_issue" then
+        light_device.log.info_with({hub_logs=true}, "Light status event, marking device offline")
         light_device:offline()
         return
       end
@@ -690,7 +692,6 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
   if not device:get_field(Fields.EVENT_SOURCE) then
     log.info_with({ hub_logs = true }, "Creating SSE EventSource for bridge " ..
       (device.label or device.device_network_id or device.id or "unknown bridge"))
-    device:offline()
     local url_table = lunchbox_util.force_url_table(bridge_url .. "/eventstream/clip/v2")
     local eventsource = EventSource.new(
       url_table,

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -680,10 +680,10 @@ light_added = function(driver, device, parent_device_id, resource_id)
   device:set_field(Fields.PARENT_DEVICE_ID, light_info.parent_device_id, { persist = true })
   device:set_field(Fields.RESOURCE_ID, device_light_resource_id, { persist = true })
   device:set_field(Fields._ADDED, true, { persist = true })
+  device:set_field(Fields._REFRESH_AFTER_INIT, true, { persist = true })
 
   driver.light_id_to_device[device_light_resource_id] = device
 
-  device:online()
   -- the refresh handler adds lights that don't have a fully initialized bridge to a queue.
   handlers.refresh_handler(driver, device)
 end


### PR DESCRIPTION
Adds explicit checking for zigbee connectivity status as part of refresh, instead of always waiting for it to come in on the SSE stream.

Note that the zigbee connectivity status itself within the Hue network can be delayed.

Because we're now doing more network calls during refresh, I also adjusted the "refresh all" handler to use the bulk endpoints.

To keep the changeset on this small, I did it by overloading the functionality of the existing refresh for single lights. It's noted in comments that this isn't the most ideal, however, I'm in the process of planning out a rearch of this driver including with a test coverage plan, so I didn't think deep surgery was warranted given that we're going to be doing a complete redo soon.

Pardon the Mess™