### PR TITLE
fix: Only allow a single discovery handler

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -18,6 +18,7 @@ local HueDiscovery = {
   light_state_disco_cache = {},
   ServiceType = SERVICE_TYPE,
   Domain = DOMAIN,
+  discovery_active = false
 }
 
 local supported_resource_types = {
@@ -33,7 +34,13 @@ process_discovered_light
 ---@param _ table
 ---@param should_continue function
 function HueDiscovery.discover(driver, _, should_continue)
+  if HueDiscovery.discovery_active then
+    log.info("Hue discovery already in progress, ignoring new discovery request")
+    return
+  end
+
   log.info_with({ hub_logs = true }, "Starting Hue discovery")
+  HueDiscovery.discovery_active = true
 
   while should_continue() do
     local known_identifier_to_device_map = {}
@@ -54,6 +61,7 @@ function HueDiscovery.discover(driver, _, should_continue)
     end)
     socket.sleep(1.0)
   end
+  HueDiscovery.discovery_active = false
   log.info_with({ hub_logs = true }, "Ending Hue discovery")
 end
 


### PR DESCRIPTION
There are some situations where many discovery handlers can be started
at the same time, and in some cases this can lead to issues like duped
devices being created because the event create requests happen close
enough together that they skirt through checks for things like DNI
duplication.

The proper fix for this is to disallow this in firmware, but this is
impacting users currently so a stop-gap fix in the LAN Edge Drivers
at a minimum -- where this is more likely to happen -- may not be a bad
idea.