### PR TITLE
Fix/default wakeup override bug 49 release

### DIFF
--- a/drivers/SmartThings/zwave-button/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-button/src/apiv6_bugfix/init.lua
@@ -1,0 +1,26 @@
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  return version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION
+end
+
+local function wakeup_notification(driver, device, cmd)
+  device:refresh()
+end
+
+local apiv6_bugfix = {
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    }
+  },
+  NAME = "apiv6_bugfix",
+  can_handle = can_handle
+}
+
+return apiv6_bugfix

--- a/drivers/SmartThings/zwave-button/src/init.lua
+++ b/drivers/SmartThings/zwave-button/src/init.lua
@@ -42,7 +42,8 @@ local driver_template = {
     added = added_handler,
   },
   sub_drivers = {
-    require("zwave-multi-button")
+    require("zwave-multi-button"),
+    require("apiv6_bugfix"),
   }
 }
 

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
@@ -153,6 +153,14 @@ test.register_coroutine_test(
         direction = "send",
         message = zw_test_utils.zwave_test_build_send_command(
           mock,
+          WakeUp:IntervalGet({})
+        )
+      },
+      {
+        channel = "zwave",
+        direction = "send",
+        message = zw_test_utils.zwave_test_build_send_command(
+          mock,
           Battery:Get({})
         )
       },

--- a/drivers/SmartThings/zwave-lock/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/apiv6_bugfix/init.lua
@@ -1,0 +1,26 @@
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  return version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION
+end
+
+local function wakeup_notification(driver, device, cmd)
+  device:refresh()
+end
+
+local apiv6_bugfix = {
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    }
+  },
+  NAME = "apiv6_bugfix",
+  can_handle = can_handle
+}
+
+return apiv6_bugfix

--- a/drivers/SmartThings/zwave-lock/src/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/init.lua
@@ -184,7 +184,8 @@ local driver_template = {
     require("zwave-alarm-v1-lock"),
     require("schlage-lock"),
     require("samsung-lock"),
-    require("keywe-lock")
+    require("keywe-lock"),
+    require("apiv6_bugfix"),
   }
 }
 

--- a/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/init.lua
@@ -1,0 +1,45 @@
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+-- doing refresh would cause incorrect state for device, see comments in wakeup-no-poll
+local NORTEK_FP = {mfr = 0x014F, prod = 0x2001, model = 0x0102} -- NorTek open/close sensor
+local POPP_THERMOSTAT_FP = {mfr = 0x0002, prod = 0x0115, model = 0xA010} --Popp thermostat
+local AEOTEC_MULTISENSOR_6_FP = {mfr = 0x0086, model = 0x0064} --Aeotec multisensor 6
+local AEOTEC_MULTISENSOR_7_FP = {mfr = 0x0371, model = 0x0018} --Aeotec multisensor 7
+local ENERWAVE_MOTION_FP = {mfr = 0x011A} --Enerwave motion sensor
+local HOMESEER_MULTI_SENSOR_FP = {mfr = 0x001E, prod = 0x0002, model = 0x0001} -- Homeseer multi sensor HSM100
+local SENSATIVE_STRIP_FP = {mfr = 0x019A, model = 0x000A}
+local FPS = {NORTEK_FP, POPP_THERMOSTAT_FP,
+             AEOTEC_MULTISENSOR_6_FP, AEOTEC_MULTISENSOR_7_FP,
+             ENERWAVE_MOTION_FP, HOMESEER_MULTI_SENSOR_FP, SENSATIVE_STRIP_FP}
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  if version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION then
+
+    for _, fp in ipairs(FPS) do
+      if device:id_match(fp.mfr, fp.prod, fp.model) then return false end
+    end
+    return true
+  else
+    return false
+  end
+end
+
+local function wakeup_notification(driver, device, cmd)
+  device:refresh()
+end
+
+local apiv6_bugfix = {
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    }
+  },
+  NAME = "apiv6_bugfix",
+  can_handle = can_handle
+}
+
+return apiv6_bugfix

--- a/drivers/SmartThings/zwave-sensor/src/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/init.lua
@@ -138,7 +138,8 @@ local driver_template = {
     require("fibaro-motion-sensor"),
     require("v1-contact-event"),
     require("timed-tamper-clear"),
-    require("wakeup-no-poll")
+    require("wakeup-no-poll"),
+    require("apiv6_bugfix")
   },
   lifecycle_handlers = {
     added = added_handler,

--- a/drivers/SmartThings/zwave-siren/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/apiv6_bugfix/init.lua
@@ -1,0 +1,26 @@
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  return version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION
+end
+
+local function wakeup_notification(driver, device, cmd)
+  device:refresh()
+end
+
+local apiv6_bugfix = {
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    }
+  },
+  NAME = "apiv6_bugfix",
+  can_handle = can_handle
+}
+
+return apiv6_bugfix

--- a/drivers/SmartThings/zwave-siren/src/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/init.lua
@@ -102,7 +102,8 @@ local driver_template = {
     require("yale-siren"),
     require("zipato-siren"),
     require("utilitech-siren"),
-    require("fortrezz")
+    require("fortrezz"),
+    require("apiv6_bugfix"),
   },
   lifecycle_handlers = {
     infoChanged = info_changed,

--- a/drivers/SmartThings/zwave-smoke-alarm/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/apiv6_bugfix/init.lua
@@ -1,0 +1,26 @@
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  return version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION
+end
+
+local function wakeup_notification(driver, device, cmd)
+  device:refresh()
+end
+
+local apiv6_bugfix = {
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    }
+  },
+  NAME = "apiv6_bugfix",
+  can_handle = can_handle
+}
+
+return apiv6_bugfix

--- a/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
@@ -55,12 +55,12 @@ local function device_added(self, device)
 end
 
 local function wakeup_notification_handler(self, device, cmd)
-    --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
-    --This is done to help the hub correctly set the checkInterval for migrated devices.
-    if not device:get_field("__wakeup_interval_get_sent") then
-      device:send(WakeUp:IntervalGetV1({}))
-      device:set_field("__wakeup_interval_get_sent", true)
-    end
+  --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
+  --This is done to help the hub correctly set the checkInterval for migrated devices.
+  if not device:get_field("__wakeup_interval_get_sent") then
+    device:send(WakeUp:IntervalGetV1({}))
+    device:set_field("__wakeup_interval_get_sent", true)
+  end
   device:emit_event(capabilities.smokeDetector.smoke.clear())
   device:send(Battery:Get({}))
   device:send(SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE}))

--- a/drivers/SmartThings/zwave-smoke-alarm/src/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/init.lua
@@ -86,7 +86,8 @@ local driver_template = {
   sub_drivers = {
     require("zwave-smoke-co-alarm-v1"),
     require("zwave-smoke-co-alarm-v2"),
-    require("fibaro-smoke-sensor")
+    require("fibaro-smoke-sensor"),
+    require("apiv6_bugfix"),
   },
   lifecycle_handlers = {
     init = device_init,

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
@@ -21,6 +21,7 @@ local t_utils = require "integration_test.utils"
 local Battery = (require "st.zwave.CommandClass.Battery")({ version=1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version=5 })
+local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version=1 })
 local Notification = (require "st.zwave.CommandClass.Notification")({ version=4 })
 
@@ -156,6 +157,18 @@ test.register_coroutine_test(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
         Configuration:Set({parameter_number=32, size=2, configuration_value=4320})
+      )
+    )
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        SensorBinary:Get({sensor_type = SensorBinary.sensor_type.FREEZE})
+      )
+    )
+    test.socket.zwave:__expect_send(
+      zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        SensorBinary:Get({sensor_type = SensorBinary.sensor_type.SMOKE})
       )
     )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
@@ -365,7 +365,15 @@ test.register_message_test(
           sensor_type = SensorBinary.sensor_type.SMOKE
         })
       )
-    }
+    },
+    {
+      channel = "zwave",
+      direction = "send",
+      message = zw_test_utils.zwave_test_build_send_command(
+        mock_device,
+        WakeUp:IntervalGet({ })
+      )
+    },
   },
   {
     inner_block_ordering = "relaxed"

--- a/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/init.lua
@@ -1,7 +1,6 @@
 local cc = require "st.zwave.CommandClass"
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
--- doing refresh would cause incorrect state for device, see comments in wakeup-no-poll
 local DANFOSS_LC13_THERMOSTAT_FPS = {
     { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0003 }, -- Danfoss LC13 Thermostat
     { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0004 } -- Danfoss LC13 Thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/init.lua
@@ -1,0 +1,37 @@
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+-- doing refresh would cause incorrect state for device, see comments in wakeup-no-poll
+local DANFOSS_LC13_THERMOSTAT_FPS = {
+    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0003 }, -- Danfoss LC13 Thermostat
+    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0004 } -- Danfoss LC13 Thermostat
+}
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  return version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION and not
+    (device:id_match(DANFOSS_LC13_THERMOSTAT_FPS[1].manufacturerId,
+      DANFOSS_LC13_THERMOSTAT_FPS[1].productType,
+      DANFOSS_LC13_THERMOSTAT_FPS[1].productId) or
+    device:id_match(DANFOSS_LC13_THERMOSTAT_FPS[2].manufacturerId,
+      DANFOSS_LC13_THERMOSTAT_FPS[2].productType,
+      DANFOSS_LC13_THERMOSTAT_FPS[2].productId))
+end
+
+local function wakeup_notification(driver, device, cmd)
+  device:refresh()
+end
+
+local apiv6_bugfix = {
+  zwave_handlers = {
+    [cc.WAKE_UP] = {
+      [WakeUp.NOTIFICATION] = wakeup_notification
+    }
+  },
+  NAME = "apiv6_bugfix",
+  can_handle = can_handle
+}
+
+return apiv6_bugfix

--- a/drivers/SmartThings/zwave-thermostat/src/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/init.lua
@@ -119,7 +119,8 @@ local driver_template = {
     require("fibaro-heat-controller"),
     require("stelpro-ki-thermostat"),
     require("qubino-flush-thermostat"),
-    require("thermostat-heating-battery")
+    require("thermostat-heating-battery"),
+    require("apiv6_bugfix"),
   }
 }
 

--- a/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/init.lua
@@ -58,7 +58,8 @@ end
 -- If device wakes up earlier, driver is convinenced that user performed manual action (like adjusting setpoint on device),
 -- and in that case, cached setpoint command is removed and not sent.
 local function wakeup_notification_handler(self, device, cmd)
-  device:send(WakeUp:IntervalGet({}))
+  local version = require "version"
+  if version.api < 6 then device:send(WakeUp:IntervalGet({})) end
   local setpoint = device:get_field(CACHED_SETPOINT)
   if setpoint ~= nil and seconds_since_latest_wakeup(device) > 0.90 * POPP_WAKEUP_INTERVAL then
     device:send(setpoint)


### PR DESCRIPTION
This is an alternative solution suggfested by @greens to #935. It seems better because it achieves the same coverage of tcases where a battery powered device is using a subdriver, but it will be easier to revert. 