### PR TITLE
wallhero add model ACL-401ON

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -2146,6 +2146,12 @@ zigbeeManufacturer:
     manufacturer: WALL HERO
     model: ACL-401S8I
     deviceProfileName: basic-switch
+  - id: "WALL HERO/ACL-401ON"
+    deviceLabel: 智能墙面五孔插座
+    manufacturer: WALL HERO
+    model: ACL-401ON
+    deviceProfileName: basic-switch
+  # End Wall Hero
   - id: "Insta GmbH/Switching Actuator"
     deviceLabel: NEXENTRO Switching Actuator
     manufacturer: Insta GmbH


### PR DESCRIPTION
Manufacturers wallhero add new model ACL-401ON zigbee-switch.
Please review it.