### PR TITLE
Find default endpoint by cluster for remaining matter drivers

### DIFF
--- a/drivers/SmartThings/matter-button/src/init.lua
+++ b/drivers/SmartThings/matter-button/src/init.lua
@@ -79,6 +79,7 @@ local function find_default_endpoint(device, component)
       break
     end
   end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
   return res
 end
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
@@ -22,7 +22,7 @@ local mock_device_record = {
   manufacturer_info = {vendor_id = 0x101D, product_id = 0x1},
   endpoints = {
     {
-      endpoint_id = 0,
+      endpoint_id = 2,
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
@@ -31,7 +31,7 @@ local mock_device_record = {
       }
     },
     {
-      endpoint_id = 1,
+      endpoint_id = 10,
       clusters = {
         {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
         {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
@@ -68,7 +68,7 @@ test.register_message_test(
     {
       channel = "matter",
       direction = "send",
-      message = {mock_device.id, clusters.DoorLock.server.commands.LockDoor(mock_device, 1)},
+      message = {mock_device.id, clusters.DoorLock.server.commands.LockDoor(mock_device, 10)},
     },
   }
 )
@@ -88,7 +88,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.DoorLock.server.commands.UnlockDoor(mock_device, 1),
+        clusters.DoorLock.server.commands.UnlockDoor(mock_device, 10),
       },
     },
   }
@@ -102,7 +102,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.DoorLock.attributes.LockState:build_test_report_data(
-          mock_device, 1, clusters.DoorLock.attributes.LockState.LOCKED
+          mock_device, 10, clusters.DoorLock.attributes.LockState.LOCKED
         ),
       },
     },
@@ -122,7 +122,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
-          mock_device, 1, 150
+          mock_device, 10, 150
         ),
       },
     },
@@ -137,8 +137,8 @@ test.register_message_test(
 )
 
 local function refresh_commands(dev)
-  local req = clusters.DoorLock.attributes.LockState:read(dev, 1)
-  req:merge(clusters.PowerSource.attributes.BatPercentRemaining:read(dev, 1))
+  local req = clusters.DoorLock.attributes.LockState:read(dev)
+  req:merge(clusters.PowerSource.attributes.BatPercentRemaining:read(dev))
   return req
 end
 
@@ -169,7 +169,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.DoorLock.events.DoorLockAlarm:build_test_event_report(
-          mock_device, 1, {alarm_code = DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED}
+          mock_device, 10, {alarm_code = DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED}
         ),
       },
     },
@@ -184,7 +184,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.DoorLock.events.DoorLockAlarm:build_test_event_report(
-          mock_device, 1, {alarm_code = DlAlarmCode.WRONG_CODE_ENTRY_LIMIT}
+          mock_device, 10, {alarm_code = DlAlarmCode.WRONG_CODE_ENTRY_LIMIT}
         ),
       },
     },
@@ -199,7 +199,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.DoorLock.events.DoorLockAlarm:build_test_event_report(
-          mock_device, 1, {alarm_code = DlAlarmCode.FORCED_USER}
+          mock_device, 10, {alarm_code = DlAlarmCode.FORCED_USER}
         ),
       },
     },
@@ -214,7 +214,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.DoorLock.events.DoorLockAlarm:build_test_event_report(
-          mock_device, 1, {alarm_code = DlAlarmCode.DOOR_FORCED_OPEN}
+          mock_device, 10, {alarm_code = DlAlarmCode.DOOR_FORCED_OPEN}
         ),
       },
     },
@@ -238,7 +238,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.DoorLock.events.DoorLockAlarm:build_test_event_report(
-          mock_device, 1, {alarm_code = DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED}
+          mock_device, 10, {alarm_code = DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED}
         ),
       },
     },
@@ -252,7 +252,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        clusters.DoorLock.events.LockOperation:build_test_event_report(mock_device, 1, lock_operation_event),
+        clusters.DoorLock.events.LockOperation:build_test_event_report(mock_device, 10, lock_operation_event),
       },
     },
     {

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -39,7 +39,7 @@ local mock_device_record = {
   manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
   endpoints = {
     {
-      endpoint_id = 0,
+      endpoint_id = 2,
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
@@ -48,7 +48,7 @@ local mock_device_record = {
       }
     },
     {
-      endpoint_id = 1,
+      endpoint_id = 10,
       clusters = {
         {
           cluster_id = DoorLock.ID,
@@ -80,7 +80,7 @@ local expect_reload_all_codes_messages = function(dev)
     )
   )
   test.socket.matter:__expect_send(
-    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 1, credential)}
+    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 10, credential)}
   )
   test.wait_for_events()
 
@@ -89,7 +89,7 @@ local expect_reload_all_codes_messages = function(dev)
     {
       dev.id,
       DoorLock.client.commands.GetCredentialStatusResponse:build_test_command_response(
-        dev, 1, -- endpoint
+        dev, 10, -- endpoint
         true, --credential exists
         1,  --user_index
         nil, --creator fabric index
@@ -117,7 +117,7 @@ local expect_reload_all_codes_messages = function(dev)
     credential_index = next_credential_index,
   })
   test.socket.matter:__expect_send(
-    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 1, credential1)}
+    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 10, credential1)}
   )
   test.wait_for_events()
 
@@ -139,7 +139,7 @@ local expect_reload_all_codes_messages = function(dev)
     {
       dev.id,
       DoorLock.client.commands.GetCredentialStatusResponse:build_test_command_response(
-        dev, 1, -- endpoint
+        dev, 10, -- endpoint
         true, --credential exists
         1,    --user_index
         nil,  --creator fabric index
@@ -186,7 +186,7 @@ local function init_code_slot(slot_number, name, device)
     {
       device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         credential, -- credential
         "1234", -- credential_data
@@ -202,7 +202,7 @@ local function init_code_slot(slot_number, name, device)
     {
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1, -- endpoint_id
+        mock_device, 10, -- endpoint_id
         DoorLock.types.DlStatus.SUCCESS, -- status
         slot_number, -- user_index
         slot_number + 1 -- next_credential_index
@@ -225,9 +225,9 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
     )
-    local req = DoorLock.attributes.MaxPINCodeLength:read(mock_device, 1)
-    req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_device, 1))
-    req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device, 1))
+    local req = DoorLock.attributes.MaxPINCodeLength:read(mock_device, 10)
+    req:merge(DoorLock.attributes.MinPINCodeLength:read(mock_device, 10))
+    req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device, 10))
     test.socket.matter:__expect_send({mock_device.id, req})
     expect_reload_all_codes_messages(mock_device)
   end
@@ -253,7 +253,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        DoorLock.attributes.MinPINCodeLength:build_test_report_data(mock_device, 1, 4),
+        DoorLock.attributes.MinPINCodeLength:build_test_report_data(mock_device, 10, 4),
       },
     },
     {
@@ -274,7 +274,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        DoorLock.attributes.MaxPINCodeLength:build_test_report_data(mock_device, 1, 4),
+        DoorLock.attributes.MaxPINCodeLength:build_test_report_data(mock_device, 10, 4),
       },
     },
     {
@@ -295,7 +295,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(mock_device, 1, 16),
+        DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(mock_device, 10, 16),
       },
     },
     {
@@ -317,7 +317,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-          mock_device, 1, -- endpoint_id
+          mock_device, 10, -- endpoint_id
           DoorLock.types.DlStatus.SUCCESS, -- status
           1, -- user_index
           2, -- next_credential_index
@@ -336,7 +336,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         DoorLock.client.commands.GetCredentialStatusResponse:build_test_command_response(
-          mock_device, 1, -- endpoint_id
+          mock_device, 10, -- endpoint_id
           true, -- credential_exists
           1, -- user_index
           nil, -- creator_fabric_index
@@ -371,14 +371,14 @@ test.register_coroutine_test(
     )
     local credential = {credential_type = types.DlCredentialType.PIN, credential_index = 1}
     test.socket.matter:__expect_send(
-      {mock_device.id, DoorLock.server.commands.GetCredentialStatus(mock_device, 1, credential)}
+      {mock_device.id, DoorLock.server.commands.GetCredentialStatus(mock_device, 10, credential)}
     )
     test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
         DoorLock.client.commands.GetCredentialStatusResponse:build_test_command_response(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           true, -- credential_exists
           1, -- user_index
           nil, -- creator_fabric_index
@@ -413,14 +413,14 @@ test.register_coroutine_test(
     )
     local credential = {credential_type = types.DlCredentialType.PIN, credential_index = 1}
     test.socket.matter:__expect_send(
-      {mock_device.id, DoorLock.server.commands.GetCredentialStatus(mock_device, 1, credential)}
+      {mock_device.id, DoorLock.server.commands.GetCredentialStatus(mock_device, 10, credential)}
     )
     test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
         DoorLock.client.commands.GetCredentialStatusResponse:build_test_command_response(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           false, -- credential_exists
           1, -- user_index
           nil, -- creator_fabric_index
@@ -463,7 +463,7 @@ test.register_coroutine_test(
       )
     )
     test.socket.matter:__expect_send(
-      {mock_device.id, DoorLock.server.commands.GetCredentialStatus(mock_device, 1, credential)}
+      {mock_device.id, DoorLock.server.commands.GetCredentialStatus(mock_device, 10, credential)}
     )
     test.wait_for_events()
 
@@ -471,7 +471,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.client.commands.GetCredentialStatusResponse:build_test_command_response(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           false, --credential exists
           1,  --user_index
           nil, --creator fabric index
@@ -526,7 +526,7 @@ test.register_coroutine_test(
       mock_device.id,
       DoorLock.server.commands.ClearCredential(
         mock_device,
-        1,
+        10,
         {credential_type = types.DlCredentialType.PIN, credential_index = 1}
       )
     })
@@ -535,7 +535,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
-        DoorLock.server.commands.ClearCredential:build_test_command_response(mock_device, 1),
+        DoorLock.server.commands.ClearCredential:build_test_command_response(mock_device, 10),
       }
     )
 
@@ -571,7 +571,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.server.commands.SetCredential(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           DoorLock.types.DlDataOperationType.ADD, -- operation_type
           DoorLock.types.DlCredential(
             {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = code_slot}
@@ -589,7 +589,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-          mock_device, 1, -- endpoint_id
+          mock_device, 10, -- endpoint_id
           DoorLock.types.DlStatus.SUCCESS, -- status
           1, -- user_index
           2 -- next_credential_index
@@ -682,7 +682,7 @@ test.register_message_test(
       message = {
         mock_device.id,
         DoorLock.server.events.LockUserChange:build_test_event_report(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           {
             lock_data_type = types.DlLockDataType.PIN,
             data_operation_type = types.DlDataOperationType.ADD,
@@ -727,7 +727,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.server.events.LockUserChange:build_test_event_report(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           {
             lock_data_type = types.DlLockDataType.PIN,
             data_operation_type = types.DlDataOperationType.CLEAR,
@@ -787,7 +787,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.server.events.LockUserChange:build_test_event_report(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           {
             lock_data_type = types.DlLockDataType.USER_INDEX,
             data_operation_type = types.DlDataOperationType.CLEAR,

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -39,7 +39,7 @@ local mock_device_record = {
   manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
   endpoints = {
     {
-      endpoint_id = 0,
+      endpoint_id = 2,
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
@@ -48,7 +48,7 @@ local mock_device_record = {
       }
     },
     {
-      endpoint_id = 1,
+      endpoint_id = 10,
       clusters = {
         {
           cluster_id = DoorLock.ID,
@@ -80,7 +80,7 @@ local expect_reload_all_codes_messages = function(dev)
     )
   )
   test.socket.matter:__expect_send(
-    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 1, credential)}
+    {dev.id, DoorLock.server.commands.GetCredentialStatus(dev, 10, credential)}
   )
   test.wait_for_events()
 end
@@ -92,10 +92,10 @@ local function expect_kick_off_cota_process(device)
   test.socket.capability:__expect_send(
     device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
   )
-  local req = DoorLock.attributes.MaxPINCodeLength:read(device, 1)
-  req:merge(DoorLock.attributes.MinPINCodeLength:read(device, 1))
-  req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(device, 1))
-  req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(device, 1))
+  local req = DoorLock.attributes.MaxPINCodeLength:read(device, 10)
+  req:merge(DoorLock.attributes.MinPINCodeLength:read(device, 10))
+  req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(device, 10))
+  req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(device, 10))
   test.socket.matter:__expect_send({device.id, req})
   expect_reload_all_codes_messages(device)
   test.wait_for_events()
@@ -103,7 +103,7 @@ local function expect_kick_off_cota_process(device)
   test.socket.capability:__expect_send(device:generate_test_message("main", capabilities.lockCodes.maxCodes(16, {visibility = {displayed = false}})))
   test.socket.matter:__queue_receive({
     device.id,
-    DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(device, 1, 16),
+    DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(device, 10, 16),
   })
 
   -- The creation of advance timers, advancing time, and waiting for events
@@ -116,7 +116,7 @@ local function expect_kick_off_cota_process(device)
     {
       device.id,
       DoorLock.attributes.RequirePINforRemoteOperation:build_test_report_data(
-        device, 1, true
+        device, 10, true
       ),
     }
   )
@@ -130,7 +130,7 @@ local function expect_kick_off_cota_process(device)
     {
       device.id,
       DoorLock.server.commands.SetCredential(
-        device, 1, -- endpoint
+        device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -162,7 +162,7 @@ test.register_coroutine_test(
     mock_device:set_field(lock_utils.COTA_CRED, "1111")
     test.socket.matter:__expect_send({
         mock_device.id,
-        clusters.DoorLock.server.commands.UnlockDoor(mock_device, 1, "1111"),
+        clusters.DoorLock.server.commands.UnlockDoor(mock_device, 10, "1111"),
       })
   end
 )
@@ -176,7 +176,7 @@ test.register_coroutine_test(
     mock_device:set_field(lock_utils.COTA_CRED, "1111")
     test.socket.matter:__expect_send({
         mock_device.id,
-        clusters.DoorLock.server.commands.LockDoor(mock_device, 1, "1111"),
+        clusters.DoorLock.server.commands.LockDoor(mock_device, 10, "1111"),
       })
   end
 )
@@ -190,7 +190,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1, --user_index
         next_credential_index
@@ -199,7 +199,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
@@ -221,7 +221,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1,  -- user_index
         nil -- next_redential_index
@@ -242,7 +242,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1,  -- user_index
         nil -- next_redential_index
@@ -261,7 +261,7 @@ test.register_coroutine_test(
       mock_device.id,
       DoorLock.server.commands.ClearCredential(
         mock_device,
-        1,
+        10,
         {credential_type = types.DlCredentialType.PIN, credential_index = 1}
       )
     })
@@ -288,7 +288,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -304,7 +304,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.SUCCESS,
         1,  -- user_index
         nil -- next_redential_index
@@ -343,7 +343,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1,  -- user_index
         nil -- next_redential_index
@@ -359,7 +359,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.server.events.LockUserChange:build_test_event_report(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           {
             lock_data_type = types.DlLockDataType.PIN,
             data_operation_type = types.DlDataOperationType.CLEAR,
@@ -385,7 +385,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -401,7 +401,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.SUCCESS,
         1,  -- user_index
         nil -- next_redential_index
@@ -440,7 +440,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1,  -- user_index
         nil -- next_redential_index
@@ -456,7 +456,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         DoorLock.server.events.LockUserChange:build_test_event_report(
-          mock_device, 1, -- endpoint
+          mock_device, 10, -- endpoint
           {
             lock_data_type = types.DlLockDataType.USER_INDEX,
             data_operation_type = types.DlDataOperationType.CLEAR,
@@ -475,7 +475,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -491,7 +491,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.SUCCESS,
         1,  -- user_index
         nil -- next_redential_index
@@ -531,7 +531,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1, --user_index
         next_credential_index
@@ -540,7 +540,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
@@ -556,7 +556,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.OCCUPIED,
         1,  --user_index
         nil --next_credential_index
@@ -565,7 +565,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -589,7 +589,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.DUPLICATE,
         1, --user_index
         next_credential_index
@@ -601,7 +601,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -624,7 +624,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.SUCCESS,
         1, --user_index
         4
@@ -656,7 +656,7 @@ test.register_coroutine_test(
       mock_device.id,
       DoorLock.server.commands.ClearCredential(
         mock_device,
-        1,
+        10,
         {credential_type = types.DlCredentialType.PIN, credential_index = 1}
       )
     })
@@ -680,7 +680,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
@@ -703,7 +703,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({
       mock_device.id,
       DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
-        mock_device, 1,
+        mock_device, 10,
         DoorLock.types.DlStatus.FAILURE,
         1, --user_index
         next_credential_index
@@ -712,7 +712,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({
       mock_device.id,
       DoorLock.server.commands.SetCredential(
-        mock_device, 1, -- endpoint
+        mock_device, 10, -- endpoint
         DoorLock.types.DlDataOperationType.ADD, -- operation_type
         DoorLock.types.DlCredential(
           {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}

--- a/drivers/SmartThings/matter-media/src/init.lua
+++ b/drivers/SmartThings/matter-media/src/init.lua
@@ -22,7 +22,30 @@ local MatterDriver = require "st.matter.driver"
 
 local VOLUME_STEP = 5
 
+local function find_default_endpoint(device, cluster)
+  local res = device.MATTER_DEFAULT_ENDPOINT
+  local eps = device:get_endpoints(cluster)
+  table.sort(eps)
+  for _, v in ipairs(eps) do
+    if v ~= 0 then --0 is the matter RootNode endpoint
+      return v
+    end
+  end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
+  return res
+end
+
+local function component_to_endpoint(device, component_name)
+  -- if this is a speaker device/component, look for endpoint that supports level control (volume)
+  if device:supports_capability(capabilities.audioVolume, component_name) then
+    return find_default_endpoint(device, clusters.LevelControl.ID)
+  else
+    return find_default_endpoint(device, clusters.MediaPlayback.ID)
+  end
+end
+
 local function device_init(driver, device)
+  device:set_component_to_endpoint_fn(component_to_endpoint)
   device:subscribe()
 end
 

--- a/drivers/SmartThings/matter-media/src/test/test_matter_media_speaker.lua
+++ b/drivers/SmartThings/matter-media/src/test/test_matter_media_speaker.lua
@@ -26,7 +26,7 @@ local mock_device = test.mock_device.build_test_matter_device({
   },
   endpoints = {
     {
-      endpoint_id = 0,
+      endpoint_id = 2,
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
@@ -35,7 +35,7 @@ local mock_device = test.mock_device.build_test_matter_device({
       }
     },
     {
-      endpoint_id = 1,
+      endpoint_id = 10,
       clusters = {
         {
           cluster_id = clusters.OnOff.ID,
@@ -83,7 +83,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.OnOff.server.commands.Off(mock_device, 1)
+                clusters.OnOff.server.commands.Off(mock_device, 10)
             }
         },
         {
@@ -99,7 +99,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.OnOff.server.commands.On(mock_device, 1)
+                clusters.OnOff.server.commands.On(mock_device, 10)
             }
         },
         {
@@ -107,7 +107,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, true)
+                clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 10, true)
             }
         },
         {
@@ -120,7 +120,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, false)
+                clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 10, false)
             }
         },
         {
@@ -147,7 +147,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.OnOff.server.commands.Off(mock_device, 1)
+                clusters.OnOff.server.commands.Off(mock_device, 10)
             }
         },
         {
@@ -163,7 +163,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.OnOff.server.commands.On(mock_device, 1)
+                clusters.OnOff.server.commands.On(mock_device, 10)
             }
         }
     }
@@ -185,7 +185,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 1, math.floor(20/100.0 * 254), 0, 0, 0)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 10, math.floor(20/100.0 * 254), 0, 0, 0)
             }
         },
         {
@@ -193,7 +193,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 10)
             }
         },
         {
@@ -201,7 +201,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50)
+                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 10, 50)
             }
         },
         {
@@ -228,7 +228,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 1, math.floor(20/100.0 * 254), 0, 0, 0)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 10, math.floor(20/100.0 * 254), 0, 0, 0)
             }
         },
         {
@@ -236,7 +236,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 10)
             }
         },
         {
@@ -244,7 +244,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50 )
+                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 10, 50 )
             }
         },
         {
@@ -266,7 +266,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 1, math.floor(25/100.0 * 254), 0, 0, 0)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 10, math.floor(25/100.0 * 254), 0, 0, 0)
             }
         },
         {
@@ -274,7 +274,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 10)
             }
         },
         {
@@ -282,7 +282,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 63 )
+                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 10, 63 )
             }
         },
         {
@@ -304,7 +304,7 @@ test.register_message_test(
             direction = "send",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 1, math.floor(20/100.0 * 254), 0, 0, 0)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 10, math.floor(20/100.0 * 254), 0, 0, 0)
             }
         },
         {
@@ -312,7 +312,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
+                clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 10)
             }
         },
         {
@@ -320,7 +320,7 @@ test.register_message_test(
             direction = "receive",
             message = {
                 mock_device.id,
-                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50 )
+                clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 10, 50 )
             }
         },
         {

--- a/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
+++ b/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
@@ -26,7 +26,7 @@ local mock_device = test.mock_device.build_test_matter_device({
   },
   endpoints = {
     {
-      endpoint_id = 0,
+      endpoint_id = 2,
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
@@ -35,7 +35,7 @@ local mock_device = test.mock_device.build_test_matter_device({
       }
     },
     {
-      endpoint_id = 1,
+      endpoint_id = 10,
       clusters = {
         {
           cluster_id = clusters.OnOff.ID,
@@ -59,7 +59,7 @@ local mock_device_variable_speed = test.mock_device.build_test_matter_device({
   },
   endpoints = {
     {
-      endpoint_id = 0,
+      endpoint_id = 2,
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
@@ -68,7 +68,7 @@ local mock_device_variable_speed = test.mock_device.build_test_matter_device({
       }
     },
     {
-      endpoint_id = 1,
+      endpoint_id = 10,
       clusters = {
         {
           cluster_id = clusters.OnOff.ID,
@@ -132,7 +132,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.OnOff.server.commands.On(mock_device, 1)
+        clusters.OnOff.server.commands.On(mock_device, 10)
       }
     },
     {
@@ -148,7 +148,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.OnOff.server.commands.Off(mock_device, 1)
+        clusters.OnOff.server.commands.Off(mock_device, 10)
       }
     },
     {
@@ -156,7 +156,7 @@ test.register_message_test(
       direction = "receive",
       message = {
           mock_device.id,
-          clusters.OnOff.server.commands.Off:build_test_command_response(mock_device, 1)
+          clusters.OnOff.server.commands.Off:build_test_command_response(mock_device, 10)
       }
     },
     {
@@ -164,7 +164,7 @@ test.register_message_test(
       direction = "receive",
       message = {
           mock_device.id,
-          clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, false )
+          clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 10, false )
       }
     },
     {
@@ -177,7 +177,7 @@ test.register_message_test(
       direction = "receive",
       message = {
           mock_device.id,
-          clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, true )
+          clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 10, true )
       }
     },
     {
@@ -204,7 +204,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.Play(mock_device, 1)
+          clusters.MediaPlayback.server.commands.Play(mock_device, 10)
       }
     },
     {
@@ -212,7 +212,7 @@ test.register_message_test(
       direction = "receive",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.attributes.CurrentState:build_test_report_data(mock_device, 1, clusters.MediaPlayback.attributes.CurrentState.PLAYING )
+          clusters.MediaPlayback.attributes.CurrentState:build_test_report_data(mock_device, 10, clusters.MediaPlayback.attributes.CurrentState.PLAYING )
       }
     },
     {
@@ -239,7 +239,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.Pause(mock_device, 1)
+          clusters.MediaPlayback.server.commands.Pause(mock_device, 10)
       }
     },
     {
@@ -247,7 +247,7 @@ test.register_message_test(
       direction = "receive",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.attributes.CurrentState:build_test_report_data(mock_device, 1, clusters.MediaPlayback.attributes.CurrentState.PAUSED )
+          clusters.MediaPlayback.attributes.CurrentState:build_test_report_data(mock_device, 10, clusters.MediaPlayback.attributes.CurrentState.PAUSED )
       }
     },
     {
@@ -274,7 +274,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.StopPlayback(mock_device, 1)
+          clusters.MediaPlayback.server.commands.StopPlayback(mock_device, 10)
       }
     },
     {
@@ -282,7 +282,7 @@ test.register_message_test(
       direction = "receive",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.attributes.CurrentState:build_test_report_data(mock_device, 1, clusters.MediaPlayback.attributes.CurrentState.NOT_PLAYING )
+          clusters.MediaPlayback.attributes.CurrentState:build_test_report_data(mock_device, 10, clusters.MediaPlayback.attributes.CurrentState.NOT_PLAYING )
       }
     },
     {
@@ -309,7 +309,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.Rewind(mock_device, 1)
+          clusters.MediaPlayback.server.commands.Rewind(mock_device, 10)
       }
     },
     {
@@ -325,7 +325,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.FastForward(mock_device, 1)
+          clusters.MediaPlayback.server.commands.FastForward(mock_device, 10)
       }
     },
   }
@@ -347,7 +347,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.Previous(mock_device, 1)
+          clusters.MediaPlayback.server.commands.Previous(mock_device, 10)
       }
     },
     {
@@ -363,7 +363,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.MediaPlayback.server.commands.Next(mock_device, 1)
+          clusters.MediaPlayback.server.commands.Next(mock_device, 10)
       }
     },
   }
@@ -385,7 +385,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.UP)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.UP)
       }
     },
     {
@@ -401,7 +401,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.DOWN)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.DOWN)
       }
     },
     {
@@ -417,7 +417,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.LEFT)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.LEFT)
       }
     },
     {
@@ -433,7 +433,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.RIGHT)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.RIGHT)
       }
     },
     {
@@ -449,7 +449,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.SELECT)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.SELECT)
       }
     },
     {
@@ -465,7 +465,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.NUMBER0_OR_NUMBER10)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.NUMBER0_OR_NUMBER10)
       }
     },
     {
@@ -481,7 +481,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.NUMBERS1)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.NUMBERS1)
       }
     },
     {
@@ -497,7 +497,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.CONTENTS_MENU)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.CONTENTS_MENU)
       }
     },
     {
@@ -513,7 +513,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.SETUP_MENU)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.SETUP_MENU)
       }
     },
     {
@@ -529,7 +529,7 @@ test.register_message_test(
       direction = "send",
       message = {
           mock_device.id,
-          clusters.KeypadInput.server.commands.SendKey(mock_device, 1, clusters.KeypadInput.types.CecKeyCode.ROOT_MENU)
+          clusters.KeypadInput.server.commands.SendKey(mock_device, 10, clusters.KeypadInput.types.CecKeyCode.ROOT_MENU)
       }
     }
   }

--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -133,6 +133,7 @@ local function find_default_endpoint(device, component)
       break
     end
   end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
   return res
 end
 

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -52,6 +52,7 @@ local function find_default_endpoint(device, component)
       break
     end
   end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
   return res
 end
 

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -82,6 +82,7 @@ local function find_default_endpoint(device, cluster)
       return v
     end
   end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
   return res
 end
 

--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -21,7 +21,27 @@ local MatterDriver = require "st.matter.driver"
 
 local DEFAULT_LEVEL = 0
 
+local function find_default_endpoint(device, cluster)
+  local res = device.MATTER_DEFAULT_ENDPOINT
+  local eps = device:get_endpoints(cluster)
+  table.sort(eps)
+  for _, v in ipairs(eps) do
+    if v ~= 0 then --0 is the matter RootNode endpoint
+      return v
+    end
+  end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
+  return res
+end
+
+local function component_to_endpoint(device, component_name)
+  -- Use the find_default_endpoint function to return the first endpoint that
+  -- supports a given cluster.
+  return find_default_endpoint(device, clusters.WindowCovering.ID)
+end
+
 local function device_init(driver, device)
+  device:set_component_to_endpoint_fn(component_to_endpoint)
   device:subscribe()
 end
 

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -26,7 +26,7 @@ local mock_device = test.mock_device.build_test_matter_device(
     preferences = { presetPosition = 30 },
     endpoints = {
       {
-        endpoint_id = 0,
+        endpoint_id = 2,
         clusters = {
           {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
         },
@@ -35,7 +35,7 @@ local mock_device = test.mock_device.build_test_matter_device(
         }
       },
       {
-        endpoint_id = 1,
+        endpoint_id = 10,
         clusters = { -- list the clusters
           {
             cluster_id = clusters.WindowCovering.ID,
@@ -76,14 +76,14 @@ test.register_coroutine_test(
       {
         mock_device.id,
         WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-          mock_device, 1, 10000
+          mock_device, 10, 10000
         ),
       }
     )
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
-        WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 0),
+        WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 0),
       }
     )
     test.socket.capability:__expect_send(
@@ -106,14 +106,14 @@ test.register_coroutine_test(
       {
         mock_device.id,
         WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-          mock_device, 1, 0
+          mock_device, 10, 0
         ),
       }
     )
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
-        WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 0),
+        WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 0),
       }
     )
     test.socket.capability:__expect_send(
@@ -136,14 +136,14 @@ test.register_coroutine_test(
       {
         mock_device.id,
         WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-          mock_device, 1, ((100 - 25) *100)
+          mock_device, 10, ((100 - 25) *100)
         ),
       }
     )
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
-        WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 0),
+        WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 0),
       }
     )
     test.socket.capability:__expect_send(
@@ -165,14 +165,14 @@ test.register_coroutine_test("WindowCovering OperationalStatus opening", functio
     {
       mock_device.id,
       WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-        mock_device, 1, ((100 - 25) *100)
+        mock_device, 10, ((100 - 25) *100)
       ),
     }
   )
   test.socket.matter:__queue_receive(
     {
       mock_device.id,
-      WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 1),
+      WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 1),
     }
   )
   test.socket.capability:__expect_send(
@@ -193,14 +193,14 @@ test.register_coroutine_test("WindowCovering OperationalStatus closing", functio
     {
       mock_device.id,
       WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-        mock_device, 1, ((100 - 25) *100)
+        mock_device, 10, ((100 - 25) *100)
       ),
     }
   )
   test.socket.matter:__queue_receive(
     {
       mock_device.id,
-      WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 2),
+      WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 2),
     }
   )
   test.socket.capability:__expect_send(
@@ -221,14 +221,14 @@ test.register_coroutine_test("WindowCovering OperationalStatus unknown", functio
     {
       mock_device.id,
       WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-        mock_device, 1, ((100 - 25) *100)
+        mock_device, 10, ((100 - 25) *100)
       ),
     }
   )
   test.socket.matter:__queue_receive(
     {
       mock_device.id,
-      WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 3),
+      WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 3),
     }
   )
   test.socket.capability:__expect_send(
@@ -252,7 +252,7 @@ test.register_coroutine_test(
       }
     )
     test.socket.matter:__expect_send(
-      {mock_device.id, WindowCovering.server.commands.UpOrOpen(mock_device, 1)}
+      {mock_device.id, WindowCovering.server.commands.UpOrOpen(mock_device, 10)}
     )
     test.wait_for_events()
   end
@@ -267,7 +267,7 @@ test.register_coroutine_test(
       }
     )
     test.socket.matter:__expect_send(
-      {mock_device.id, WindowCovering.server.commands.DownOrClose(mock_device, 1)}
+      {mock_device.id, WindowCovering.server.commands.DownOrClose(mock_device, 10)}
     )
     test.wait_for_events()
   end
@@ -282,7 +282,7 @@ test.register_coroutine_test(
       }
     )
     test.socket.matter:__expect_send(
-      {mock_device.id, WindowCovering.server.commands.StopMotion(mock_device, 1)}
+      {mock_device.id, WindowCovering.server.commands.StopMotion(mock_device, 10)}
     )
     test.wait_for_events()
   end
@@ -324,7 +324,7 @@ test.register_coroutine_test("WindowShade setShadeLevel cmd handler", function()
     }
   )
   test.socket.matter:__expect_send(
-    {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 1, 8000)}
+    {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 10, 8000)}
   )
 end)
 
@@ -332,7 +332,7 @@ test.register_coroutine_test("LevelControl CurrentLevel handler", function()
   test.socket.matter:__queue_receive(
     {
       mock_device.id,
-      clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 100),
+      clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 10, 100),
     }
   )
   test.socket.capability:__expect_send(
@@ -349,7 +349,7 @@ test.register_coroutine_test(
       {
         mock_device.id,
         clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
-          mock_device, 1, 150
+          mock_device, 10, 150
         ),
       }
     )
@@ -364,9 +364,9 @@ test.register_coroutine_test(
 test.register_coroutine_test("OperationalStatus report contains current position report", function()
   test.socket.capability:__set_channel_ordering("relaxed")
   local report = WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-    mock_device, 1, ((100 - 25) *100)
+    mock_device, 10, ((100 - 25) *100)
   )
-  table.insert(report.info_blocks, WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 1, 0).info_blocks[1])
+  table.insert(report.info_blocks, WindowCovering.attributes.OperationalStatus:build_test_report_data(mock_device, 10, 0).info_blocks[1])
   test.socket.matter:__queue_receive({ mock_device.id, report})
   test.socket.capability:__expect_send(
     mock_device:generate_test_message(
@@ -388,7 +388,7 @@ test.register_coroutine_test("Handle windowcoveringPreset", function()
     }
   )
   test.socket.matter:__expect_send(
-    {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 1, 7000)}
+    {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 10, 7000)}
   )
 end)
 


### PR DESCRIPTION
The default endpoint used in matter drivers is currently the first non-zero endpoint. However, this can cause problems in cases like composed matter devices or aggregated bridged devices where the first non-zero endpoint is not where we would expect to find the relevant clusters for each driver. These changes return the first endpoint that supports a relevant cluster for each driver in order to prevent this issue.

These changes were already ported to matter-switch, matter-button, and matter-thermostat.

[CHAD-11752](https://smartthings.atlassian.net/browse/CHAD-11752)