### PR TITLE
wallhero add model ACL-401S1I

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -2146,6 +2146,12 @@ zigbeeManufacturer:
     manufacturer: WALL HERO
     model: ACL-401S8I
     deviceProfileName: basic-switch
+  - id: "WALL HERO/ACL-401S1I"
+    deviceLabel: 一位智能开关面板
+    manufacturer: WALL HERO
+    model: ACL-401S1I
+    deviceProfileName: basic-switch
+  # End Wall Hero
   - id: "Insta GmbH/Switching Actuator"
     deviceLabel: NEXENTRO Switching Actuator
     manufacturer: Insta GmbH


### PR DESCRIPTION
Manufacturers wallhero add new model ACL-401S1I zigbee-switch.
Please review it.