### PR TITLE
Eve Energy: Improve the performance when the device is off

### DIFF
--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -30,9 +30,14 @@ local PRIVATE_ATTR_ID_WATT = 0x130A000A
 local PRIVATE_ATTR_ID_WATT_ACCUMULATED = 0x130A000B
 local PRIVATE_ATTR_ID_ACCUMULATED_CONTROL_POINT = 0x130A000E
 
-local LAST_REPORT_TIME = "LAST_REPORT_TIME"
+-- Timer to update the data each minute if the device is on
 local RECURRING_POLL_TIMER = "RECURRING_POLL_TIMER"
-local TIMER_REPEAT = (1 * 60)    -- Run the timer each minute
+local TIMER_REPEAT = (1 * 60) -- Run the timer each minute
+
+-- Timer to report the power consumption every 15 minutes to satisfy the ST energy requirement
+local RECURRING_REPORT_POLL_TIMER = "RECURRING_REPORT_POLL_TIMER"
+local LAST_REPORT_TIME = "LAST_REPORT_TIME"
+local LATEST_TOTAL_CONSUMPTION_WH = "LATEST_TOTAL_CONSUMPTION_WH"
 local REPORT_TIMEOUT = (15 * 60) -- Report the value each 15 minutes
 
 
@@ -55,38 +60,11 @@ local function iso8061Timestamp(time)
 end
 
 local function updateEnergyMeter(device, totalConsumptionWh)
+  -- Remember the total consumption so we can report it every 15 minutes
+  device:set_field(LATEST_TOTAL_CONSUMPTION_WH, totalConsumptionWh, { persist = true })
+
   -- Report the energy consumed
   device:emit_event(capabilities.energyMeter.energy({ value = totalConsumptionWh, unit = "Wh" }))
-
-  -- Only send powerConsumptionReport every couple of minutes (REPORT_TIMEOUT)
-  local current_time = os.time()
-  local last_time = device:get_field(LAST_REPORT_TIME) or 0
-  local next_time = last_time + REPORT_TIMEOUT
-  if current_time < next_time then
-    return
-  end
-
-  device:set_field(LAST_REPORT_TIME, current_time, { persist = true })
-
-  -- Calculate the energy consumed between the start and the end time
-  local previousTotalConsumptionWh = device:get_latest_state("main", capabilities.powerConsumptionReport.ID,
-    capabilities.powerConsumptionReport.powerConsumption.NAME)
-
-  local deltaEnergyWh = 0.0
-  if previousTotalConsumptionWh ~= nil and previousTotalConsumptionWh.energy ~= nil then
-    deltaEnergyWh = math.max(totalConsumptionWh - previousTotalConsumptionWh.energy, 0.0)
-  end
-
-  local startTime = iso8061Timestamp(last_time)
-  local endTime = iso8061Timestamp(current_time - 1)
-
-  -- Report the energy consumed during the time interval. The unit of these values should be 'Wh'
-  device:emit_event(capabilities.powerConsumptionReport.powerConsumption({
-    start = startTime,
-    ["end"] = endTime,
-    deltaEnergy = deltaEnergyWh,
-    energy = totalConsumptionWh
-  }))
 end
 
 
@@ -106,19 +84,60 @@ local function requestData(device)
 end
 
 local function create_poll_schedule(device)
+  local poll_timer = device:get_field(RECURRING_POLL_TIMER)
+  if poll_timer ~= nil then
+    return
+  end
+
   -- The powerConsumption report needs to be updated at least every 15 minutes in order to be included in SmartThings Energy
   -- Eve Energy generally report changes every 10 or 17 minutes
   local timer = device.thread:call_on_schedule(TIMER_REPEAT, function()
-    -- We want to prevent to read the power reports of the device if the device is off
-    local is_off = device:get_latest_state("main", capabilities.switch.ID, capabilities.switch.switch.NAME) == "off"
-    if is_off then
-      return
-    end
-
     requestData(device)
   end, "polling_schedule_timer")
 
   device:set_field(RECURRING_POLL_TIMER, timer)
+end
+
+local function delete_poll_schedule(device)
+  local poll_timer = device:get_field(RECURRING_POLL_TIMER)
+  if poll_timer ~= nil then
+    device.thread:cancel_timer(poll_timer)
+    device:set_field(RECURRING_POLL_TIMER, nil)
+  end
+end
+
+
+local function create_poll_report_schedule(device)
+  -- The powerConsumption report needs to be updated at least every 15 minutes in order to be included in SmartThings Energy
+  local timer = device.thread:call_on_schedule(REPORT_TIMEOUT, function()
+    local current_time = os.time()
+    local last_time = device:get_field(LAST_REPORT_TIME) or 0
+    local latestTotalConsumptionWH = device:get_field(LATEST_TOTAL_CONSUMPTION_WH) or 0
+
+    device:set_field(LAST_REPORT_TIME, current_time, { persist = true })
+
+    -- Calculate the energy consumed between the start and the end time
+    local previousTotalConsumptionWh = device:get_latest_state("main", capabilities.powerConsumptionReport.ID,
+      capabilities.powerConsumptionReport.powerConsumption.NAME)
+
+    local deltaEnergyWh = 0.0
+    if previousTotalConsumptionWh ~= nil and previousTotalConsumptionWh.energy ~= nil then
+      deltaEnergyWh = math.max(latestTotalConsumptionWH - previousTotalConsumptionWh.energy, 0.0)
+    end
+
+    local startTime = iso8061Timestamp(last_time)
+    local endTime = iso8061Timestamp(current_time - 1)
+
+    -- Report the energy consumed during the time interval. The unit of these values should be 'Wh'
+    device:emit_event(capabilities.powerConsumptionReport.powerConsumption({
+      start = startTime,
+      ["end"] = endTime,
+      deltaEnergy = deltaEnergyWh,
+      energy = latestTotalConsumptionWH
+    }))
+  end, "polling_report_schedule_timer")
+
+  device:set_field(RECURRING_REPORT_POLL_TIMER, timer)
 end
 
 
@@ -171,6 +190,7 @@ local function device_init(driver, device)
   device:subscribe()
 
   create_poll_schedule(device)
+  create_poll_report_schedule(device)
 end
 
 local function device_added(driver, device)
@@ -180,11 +200,7 @@ local function device_added(driver, device)
 end
 
 local function device_removed(driver, device)
-  local poll_timer = device:get_field(RECURRING_POLL_TIMER)
-  if poll_timer ~= nil then
-    device.thread:cancel_timer(poll_timer)
-    device:set_field(RECURRING_POLL_TIMER, nil)
-  end
+  delete_poll_schedule(device)
 end
 
 local function handle_refresh(self, device)
@@ -226,13 +242,17 @@ end
 local function on_off_attr_handler(driver, device, ib, response)
   if ib.data.value then
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switch.switch.on())
+
+    create_poll_schedule(device)
   else
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switch.switch.off())
 
     -- We want to prevent to read the power reports of the device if the device is off
-    -- As such, the timer in create_poll_schedule does nothing if the device is off
     -- We set here the power to 0 before the read is skipped so that the power is correctly displayed and not using a stale value
     device:emit_event(capabilities.powerMeter.power({ value = 0, unit = "W" }))
+
+    -- Stop the timer when the device is off
+    delete_poll_schedule(device)
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -311,4 +311,28 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Test the on attribute", function()
+	local data = data_types.validate_or_build_type(1, data_types.Uint16, "on")
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        cluster_base.build_test_report_data(
+          mock_device,
+          0x01,
+          clusters.OnOff.ID,
+          clusters.OnOff.attributes.OnOff.ID,
+          data
+        )
+      }
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.switch.switch({ value = "on" }))
+    )
+
+    test.wait_for_events()
+  end
+)
+
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -262,16 +262,6 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 50000, unit = "Wh" }))
     )
 
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main",
-        capabilities.powerConsumptionReport.powerConsumption({
-          energy = 50000,
-          deltaEnergy = 0.0,
-          start = "1970-01-01T00:00:00Z",
-          ["end"] = "1970-01-01T16:39:59Z"
-        }))
-    )
-
     test.wait_for_events()
   end
 )

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -339,4 +339,56 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Report with power consumption after 15 minutes even when device is off", function()
+    -- device is off
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, false)
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.switch.switch({ value = "off" }))
+    )
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 0, unit = "W" }))
+    )
+
+    test.wait_for_events()
+    -- after 15 minutes, the device should still report power consumption even when off
+    test.mock_time.advance_time(60 * 15) -- Ensure that the timer created in create_poll_schedule triggers
+
+
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main",
+        capabilities.powerConsumptionReport.powerConsumption({
+          energy = 0,
+          deltaEnergy = 0.0,
+          start = "1970-01-01T00:00:00Z",
+          ["end"] = "1970-01-01T00:14:59Z"
+        }))
+    )
+
+    test.wait_for_events()
+  end,
+  {
+    test_init = function()
+      local cluster_subscribe_list = {
+        clusters.OnOff.attributes.OnOff,
+      }
+      test.socket.matter:__set_channel_ordering("relaxed")
+      local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+      for i, cluster in ipairs(cluster_subscribe_list) do
+        if i > 1 then
+          subscribe_request:merge(cluster:subscribe(mock_device))
+        end
+      end
+      test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
+      test.mock_device.add_test_device(mock_device)
+      test.timer.__create_and_queue_test_time_advance_timer(60 * 15, "interval", "create_poll_report_schedule")
+      test.timer.__create_and_queue_test_time_advance_timer(60, "interval", "create_poll_schedule")
+    end
+  }
+)
+
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -138,6 +138,20 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Check when the device is removed", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+
+    local poll_timer = mock_device:get_field("RECURRING_POLL_TIMER")
+    assert(poll_timer ~= nil, "poll_timer should exist")
+
+    local report_poll_timer = mock_device:get_field("RECURRING_REPORT_POLL_TIMER")
+    assert(report_poll_timer ~= nil, "report_poll_timer should exist")
+
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "removed" })
+    test.wait_for_events()
+  end
+)
 
 test.register_coroutine_test(
   "Check that the timer created in create_poll_schedule properly reads the device in requestData",
@@ -303,7 +317,7 @@ test.register_coroutine_test(
 
 test.register_coroutine_test(
   "Test the on attribute", function()
-	local data = data_types.validate_or_build_type(1, data_types.Uint16, "on")
+    local data = data_types.validate_or_build_type(1, data_types.Uint16, "on")
     test.socket.matter:__queue_receive(
       {
         mock_device.id,


### PR DESCRIPTION
- Don't the power reports of the device if the device is off
- In the timer, we now check if the device is off using device:get_latest_state()
- Set the power to 0 before the read is skipped so that the power is correctly displayed and not using a stale value