### PR TITLE
matter-switch: Fix devices (ex: Hue White) that did not have levelControl

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -121,21 +121,42 @@ matterGeneric:
     deviceTypes:
       - id: 0x0101 # Dimmable Light
     deviceProfileName: light-level
+  - id: "matter/dimmable/light/2"
+    deviceLabel: Matter Dimmable Light
+    deviceTypes:
+      - id: 0x0100 # OnOff Light
+      - id: 0x0101 # Dimmable Light
+    deviceProfileName: light-level
   - id: "matter/colorTemperature/light"
     deviceLabel: Matter Color Temperature Light
     deviceTypes:
       - id: 0x010C # Color Temperature Light
     deviceProfileName: light-level-colorTemperature
-  - id: "matter/color/light"
+  - id: "matter/colorTemperature/light/2"
     deviceLabel: Matter Color Temperature Light
+    deviceTypes:
+      - id: 0x0100 # OnOff Light
+      - id: 0x0101 # Dimmable Light
+      - id: 0x010C # Color Temperature Light
+    deviceProfileName: light-level-colorTemperature
+  - id: "matter/color/light"
+    deviceLabel: Matter Color Light
     deviceTypes:
       - id: 0x010D # Extended Color Light
     deviceProfileName: light-color-level
   - id: "matter/color/temp/light"
-    deviceLabel: Matter Color Temperature Light
+    deviceLabel: Matter Color Light
     deviceTypes:
-      - id: 0x010D # Extended Color Light
       - id: 0x010C # Color Temperature Light
+      - id: 0x010D # Extended Color Light
+    deviceProfileName: light-color-level
+  - id: "matter/color/temp/light/2"
+    deviceLabel: Matter Color Light
+    deviceTypes:
+      - id: 0x0100 # OnOff Light
+      - id: 0x0101 # Dimmable Light
+      - id: 0x010C # Color Temperature Light
+      - id: 0x010D # Extended Color Light
     deviceProfileName: light-color-level
   - id: "matter/on-off/plug"
     deviceLabel: Matter OnOff Plug


### PR DESCRIPTION
In Matter it is valid for an endpoint that supports a specific device type to also support additional device types that are subsets of that device type. The Hue White is an example of a device that does this. Since we didn't have a fingerprint for an endpoint with both OnOff Light and Dimmable Light device types the fingerprinting logic happened to be picking the fingerprint with just the OnOff device type which uses a profile without levelControl.

The fix is to add additional fingerprints for each of the device types that are a superset of other device type(s).

**Note: This requires devices to be removed and re-added since it only changes the fingerprinting and does not change the profile of already joined devices.**

https://smartthings.atlassian.net/browse/MTR-473