### PR TITLE
bugfix: Matter Switch Device Type (0x010C) profile

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -138,7 +138,7 @@ matterGeneric:
     deviceLabel: Matter Color Temperature Light
     deviceTypes:
       - id: 0x010C # Color Temperature Light
-    deviceProfileName: light-level-colorTemperature
+    deviceProfileName: light-color-level
   - id: "matter/colorTemperature/light/2"
     deviceLabel: Matter Color Temperature Light
     deviceTypes:


### PR DESCRIPTION
Per Matter Specification, 0x010C has color control as well as temperate, switching the profile to "light-color-level" to add the Color control support.