### PR TITLE
Update Hue Driver to accommodate 0.49.x changes for LAN Child Device Health

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -398,7 +398,7 @@ function HueDiscovery.do_mdns_scan(driver)
 
     if driver.joined_bridges[bridge_id] and not driver.ignored_bridges[bridge_id] then
       local bridge_device = driver:get_device_by_dni(bridge_id, true)
-      update_needed = update_needed or (bridge_device:get_field(Fields.IPV4) ~= bridge_info.ip)
+      update_needed = update_needed or (bridge_device and (bridge_device:get_field(Fields.IPV4) ~= bridge_info.ip))
       if update_needed then
         driver:update_bridge_netinfo(bridge_id, bridge_info)
       end

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -250,6 +250,8 @@ function PhilipsHueApi:get_lights() return do_get(self, "/clip/v2/resource/light
 
 function PhilipsHueApi:get_devices() return do_get(self, "/clip/v2/resource/device") end
 
+function PhilipsHueApi:get_connectivity_status() return do_get(self, "/clip/v2/resource/zigbee_connectivity") end
+
 function PhilipsHueApi:get_rooms() return do_get(self, "/clip/v2/resource/room") end
 
 function PhilipsHueApi:get_light_by_id(id)

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -680,6 +680,8 @@ light_added = function(driver, device, parent_device_id, resource_id)
   device:set_field(Fields._ADDED, true, { persist = true })
 
   driver.light_id_to_device[device_light_resource_id] = device
+
+  device:online()
   -- the refresh handler adds lights that don't have a fully initialized bridge to a queue.
   handlers.refresh_handler(driver, device)
 end
@@ -700,10 +702,60 @@ local function do_bridge_network_init(driver, device, bridge_url, api_key)
       log.info_with({ hub_logs = true },
         string.format("Event Source Connection for Hue Bridge \"%s\" established, marking online", device.label))
       device:online()
+
+      local bridge_api = device:get_field(Fields.BRIDGE_API)
+      local child_device_map = {}
+      for _, device_record in ipairs(device:get_child_list()) do
+        local hue_device_id = device_record:get_field(Fields.HUE_DEVICE_ID)
+        if hue_device_id ~= nil then
+          child_device_map[hue_device_id] = device_record
+        end
+      end
+
+      local connectivity_status, rest_err = bridge_api:get_connectivity_status()
+      if rest_err ~= nil then
+        log.error(string.format("Couldn't query Hue Bridge %s for zigbee connectivity status for child devices: %s",
+          device.label, rest_err))
+        return
+      end
+
+      if connectivity_status.errors and #connectivity_status.errors > 0 then
+        log.error(
+          string.format(
+            "Hue Bridge %s replied with the following error message(s) " ..
+            "when querying child device connectivity status:",
+            device.label
+          )
+        )
+        for _, err in ipairs(connectivity_status.errors) do
+          log.error(string.format("--- %s", err))
+        end
+        return
+      end
+
+      for _, status in ipairs(connectivity_status.data) do
+        local hue_device_id = (status.owner and status.owner.rid) or ""
+        log.trace(string.format("Checking connectivity status for device resource id %s", hue_device_id))
+        local child_device = child_device_map[hue_device_id]
+        if child_device then
+          if status.status == "connected" then
+            child_device.log.trace("Marking Online after SSE Reconnect")
+            child_device:online()
+          elseif status.status == "connectivity_issue" then
+            child_device.log.trace("Marking Offline after SSE Reconnect")
+            child_device:offline()
+          end
+        end
+      end
     end
 
     eventsource.onerror = function()
       log.error_with({ hub_logs = true }, string.format("Hue Bridge \"%s\" Event Source Error", device.label))
+
+      for _, device_record in ipairs(device:get_child_list()) do
+        device_record:offline()
+      end
+
       device:offline()
     end
 
@@ -920,7 +972,6 @@ init_light = function(driver, device)
     handlers.refresh_handler(driver, device)
     device:set_field(Fields._REFRESH_AFTER_INIT, false, { persist = true })
   end
-  device:online()
 end
 
 ---@param driver HueDriver

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -920,6 +920,7 @@ init_light = function(driver, device)
     handlers.refresh_handler(driver, device)
     device:set_field(Fields._REFRESH_AFTER_INIT, false, { persist = true })
   end
+  device:online()
 end
 
 ---@param driver HueDriver


### PR DESCRIPTION
Changes in hubcore 0.49 require LAN-parented Child Devices to manage their online/offline state explicitly instead of automagically following the parent's health, which is needed to allow for child devices to mark themselves offline independently.

There were places in the Hue driver that made assumptions around child devices always following their parents, so we need to make a few tweaks to address that.

Primarily:
1. Bulbs call `online()` on themselves at the end of their `init` block;
2. The Hue Bridge will walk all of its children and manually update their state to `offline` when the bridge goes offline, and will poll the actual Zigbee connectivity status reported by the bridge when the bridge comes `online`.

The goal here is to try and minimize state divergence between local device watch and cloud health state; the cloud still has some rudimentary assumptions that child devices will follow parent devices, so we need to make the child devices behave the same way they would have in the past.

This supercedes #926 and #922 