### PR TITLE
matter-switch: remove unsupported and duplicate fingerprints

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,4 +1,4 @@
-matterManufacturer:    
+matterManufacturer:
 #Eve
   - id: "Eve/Energy/US"
     deviceLabel: Eve Energy
@@ -168,26 +168,6 @@ matterGeneric:
     deviceTypes:
       - id: 0x010B # Dimmable Plug-in Unit
     deviceProfileName: plug-level
-  - id: "matter/on-off/switch"
-    deviceLabel: Matter OnOff Switch
-    deviceTypes:
-      - id: 0x0103 # OnOff Switch
-    deviceProfileName: switch-binary
-  - id: "matter/dimmable/switch"
-    deviceLabel: Matter Dimmable Switch
-    deviceTypes:
-      - id: 0x0104 # Dimmer Switch
-    deviceProfileName: switch-level
-  - id: "matter/dimmable/inunitswitch"
-    deviceLabel: Matter Dimmable Switch
-    deviceTypes:
-      - id: 0x010B # Dimmable PlugIn Unit
-    deviceProfileName: switch-level
-  - id: "matter/color/switch"
-    deviceLabel: Matter Color Switch
-    deviceTypes:
-      - id: 0x0105 # Color Dimmer Switch
-    deviceProfileName: switch-color-level
 
 matterThing:
   - id: SmartThings/MatterThing


### PR DESCRIPTION
The OnOff Switch, Dimmer Switch, and Color Dimmer Switch are all device types that require bindings in order to work correctly. At the moment we do not support bindings, so we will remove these fingerprints so the devices will join as matter-things instead.

Also, removes a duplicate fingerprint for matter dimmable switch.