### PR TITLE
CHAD-11890: Switch Driver fails to profile color temperature lights if paired with an onoff device type

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -146,6 +146,12 @@ matterGeneric:
       - id: 0x0101 # Dimmable Light
       - id: 0x010C # Color Temperature Light
     deviceProfileName: light-level-colorTemperature
+  - id: "matter/colorTemperature/light/3"
+    deviceLabel: Matter Color Temperature Light
+    deviceTypes:
+      - id: 0x0100 # OnOff Light
+      - id: 0x010C # Color Temperature Light
+    deviceProfileName: light-level-colorTemperature
   - id: "matter/color/light"
     deviceLabel: Matter Color Light
     deviceTypes:


### PR DESCRIPTION
ticket: https://smartthings.atlassian.net/browse/CHAD-11890

```
Not Working

color temperature light
  DeviceType { id: 268, revision: 1 }, 
onoff
  DeviceType { id: 256, revision: 1 }, 
bridged device
  DeviceType { id: 19, revision: 1 }],

Working 

color temperature light
  DeviceType { id: 268, revision: 1 }, 
bridged device
  DeviceType { id: 19, revision: 1 }]
```

Bug Description

* Current matter switch fingerprinting fails to accurately fingerprint a color temperature light if it also contains support for an onoff device type. In the example above, the working device would be fingerprinted to `light-level-colorTemperature` where as the not working device would fingerprint to `light-binary`.

 

How/When it Happens

* When onboarding a matter light which only contains support for a color temperature light and onoff light. Bridged device type won’t effect this.

User Impact

* The user would only have onoff functionality and dimming won’t be available.


Options/Chosen Solution

* We can include an additional fingerprint including the onoff device
* We can move the existing color temperature light fingerprint above the onoff finger print since fingerprints are ordered in priority.