### PR TITLE
Matter Sensor: check for battery on init

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor.lua
@@ -73,6 +73,8 @@ end
 local function test_init()
   test.socket.matter:__expect_send({mock_device.id, subscribe_on_init(mock_device)})
   test.mock_device.add_test_device(mock_device)
+  -- don't check the battery for this device because we are using the catch-all "sensor.yml" profile just for testing
+  mock_device:set_field("__battery_checked", 1, {persist = true})
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
@@ -127,6 +127,7 @@ local function test_init_humidity_battery()
 
   test.socket.matter:__expect_send({mock_device_humidity_battery.id, subscribe_request_humidity_battery})
   test.mock_device.add_test_device(mock_device_humidity_battery)
+  mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-battery" })
 end
 
 local function test_init_humidity_no_battery()
@@ -139,6 +140,7 @@ local function test_init_humidity_no_battery()
 
   test.socket.matter:__expect_send({mock_device_humidity_no_battery.id, subscribe_request_humidity_no_battery})
   test.mock_device.add_test_device(mock_device_humidity_no_battery)
+  mock_device_humidity_no_battery:expect_metadata_update({ profile = "humidity" })
 end
 
 local function test_init_temp_humidity()
@@ -151,34 +153,26 @@ local function test_init_temp_humidity()
 
   test.socket.matter:__expect_send({mock_device_temp_humidity.id, subscribe_request_temp_humidity})
   test.mock_device.add_test_device(mock_device_temp_humidity)
+  mock_device_temp_humidity:expect_metadata_update({ profile = "temperature-humidity" })
 end
 
 test.register_coroutine_test(
-  "Profile remains the same for battery-supported devices on doConfigure lifecycle event due to cluster feature map",
+  "Test profile change on init for humidity sensor with battery",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
-    mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-battery" })
-    mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   { test_init = test_init_humidity_battery }
 )
 
 test.register_coroutine_test(
-  "Profile change to non-battery profile on doConfigure lifecycle event due to cluster feature map",
+  "Test profile change on init for humidity sensor without battery",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_no_battery.id, "doConfigure" })
-    mock_device_humidity_no_battery:expect_metadata_update({ profile = "humidity" })
-    mock_device_humidity_no_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   { test_init = test_init_humidity_no_battery }
 )
 
 test.register_coroutine_test(
-  "Profile change to non-battery profile on doConfigure lifecycle event due to cluster feature map",
+  "Test profile change on init for temperature-humidity sensor",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_temp_humidity.id, "doConfigure" })
-    mock_device_temp_humidity:expect_metadata_update({ profile = "temperature-humidity" })
-    mock_device_temp_humidity:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   { test_init = test_init_temp_humidity }
 )


### PR DESCRIPTION
This moves the battery-checking logic from do_configure to init so that device will not have to be removed and re-added in order to join the correct profile.