### PR TITLE
fix(hue): Don't mDNS scan every minute

### DIFF
--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -1445,7 +1445,7 @@ end
 hue:call_with_delay(3, Discovery.do_mdns_scan, "Philips Hue mDNS Initial Scan")
 
 -- re-scan every minute
-local MDNS_SCAN_INTERVAL_SECONDS = 60
+local MDNS_SCAN_INTERVAL_SECONDS = 600
 hue:call_on_schedule(MDNS_SCAN_INTERVAL_SECONDS, Discovery.do_mdns_scan, "Philips Hue mDNS Scan Task")
 
 log.info("Starting Hue driver")


### PR DESCRIPTION
We like a lower interval to be kinder to the LAN and the hub, and we like
10 minutes. This was done in Sonos already but we left Hue at 1 minute, which
was the development testing period.