### PR TITLE
Fix up unit tests and refresh behavior for subdrivers

### DIFF
--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
@@ -156,6 +156,17 @@ test.register_coroutine_test(
           Battery:Get({})
         )
       },
+      {
+        channel = "zwave",
+        direction = "send",
+        message = zw_test_utils.zwave_test_build_send_command(
+          mock,
+          WakeUp:IntervalGet({})
+        )
+      },
+    },
+    {
+      inner_block_ordering = "relaxed"
     }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/samsung-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/samsung-lock/init.lua
@@ -17,6 +17,7 @@ local cc = require "st.zwave.CommandClass"
 
 local Notification = (require "st.zwave.CommandClass.Notification")({version=3})
 local UserCode = (require "st.zwave.CommandClass.UserCode")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local access_control_event = Notification.event.access_control
 
 local json = require "dkjson"
@@ -95,11 +96,21 @@ local function do_configure(self, device)
   device:emit_event(capabilities.lockCodes.lockCodes(json.encode({["0"] = "Master Code"} ), { visibility = { displayed = false } }))
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local samsung_lock = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = notification_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     doConfigure = do_configure

--- a/drivers/SmartThings/zwave-lock/src/schlage-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/schlage-lock/init.lua
@@ -24,6 +24,7 @@ local access_control_event = Notification.event.access_control
 local Configuration = (require "st.zwave.CommandClass.Configuration")({version=2})
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local Association = (require "st.zwave.CommandClass.Association")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local LockCodesDefaults = require "st.zwave.defaults.lockCodes"
 
@@ -164,6 +165,13 @@ local function user_code_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local schlage_lock = {
   capability_handlers = {
     [capabilities.lockCodes.ID] = {
@@ -181,7 +189,10 @@ local schlage_lock = {
     },
     [cc.BASIC] = {
       [Basic.SET] = basic_set_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     doConfigure = do_configure,

--- a/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
@@ -20,6 +20,7 @@ local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 1 })
 --- @type st.zwave.CommandClass.Battery
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
 --- @type st.zwave.defaults.lockCodes
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local lock_code_defaults = require "st.zwave.defaults.lockCodes"
 local json = require "dkjson"
 
@@ -152,11 +153,21 @@ local function alarm_report_handler(driver, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zwave_lock = {
   zwave_handlers = {
     [cc.ALARM] = {
       [Alarm.REPORT] = alarm_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   NAME = "Z-Wave lock alarm V1",
   can_handle = can_handle_v1_alarm,

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
@@ -17,6 +17,7 @@ local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local AEOTEC_MULTISENSOR_FINGERPRINTS = {
   { manufacturerId = 0x0086, productId = 0x0064 }, -- MultiSensor 6
@@ -54,11 +55,21 @@ local function notification_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local aeotec_multisensor = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = notification_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   sub_drivers = {
     require("aeotec-multisensor/multisensor-6"),

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
@@ -29,7 +29,8 @@ end
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
   --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
+  local version = require "version"
+  if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
     device:send(WakeUp:IntervalGetV1({}))
     device:set_field("__wakeup_interval_get_sent", true)
   end

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
@@ -29,7 +29,8 @@ end
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
   --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
+  local version = require "version"
+  if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
     device:send(WakeUp:IntervalGetV1({}))
     device:set_field("__wakeup_interval_get_sent", true)
   end

--- a/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
@@ -29,7 +29,8 @@ end
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
   --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
+  local version = require "version"
+  if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
     device:send(WakeUp:IntervalGetV1({}))
     device:set_field("__wakeup_interval_get_sent", true)
   end

--- a/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
@@ -25,6 +25,7 @@ local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local SwitchColor = (require "st.zwave.CommandClass.SwitchColor")({version=1})
 --- @type st.zwave.CommandClass.SwitchBinary
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({version=2})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local CAP_CACHE_KEY = "st.capabilities." .. capabilities.colorControl.ID
 
@@ -92,11 +93,21 @@ local function set_color(driver, device, command)
   device.thread:call_with_delay(constants.DEFAULT_GET_STATUS_DELAY, query_color)
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local ezmultipli_multipurpose_sensor = {
   NAME = "EZmultiPli Multipurpose Sensor",
   zwave_handlers = {
     [cc.BASIC] = {
       [Basic.REPORT] = basic_report_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     },
   },
   capability_handlers = {

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
@@ -19,6 +19,7 @@ local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=2 })
 local SensorAlarm = (require "st.zwave.CommandClass.SensorAlarm")({ version = 1 })
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 1 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local configurationsMap = require "configurations"
 
 local FIBARO_DOOR_WINDOW_SENSOR_1_FINGERPRINTS = {
@@ -72,6 +73,12 @@ local function device_added(driver, device)
   device:emit_event(capabilities.contactSensor.contact.open())
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
 
 local fibaro_door_window_sensor_1 = {
   NAME = "fibaro door window sensor 1",
@@ -82,7 +89,10 @@ local fibaro_door_window_sensor_1 = {
   zwave_handlers = {
     [cc.SENSOR_ALARM ] = {
       [SensorAlarm.REPORT] = sensor_alarm_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   [capabilities.refresh.ID] = {
     [capabilities.refresh.commands.refresh.NAME] = do_refresh

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
@@ -17,6 +17,7 @@ local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Alarm
 local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 2 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 2 })
 
 local FIBARO_DOOR_WINDOW_SENSOR_2_FINGERPRINTS = {
   { manufacturerId = 0x010F, productType = 0x0702, productId = 0x1000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / Europe
@@ -67,11 +68,21 @@ local function alarm_report_handler(self, device, cmd)
   if event ~= nil then device:emit_event(event) end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fibaro_door_window_sensor_2 = {
   NAME = "fibaro door window sensor 2",
   zwave_handlers = {
     [cc.ALARM] = {
       [Alarm.REPORT] = alarm_report_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
   lifecycle_handlers = {

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/init.lua
@@ -132,6 +132,13 @@ local function notification_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fibaro_door_window_sensor = {
   NAME = "fibaro door window sensor",
   zwave_handlers = {
@@ -140,6 +147,9 @@ local fibaro_door_window_sensor = {
     },
     [cc.CONFIGURATION] = {
       [Configuration.REPORT] = configuration_report
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
   lifecycle_handlers = {

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
@@ -23,6 +23,7 @@ local SensorAlarm = (require "st.zwave.CommandClass.SensorAlarm")({ version = 1 
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
 --- @type st.zwave.CommandClass.SensorMultilevel
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version = 5 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local preferences = require "preferences"
 local configurations = require "configurations"
@@ -86,6 +87,13 @@ local function do_configure(driver, device)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fibaro_flood_sensor = {
   NAME = "fibaro flood sensor",
   zwave_handlers = {
@@ -100,7 +108,10 @@ local fibaro_flood_sensor = {
     },
     [cc.SENSOR_MULTILEVEL] = {
       [SensorMultilevel.REPORT] = sensor_multilevel_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     doConfigure = do_configure

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/init.lua
@@ -17,6 +17,7 @@ local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.SensorAlarm
 local SensorAlarm = (require "st.zwave.CommandClass.SensorAlarm")({ version = 1 })
 local capabilities = require "st.capabilities"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local FIBARO_MOTION_MFR = 0x010F
 local FIBARO_MOTION_PROD = 0x0800
@@ -33,11 +34,21 @@ local function sensor_alarm_report(driver, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fibaro_motion_sensor = {
   NAME = "Fibaro Motion Sensor",
   zwave_handlers = {
     [cc.SENSOR_ALARM] = {
       [SensorAlarm.REPORT] = sensor_alarm_report
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
   can_handle = can_handle_fibaro_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/init.lua
@@ -17,6 +17,7 @@ local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS = {
   { manufacturerId = 0x0084, productType = 0x0093, productId = 0x0114 } -- glentronics water leak sensor
@@ -69,11 +70,21 @@ local function device_added(driver, device)
   device:emit_event(capabilities.powerSource.powerSource.mains())
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local glentronics_water_leak_sensor = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = notification_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     added = device_added

--- a/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
@@ -59,7 +59,8 @@ end
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
   --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
+  local version = require "version"
+  if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
     device:send(WakeUp:IntervalGetV1({}))
     device:set_field("__wakeup_interval_get_sent", true)
   end

--- a/drivers/SmartThings/zwave-sensor/src/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/init.lua
@@ -61,14 +61,16 @@ local function basic_set_handler(driver, device, cmd)
   end
 end
 
-local function wakeup_notification(driver, device, cmd)
-  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
-  --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
-    device:send(WakeUp:IntervalGetV1({}))
-    device:set_field("__wakeup_interval_get_sent", true)
+local wakeup_notification = nil
+local version = require "version"
+if version.api < 6 then
+  wakeup_notification = function(driver, device, cmd)
+    if not device:get_field("__wakeup_interval_get_sent") then
+      device:send(WakeUp:IntervalGetV1({}))
+      device:set_field("__wakeup_interval_get_sent", true)
+    end
+    device:refresh()
   end
-  device:refresh()
 end
 
 local function do_configure(driver, device)

--- a/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
@@ -50,7 +50,8 @@ end
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
   --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
+  local version = require "version"
+  if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
     device:send(WakeUp:IntervalGetV1({}))
     device:set_field("__wakeup_interval_get_sent", true)
   end

--- a/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
@@ -17,6 +17,7 @@ local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 4 })
 local capabilities = require "st.capabilities"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local TAMPER_TIMER = "_tamper_timer"
 local TAMPER_CLEAR = 10
@@ -49,11 +50,21 @@ local function handle_tamper_event(driver, device, cmd)
   end))
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local timed_tamper_clear = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = handle_tamper_event
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   NAME = "timed tamper clear",
   can_handle = can_handle_tamper_event

--- a/drivers/SmartThings/zwave-sensor/src/v1-contact-event/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/v1-contact-event/init.lua
@@ -16,6 +16,7 @@
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 4 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local capabilities = require "st.capabilities"
 
 local function can_handle_v1_contact_event(opts, driver, device, cmd, ...)
@@ -41,11 +42,21 @@ local function handle_v1_contact_event(driver, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local v1_contact_event = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = handle_v1_contact_event
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   NAME = "v1 contact event",
   can_handle = can_handle_v1_contact_event

--- a/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
@@ -31,7 +31,8 @@ end
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
   --This is done to help the hub correctly set the checkInterval for migrated devices.
-  if not device:get_field("__wakeup_interval_get_sent") then
+  local version = require "version"
+  if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
     device:send(WakeUp:IntervalGetV1({}))
     device:set_field("__wakeup_interval_get_sent", true)
   end

--- a/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/init.lua
@@ -19,6 +19,7 @@ local cc = require "st.zwave.CommandClass"
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
 --- @type st.zwave.CommandClass.SensorMultilevel
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version = 5 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 --- @type st.utils
 local utils = require "st.utils"
 
@@ -102,6 +103,13 @@ local function sensor_multilevel_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zooz_4_in_1_sensor = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
@@ -109,6 +117,9 @@ local zooz_4_in_1_sensor = {
     },
     [cc.SENSOR_MULTILEVEL] = {
       [SensorMultilevel.REPORT] = sensor_multilevel_report_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
   NAME = "zooz 4 in 1 sensor",

--- a/drivers/SmartThings/zwave-sensor/src/zwave-water-temp-humidity-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zwave-water-temp-humidity-sensor/init.lua
@@ -17,6 +17,7 @@ local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local ZWAVE_WATER_TEMP_HUMIDITY_FINGERPRINTS = {
   { manufacturerId = 0x0371, productType = 0x0002, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro EU
@@ -63,10 +64,20 @@ local function notification_report_handler(self, device, cmd)
   if (event ~= nil) then device:emit_event(event) end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zwave_water_temp_humidity_sensor = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = notification_report_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     },
   },
   NAME = "zwave water temp humidity sensor",

--- a/drivers/SmartThings/zwave-siren/src/aeon-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeon-siren/init.lua
@@ -14,6 +14,8 @@
 
 local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local AEON_MFR = 0x0086
 local AEON_SIREN_PRODUCT_ID = 0x0050
@@ -62,9 +64,21 @@ local function info_changed(driver, device, event, args)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local aeon_siren = {
   NAME = "aeon-siren",
   can_handle = can_handle_aeon_siren,
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
+  },
   lifecycle_handlers = {
     doConfigure = do_configure,
     infoChanged = info_changed

--- a/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/init.lua
@@ -18,6 +18,7 @@ local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=4 })
 local Notification = (require "st.zwave.CommandClass.Notification")({version=3})
 local SoundSwitch = (require "st.zwave.CommandClass.SoundSwitch")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local preferencesMap = require "preferences"
 
 local AEOTEC_DOORBELL_SIREN_FINGERPRINTS = {
@@ -295,6 +296,13 @@ local function notification_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local function alarmChimeOnOff(device, command, newValue)
   if (device and command and newValue) then
     local endpoint = component_to_endpoint(device, command.component)
@@ -330,7 +338,10 @@ local aeotec_doorbell_siren = {
     },
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = notification_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   capabilities_handlers = {
     [capabilities.refresh.ID] = {

--- a/drivers/SmartThings/zwave-siren/src/fortrezz/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/fortrezz/init.lua
@@ -15,6 +15,7 @@
 local cc = require "st.zwave.CommandClass"
 local capabilities = require "st.capabilities"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local function can_handle_fortrezz_siren(opts, self, device, ...)
   return device.zwave_manufacturer_id == 0x0084 and
@@ -45,6 +46,13 @@ local function basic_report_handler(self, device, cmd)
   device:emit_event(switch_event)
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fortrezz_siren = {
   NAME = "fortrezz-siren",
   can_handle = can_handle_fortrezz_siren,
@@ -63,7 +71,10 @@ local fortrezz_siren = {
   zwave_handlers = {
     [cc.BASIC] = {
       [Basic.REPORT] = basic_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   }
 }
 

--- a/drivers/SmartThings/zwave-siren/src/philio-sound-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/philio-sound-siren/init.lua
@@ -18,6 +18,7 @@ local Basic = (require "st.zwave.CommandClass.Basic")({version =1})
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({version=2})
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
 local preferencesMap = require "preferences"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local PHILIO_SOUND_SIREN = {
   { manufacturerId = 0x013C, productType = 0x0004, productId = 0x000A }
@@ -155,6 +156,13 @@ local function sensor_binary_report_handler(driver, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local philio_sound_siren = {
   NAME = "Philio sound siren",
   can_handle = can_handle_philio_sound_siren,
@@ -167,7 +175,10 @@ local philio_sound_siren = {
     },
     [cc.SENSOR_BINARY] = {
       [SensorBinary.REPORT] = sensor_binary_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   capability_handlers = {
     [capabilities.alarm.ID] = {

--- a/drivers/SmartThings/zwave-siren/src/test/test_aeon_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_aeon_siren.lua
@@ -17,6 +17,7 @@ local capabilities = require "st.capabilities"
 local zw = require "st.zwave"
 local zw_test_utils = require "integration_test.zwave_test_utils"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({version=1})
 local t_utils = require "integration_test.utils"
 

--- a/drivers/SmartThings/zwave-siren/src/utilitech-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/utilitech-siren/init.lua
@@ -16,6 +16,7 @@ local cc = require "st.zwave.CommandClass"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1,strict=true})
 local Battery = (require "st.zwave.CommandClass.Battery")({version=1})
 local BatteryDefaults = require "st.zwave.defaults.battery"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local UTILITECH_MFR = 0x0060
 local UTILITECH_SIREN_PRODUCT_ID = 0x0001
@@ -37,13 +38,23 @@ local function battery_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local utilitech_siren = {
   NAME = "utilitech-siren",
   can_handle = can_handle_utilitech_siren,
   zwave_handlers = {
     [cc.BATTERY] = {
       [Battery.REPORT] = battery_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     added = device_added

--- a/drivers/SmartThings/zwave-siren/src/yale-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/yale-siren/init.lua
@@ -18,6 +18,7 @@ local Battery = (require "st.zwave.CommandClass.Battery")({version=1})
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local Configuration = (require "st.zwave.CommandClass.Configuration")({version=1})
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local preferencesMap = require "preferences"
 
 local YALE_MFR = 0x0129
@@ -92,6 +93,13 @@ local function configuration_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local function device_added(driver, device)
   do_refresh(driver, device)
 end
@@ -113,7 +121,10 @@ local yale_siren = {
   zwave_handlers = {
     [cc.CONFIGURATION] = {
       [Configuration.REPORT] = configuration_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     infoChanged = info_changed,

--- a/drivers/SmartThings/zwave-siren/src/zipato-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/zipato-siren/init.lua
@@ -17,6 +17,7 @@ local cc  = require "st.zwave.CommandClass"
 local AlarmDefaults = require "st.zwave.defaults.alarm"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local Battery = (require "st.zwave.CommandClass.Battery")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local ZIPATO_MFR = 0x0131
 local BASIC_AND_SWITCH_BINARY_REPORT_STROBE_LIMIT = 33
@@ -62,6 +63,13 @@ local function device_added(self, device)
   device:send(Battery:Get({}))
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zipato_siren = {
   NAME = "zipato-siren",
   can_handle = can_handle_zipato_siren,
@@ -75,6 +83,9 @@ local zipato_siren = {
   zwave_handlers = {
     [cc.BASIC] = {
       [Basic.REPORT] = basic_report_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     },
   },
   lifecycle_handlers = {

--- a/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/init.lua
@@ -17,6 +17,7 @@ local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Alarm
 local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 2 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local ZWAVE_SOUND_SENSOR_FINGERPRINTS = {
   { manufacturerId = 0x014A, productType = 0x0005, productId = 0x000F } --Ecolink Firefighter
@@ -63,11 +64,21 @@ local function added_handler(self, device)
   device:emit_event(capabilities.soundSensor.sound.not_detected())
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zwave_sound_sensor = {
   zwave_handlers = {
     [cc.ALARM] = {
       [Alarm.REPORT] = alarm_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   lifecycle_handlers = {
     added = added_handler,

--- a/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
@@ -55,12 +55,6 @@ local function device_added(self, device)
 end
 
 local function wakeup_notification_handler(self, device, cmd)
-    --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
-    --This is done to help the hub correctly set the checkInterval for migrated devices.
-    if not device:get_field("__wakeup_interval_get_sent") then
-      device:send(WakeUp:IntervalGetV1({}))
-      device:set_field("__wakeup_interval_get_sent", true)
-    end
   device:emit_event(capabilities.smokeDetector.smoke.clear())
   device:send(Battery:Get({}))
   device:send(SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE}))

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
@@ -21,6 +21,7 @@ local t_utils = require "integration_test.utils"
 local Battery = (require "st.zwave.CommandClass.Battery")({ version=1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version=5 })
+local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version=1 })
 local Notification = (require "st.zwave.CommandClass.Notification")({ version=4 })
 
@@ -86,6 +87,20 @@ test.register_coroutine_test(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
         SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        SensorBinary:Get({sensor_type = SensorBinary.sensor_type.FREEZE})
+      )
+    )
+
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        SensorBinary:Get({sensor_type = SensorBinary.sensor_type.SMOKE})
       )
     )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
@@ -365,7 +365,15 @@ test.register_message_test(
           sensor_type = SensorBinary.sensor_type.SMOKE
         })
       )
-    }
+    },
+    {
+      channel = "zwave",
+      direction = "send",
+      message = zw_test_utils.zwave_test_build_send_command(
+          mock_device,
+          WakeUp:IntervalGet({})
+        )
+    },
   },
   {
     inner_block_ordering = "relaxed"

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v1/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v1/init.lua
@@ -15,6 +15,7 @@
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 2 })
 --- @type st.zwave.CommandClass.Alarm
 local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 1 })
 
@@ -67,11 +68,21 @@ local function alarm_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zwave_alarm = {
   zwave_handlers = {
     [cc.ALARM] = {
       -- also shall handle cc.ALARM
       [Alarm.REPORT] = alarm_report_handler
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
   NAME = "Z-Wave smoke and CO alarm V1",

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/init.lua
@@ -19,6 +19,7 @@ local cc = require "st.zwave.CommandClass"
 local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 2 })
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({version=3})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 2 })
 
 local SMOKE_CO_ALARM_V2_FINGERPRINTS = {
   { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1000 }, -- Fibaro CO Sensor
@@ -87,11 +88,21 @@ local function alarm_report_handler(self, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local zwave_alarm = {
   zwave_handlers = {
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = alarm_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   NAME = "Z-Wave smoke and CO alarm V2",
   can_handle = can_handle_v2_alarm,

--- a/drivers/SmartThings/zwave-switch/src/ecolink-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/ecolink-switch/init.lua
@@ -15,6 +15,7 @@
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local ECOLINK_FINGERPRINTS = {
   {mfr = 0x014A, prod = 0x0006, model = 0x0002},
@@ -41,12 +42,22 @@ local function basic_set_handler(driver, device, cmd)
   end
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local ecolink_switch = {
   NAME = "Ecolink Switch",
   zwave_handlers = {
     [cc.BASIC] = {
       [Basic.SET] = basic_set_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   can_handle = can_handle_ecolink
 }

--- a/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/init.lua
@@ -28,6 +28,7 @@ local ThermostatFanMode = (require "st.zwave.CommandClass.ThermostatFanMode")({ 
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
 --- @type st.zwave.CommandClass.MultiChannel
 local MultiChannel = (require "st.zwave.CommandClass.MultiChannel")({ version = 4 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local heating_setpoint_defaults = require "st.zwave.defaults.thermostatHeatingSetpoint"
 local cooling_setpoint_defaults = require "st.zwave.defaults.thermostatCoolingSetpoint"
 local constants = require "st.zwave.constants"
@@ -183,6 +184,13 @@ local function added_handler(self, device)
   do_refresh(self, device)
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local ct100_thermostat = {
   NAME = "CT100 thermostat",
   lifecycle_handlers = {
@@ -197,7 +205,10 @@ local ct100_thermostat = {
     },
     [cc.THERMOSTAT_SETPOINT] = {
       [ThermostatSetpoint.REPORT] = setpoint_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   capability_handlers = {
     [capabilities.thermostatCoolingSetpoint.ID] = {

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
@@ -27,6 +27,7 @@ local ThermostatSetpoint = (require "st.zwave.CommandClass.ThermostatSetpoint")(
 local Configuration = (require "st.zwave.CommandClass.Configuration")({version=1})
 --- @type st.zwave.CommandClass.ApplicationStatus
 local ApplicationStatus = (require "st.zwave.CommandClass.ApplicationStatus")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local utils = require "st.utils"
 
@@ -163,6 +164,13 @@ local function device_added(self, device)
   do_refresh(self, device)
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fibaro_heat_controller = {
   NAME = "fibaro heat controller",
   zwave_handlers = {
@@ -174,7 +182,10 @@ local fibaro_heat_controller = {
     },
     [cc.APPLICATION_STATUS] = {
       [ApplicationStatus.APPLICATION_BUSY] = application_busy_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   capability_handlers = {
     [capabilities.thermostatMode.ID] = {

--- a/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/init.lua
@@ -58,7 +58,10 @@ end
 -- If device wakes up earlier, driver is convinenced that user performed manual action (like adjusting setpoint on device),
 -- and in that case, cached setpoint command is removed and not sent.
 local function wakeup_notification_handler(self, device, cmd)
-  device:send(WakeUp:IntervalGet({}))
+  local version = require "version"
+  if version.api < 6 then --sent automatically after api version 6
+    device:send(WakeUp:IntervalGet({}))
+  end
   local setpoint = device:get_field(CACHED_SETPOINT)
   if setpoint ~= nil and seconds_since_latest_wakeup(device) > 0.90 * POPP_WAKEUP_INTERVAL then
     device:send(setpoint)

--- a/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/init.lua
@@ -212,7 +212,9 @@ end
 local function wakeup_notification_handler(self, device, cmd)
     --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
     --This is done to help the hub correctly set the checkInterval for migrated devices.
-    if not device:get_field("__wakeup_interval_get_sent") then
+    --Done by default after api version 6
+    local version = require "version"
+    if version.api < 6 and not device:get_field("__wakeup_interval_get_sent") then
       device:send(WakeUp:IntervalGetV1({}))
       device:set_field("__wakeup_interval_get_sent", true)
     end

--- a/drivers/SmartThings/zwave-window-treatment/src/aeotec-nano-shutter/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/aeotec-nano-shutter/init.lua
@@ -19,6 +19,7 @@ local cc = require "st.zwave.CommandClass"
 local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
 --- @type st.zwave.CommandClass.Configuration
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 1 })
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local SHADE_STATE_OPENING = "opening"
 local SHADE_STATE_CLOSING = "closing"
@@ -104,11 +105,21 @@ local function do_configure(driver, device)
   device:send(Configuration:Set({parameter_number = 85, size = 1, configuration_value = 1}))
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local aeotec_nano_shutter = {
   zwave_handlers = {
     [cc.BASIC] = {
         [Basic.REPORT] = basic_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   capability_handlers = {
     [capabilities.statelessCurtainPowerButton.ID] = {

--- a/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/fibaro-roller-shutter/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/fibaro-roller-shutter/init.lua
@@ -16,6 +16,7 @@
 local cc = (require "st.zwave.CommandClass")
 --- @type st.zwave.CommandClass.Configuration
 local Configuration = (require "st.zwave.CommandClass.Configuration")({version=1})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local FIBARO_ROLLER_SHUTTER_FINGERPRINTS = {
   {mfr = 0x010F, prod = 0x1D01, model = 0x1000}, -- Fibaro Walli Roller Shutter
@@ -72,11 +73,21 @@ local function device_added(self, device)
   device:do_refresh()
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local fibaro_roller_shutter = {
   zwave_handlers = {
     [cc.CONFIGURATION] = {
       [Configuration.REPORT] = configuration_report
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   NAME = "fibaro roller shutter",
   can_handle = can_handle_fibaro_roller_shutter,

--- a/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/init.lua
@@ -15,6 +15,7 @@
 local cc = (require "st.zwave.CommandClass")
 local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
 local SwitchMultilevel = (require "st.zwave.CommandClass.SwitchMultilevel")({version=3})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local WindowShadeDefaults = require "st.zwave.defaults.windowShade"
 local WindowShadeLevelDefaults = require "st.zwave.defaults.windowShadeLevel"
@@ -60,6 +61,13 @@ local function map_components(self, device)
   device:set_component_to_endpoint_fn(component_to_endpoint)
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local window_treatment_venetian = {
   NAME = "window treatment venetian",
   zwave_handlers = {
@@ -68,7 +76,10 @@ local window_treatment_venetian = {
     },
     [cc.SWITCH_MULTILEVEL] = {
       [SwitchMultilevel.REPORT] = shade_event_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   can_handle = can_handle_window_treatment_venetian,
   lifecycle_handlers = {

--- a/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/qubino-flush-shutter/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/window-treatment-venetian/qubino-flush-shutter/init.lua
@@ -23,6 +23,7 @@ local Association = (require "st.zwave.CommandClass.Association")({version=2})
 local SwitchMultilevel = (require "st.zwave.CommandClass.SwitchMultilevel")({version=3})
 --- @type st.zwave.CommandClass.Meter
 local Meter = (require "st.zwave.CommandClass.Meter")({version=3})
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local preferencesMap = require "preferences"
 
@@ -168,6 +169,13 @@ local function device_added(self, device)
   device:refresh()
 end
 
+local wakeup_notification = nil
+local version = require "version"
+if version.api == 6 then
+  --TODO remove once this happens properly for subdrivers that dont override the default
+  wakeup_notification = function(driver, device, cmd) device:refresh() end
+end
+
 local qubino_flush_shutter = {
   NAME = "qubino flush shutter",
   zwave_handlers = {
@@ -179,7 +187,10 @@ local qubino_flush_shutter = {
     },
     [cc.METER] = {
       [Meter.REPORT] = meter_report_handler
-    }
+    },
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    },
   },
   capability_handlers = {
     [capabilities.windowShadeLevel.ID] = {


### PR DESCRIPTION
I think we should hotfix this to our beta channel asap to make the prod driver release this week. It seems there were a few cases that were not fully addressed by the lua libs in 0.49 wrt sending wake up interval get commands once when a driver starts up. These changes address those.