### PR TITLE
BUG-8648: Give PGC sensors the garage door preference

### DIFF
--- a/drivers/SmartThings/zigbee-contact/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-contact/fingerprints.yml
@@ -178,12 +178,12 @@ zigbeeManufacturer:
     deviceLabel: Multipurpose Sensor
     manufacturer: SmartThings
     model: PGC313
-    deviceProfileName: smartsense-multi
+    deviceProfileName: multi-sensor
   - id: Smartsense/multi/2
     deviceLabel: Multipurpose Sensor
     manufacturer: SmartThings
     model: PGC313EU
-    deviceProfileName: smartsense-multi
+    deviceProfileName: multi-sensor
 zigbeeGeneric:
   - id: "contact-generic"
     deviceLabel: "Zigbee Contact Sensor"
@@ -207,4 +207,4 @@ zigbeeGeneric:
       - 0xFC01
     deviceIdentifiers:
       - 0x0139
-    deviceProfileName: smartsense-multi
+    deviceProfileName: multi-sensor


### PR DESCRIPTION
On DTHs this could have been accomplished by manually switching the DTH.