### PR TITLE
Fingerprint add for the Zemismart Thread Smart Switch Binary  MT606-1

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -71,7 +71,7 @@ matterManufacturer:
     vendorId: 0x1312
     productId: 0x01
     deviceProfileName: light-level-colorTemperature-2710k-6500k
-#Zemismart
+# Zemismart
   - id: "5020/43522"
     deviceLabel: "Zemismart Thread Smart Switch"
     vendorId: 0x139C

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -76,7 +76,7 @@ matterManufacturer:
     deviceLabel: "Zemismart Thread Smart Switch"
     vendorId: 0x139C
     productId: 0xAA02
-   deviceProfileName: "switch-binary"
+    deviceProfileName: "switch-binary"
 
 # Sengled
 # Not WWST Certified: As of the device's software release of "780014029", the device reports itself with device type of 0x10C,

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -71,6 +71,12 @@ matterManufacturer:
     vendorId: 0x1312
     productId: 0x01
     deviceProfileName: light-level-colorTemperature-2710k-6500k
+#Zemismart
+  - id: "5020/43522"
+    deviceLabel: "Zemismart Thread Smart Switch"
+    vendorId: 0x139C
+    productId: 0xAA02
+   deviceProfileName: "switch-binary"
 
 # Sengled
 # Not WWST Certified: As of the device's software release of "780014029", the device reports itself with device type of 0x10C,


### PR DESCRIPTION
WWST Cert submission from the Edge Builder Tool to add a fingerprint for the Zemismart Thread Smart Switch Binary  MT606-1 device