### PR TITLE
wallhero add model ACL-401S2I

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -2146,6 +2146,12 @@ zigbeeManufacturer:
     manufacturer: WALL HERO
     model: ACL-401S8I
     deviceProfileName: basic-switch
+  - id: "WALL HERO/ACL-401S2I"
+    deviceLabel: 二位智能开关面板 1
+    manufacturer: WALL HERO
+    model: ACL-401S2I
+    deviceProfileName: basic-switch
+  # End Wall Hero
   - id: "Insta GmbH/Switching Actuator"
     deviceLabel: NEXENTRO Switching Actuator
     manufacturer: Insta GmbH

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
@@ -21,7 +21,8 @@ local Scenes = zcl_clusters.Scenes
 
 local FINGERPRINTS = {
   { mfr = "WALL HERO", model = "ACL-401S4I", switches = 4, buttons = 0 },
-  { mfr = "WALL HERO", model = "ACL-401S8I", switches = 4, buttons = 4 }
+  { mfr = "WALL HERO", model = "ACL-401S8I", switches = 4, buttons = 4 },
+  { mfr = "WALL HERO", model = "ACL-401S2I", switches = 2, buttons = 0 }
 }
 
 local function can_handle_wallhero_switch(opts, driver, device, ...)


### PR DESCRIPTION
Manufacturers wallhero add new model ACL-401S2I zigbee-switch.
Please review it.