### PR TITLE
 fix: finish restoring popp_danfoss -> danfoss

### DIFF
--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -293,8 +293,7 @@ local zigbee_thermostat_driver = {
     require("lux-konoz"),
     require("leviton"),
     require("danfoss"),
-    require("popp")
-    require("popp_danfoss"),
+    require("popp"),
     require("vimar")
   },
 }


### PR DESCRIPTION
Some changes in another PR modified an existing profile in an breaking
way, and we asked for those changes to be reverted in the PR. Some stuff
got missed, though. This addresses the stragglers.