### PR TITLE
Samsung audio fallback to http when https fails

### DIFF
--- a/drivers/SmartThings/samsung-audio/src/command.lua
+++ b/drivers/SmartThings/samsung-audio/src/command.lua
@@ -348,14 +348,40 @@ function Command.getPlayStatus(ip)
   return response_map
 end
 
+--- Return err code from xml handler or nil if it doesn't exist
+local get_err_code = function(response_map)
+  if response_map ~= nil and
+      response_map.handler_res~= nil and
+      response_map.handler_res.root ~= nil and
+      response_map.handler_res.root.UIC ~= nil and
+      response_map.handler_res.root.UIC.response ~= nil then
+    return response_map.handler_res.root.UIC.response.errCode
+  else
+    return nil
+  end
+
+end
+
+local format_streaming_path = function(uri)
+  return "/UIC?cmd=%3Cpwron%3Eon%3C/pwron%3E%3Cname%3ESetUrlPlayback%3C/name%3E%3Cp%20type=%22cdata%22%20name=%22url%22%20val=%22empty%22%3E%3C![CDATA[" .. uri .. "]]%3E%3C/p%3E%3Cp%20type=%22dec%22%20name=%22buffersize%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22seektime%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22resume%22%20val=%221%22/%3E"
+end
+
 function Command.play_streaming_uri(ip, uri)
   log.trace("Triggering UPnP Command Request for [Audio Notification -> SetUrlPlayback]")
   local response_map = nil
   if ip then
-   local path = "/UIC?cmd=%3Cpwron%3Eon%3C/pwron%3E%3Cname%3ESetUrlPlayback%3C/name%3E%3Cp%20type=%22cdata%22%20name=%22url%22%20val=%22empty%22%3E%3C![CDATA[" .. uri .. "]]%3E%3C/p%3E%3Cp%20type=%22dec%22%20name=%22buffersize%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22seektime%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22resume%22%20val=%221%22/%3E"
-   local url = format_url(ip, path)
-   log.trace(string.format("Final Notification Command URL for making Audio Notification http request = %s", url))
-   response_map = handle_http_request(ip, url)
+    local path = format_streaming_path(uri)
+    local url = format_url(ip, path)
+    log.trace(string.format("Final Notification Command URL for making Audio Notification http request = %s", url))
+    response_map = handle_http_request(ip, url)
+    local err_code = get_err_code(response_map)
+    if err_code == "URL_OPEN_FAIL" then
+      uri = string.gsub(uri, "https://", "http://")
+      local path = format_streaming_path(uri)
+      local url = format_url(ip, path)
+      log.info(string.format("Falling back to http for AudioNotification Command %s", url))
+      response_map = handle_http_request(ip, url)
+    end
   end
   return response_map
 end


### PR DESCRIPTION
Sometimes old devices are failing to successfully use https to download samsung hosted audio notification files, in that case we should re-attempt with http before completely failing.