### PR TITLE
Add multi-button support for matter button devices.

### DIFF
--- a/drivers/SmartThings/matter-button/fingerprints.yml
+++ b/drivers/SmartThings/matter-button/fingerprints.yml
@@ -3,4 +3,4 @@ matterGeneric:
     deviceLabel: Matter Button
     deviceTypes:
       - id: 0x000F
-    deviceProfileName: button-profile
+    deviceProfileName: button-battery # err on the side of buttons having batteries, it'll get fixed in the driver

--- a/drivers/SmartThings/matter-button/profiles/2-button-battery.yml
+++ b/drivers/SmartThings/matter-button/profiles/2-button-battery.yml
@@ -1,0 +1,20 @@
+name: 2-button-battery
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/profiles/2-button.yml
+++ b/drivers/SmartThings/matter-button/profiles/2-button.yml
@@ -1,12 +1,18 @@
-name: button-profile
+name: 2-button
 components:
   - id: main
     capabilities:
       - id: button
         version: 1
-      - id: battery
+      - id: firmwareUpdate
         version: 1
       - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
         version: 1
     categories:
     - name: RemoteController

--- a/drivers/SmartThings/matter-button/profiles/4-button-battery.yml
+++ b/drivers/SmartThings/matter-button/profiles/4-button-battery.yml
@@ -1,0 +1,32 @@
+name: 4-button-battery
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/profiles/4-button.yml
+++ b/drivers/SmartThings/matter-button/profiles/4-button.yml
@@ -1,0 +1,30 @@
+name: 4-button
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/profiles/8-button-battery.yml
+++ b/drivers/SmartThings/matter-button/profiles/8-button-battery.yml
@@ -1,0 +1,57 @@
+name: 8-button-battery
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button5
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button6
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button7
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button8
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+

--- a/drivers/SmartThings/matter-button/profiles/8-button.yml
+++ b/drivers/SmartThings/matter-button/profiles/8-button.yml
@@ -1,0 +1,55 @@
+name: 8-button
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button5
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button6
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button7
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button8
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+

--- a/drivers/SmartThings/matter-button/profiles/button-battery.yml
+++ b/drivers/SmartThings/matter-button/profiles/button-battery.yml
@@ -1,0 +1,14 @@
+name: button-battery
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/profiles/button.yml
+++ b/drivers/SmartThings/matter-button/profiles/button.yml
@@ -1,0 +1,12 @@
+name: button
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/src/init.lua
+++ b/drivers/SmartThings/matter-button/src/init.lua
@@ -3,142 +3,244 @@ local log = require "log"
 local clusters = require "st.matter.generated.zap_clusters"
 local MatterDriver = require "st.matter.driver"
 local lua_socket = require "socket"
+local device_lib = require "st.device"
 
---button state machine states
-local BUTTON_STATE_MAP = {
-  WAIT = 1,
-  PRESSED = 2,
-  HELD_COMPLETE = 3,
-}
-local STATE = "state"
--- singlepress, multipress, latching switch
-local BUTTON_TYPE = "__button_type" --should get set when device is added
-local BUTTON_TYPE_MAP = {
-  SINGLE_PRESS = 1,
-  MULTI_PRESS = 2,
-  LATCH_SWITCH = 3
-}
-local MAX_PRESS = "__max_press"
-local BUTTON_X_PRESS_TIME = "button_%d_pressed_time"
-local TIMEOUT_THRESHOLD = 50 --arbitrary timeout
+local START_BUTTON_PRESS = "__start_button_press"
+local TIMEOUT_THRESHOLD = 10 --arbitrary timeout
+local HELD_THRESHOLD = 1
+-- this is the number of buttons for which we have a static profile already made
+local STATIC_PROFILE_SUPPORTED = {2, 4, 8}
 
+local ENDPOINT_TO_COMPONENT_MAP = "__endpoint_to_component_map"
+local DEFERRED_CONFIGURE = "__DEFERRED_CONFIGURE"
+local IGNORE_NEXT_MPC = "__ignore_next_mpc"
+
+-- These are essentially storing the supported features of a given endpoint
+-- TODO: add an is_feature_supported_for_endpoint function to matter.device that takes an endpoint
+local EMULATE_HELD = "__emulate_held" -- for MSR devices we can emulate this on the software side
+local MULTI_BUTTON = "__multi_button" -- for multi-press devices, only trigger an event on a multi-button complete
+local INITIAL_PRESS_ONLY = "__initial_press_only" -- for devices that support MS, but not MSR
 
 --helper function to create liste of multi press values
-local function create_multi_list(size)
-  local list = {"pushed", "held", "double"}
-  if size > 2 then
-    for i=3, size do
-      table.insert(list, string.format("pushed_%dx", i))
-    end
+local function create_multi_list(size, supportsHeld)
+  local list = {"pushed", "double"}
+  if supportsHeld then table.insert(list, "held") end
+  for i=3, size do
+    table.insert(list, string.format("pushed_%dx", i))
   end
   return list
 end
 
---helper functions for button timing
---button_number is which button was pressed?
-local function init_press(device, button_number)
-  device:set_field(string.format(BUTTON_X_PRESS_TIME, button_number or 0), lua_socket.gettime())
+local function contains(array, value)
+  for _, element in ipairs(array) do
+    if element == value then
+      return true
+    end
+  end
+  return false
 end
 
---helper function for pseudo state machine
-local function next_button_state(device, next_state, button_number)
-  local press_time = device:get_field(string.format(BUTTON_X_PRESS_TIME, button_number or 0))
-  local time_diff = lua_socket.gettime() - press_time
-  local state = device:get_field(STATE)
-  if state == nil then
-    state = BUTTON_STATE_MAP.WAIT
-  end
-
-  local set_state
-  if time_diff < TIMEOUT_THRESHOLD then
-    if next_state == BUTTON_STATE_MAP.PRESSED and state == BUTTON_STATE_MAP.WAIT then
-      set_state = BUTTON_STATE_MAP.PRESSED
-    elseif next_state == BUTTON_STATE_MAP.HELD_COMPLETE and state == BUTTON_STATE_MAP.PRESSED then
-      set_state = BUTTON_STATE_MAP.HELD_COMPLETE
-    else
-      set_state = BUTTON_STATE_MAP.WAIT
-    end
-  else
-    set_state = BUTTON_STATE_MAP.WAIT
-  end
-  device:set_field(STATE, set_state)
+local function get_field_for_endpoint(device, field, endpoint)
+  return device:get_field(string.format("%s_%d", field, endpoint))
 end
 
---emit the proper events
-local function button_event(device, ib,  multi_press)
-  local state = device:get_field(STATE)
-  local button_type = device:get_field(BUTTON_TYPE)
-  if button_type == nil then
-    if multi_press > 0 then
-      button_type = BUTTON_TYPE_MAP.MULTI_PRESS
-    else
-      button_type = BUTTON_TYPE_MAP.SINGLE_PRESS
-    end
-  end
+local function set_field_for_endpoint(device, field, endpoint, value, persist)
+  device:set_field(string.format("%s_%d", field, endpoint), value, {persist = persist})
+end
 
-  if button_type ~= BUTTON_TYPE_MAP.LATCH_SWITCH then
-    local event
-    if button_type == BUTTON_TYPE_MAP.SINGLE_PRESS then
-      if state == BUTTON_STATE_MAP.HELD_COMPLETE then
-        event = capabilities.button.button.held({state_change = true})
-      elseif state == BUTTON_STATE_MAP.PRESSED then
-        event = capabilities.button.button.pushed({state_change = true})
-      end
-    elseif button_type == BUTTON_TYPE_MAP.MULTI_PRESS then
-      if state == BUTTON_STATE_MAP.HELD_COMPLETE then
-        if multi_press == 2 then
-          event = capabilities.button.button.double({state_change = true})
-        else
-          event = capabilities.button.button(string.format("pushed_%dx", multi_press))
-        end
-      end
-    end
-    if event ~= nil then
-      device:emit_event_for_endpoint(ib.endpoint_id, event)
+local function init_press(device, endpoint)
+  set_field_for_endpoint(device, START_BUTTON_PRESS, endpoint, lua_socket.gettime(), false)
+end
+
+local function emulate_held_event(device, ep)
+  local now = lua_socket.gettime()
+  local press_init = get_field_for_endpoint(device, START_BUTTON_PRESS, ep) or now -- if we don't have an init time, assume instant release
+  if (now - press_init) < TIMEOUT_THRESHOLD then
+    if (now - press_init) > HELD_THRESHOLD then
+      device:emit_event_for_endpoint(ep, capabilities.button.button.held({state_change = true}))
+    else
+      device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = true}))
     end
   end
+  set_field_for_endpoint(device, START_BUTTON_PRESS, ep, nil, false)
 end
 
 --end of helper functions
 --------------------------------------------------------------------------
+
+local function endpoint_to_component(device, ep)
+  local map = device:get_field(ENDPOINT_TO_COMPONENT_MAP) or {}
+  if map[ep] and device.profile.components[map[ep]] then
+    return map[ep]
+  end
+  return "main"
+end
+
+local function component_to_endpoint(device, component_name)
+  local map = device:get_field(ENDPOINT_TO_COMPONENT_MAP) or {}
+  for ep, component in pairs(map) do
+    if component == component_name then return ep end
+  end
+end
+
+local function find_child(parent, ep_id)
+  return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))
+end
+
 local function device_init(driver, device)
-  device:subscribe()
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
+    device:subscribe()
+    device:set_find_child(find_child)
+    device:set_endpoint_to_component_fn(endpoint_to_component)
+    device:set_component_to_endpoint_fn(component_to_endpoint)
+  end
+end
+
+-- This is called either on add for parent/child devices, or after the device profile changes for components
+local function configure_buttons(device)
+  if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
+    local MSR = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_RELEASE})
+    device.log.debug(#MSR.." momentary switch release endpoints")
+    local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS})
+    device.log.debug(#MSL.." momentary switch long press endpoints")
+    local MSM = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS})
+    device.log.debug(#MSM.." momentary switch multi press endpoints")
+    for _, ep in ipairs(MS) do
+      local supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})
+      -- this ordering is important, as MSL & MSM devices must also support MSR
+      if contains(MSM, ep) then
+        -- ask the device to tell us its max number of presses
+        device.log.debug("sending multi press max read")
+        device:send(clusters.Switch.attributes.MultiPressMax:read(device, ep))
+        set_field_for_endpoint(device, MULTI_BUTTON, ep, true, true)
+        supportedButtonValues_event = nil -- deferred until max press handler
+      elseif contains(MSL, ep) then
+        device.log.debug("configuring for long press device")
+      elseif contains(MSR, ep) then
+        device.log.debug("configuring for emulated held")
+        set_field_for_endpoint(device, EMULATE_HELD, ep, true, true)
+      else -- device only supports momentary switch, no release events
+        device.log.debug("configuring for press event only")
+        supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})
+        set_field_for_endpoint(device, INITIAL_PRESS_ONLY, ep, true, true)
+      end
+
+      if supportedButtonValues_event then
+        device:emit_event_for_endpoint(ep, supportedButtonValues_event)
+      end
+      device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = false}))
+    end
+  end
 end
 
 local function device_added(driver, device)
-  local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
-  local MSR = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_RELEASE})
-  local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS})
-  local MSM = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS})
+  if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
+    device.log.debug(#MS.." momentary switch endpoints")
+    -- local LS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.LATCHING_SWITCH})
 
-  if #MS > 0 then
-    if #MSL < 1 and #MSM < 1 then
-      device:set_field(BUTTON_TYPE, BUTTON_TYPE_MAP.SINGLE_PRESS) --singlepress
-      device:emit_event(capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})) --supported values
-
-    elseif #MSR > 0 and #MSL > 0 and #MSM < 1 then
-      device:set_field(BUTTON_TYPE, BUTTON_TYPE_MAP.SINGLE_PRESS) --singlepress
-      device:emit_event(capabilities.button.supportedButtonValues({"pushed", "held"},{visibility = {displayed = false}})) --supported values
-
-    elseif #MSM > 0 then
-      device:set_field(BUTTON_TYPE, BUTTON_TYPE_MAP.MULTI_PRESS) -- multipress
-
-      --send read MultiPressMax attribute request
-      local req = clusters.Switch.attributes.MultiPressMax:read(device)
-      device:send(req)
-
+    -- find the default/main endpoint, the device with the lowest EP that supports MS
+    table.sort(MS)
+    local main_endpoint = device.MATTER_DEFAULT_ENDPOINT
+    if #MS > 0 then
+      main_endpoint = MS[1] -- the endpoint matching to the non-child device
+      if MS[1] == 0 then main_endpoint = MS[2] end -- we shouldn't hit this, but just in case
     end
-    device:emit_event(capabilities.button.button.pushed({state_change = false})) --button is not pressed yet
+    device.log.debug("main button endpoint is "..main_endpoint)
 
-  else
-    --it is a latching switch
-    device:set_field(BUTTON_TYPE, BUTTON_TYPE_MAP.LATCH_SWITCH) -- latching switch
-    device:emit_event(capabilities.button.supportedButtonValues({"up","down"}, {visibility = {displayed = false}}))
+
+    local battery_support = device:get_endpoints(clusters.PowerSource.ID)
+
+    local new_profile = nil
+    -- We have a static profile that will work for this number of buttons
+    if contains(STATIC_PROFILE_SUPPORTED, #MS) then
+      if #battery_support == 0 then
+        new_profile = string.format("%d-button", #MS)
+      else
+        new_profile = string.format("%d-button-battery", #MS)
+      end
+    elseif #battery_support == 0 then
+      -- a battery-less button/remote (either single or will use parent/child)
+      new_profile = "button"
+    end
+
+    if new_profile then device:try_update_metadata({profile = new_profile}) end
+
+    -- At the moment, we're taking it for granted that all momentary switches only have 2 positions
+    -- TODO: flesh this out for NumberOfPositions > 2
+    local current_component_number = 2
+    local endpoint_map = {}
+    for _, ep in ipairs(MS) do -- for each momentary switch endpoint (including main)
+      device.log.debug("Configuring endpoint "..ep)
+      -- build the mapping of endpoints to components if we have a static profile (multi-component)
+      if contains(STATIC_PROFILE_SUPPORTED, #MS) then
+        if ep ~= main_endpoint then
+          endpoint_map[ep] = string.format("button%d", current_component_number)
+          current_component_number = current_component_number + 1
+        else
+          endpoint_map[ep] = "main"
+        end
+      else -- use parent/child
+        if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
+          local name = string.format("%s %d", device.label, current_component_number)
+          driver:try_create_device(
+            {
+              type = "EDGE_CHILD",
+              label = name,
+              profile = "button",
+              parent_device_id = device.id,
+              parent_assigned_child_key = string.format("%02X", ep),
+              vendor_provided_label = name
+            }
+          )
+          current_component_number = current_component_number + 1
+        end
+      end
+    end
+
+    if #endpoint_map > 0 then
+      device:set_field(ENDPOINT_TO_COMPONENT_MAP, endpoint_map, {persist = true})
+    end
+
+    if new_profile then
+      device:set_field(DEFERRED_CONFIGURE, true)
+    else
+      configure_buttons(device)
+    end
+
+    -- TODO: Solution for latching switches
+    -- for _, ep in ipairs(LS) do
+    --   local name = string.format("%s %d", device.label, ep)
+    --   local child = driver:try_create_device(
+    --     {
+    --       type = "EDGE_CHILD",
+    --       label = name,
+    --       profile = "child-button",
+    --       parent_device_id = device.id,
+    --       parent_assigned_child_key = string.format("%02X", ep),
+    --       vendor_provided_label = name
+    --     }
+    --   )
+    --   -- Latching switches are switches that don't return to an idle position after being pressed.
+    --   -- In that sense, they can be all sorts of things, like dials or radio buttons. This means
+    --   -- they can have any number of states > 2. However, due to the current nature of our capabilities
+    --   -- our ability to support the full range of options here is limited, so we will stick with
+    --   -- up/down rocker switches (kind of).
+    --   child:emit_event(capabilities.button.supportedButtonValues({"up","down"}, {visibility = {displayed = false}}))
+    -- end
+
   end
-  device:set_field(STATE, BUTTON_STATE_MAP.WAIT) --set wait state
+end
 
-  device:emit_event(capabilities.button.numberOfButtons({value=1}, {visibility = {displayed = false}})) --number of buttons
-
+local function info_changed(driver, device, event, args)
+  if device.profile.id ~= args.old_st_store.profile.id
+    and device:get_field(DEFERRED_CONFIGURE)
+    and device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    -- profile has changed, and we deferred setting up our buttons, so do that now
+    configure_buttons(device)
+    device:set_field(DEFERRED_CONFIGURE, nil)
+  end
 end
 
 --end of lifecyle handlers
@@ -146,29 +248,35 @@ end
 
 -- initial press
 local function initial_event_handler(driver, device, ib, response)
-  --button 0 has been pressed
-  init_press(device, 0)
-  -- move to PRESSED state
-  next_button_state(device, BUTTON_STATE_MAP.PRESSED, 0) -- 0 is for multipress
-  button_event(device, ib, 0)
+  if not get_field_for_endpoint(device, MULTI_BUTTON, ib.endpoint_id) then
+    if get_field_for_endpoint(device, INITIAL_PRESS_ONLY, ib.endpoint_id) then
+      device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.pushed({state_change = true}))
+    elseif get_field_for_endpoint(device, EMULATE_HELD, ib.endpoint_id) then
+      -- if our button doesn't differentiate between short and long holds, do it in code by keeping track of the press down time
+      init_press(device, ib.endpoint_id)
+    end
+  end
 end
 
-local function long_event_handler(driver, device, ib, response)
-  -- long press, button is being held
-  -- move to HELD state
-  next_button_state(device, BUTTON_STATE_MAP.HELD_COMPLETE, 0)
-
-  --0 is for multpress
-  button_event(device, ib, 0)
+-- if the devce distinguishes a long press event, it will always be a "held"
+-- there's also a "long release" event, but this event is required to come first
+local function long_press_event_handler(driver, device, ib, response)
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.held({state_change = true}))
+  local MSM = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS})
+  if contains(MSM, ib.endpoint_id) then
+    set_field_for_endpoint(device, IGNORE_NEXT_MPC, ib.endpoint_id, true)
+  end
 end
 
--- release event handler
-local function release_event_handler(driver, device, ib, response)
-  -- button has been released
-  -- move to WAIT state
-  next_button_state(device, BUTTON_STATE_MAP.WAIT, 0)
-  button_event(device, ib, 0)
-
+-- short release event handler
+local function short_release_event_handler(driver, device, ib, response)
+  if not get_field_for_endpoint(device, MULTI_BUTTON, ib.endpoint_id) then
+    if get_field_for_endpoint(device, EMULATE_HELD, ib.endpoint_id) then
+      emulate_held_event(device, ib.endpoint_id)
+    else
+      device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.pushed({state_change = true}))
+    end
+  end
 end
 
 
@@ -180,13 +288,24 @@ local function multi_event_handler(driver, device, ib, response)
     local press_value = ib.data.elements.total_number_of_presses_counted.value
     --capability only supports up to 6 presses
     if press_value < 7 then
-      next_button_state(device, BUTTON_STATE_MAP.HELD_COMPLETE, 0)
-      button_event(device, ib, press_value)
-      next_button_state(device, BUTTON_STATE_MAP.WAIT, 0)
+      local button_event = capabilities.button.button.pushed({state_change = true})
+      if press_value == 2 then
+        button_event = capabilities.button.button.double({state_change = true})
+      elseif press_value > 2 then
+        button_event = capabilities.button.button(string.format("pushed_%dx", press_value), {state_change = true})
+      end
+      if get_field_for_endpoint(device, IGNORE_NEXT_MPC, ib.endpoint_id) then
+        -- We do this so that a held (LongPress) event does not generate a subsequent pushed event
+        -- when the multipresscomplete event comes through. This means that a sequence of held, pushed,
+        -- multipresscomplete(2) will only generate a held event and not a double event.
+        button_event = nil
+      end
+      if button_event then device:emit_event_for_endpoint(ib.endpoint_id, button_event) end
     else
       log.info("Number of presses not supported by capability")
     end
   end
+  set_field_for_endpoint(device, IGNORE_NEXT_MPC, ib.endpoint_id, nil)
 end
 
 --end of event handlers
@@ -199,35 +318,28 @@ end
 
 --need to find out max number of times a button can be pressed
 local function max_press_handler(driver, device, ib, response)
-  if ib.data.value then
-    local MAX = ib.data.value or 1 --get max number of presses
-    -- capability only supports up to 6 presses
-    if MAX < 7 then
-      local values = create_multi_list(MAX)
-      device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.supportedButtonValues(values, {visibility = {displayed = false}}))
-      device:set_field(MAX_PRESS, MAX)
-    else
-      log.info("Number of presses not supported by capability")
-    end
+  local max = ib.data.value or 1 --get max number of presses
+  device.log.debug("Device supports "..max.." presses")
+  -- capability only supports up to 6 presses
+  if max > 6 then
+    log.info("Device supports more than 6 presses")
+    max = 6
   end
+  local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS})
+  local supportsHeld = contains(MSL, ib.endpoint_id)
+  local values = create_multi_list(max, supportsHeld)
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.supportedButtonValues(values, {visibility = {displayed = false}}))
 end
 
---needed for latching switch
-local function current_pos_handler(driver, device, ib, response)
-  local button_type = device:get_field(BUTTON_TYPE)
-  if ib.data.value and button_type == BUTTON_TYPE_MAP.LATCH_SWITCH then
-    if ib.data.value == 1 then
-      device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.up({state_change = true})) --off
-    else
-      device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.down({state_change = true})) --on
-    end
-  end
-end
 
 -- end of attribute handlers
 -- ------------------------------------------------------------------------
 local matter_driver_template = {
-  lifecycle_handlers = {init = device_init, added = device_added},
+  lifecycle_handlers = {
+    init = device_init,
+    added = device_added,
+    infoChanged = info_changed
+  },
   matter_handlers = {
     attr = {
       [clusters.PowerSource.ID] = {
@@ -235,16 +347,13 @@ local matter_driver_template = {
       },
       [clusters.Switch.ID] = {
         [clusters.Switch.attributes.MultiPressMax.ID] = max_press_handler,
-        [clusters.Switch.attributes.CurrentPosition.ID] = current_pos_handler,
-        --number of positions attribute? for switches with more than two positions
       }
     },
     event = {
       [clusters.Switch.ID] = {
         [clusters.Switch.events.InitialPress.ID] = initial_event_handler,
-        [clusters.Switch.events.LongPress.ID] = long_event_handler,
-        [clusters.Switch.events.ShortRelease.ID] = release_event_handler,
-        [clusters.Switch.events.LongRelease.ID] = release_event_handler,
+        [clusters.Switch.events.LongPress.ID] = long_press_event_handler,
+        [clusters.Switch.events.ShortRelease.ID] = short_release_event_handler,
         [clusters.Switch.events.MultiPressComplete.ID] = multi_event_handler,
       }
     },
@@ -253,17 +362,12 @@ local matter_driver_template = {
     [capabilities.battery.ID] = {
       clusters.PowerSource.attributes.BatPercentRemaining,
     },
-    [capabilities.button.ID] = {
-      clusters.Switch.attributes.MultiPressMax,
-      clusters.Switch.attributes.CurrentPosition
-    }
   },
   subscribed_events = {
     [capabilities.button.ID] = {
       clusters.Switch.events.InitialPress,
       clusters.Switch.events.LongPress,
       clusters.Switch.events.ShortRelease,
-      clusters.Switch.events.LongRelease,
       clusters.Switch.events.MultiPressComplete
     }
   },

--- a/drivers/SmartThings/matter-button/src/test/skip_test_latching_switch.lua
+++ b/drivers/SmartThings/matter-button/src/test/skip_test_latching_switch.lua
@@ -8,7 +8,7 @@ local clusters = require "st.matter.generated.zap_clusters"
 local mock_device = test.mock_device.build_test_matter_device(
   {
     profile = t_utils.get_profile_definition("button-profile.yml"),
-    manufacture_info = {vendor_id = 0x0000, product_id = 0x0000},
+    manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
     endpoints = {
     {
       endpoint_id = 1,

--- a/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
@@ -5,14 +5,17 @@ local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.generated.zap_clusters"
 local button_attr = capabilities.button.button
 
+local child_profile = t_utils.get_profile_definition("button.yml")
+
 --mock the actual device
 local mock_device = test.mock_device.build_test_matter_device(
   {
+    label = "Matter Button",
     profile = t_utils.get_profile_definition("button-battery.yml"),
     manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
     endpoints = {
     {
-      endpoint_id = 1,
+      endpoint_id = 2,
       clusters = {
         {
           cluster_id = clusters.Switch.ID,
@@ -22,9 +25,62 @@ local mock_device = test.mock_device.build_test_matter_device(
         {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"}
       },
     },
+    {
+      endpoint_id = 3,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_RELEASE,
+          cluster_type = "SERVER"
+        },
+      },
+    },
+    {
+      endpoint_id = 4,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS,
+          cluster_type = "SERVER"
+        },
+      },
+    },
+    {
+      endpoint_id = 5,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS,
+          cluster_type = "SERVER"
+        },
+      },
+    },
+    {
+      endpoint_id = 6,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS,
+          cluster_type = "SERVER"
+        },
+      },
+    },
   },
 }
 )
+
+local mock_children = {}
+for _, endpoint in ipairs(mock_device.endpoints) do
+  if endpoint.endpoint_id ~= 2 then
+    local child_data = {
+      profile = child_profile,
+      device_network_id = string.format("%s:%02X", mock_device.id, endpoint.endpoint_id),
+      parent_device_id = mock_device.id,
+      parent_assigned_child_key = string.format("%02X", endpoint.endpoint_id)
+    }
+    mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
 
 -- add device for each mock device
 local CLUSTER_SUBSCRIBE_LIST ={
@@ -41,10 +97,56 @@ local function test_init()
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
   test.mock_device.add_test_device(mock_device)
+  for _, child in pairs(mock_children) do
+    test.mock_device.add_test_device(child)
+  end
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+
   test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
   test.socket.capability:__expect_send(mock_device:generate_test_message("main", button_attr.pushed({state_change = false})))
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Button 2",
+    profile = "button",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = "03"
+  })
+  test.socket.capability:__expect_send(mock_children[3]:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
+  test.socket.capability:__expect_send(mock_children[3]:generate_test_message("main", button_attr.pushed({state_change = false})))
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Button 3",
+    profile = "button",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = "04"
+  })
+  test.socket.capability:__expect_send(mock_children[4]:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
+  test.socket.capability:__expect_send(mock_children[4]:generate_test_message("main", button_attr.pushed({state_change = false})))
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Button 4",
+    profile = "button",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = "05"
+  })
+  test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 5)})
+  test.socket.capability:__expect_send(mock_children[5]:generate_test_message("main", button_attr.pushed({state_change = false})))
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Button 5",
+    profile = "button",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = "06"
+  })
+  test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 6)})
+  test.socket.capability:__expect_send(mock_children[6]:generate_test_message("main", button_attr.pushed({state_change = false})))
+
 end
 
 test.set_test_init_function(test_init)
@@ -57,7 +159,7 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}  --move to position 1?
+        mock_device, 2, {new_position = 1}  --move to position 1?
       ),
     }
   },
@@ -65,41 +167,6 @@ test.register_message_test(
     channel = "capability",
     direction = "send",
     message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true})) --should send initial press
-  }
-}
-)
-
-test.register_message_test(
-  "Handle single press sequence, with hold", {
-  {
-    channel = "matter",
-    direction = "receive",
-    message = {
-      mock_device.id,
-      clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
-      ),
-    }
-  },
-  {
-    channel = "capability",
-    direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true})) --should send initial press
-  },
-  {
-    channel = "matter",
-    direction = "receive",
-    message = {
-      mock_device.id,
-      clusters.Switch.events.LongPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
-      ),
-    }
-  },
-  {
-    channel = "capability",
-    direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.held({state_change = true}))
   }
 }
 )
@@ -112,14 +179,9 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
+        mock_device, 3, {new_position = 1}
       )
     }
-  },
-  {
-    channel = "capability",
-    direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
   },
   {
     channel = "matter",
@@ -127,7 +189,7 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.ShortRelease:build_test_event_report(
-        mock_device, 1, {previous_position = 1}
+        mock_device, 3, {previous_position = 1}
       )
     }
   },
@@ -135,7 +197,7 @@ test.register_message_test(
     -- but we handle it anyway
     channel = "capability",
     direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
+    message = mock_children[3]:generate_test_message("main", button_attr.pushed({state_change = true}))
   },
   }
 )
@@ -148,14 +210,9 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
+        mock_device, 4, {new_position = 1}
       )
     }
-  },
-  {
-    channel = "capability",
-    direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
   },
   {
     channel = "matter",
@@ -163,14 +220,14 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.LongPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
+        mock_device, 4, {new_position = 1}
       ),
     }
   },
   {
     channel = "capability",
     direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.held({state_change = true}))
+    message = mock_children[4]:generate_test_message("main", button_attr.held({state_change = true}))
   },
   {
     channel = "matter",
@@ -178,7 +235,7 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.LongRelease:build_test_event_report(
-        mock_device, 1, {previous_position = 1}
+        mock_device, 4, {previous_position = 1}
       )
     }
   },
@@ -193,14 +250,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.Switch.attributes.MultiPressMax:build_test_report_data(
-          mock_device, 1, 2
+          mock_device, 6, 2
         )
       },
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main",
+      message = mock_children[6]:generate_test_message("main",
         capabilities.button.supportedButtonValues({"pushed", "double"}, {visibility = {displayed = false}}))
     },
   }
@@ -214,14 +271,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.Switch.attributes.MultiPressMax:build_test_report_data(
-          mock_device, 1, 3
+          mock_device, 5, 3
         )
       },
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main",
+      message = mock_children[5]:generate_test_message("main",
         capabilities.button.supportedButtonValues({"pushed", "double", "pushed_3x"}, {visibility = {displayed = false}}))
     },
   }
@@ -235,7 +292,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.Switch.attributes.MultiPressMax:build_test_report_data(
-          mock_device, 1, 7
+          mock_device, 2, 7
         )
       },
     },
@@ -256,15 +313,9 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
+        mock_device, 5, {new_position = 1}
       )
     }
-  },
-  { -- again, on a device that reports that it supports double press, this event
-    -- will not be generated. See a multi-button test file for that case
-    channel = "capability",
-    direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
   },
   {
     channel = "matter",
@@ -272,14 +323,14 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.MultiPressComplete:build_test_event_report(
-        mock_device, 1, {new_position = 1, total_number_of_presses_counted = 2, previous_position = 0}
+        mock_device, 5, {new_position = 1, total_number_of_presses_counted = 2, previous_position = 0}
       )
     }
   },
   {
     channel = "capability",
     direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.double({state_change = true}))
+    message = mock_children[5]:generate_test_message("main", button_attr.double({state_change = true}))
   },
 
 }
@@ -293,15 +344,9 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 1, {new_position = 1}
+        mock_device, 6, {new_position = 1}
       )
     }
-  },
-  { -- again, on a device that reports that it supports double press, this event
-    -- will not be generated. See a multi-button test file for that case
-    channel = "capability",
-    direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
   },
   {
     channel = "matter",
@@ -309,14 +354,14 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.MultiPressComplete:build_test_event_report(
-        mock_device, 1, {new_position = 1, total_number_of_presses_counted = 4, previous_position = 0}
+        mock_device, 6, {new_position = 1, total_number_of_presses_counted = 4, previous_position = 0}
       )
     }
   },
   {
     channel = "capability",
     direction = "send",
-    message = mock_device:generate_test_message("main", button_attr.pushed_4x({state_change = true}))
+    message = mock_children[6]:generate_test_message("main", button_attr.pushed_4x({state_change = true}))
   },
 
 }
@@ -330,7 +375,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
-          mock_device, 1, 150
+          mock_device, 2, 150
         ),
       },
     },

--- a/drivers/SmartThings/matter-button/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_multi_button.lua
@@ -1,0 +1,630 @@
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local t_utils = require "integration_test.utils"
+local utils = require "st.utils"
+local dkjson = require "dkjson"
+
+local clusters = require "st.matter.generated.zap_clusters"
+local button_attr = capabilities.button.button
+
+--mock the actual device
+local mock_device = test.mock_device.build_test_matter_device(
+  {
+    profile = t_utils.get_profile_definition("4-button-battery.yml"), -- on a real device we would switch to this, rather than fingerprint to it
+    manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
+    endpoints = {
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH,
+          cluster_type = "SERVER"
+        },
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"}
+      },
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_RELEASE,
+          cluster_type = "SERVER"
+        },
+      },
+    },
+    {
+      endpoint_id = 3,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS,
+          cluster_type = "SERVER"
+        },
+      },
+    },
+    {
+      endpoint_id = 5,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH |
+            clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS |
+            clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS,
+          cluster_type = "SERVER"
+        },
+      },
+    },
+  },
+}
+)
+
+-- add device for each mock device
+local CLUSTER_SUBSCRIBE_LIST ={
+  clusters.PowerSource.server.attributes.BatPercentRemaining,
+  clusters.Switch.server.events.InitialPress,
+  clusters.Switch.server.events.LongPress,
+  clusters.Switch.server.events.ShortRelease,
+  clusters.Switch.server.events.MultiPressComplete,
+}
+
+local function test_init()
+  local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
+  for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
+    if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  mock_device:expect_metadata_update({ profile = "4-button-battery" })
+  local device_info_copy = utils.deep_copy(mock_device.raw_st_data)
+  device_info_copy.profile.id = "4-buttons-battery"
+  local device_info_json = dkjson.encode(device_info_copy)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "infoChanged", device_info_json })
+
+  test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
+  test.socket.capability:__expect_send(mock_device:generate_test_message("main", button_attr.pushed({state_change = false})))
+
+  test.socket.capability:__expect_send(mock_device:generate_test_message("button2", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
+  test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.pushed({state_change = false})))
+
+  test.socket.capability:__expect_send(mock_device:generate_test_message("button3", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
+  test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = false})))
+
+  test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 5)})
+  test.socket.capability:__expect_send(mock_device:generate_test_message("button4", button_attr.pushed({state_change = false})))
+end
+
+test.set_test_init_function(test_init)
+
+test.register_message_test(
+  "Handle single press sequence, no hold", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}  --move to position 1?
+      ),
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true})) --should send initial press
+  }
+}
+)
+
+test.register_message_test(
+  "Handle single press sequence for short release-supported button", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 2, {new_position = 1}  --move to position 1?
+      ),
+    }
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.ShortRelease:build_test_event_report(
+        mock_device, 2, {previous_position = 0}  --move to position 1?
+      ),
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("button2", button_attr.pushed({state_change = true})) --should send initial press
+  }
+}
+)
+
+test.register_coroutine_test(
+  "Handle single press sequence for emulated hold on short-release-only button",
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 2, {new_position = 1}
+      )
+    })
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.ShortRelease:build_test_event_report(
+        mock_device, 2, {previous_position = 0}
+      )
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.held({state_change = true})))
+  end
+)
+
+test.register_coroutine_test(
+  "Handle single press sequence for a long hold on long-release-capable button", -- only a long press event should generate a held event
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 3, {new_position = 1}
+      )
+    })
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.ShortRelease:build_test_event_report(
+        mock_device, 3, {previous_position = 0}
+      )
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = true})))
+  end
+)
+
+test.register_coroutine_test(
+  "Handle single press sequence for a long hold on multi button", -- pushes should only be generated from multiPressComplete events
+  function ()
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    })
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.ShortRelease:build_test_event_report(
+        mock_device, 5, {previous_position = 0}
+      )
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Handle single press sequence for a multi press on multi button",
+  function ()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.ShortRelease:build_test_event_report(
+        mock_device, 5, {previous_position = 0}
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.MultiPressOngoing:build_test_event_report(
+        mock_device, 5, {new_position = 1, current_number_of_presses_counted = 2}
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.MultiPressComplete:build_test_event_report(
+        mock_device, 5, {new_position = 0, total_number_of_presses_counted = 2, previous_position = 1}
+      )
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("button4", button_attr.double({state_change = true})))
+  end
+)
+
+test.register_coroutine_test(
+  "Handle long press sequence for a long hold on long-release-capable button", -- only a long press event should generate a held event
+  function ()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 3, {new_position = 1}
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.LongPress:build_test_event_report(
+        mock_device, 3, {new_position = 1}
+      )
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.held({state_change = true})))
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.LongRelease:build_test_event_report(
+        mock_device, 3, {previous_position = 0}
+      )
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Handle long press sequence for a long hold on multi button",
+  function ()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.LongPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("button4", button_attr.held({state_change = true})))
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Switch.events.LongRelease:build_test_event_report(
+        mock_device, 5, {previous_position = 0}
+      )
+    })
+  end
+)
+
+test.register_message_test(
+  "Handle single press sequence, with hold", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      ),
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true})) --should send initial press
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.LongPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      ),
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.held({state_change = true}))
+  }
+}
+)
+
+test.register_message_test(
+  "Handle release after short press", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      )
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.ShortRelease:build_test_event_report(
+        mock_device, 1, {previous_position = 1}
+      )
+    }
+  },
+  { -- this is a double event because the test device in this test shouldn't support the above event
+    -- but we handle it anyway
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
+  },
+  }
+)
+
+test.register_message_test(
+  "Handle release after long press", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      )
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.LongPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      ),
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.held({state_change = true}))
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.LongRelease:build_test_event_report(
+        mock_device, 1, {previous_position = 1}
+      )
+    }
+  },
+  }
+)
+
+test.register_message_test(
+  "Receiving a max press attribute of 2 should emit correct event", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Switch.attributes.MultiPressMax:build_test_report_data(
+          mock_device, 1, 2
+        )
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main",
+        capabilities.button.supportedButtonValues({"pushed", "double"}, {visibility = {displayed = false}}))
+    },
+  }
+)
+
+test.register_message_test(
+  "Receiving a max press attribute of 3 should emit correct event", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Switch.attributes.MultiPressMax:build_test_report_data(
+          mock_device, 5, 3
+        )
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("button4",
+        capabilities.button.supportedButtonValues({"pushed", "double", "held", "pushed_3x"}, {visibility = {displayed = false}}))
+    },
+  }
+)
+
+test.register_message_test(
+  "Receiving a max press attribute of greater than 6 should only emit up to pushed_6x", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Switch.attributes.MultiPressMax:build_test_report_data(
+          mock_device, 1, 7
+        )
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main",
+        capabilities.button.supportedButtonValues({"pushed", "double", "pushed_3x", "pushed_4x", "pushed_5x", "pushed_6x"}, {visibility = {displayed = false}}))
+    },
+  }
+)
+
+test.register_message_test(
+  "Handle double press", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      )
+    }
+  },
+  { -- again, on a device that reports that it supports double press, this event
+    -- will not be generated. See a multi-button test file for that case
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.MultiPressComplete:build_test_event_report(
+        mock_device, 1, {new_position = 1, total_number_of_presses_counted = 2, previous_position = 0}
+      )
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.double({state_change = true}))
+  },
+
+}
+)
+
+test.register_message_test(
+  "Handle multi press for 4 times", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 1, {new_position = 1}
+      )
+    }
+  },
+  { -- again, on a device that reports that it supports double press, this event
+    -- will not be generated. See a multi-button test file for that case
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed({state_change = true}))
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.MultiPressComplete:build_test_event_report(
+        mock_device, 1, {new_position = 1, total_number_of_presses_counted = 4, previous_position=0}
+      )
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("main", button_attr.pushed_4x({state_change = true}))
+  },
+
+}
+)
+
+test.register_message_test(
+  "Handle received BatPercentRemaining from device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
+          mock_device, 1, 150
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message(
+        "main", capabilities.battery.battery(math.floor(150 / 2.0 + 0.5))
+      ),
+    },
+  }
+)
+
+
+test.register_message_test(
+  "Handle a held event in a multi-press sequence", {
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    }
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.LongPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    }
+  },
+  {
+    channel = "capability",
+    direction = "send",
+    message = mock_device:generate_test_message("button4", button_attr.held({state_change = true}))
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.InitialPress:build_test_event_report(
+        mock_device, 5, {new_position = 1}
+      )
+    }
+  },
+  {
+    channel = "matter",
+    direction = "receive",
+    message = {
+      mock_device.id,
+      clusters.Switch.events.MultiPressComplete:build_test_event_report(
+        mock_device, 5, {new_position = 0, total_number_of_presses_counted = 2, previous_position=0}
+      )
+    }
+  }
+  -- no double event
+}
+)
+-- run the tests
+test.run_registered_tests()


### PR DESCRIPTION
re-order type handling so that multi-press buttons have priority keep newly-created components and devices around in a map to avoid race conditions updating device storage

avoid race condition when switching profile

change multi buttons to support held events