### PR TITLE
Matter lock subscribe request unit test expectation fix

### DIFF
--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -66,6 +66,8 @@ local function test_init()
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device))
+  subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
+  subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
 end

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -66,6 +66,8 @@ local function test_init()
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device))
+  subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
+  subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
 end


### PR DESCRIPTION
A bug in the unit test framework has allowed these tests to get past. The integration test framework bugfix will be released with the 51 lua libs.

- [x] Investigate if the workarounds for multiple test init functions (seen [here](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/967/files#diff-9302cdbb223bfda1db868ce1766871b4e8faa95fa4da3ed0e162f64556d5247dR120)) are still needed