### PR TITLE
BUG-8651 Aeotec Nano Shutter: add missing event

### DIFF
--- a/drivers/SmartThings/zwave-window-treatment/src/aeotec-nano-shutter/init.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/aeotec-nano-shutter/init.lua
@@ -93,7 +93,24 @@ end
 
 --- @param driver st.zwave.Driver
 --- @param device st.zwave.Device
+local function added_handler(driver, device)
+  device:emit_event(capabilities.statelessCurtainPowerButton.availableCurtainPowerButtons(
+    {SET_BUTTON_TO_OPEN, SET_BUTTON_TO_CLOSE, SET_BUTTON_TO_PAUSE},
+    {visibility = {displayed = false}})
+  )
+end
+
+--- @param driver st.zwave.Driver
+--- @param device st.zwave.Device
 local function refresh(driver, device)
+  -- if we've already got an added device that hasn't set this value, this should cause it to be set on refresh
+  -- this can be removed later
+  if device:get_latest_state(
+    "main",
+    capabilities.statelessCurtainPowerButton.ID,
+    capabilities.statelessCurtainPowerButton.availableCurtainPowerButtons.NAME) == nil then
+    added_handler(driver, device)
+  end
   device:send(Basic:Get({}))
 end
 
@@ -119,7 +136,8 @@ local aeotec_nano_shutter = {
     }
   },
   lifecycle_handlers = {
-    doConfigure = do_configure
+    doConfigure = do_configure,
+    added = added_handler
   },
   NAME = "Aeotec nano shutter",
   can_handle = can_handle_aeotec_nano_shutter

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_aeotec_nano_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_aeotec_nano_shutter.lua
@@ -18,6 +18,7 @@ local zw_test_utils = require "integration_test.zwave_test_utils"
 local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 1 })
 local t_utils = require "integration_test.utils"
+local capabilities = require "st.capabilities"
 
 local zwave_window_button_endpoint = {
   {
@@ -147,23 +148,23 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle():__queue_receive(mock_window_button:generate_info_changed(
       {
-          preferences = {
-            reverse = true
-          }
+        preferences = {
+          reverse = true
+        }
       }
     ))
     test.wait_for_events()
     test.socket.capability:__queue_receive(
-        {
-          mock_window_button.id,
-          { capability = "statelessCurtainPowerButton", command = "setButton", args = { "open" } }
-        }
+      {
+        mock_window_button.id,
+        { capability = "statelessCurtainPowerButton", command = "setButton", args = { "open" } }
+      }
     )
     test.socket.zwave:__expect_send(
-        zw_test_utils.zwave_test_build_send_command(
-          mock_window_button,
-          Basic:Set({ value = 0xFF })
-        )
+      zw_test_utils.zwave_test_build_send_command(
+        mock_window_button,
+        Basic:Set({ value = 0xFF })
+      )
     )
   end
 )
@@ -173,23 +174,23 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle():__queue_receive(mock_window_button:generate_info_changed(
       {
-          preferences = {
-            reverse = true
-          }
+        preferences = {
+          reverse = true
+        }
       }
     ))
     test.wait_for_events()
-    test.socket.capability:__queue_receive(
-        {
-          mock_window_button.id,
-          { capability = "statelessCurtainPowerButton", command = "setButton", args = { "close" } }
-        }
+  test.socket.capability:__queue_receive(
+      {
+        mock_window_button.id,
+        { capability = "statelessCurtainPowerButton", command = "setButton", args = { "close" } }
+      }
     )
     test.socket.zwave:__expect_send(
-        zw_test_utils.zwave_test_build_send_command(
-          mock_window_button,
-          Basic:Set({ value = 0x00 })
-        )
+      zw_test_utils.zwave_test_build_send_command(
+        mock_window_button,
+        Basic:Set({ value = 0x00 })
+      )
     )
   end
 )
@@ -199,9 +200,9 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle():__queue_receive(mock_window_button:generate_info_changed(
       {
-          preferences = {
-            reverse = true
-          }
+        preferences = {
+          reverse = true
+        }
       }
     ))
     test.wait_for_events()
@@ -237,9 +238,9 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle():__queue_receive(mock_window_button:generate_info_changed(
       {
-          preferences = {
-            reverse = true
-          }
+        preferences = {
+          reverse = true
+        }
       }
     ))
     test.wait_for_events()
@@ -277,14 +278,14 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-    "doConfigure lifecycle event should generate the correct commands",
-    function ()
-      test.socket.zwave:__set_channel_ordering("relaxed")
-      test.socket.device_lifecycle:__queue_receive({ mock_window_button.id, "doConfigure" })
-      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(mock_window_button, Configuration:Set({parameter_number = 80, size = 1, configuration_value = 1})))
-      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(mock_window_button, Configuration:Set({parameter_number = 85, size = 1, configuration_value = 1})))
-      mock_window_button:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    end
+  "doConfigure lifecycle event should generate the correct commands",
+  function ()
+    test.socket.zwave:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_window_button.id, "doConfigure" })
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(mock_window_button, Configuration:Set({parameter_number = 80, size = 1, configuration_value = 1})))
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(mock_window_button, Configuration:Set({parameter_number = 85, size = 1, configuration_value = 1})))
+    mock_window_button:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
 )
 
 test.register_message_test(
@@ -299,6 +300,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "capability",
+      direction = "send",
+      message = mock_window_button:generate_test_message(
+        "main",
+        capabilities.statelessCurtainPowerButton.availableCurtainPowerButtons({"open", "close", "pause"},
+        {visibility = {displayed = false}}))
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -310,20 +319,32 @@ test.register_message_test(
 )
 
 test.register_coroutine_test(
-    "Set open close time preference should generated proper zwave commands",
-    function()
-      test.socket.device_lifecycle():__queue_receive(mock_window_button:generate_info_changed(
-          {
-              preferences = {
-                openCloseTiming = 100
-              }
-          }
-      ))
-      test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-          mock_window_button,
-          Configuration:Set({parameter_number = 35, size = 1, configuration_value = 100})
-      ))
-    end
+  "added lifecycle event should generate the correct events",
+  function ()
+    test.socket.device_lifecycle:__queue_receive({ mock_window_button.id, "added" })
+    test.socket.capability:__expect_send(mock_window_button:generate_test_message(
+      "main",
+      capabilities.statelessCurtainPowerButton.availableCurtainPowerButtons({"open", "close", "pause"},
+      {visibility = {displayed = false}}))
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Set open close time preference should generated proper zwave commands",
+  function()
+    test.socket.device_lifecycle():__queue_receive(mock_window_button:generate_info_changed(
+      {
+        preferences = {
+          openCloseTiming = 100
+        }
+      }
+    ))
+    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
+      mock_window_button,
+      Configuration:Set({parameter_number = 35, size = 1, configuration_value = 100})
+    ))
+  end
 )
 
 test.run_registered_tests()


### PR DESCRIPTION
The stateless curtain power button needs to set its available command values before it will function correctly in the app. This was done in the DTH but was missed in the porting work.

I've added changes so that a refresh of the device should bring an already-installed device back to a good state. These changes can be removed at a later date as future installs will have them from the added handler changes.