### PR TITLE
Bose use current volume as default audio notification

### DIFF
--- a/drivers/SmartThings/bose/src/handlers.lua
+++ b/drivers/SmartThings/bose/src/handlers.lua
@@ -141,11 +141,11 @@ end
 
 function CapabilityHandlers.handle_audio_notification(driver, device, cmd)
   local ip = device:get_field("ip")
-  local DEFAULT_LEVEL = 30
+  local default_level = device:get_latest_state("main", caps.audioVolume.ID, caps.audioVolume.volume.NAME, 30)
   log.info(string.format("[%s](%s) BoseCmd: audio notification with uri %s at level %d", bose_utils.get_serial_number(device),
-                         device.label, cmd.args.uri, cmd.args.level or DEFAULT_LEVEL))
-  local err = command.play_streaming_uri(ip, cmd.args.uri, cmd.args.level or DEFAULT_LEVEL)
-  if err then log.error_with({hub_logs=true}, string.format("failed to handle set volume: %s", err)) end
+                         device.label, cmd.args.uri, cmd.args.level or default_level))
+  local err = command.play_streaming_uri(ip, cmd.args.uri, cmd.args.level or default_level)
+  if err then log.error_with({hub_logs=true}, string.format("failed to handle audio notification: %s", err)) end
 end
 
 


### PR DESCRIPTION
Rather than defaulting to 30 if the audio notification doesn't provide a volume level, default to the current volume with a default of 30 only if the current volume is unknown.

addresses: #911 