### PR TITLE
BUG2-521 Rework yoolax window shade driver

### DIFF
--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_battery_yoolax.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_battery_yoolax.lua
@@ -19,6 +19,13 @@ local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 
+local messages = require "st.zigbee.messages"
+local default_response = require "st.zigbee.zcl.global_commands.default_response"
+local zb_const = require "st.zigbee.constants"
+local Status = require "st.zigbee.generated.types.ZclStatus"
+local data_types = require "st.zigbee.data_types"
+local zcl_messages = require "st.zigbee.zcl"
+
 local WindowCovering = clusters.WindowCovering
 
 local mock_device = test.mock_device.build_test_zigbee_device(
@@ -35,6 +42,29 @@ local mock_device = test.mock_device.build_test_zigbee_device(
   }
 )
 
+local function build_default_response_msg(cluster, command, status)
+  local addr_header = messages.AddressHeader(
+    mock_device:get_short_address(),
+    mock_device.fingerprinted_endpoint_id,
+    zb_const.HUB.ADDR,
+    zb_const.HUB.ENDPOINT,
+    zb_const.HA_PROFILE_ID,
+    cluster
+  )
+  local default_response_body = default_response.DefaultResponse(command, status)
+  local zcl_header = zcl_messages.ZclHeader({
+    cmd = data_types.ZCLCommandId(default_response_body.ID)
+  })
+  local message_body = zcl_messages.ZclMessageBody({
+    zcl_header = zcl_header,
+    zcl_body = default_response_body
+  })
+  return messages.ZigbeeMessageRx({
+    address_header = addr_header,
+    body = message_body
+  })
+end
+
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
   test.mock_device.add_test_device(mock_device)
@@ -44,9 +74,8 @@ end
 test.set_test_init_function(test_init)
 
 test.register_coroutine_test(
-  "State transition from opening to partially open",
+  "Initial level report",
   function()
-    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.zigbee:__queue_receive(
       {
         mock_device.id,
@@ -54,20 +83,10 @@ test.register_coroutine_test(
       }
     )
     test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "windowShadeLevel", component_id = "main",
-            attribute_id = "shadeLevel", state = { value = 99 }
-          }
-        }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.opening())
-    )
-    test.mock_time.advance_time(2)
-    test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(99))
     )
     test.wait_for_events()
   end
@@ -76,7 +95,7 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "State transition from opening to closing",
   function()
-    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.zigbee:__queue_receive(
       {
         mock_device.id,
@@ -84,38 +103,23 @@ test.register_coroutine_test(
       }
     )
     test.socket.capability:__expect_send(
-        {
-          mock_device.id,
-          {
-            capability_id = "windowShadeLevel", component_id = "main",
-            attribute_id = "shadeLevel", state = { value = 90 }
-          }
-        }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.opening())
-    )
-    test.mock_time.advance_time(2)
-    test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
     )
-    test.wait_for_events()
-    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(90))
+    )
     test.socket.zigbee:__queue_receive({
       mock_device.id,
       WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_device, 15)
     })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "windowShadeLevel", component_id = "main",
-        attribute_id = "shadeLevel", state = { value = 85 }
-      }
-    })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closing())
     )
-    test.mock_time.advance_time(3)
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(85))
+    )
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
     )
@@ -196,10 +200,9 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "an attribute read should not be sent after 30s if there is a response",
+  "an attribute read should not be sent after 30s if there is a matching response",
   function ()
     test.timer.__create_and_queue_test_time_advance_timer(30, "oneshot") --Only one timer in the driver
-    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot") --delay timer for defaults parially open delay
     test.socket.capability:__queue_receive(
       {
         mock_device.id,
@@ -214,36 +217,25 @@ test.register_coroutine_test(
 
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_device, 15)
-    })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "windowShadeLevel", component_id = "main",
-        attribute_id = "shadeLevel", state = { value = 85 }
-      }
+      WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_device, 0)
     })
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.opening())
+      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.open())
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(100))
     )
     test.wait_for_events()
 
-    test.mock_time.advance_time(20)
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
-    )
-    test.wait_for_events()
-
-    test.mock_time.advance_time(11)
+    test.mock_time.advance_time(30)
     test.wait_for_events()
   end
 )
 
 test.register_coroutine_test(
-  "an attribute read should not be sent after 30s if there is a response another timing",
+  "an attribute read should be sent after 30s if there is a non-matching response",
   function ()
     test.timer.__create_and_queue_test_time_advance_timer(30, "oneshot") --Only one timer in the driver
-    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot") --delay timer for defaults parially open delay
     test.socket.capability:__queue_receive(
       {
         mock_device.id,
@@ -255,32 +247,82 @@ test.register_coroutine_test(
       WindowCovering.server.commands.GoToLiftPercentage(mock_device, 0)
     })
     test.wait_for_events()
-
-    test.mock_time.advance_time(1)
     test.socket.zigbee:__queue_receive({
       mock_device.id,
       WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_device, 15)
     })
-    test.socket.capability:__expect_send({
-      mock_device.id,
-      {
-        capability_id = "windowShadeLevel", component_id = "main",
-        attribute_id = "shadeLevel", state = { value = 85 }
-      }
-    })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.opening())
-    )
-    test.wait_for_events()
-
-    test.mock_time.advance_time(1)
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
     )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(85)))
     test.wait_for_events()
 
-    test.mock_time.advance_time(28)
+    test.mock_time.advance_time(30)
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device,
+                                            zigbee_test_utils.mock_hub_eui,
+                                            clusters.WindowCovering.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      clusters.WindowCovering.attributes.CurrentPositionLiftPercentage:configure_reporting(mock_device,
+                                                                                          0,
+                                                                                          600,
+                                                                                          1)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      clusters.WindowCovering.attributes.CurrentPositionLiftPercentage:read(mock_device)
+    })
     test.wait_for_events()
+  end
+)
+
+test.register_coroutine_test(
+  "Command success should result in opening/closing event",
+  function()
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_device, 0)
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.open())
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(100))
+    )
+    test.wait_for_events()
+    test.socket.capability:__queue_receive(
+      {
+        mock_device.id,
+        { capability = "windowShade", component = "main", command = "close", args = {} }
+      }
+    )
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      WindowCovering.server.commands.GoToLiftPercentage(mock_device, 100)
+    })
+    test.wait_for_events()
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      build_default_response_msg(WindowCovering.ID, WindowCovering.server.commands.GoToLiftPercentage.ID, Status.SUCCESS)
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closing())
+    )
+    test.wait_for_events()
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_device, 100)
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closed())
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0))
+    )
   end
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/yoolax/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/yoolax/init.lua
@@ -14,12 +14,14 @@
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
+local zcl_global_commands = require "st.zigbee.zcl.global_commands"
+local Status = require "st.zigbee.generated.types.ZclStatus"
 local WindowCovering = zcl_clusters.WindowCovering
-local windowShadeDefaults = require "st.zigbee.defaults.windowShade_defaults"
 
 local device_management = require "st.zigbee.device_management"
 
 local LEVEL_UPDATE_TIMEOUT = "__level_update_timeout"
+local MOST_RECENT_SETLEVEL = "__most_recent_setlevel"
 
 local YOOLAX_WINDOW_SHADE_FINGERPRINTS = {
     { mfr = "Yookee", model = "D10110" },                                 -- Yookee Window Treatment
@@ -35,10 +37,34 @@ local function is_yoolax_window_shade(opts, driver, device)
   return false
 end
 
+local function default_response_handler(driver, device, zb_message)
+  local is_success = zb_message.body.zcl_body.status.value
+  local command = zb_message.body.zcl_body.cmd.value
+
+  if is_success == Status.SUCCESS and command == WindowCovering.server.commands.GoToLiftPercentage.ID then
+    local current_level = device:get_latest_state("main", capabilities.windowShadeLevel.ID, capabilities.windowShadeLevel.shadeLevel.NAME)
+    if current_level then current_level = 100 - current_level end -- convert to the zigbee value
+    local most_recent_setlevel = device:get_field(MOST_RECENT_SETLEVEL)
+    if current_level and most_recent_setlevel and current_level ~= most_recent_setlevel then
+      if current_level > most_recent_setlevel then
+        device:emit_event(capabilities.windowShade.windowShade.opening())
+      else
+        device:emit_event(capabilities.windowShade.windowShade.closing())
+      end
+    end
+  end
+end
+
 local function set_shade_level(driver, device, value, command)
   local level = 100 - value
   device:send_to_component(command.component, WindowCovering.server.commands.GoToLiftPercentage(device, level))
-  local timer = device.thread:call_with_delay(30, function ()
+  device:set_field(MOST_RECENT_SETLEVEL, level) -- set the value to the zigbee protocol value
+
+  local timer = device:get_field(LEVEL_UPDATE_TIMEOUT)
+  if timer then
+    device.thread.cancel_timer(timer)
+  end
+  timer = device.thread:call_with_delay(30, function ()
     -- for some reason the device isn't updating us about its state so we'll send another bind request
     device:send(device_management.build_bind_request(device, WindowCovering.ID, driver.environment_info.hub_zigbee_eui))
     device:send(WindowCovering.attributes.CurrentPositionLiftPercentage:configure_reporting(device, 0, 600, 1))
@@ -63,12 +89,49 @@ local function set_window_shade_level(level)
 end
 
 local function current_position_attr_handler(driver, device, value, zb_rx)
-  local timer = device:get_field(LEVEL_UPDATE_TIMEOUT)
-  if timer then
-    device.thread:cancel_timer(timer)
-    device:set_field(LEVEL_UPDATE_TIMEOUT, nil)
+  local current_level = device:get_latest_state("main", capabilities.windowShadeLevel.ID, capabilities.windowShadeLevel.shadeLevel.NAME)
+  if current_level then current_level = 100 - current_level end -- convert to the zigbee value
+
+  if value.value == 0 then
+    device:emit_event(capabilities.windowShade.windowShade.open())
+  elseif value.value == 100 then
+    device:emit_event(capabilities.windowShade.windowShade.closed())
+  elseif current_level == nil then
+    -- our first level change to a non-open/closed value
+    device:emit_event(capabilities.windowShade.windowShade.partially_open())
   end
-  windowShadeDefaults.default_current_lift_percentage_handler(driver, device, {value = 100 - value.value}, zb_rx)
+
+  local most_recent_setlevel = device:get_field(MOST_RECENT_SETLEVEL)
+  if most_recent_setlevel and value.value == most_recent_setlevel then
+    -- this is a report matching our most recent set level command, assume we've stopped
+    device:set_field(MOST_RECENT_SETLEVEL, nil)
+    if value.value ~= 0 and value.value ~= 100 then
+      device:emit_event(capabilities.windowShade.windowShade.partially_open())
+    end
+    local timer = device:get_field(LEVEL_UPDATE_TIMEOUT)
+    if timer then
+      device.thread:cancel_timer(timer)
+      device:set_field(LEVEL_UPDATE_TIMEOUT, nil)
+    end
+  elseif most_recent_setlevel == nil then
+    -- this is a spontaneous level change
+    if current_level and current_level ~= value.value then
+      if current_level > value.value then
+        device:emit_event(capabilities.windowShade.windowShade.opening())
+      else
+        device:emit_event(capabilities.windowShade.windowShade.closing())
+      end
+      device.thread:call_with_delay(2, function()
+        -- if we don't have a changed level value within the next 2s, assume we've stopped moving
+        local current_level_now = device:get_latest_state("main", capabilities.windowShadeLevel.ID, capabilities.windowShadeLevel.shadeLevel.NAME)
+        if current_level_now then current_level_now = 100 - current_level_now end -- convert to the zigbee value
+        if current_level_now == value.value and current_level_now ~= 0 and current_level_now ~= 100 then
+          device:emit_event(capabilities.windowShade.windowShade.partially_open())
+        end
+      end)
+    end
+  end
+  device:emit_event(capabilities.windowShadeLevel.shadeLevel(100 - value.value))
 end
 
 local yoolax_window_shade = {
@@ -76,8 +139,8 @@ local yoolax_window_shade = {
   capability_handlers = {
     [capabilities.windowShade.ID] = {
       [capabilities.windowShadeLevel.commands.setShadeLevel.NAME] = window_shade_level_cmd,
-      [capabilities.windowShade.commands.open.NAME] = set_window_shade_level(100),
-      [capabilities.windowShade.commands.close.NAME] = set_window_shade_level(0),
+      [capabilities.windowShade.commands.open.NAME] = set_window_shade_level(100), -- a report of 0 = open
+      [capabilities.windowShade.commands.close.NAME] = set_window_shade_level(0), -- a report of 100 = closed
     },
     [capabilities.windowShadePreset.ID] = {
       [capabilities.windowShadePreset.commands.presetPosition.NAME] = window_shade_preset_cmd
@@ -88,7 +151,12 @@ local yoolax_window_shade = {
       [WindowCovering.ID] = {
         [WindowCovering.attributes.CurrentPositionLiftPercentage.ID] = current_position_attr_handler
       }
-    }
+    },
+    global = {
+      [WindowCovering.ID] = {
+        [zcl_global_commands.DEFAULT_RESPONSE_ID] = default_response_handler
+      }
+    },
   },
   can_handle = is_yoolax_window_shade
 }


### PR DESCRIPTION
Consolidates the timer logic used to check up on changing window shades into the sub-driver. Also uses a default response success from the device to indicate that the shade is moving. A subsequent poll should change the status to a stationary one if no updates are received within 30s.