### PR TITLE
matter-switch: Add firmwareUpdate capability to the profile used by bridges

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/matter-bridge.yml
+++ b/drivers/SmartThings/matter-switch/profiles/matter-bridge.yml
@@ -1,8 +1,10 @@
 name: matter-bridge
 components:
-- id: main
-  capabilities:
-  - id: refresh
-    version: 1
-  categories:
-  - name: Bridges
+  - id: main
+    capabilities:
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: Bridges


### PR DESCRIPTION
Matter bridges do expose their firmware version but it wasn't visible to users in the SmartThings app because the profile did not include the necessary firmwareUpdate capability. This just adds that capability to the profile.

https://smartthings.atlassian.net/browse/MTR-475