### PR TITLE
Matter-sensor add support for mains powered sensors

### DIFF
--- a/drivers/SmartThings/matter-sensor/fingerprints.yml
+++ b/drivers/SmartThings/matter-sensor/fingerprints.yml
@@ -10,7 +10,7 @@ matterManufacturer:
     deviceLabel: Eve Motion
     vendorId: 0x130a
     productId: 0x0059
-    deviceProfileName: matter-motion-battery-illuminance
+    deviceProfileName: motion-illuminance-battery
   - id: "Eve/DoorAndWindow"
     deviceLabel: Eve Door and Window
     vendorId: 0x130a
@@ -49,12 +49,12 @@ matterGeneric:
     deviceTypes:
       - id: 0x0107 # Occupancy Sensor
       - id: 0x0106 # Light Sensor
-    deviceProfileName: matter-motion-battery-illuminance
+    deviceProfileName: motion-illuminance-battery
   - id: "matter/motion-sensor"
     deviceLabel: Matter Motion Sensor
     deviceTypes:
       - id: 0x0107 # Occupancy Sensor
-    deviceProfileName: matter-motion-battery
+    deviceProfileName: motion-battery
   - id: "matter/motion-sensor/contact"
     deviceLabel: Matter Motion/Contact Sensor
     deviceTypes:

--- a/drivers/SmartThings/matter-sensor/profiles/matter-motion-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/matter-motion-battery.yml
@@ -1,4 +1,4 @@
-name: motion-battery
+name: matter-motion-battery
 components:
 - id: main
   capabilities:

--- a/drivers/SmartThings/matter-sensor/profiles/motion-contact.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-contact.yml
@@ -1,10 +1,10 @@
-name: motion-battery
+name: motion-contact
 components:
 - id: main
   capabilities:
   - id: motionSensor
     version: 1
-  - id: battery
+  - id: contactSensor
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-battery.yml
@@ -1,10 +1,12 @@
-name: motion-battery
+name: motion-illuminance-battery
 components:
 - id: main
   capabilities:
   - id: motionSensor
     version: 1
   - id: battery
+    version: 1
+  - id: illuminanceMeasurement
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance.yml
@@ -1,10 +1,10 @@
-name: motion-battery
+name: motion-illuminance
 components:
 - id: main
   capabilities:
   - id: motionSensor
     version: 1
-  - id: battery
+  - id: illuminanceMeasurement
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
@@ -1,0 +1,186 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local clusters = require "st.matter.clusters"
+
+local mock_device_humidity_battery = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("humidity-battery.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
+      }
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 2},
+      }
+    }
+  }
+})
+
+local mock_device_humidity_no_battery = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("humidity-battery.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
+      }
+    }
+  }
+})
+
+local mock_device_temp_humidity = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("temperature-humidity.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
+      }
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "BOTH"},
+      }
+    }
+  }
+})
+
+local cluster_subscribe_list_humidity_battery = {
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+  clusters.PowerSource.attributes.BatPercentRemaining
+}
+
+local cluster_subscribe_list_humidity_no_battery = {
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue
+}
+
+local cluster_subscribe_list_temp_humidity = {
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+  clusters.TemperatureMeasurement.attributes.MeasuredValue
+}
+
+local function test_init_humidity_battery()
+  local subscribe_request_humidity_battery = cluster_subscribe_list_humidity_battery[1]:subscribe(mock_device_humidity_battery)
+  for i, cluster in ipairs(cluster_subscribe_list_humidity_battery) do
+    if i > 1 then
+      subscribe_request_humidity_battery:merge(cluster:subscribe(mock_device_humidity_battery))
+    end
+  end
+
+  test.socket.matter:__expect_send({mock_device_humidity_battery.id, subscribe_request_humidity_battery})
+  test.mock_device.add_test_device(mock_device_humidity_battery)
+end
+
+local function test_init_humidity_no_battery()
+  local subscribe_request_humidity_no_battery = cluster_subscribe_list_humidity_no_battery[1]:subscribe(mock_device_humidity_no_battery)
+  for i, cluster in ipairs(cluster_subscribe_list_humidity_no_battery) do
+    if i > 1 then
+      subscribe_request_humidity_no_battery:merge(cluster:subscribe(mock_device_humidity_no_battery))
+    end
+  end
+
+  test.socket.matter:__expect_send({mock_device_humidity_no_battery.id, subscribe_request_humidity_no_battery})
+  test.mock_device.add_test_device(mock_device_humidity_no_battery)
+end
+
+local function test_init_temp_humidity()
+  local subscribe_request_temp_humidity = cluster_subscribe_list_temp_humidity[1]:subscribe(mock_device_temp_humidity)
+  for i, cluster in ipairs(cluster_subscribe_list_temp_humidity) do
+    if i > 1 then
+      subscribe_request_temp_humidity:merge(cluster:subscribe(mock_device_temp_humidity))
+    end
+  end
+
+  test.socket.matter:__expect_send({mock_device_temp_humidity.id, subscribe_request_temp_humidity})
+  test.mock_device.add_test_device(mock_device_temp_humidity)
+end
+
+test.register_coroutine_test(
+  "Profile remains the same for battery-supported devices on doConfigure lifecycle event due to cluster feature map",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
+    mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-battery" })
+    mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  { test_init = test_init_humidity_battery }
+)
+
+test.register_coroutine_test(
+  "Profile change to non-battery profile on doConfigure lifecycle event due to cluster feature map",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_no_battery.id, "doConfigure" })
+    mock_device_humidity_no_battery:expect_metadata_update({ profile = "humidity" })
+    mock_device_humidity_no_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  { test_init = test_init_humidity_no_battery }
+)
+
+test.register_coroutine_test(
+  "Profile change to non-battery profile on doConfigure lifecycle event due to cluster feature map",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_temp_humidity.id, "doConfigure" })
+    mock_device_temp_humidity:expect_metadata_update({ profile = "temperature-humidity" })
+    mock_device_temp_humidity:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  { test_init = test_init_temp_humidity }
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
The `matter-sensor` generic fingerprints all join to profiles with `battery` support by default. This change will attempt to check for battery support when the device is configured and then change to the appropriate version of the profile (battery or no battery).