### PR TITLE
Matter Thermostat: Fix thermostatMode capability

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -26,7 +26,7 @@ local THERMOSTAT_MODE_MAP = {
   [clusters.Thermostat.types.ThermostatSystemMode.COOL]              = capabilities.thermostatMode.thermostatMode.cool,
   [clusters.Thermostat.types.ThermostatSystemMode.HEAT]              = capabilities.thermostatMode.thermostatMode.heat,
   [clusters.Thermostat.types.ThermostatSystemMode.EMERGENCY_HEATING] = capabilities.thermostatMode.thermostatMode.emergency_heat,
-  [clusters.Thermostat.types.ThermostatSystemMode.FAN_ONLY]          = capabilities.thermostatMode.thermostatMode.fanOnly
+  [clusters.Thermostat.types.ThermostatSystemMode.FAN_ONLY]          = capabilities.thermostatMode.thermostatMode.fanonly
 }
 
 local THERMOSTAT_OPERATING_MODE_MAP = {


### PR DESCRIPTION
The matter-thermostat driver is using the "fanOnly" value of the thermostatMode capability. But since this capability requires using the "fanonly" value, events using the "fanOnly" value are ignored. This change renames "fanOnly" to "fanonly".

https://developer.smartthings.com/docs/devices/capabilities/capabilities-reference/#thermostatMode