### PR TITLE
Add back matter switch fingerprints

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,4 +1,4 @@
-matterManufacturer:
+matterManufacturer:    
 #Eve
   - id: "Eve/Energy/US"
     deviceLabel: Eve Energy
@@ -196,6 +196,26 @@ matterGeneric:
     deviceTypes:
       - id: 0x010B # Dimmable Plug-in Unit
     deviceProfileName: plug-level
+  - id: "matter/on-off/switch"
+    deviceLabel: Matter OnOff Switch
+    deviceTypes:
+      - id: 0x0103 # OnOff Switch
+    deviceProfileName: switch-binary
+  - id: "matter/dimmable/switch"
+    deviceLabel: Matter Dimmable Switch
+    deviceTypes:
+      - id: 0x0104 # Dimmer Switch
+    deviceProfileName: switch-level
+  - id: "matter/dimmable/inunitswitch"
+    deviceLabel: Matter Dimmable Switch
+    deviceTypes:
+      - id: 0x010B # Dimmable PlugIn Unit
+    deviceProfileName: switch-level
+  - id: "matter/color/switch"
+    deviceLabel: Matter Color Switch
+    deviceTypes:
+      - id: 0x0105 # Color Dimmer Switch
+    deviceProfileName: switch-color-level
 
 matterThing:
   - id: SmartThings/MatterThing

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,4 +1,4 @@
-matterManufacturer:    
+matterManufacturer:
 #Eve
   - id: "Eve/Energy/US"
     deviceLabel: Eve Energy
@@ -32,7 +32,7 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0xAC
     deviceProfileName: plug-binary
-    
+
 #Nanoleaf
   - id: "Nanoleaf NL53"
     deviceLabel: Essentials BR30
@@ -205,11 +205,6 @@ matterGeneric:
     deviceLabel: Matter Dimmable Switch
     deviceTypes:
       - id: 0x0104 # Dimmer Switch
-    deviceProfileName: switch-level
-  - id: "matter/dimmable/inunitswitch"
-    deviceLabel: Matter Dimmable Switch
-    deviceTypes:
-      - id: 0x010B # Dimmable PlugIn Unit
     deviceProfileName: switch-level
   - id: "matter/color/switch"
     deviceLabel: Matter Color Switch


### PR DESCRIPTION
Generic fingerprints for the OnOff Switch, Dimmer Switch, and Color Dimmer Switch device types were removed because they require bindings to work correctly, and we do not currently support bindings (removed here: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1003). These generic fingerprints were removed in favor of having these devices join as `matter-thing` until binding support is added. However, the Matter Test app does currently have support for OnOff Switch, Dimmer Switch, and Color Dimmer Switch devices, but with the removal of these generic fingerprints these devices just show up as `matter-thing`. We want to add back these fingerprints so that these test app devices show up correctly in the SmartThings app.

https://smartthings.atlassian.net/browse/BUG2-624