### PR TITLE
Samsung Audio notification fallback to http to handle cooldown period

### DIFF
--- a/drivers/SmartThings/samsung-audio/src/command.lua
+++ b/drivers/SmartThings/samsung-audio/src/command.lua
@@ -407,5 +407,4 @@ function Command.play_streaming_uri(ip, uri)
   end 
   return response_map
 end
-
 return Command

--- a/drivers/SmartThings/samsung-audio/src/command.lua
+++ b/drivers/SmartThings/samsung-audio/src/command.lua
@@ -404,7 +404,8 @@ function Command.play_streaming_uri(ip, uri)
       log.info(string.format("Recieved error code %s",resp.err_code))
       response_map= fallback_to_http(ip,uri)
     end
-  end 
+  end
   return response_map
 end
+
 return Command

--- a/drivers/SmartThings/samsung-audio/src/command.lua
+++ b/drivers/SmartThings/samsung-audio/src/command.lua
@@ -18,6 +18,7 @@ local ltn12 = require "ltn12"
 local xml2lua = require "xml2lua"
 local xml_handler = require "xmlhandler.tree"
 local log = require "log"
+local utils = require "st.utils"
 
 
 local SAMSUNG_AUDIO_HTTP_PORT = 55001
@@ -349,21 +350,38 @@ function Command.getPlayStatus(ip)
 end
 
 --- Return err code from xml handler or nil if it doesn't exist
-local get_err_code = function(response_map)
+local get_resp = function(response_map)
   if response_map ~= nil and
       response_map.handler_res~= nil and
       response_map.handler_res.root ~= nil and
       response_map.handler_res.root.UIC ~= nil and
-      response_map.handler_res.root.UIC.response ~= nil then
-    return response_map.handler_res.root.UIC.response.errCode
+      response_map.handler_res.root.UIC.response ~=nil then
+      return {
+        method = response_map.handler_res.root.UIC.method,
+        err_code= response_map.handler_res.root.UIC.response.errCode
+      }
   else
-    return nil
+    log.trace("errorCode not found")
+    return {
+      method = nil,
+      err_code = nil
+    }
   end
 
 end
 
 local format_streaming_path = function(uri)
   return "/UIC?cmd=%3Cpwron%3Eon%3C/pwron%3E%3Cname%3ESetUrlPlayback%3C/name%3E%3Cp%20type=%22cdata%22%20name=%22url%22%20val=%22empty%22%3E%3C![CDATA[" .. uri .. "]]%3E%3C/p%3E%3Cp%20type=%22dec%22%20name=%22buffersize%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22seektime%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22resume%22%20val=%221%22/%3E"
+end
+
+local fallback_to_http = function(ip,uri)
+  uri = string.gsub(uri, "https://", "http://")
+  local path = format_streaming_path(uri)
+  local url = format_url(ip, path)
+  log.info(string.format("Falling back to http for AudioNotification Command %s", url))
+  local response_map= handle_http_request(ip, url)
+  log.debug("Response Map table with http: ", utils.stringify_table(response_map))
+  return response_map
 end
 
 function Command.play_streaming_uri(ip, uri)
@@ -374,15 +392,19 @@ function Command.play_streaming_uri(ip, uri)
     local url = format_url(ip, path)
     log.trace(string.format("Final Notification Command URL for making Audio Notification http request = %s", url))
     response_map = handle_http_request(ip, url)
-    local err_code = get_err_code(response_map)
-    if err_code == "URL_OPEN_FAIL" then
-      uri = string.gsub(uri, "https://", "http://")
-      local path = format_streaming_path(uri)
-      local url = format_url(ip, path)
-      log.info(string.format("Falling back to http for AudioNotification Command %s", url))
-      response_map = handle_http_request(ip, url)
+    --- Adding extra debug logs in case some issue comes in future
+    log.debug("Response Map table with https: ", utils.stringify_table(response_map))
+    local resp = get_resp(response_map)
+    log.debug("resp method and error code : ", utils.stringify_table(resp))
+    if resp.method == "ErrorEvent" then
+      log.info(string.format("Recieved error code %s",resp.err_code))
+      response_map= fallback_to_http(ip,uri)
     end
-  end
+    if resp.method == "PausePlaybackEvent" then
+      log.info(string.format("Recieved error code %s",resp.err_code))
+      response_map= fallback_to_http(ip,uri)
+    end
+  end 
   return response_map
 end
 


### PR DESCRIPTION
These changes are being added to handle cooldown period in certain speaker models. After the notification is played, the speaker assumes the notification to keep on playing for sometime. During this period, if another message is played, it sends "ok" response for PausePlaybackEvent and the notification actually fails. 
Refer to below ticket for details.
https://smartthings.atlassian.net/browse/BUG-8312 