### PR TITLE
Yale-Assure-2-Biometric

### DIFF
--- a/drivers/SmartThings/zwave-lock/fingerprints.yml
+++ b/drivers/SmartThings/zwave-lock/fingerprints.yml
@@ -219,6 +219,12 @@ zwaveManufacturer:
     productType: 0x8104
     productId: 0x05D4
     deviceProfileName: base-lock
+  - id: "297/33031/18898"
+    deviceLabel: "Yale Assure 2 Biometric "
+    manufacturerId: 0x0129
+    productId: 0x49D2
+    productType: 0x8107
+    deviceProfileName: "base-lock"
   # Samsung
   - id: "Samsung/SmartDoorlock"
     deviceLabel: Samsung Door Lock


### PR DESCRIPTION
WWST CERT Submission for the Yale Assure 2 Biometric device, Z-Wave Lock