### PR TITLE
Add a nil check for matter window covering level in status handler

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -97,7 +97,8 @@ local function current_status_handler(driver, device, ib, response)
                    ) or DEFAULT_LEVEL
   for _, rb in ipairs(response.info_blocks) do
     if rb.info_block.attribute_id == clusters.WindowCovering.attributes.CurrentPositionLiftPercent100ths.ID and
-       rb.info_block.cluster_id == clusters.WindowCovering.ID then
+       rb.info_block.cluster_id == clusters.WindowCovering.ID and
+       rb.info_block.data.value ~= nil then
       position = 100 - math.floor((rb.info_block.data.value / 100))
     end
   end


### PR DESCRIPTION
The CurrentPositionLiftPercent100ths attribute can report a value of nil when the current position is unknown (e.g. calibration is needed). Add a check to make sure we do not try to use position if it is nil.