### PR TITLE
CHAD-11987: Fix potential infinite loops in lunchbox

### DIFF
--- a/drivers/SmartThings/jbl/src/lunchbox/rest.lua
+++ b/drivers/SmartThings/jbl/src/lunchbox/rest.lua
@@ -94,6 +94,8 @@ local function parse_chunked_response(original_response, sock)
         if partial ~= nil and #partial >= 1 then
           full_response:append_body(partial)
           next_chunk_bytes = 0
+        else
+          return nil, next_err
         end
       else
         return nil, ("unexpected error reading chunked transfer: " .. next_err)
@@ -172,7 +174,11 @@ local function handle_response(sock)
     if headers:get_one("Content-Length") then
       full_response = recv_additional_response(initial_recv, sock)
     elseif headers:get_one("Transfer-Encoding") == "chunked" then
-      full_response = parse_chunked_response(initial_recv, sock)
+      local response, err = parse_chunked_response(initial_recv, sock)
+      if err ~= nil then
+        return nil, err
+      end
+      full_response = response
     else
       full_response = initial_recv
     end

--- a/drivers/SmartThings/philips-hue/src/lunchbox/rest.lua
+++ b/drivers/SmartThings/philips-hue/src/lunchbox/rest.lua
@@ -92,6 +92,8 @@ local function parse_chunked_response(original_response, sock)
         if partial ~= nil and #partial >= 1 then
           full_response:append_body(partial)
           next_chunk_bytes = 0
+        else
+          return nil, next_err
         end
       else
         return nil, ("unexpected error reading chunked transfer: " .. next_err)
@@ -136,7 +138,11 @@ local function handle_response(sock)
     local headers = initial_recv:get_headers()
 
     if headers:get_one("Transfer-Encoding") == "chunked" then
-      full_response = parse_chunked_response(initial_recv, sock)
+      local response, err = parse_chunked_response(initial_recv, sock)
+      if err ~= nil then
+        return nil, err
+      end
+      full_response = response
     else
       full_response = initial_recv
     end


### PR DESCRIPTION
Previously, it was possible to get stuck in an infinite loop while parsing a chunked response if the socket was closed and didn't return any partial data. Now, we will return in that case and propagate the "closed" error so that try to reconnect after the error.

I have tested this with hue and can with sonos but I don't have a JBL to test with.