### PR TITLE
add certifiedpreferences.doNotDisturbPlayback for L42ms

### DIFF
--- a/drivers/SmartThings/harman-luxury/profiles/l42ms.yaml
+++ b/drivers/SmartThings/harman-luxury/profiles/l42ms.yaml
@@ -20,4 +20,6 @@ components:
     version: 1
   categories:
   - name: Speaker
-  
+preferences:
+- preferenceId: certifiedpreferences.doNotDisturbPlayback
+  explicit: true


### PR DESCRIPTION
certifiedpreferences.doNotDisturbPlayback is available from ST App R4 to support Harman Luxury L42ms.