### PR TITLE
Fix color temperature handling when attribute is outside capability range

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -529,4 +529,18 @@ test.register_message_test(
   }
 )
 
+test.register_message_test(
+  "Do not report when receiving a color temperature of 0 mireds",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, 1, 0)
+      }
+    }
+  }
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
Some devices could report a value of 0 mireds, which would result
in a divide by zero error when converting to kelvin. This
introduces a check to make sure that 0 and other mired values
that are outside the range of the colorTemperature capability are
not handled since they are likely not real values.