### PR TITLE
Eve Energy: Improve the performance by removing unnecessary read

### DIFF
--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -95,9 +95,6 @@ end
 -------------------------------------------------------------------------------------
 
 local function requestData(device)
-  -- Update the on/off status
-  device:send(clusters.OnOff.attributes.OnOff:read(device))
-
   -- Update the Watt usage
   device:send(cluster_base.read(device, 0x01, PRIVATE_CLUSTER_ID, PRIVATE_ATTR_ID_WATT, nil))
 

--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -18,7 +18,6 @@
 
 local capabilities = require "st.capabilities"
 local log = require "log"
-local clusters = require "st.matter.clusters"
 local cluster_base = require "st.matter.cluster_base"
 local utils = require "st.utils"
 local data_types = require "st.matter.data_types"

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -145,7 +145,6 @@ test.register_coroutine_test(
     test.mock_time.advance_time(60000) -- Ensure that the timer created in create_poll_schedule triggers
     test.socket.matter:__set_channel_ordering("relaxed")
 
-    test.socket.matter:__expect_send({ mock_device.id, clusters.OnOff.attributes.OnOff:read(mock_device) })
     test.socket.matter:__expect_send({ mock_device.id,
       cluster_base.read(mock_device, 0x01, PRIVATE_CLUSTER_ID, PRIVATE_ATTR_ID_WATT, nil) })
     test.socket.matter:__expect_send({ mock_device.id,
@@ -182,7 +181,6 @@ test.register_coroutine_test(
       }
     )
 
-    test.socket.matter:__expect_send({ mock_device.id, clusters.OnOff.attributes.OnOff:read(mock_device) })
     test.socket.matter:__expect_send({ mock_device.id,
       cluster_base.read(mock_device, 0x01, PRIVATE_CLUSTER_ID, PRIVATE_ATTR_ID_WATT, nil) })
     test.socket.matter:__expect_send({ mock_device.id,


### PR DESCRIPTION
Remove an unnecessary switch state read. The switch state should be already reported by the device itself so this frequent read is not necessary here.