### PR TITLE
motion-sensor: (Hue) Expose temperature and remove non-functional battery

### DIFF
--- a/drivers/SmartThings/matter-sensor/fingerprints.yml
+++ b/drivers/SmartThings/matter-sensor/fingerprints.yml
@@ -17,10 +17,10 @@ matterManufacturer:
     productId: 0x004D
     deviceProfileName: contact-battery
   - id: "TUO/ContactDoorAndWindow"
-   deviceLabel: TUO Contact Sensor
-   vendorId: 0x141E
-   productId: 0x0002
-   deviceProfileName: contact-battery
+    deviceLabel: TUO Contact Sensor
+    vendorId: 0x141E
+    productId: 0x0002
+    deviceProfileName: contact-battery
 
 matterGeneric:
   - id: "matter/contact/sensor"
@@ -55,6 +55,13 @@ matterGeneric:
       - id: 0x0107 # Occupancy Sensor
       - id: 0x0106 # Light Sensor
     deviceProfileName: motion-illuminance-battery
+  - id: "matter/motion-illuminance-temp"
+    deviceLabel: Matter Motion/Illuminance Sensor
+    deviceTypes:
+      - id: 0x0107 # Occupancy Sensor
+      - id: 0x0106 # Light Sensor
+      - id: 0x0302 # Temperature Sensor
+    deviceProfileName: motion-illuminance-temperature-battery
   - id: "matter/motion-sensor"
     deviceLabel: Matter Motion Sensor
     deviceTypes:

--- a/drivers/SmartThings/matter-sensor/profiles/matter-motion-battery-illuminance.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/matter-motion-battery-illuminance.yml
@@ -4,9 +4,9 @@ components:
   capabilities:
   - id: motionSensor
     version: 1
-  - id: battery
-    version: 1
   - id: illuminanceMeasurement
+    version: 1
+  - id: battery
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature-battery.yml
@@ -1,10 +1,12 @@
-name: motion-illuminance-battery
+name: motion-illuminance-temperature-battery
 components:
 - id: main
   capabilities:
   - id: motionSensor
     version: 1
   - id: illuminanceMeasurement
+    version: 1
+  - id: temperatureMeasurement
     version: 1
   - id: battery
     version: 1

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature.yml
@@ -1,4 +1,4 @@
-name: motion-illuminance-battery
+name: motion-illuminance-temperature
 components:
 - id: main
   capabilities:
@@ -6,7 +6,7 @@ components:
     version: 1
   - id: illuminanceMeasurement
     version: 1
-  - id: battery
+  - id: temperatureMeasurement
     version: 1
   - id: firmwareUpdate
     version: 1


### PR DESCRIPTION
The Hue motion sensor supports motion, temperature and illuminance sensors so added a fingerprint for those device types. Like the other battery powered Hue accessories, the motion does not support reporting battery percentage remaining so the battery capability is not used for Hue sensors.

**Note**: This fix only applies to newly joined devices so existing devices will need to be removed and re-added.

https://smartthings.atlassian.net/browse/MTR-476