### PR TITLE
Reverse switch operation

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
@@ -327,7 +327,7 @@ test.register_coroutine_test(
   "Handle turnOffIndicatorLight in infochanged : On",
   function()
     test.socket.device_lifecycle:__queue_receive(mock_parent_device:generate_info_changed({
-      preferences = { ["stse.turnOffIndicatorLight"] = true }
+      preferences = { ["stse.turnOffIndicatorLight"] = false }
     }))
     test.socket.zigbee:__expect_send({ mock_parent_device.id,
       cluster_base.write_manufacturer_specific_attribute(mock_parent_device, 0x0006,
@@ -339,7 +339,7 @@ test.register_coroutine_test(
   "Handle turnOffIndicatorLight in infochanged : Off",
   function()
     test.socket.device_lifecycle:__queue_receive(mock_parent_device:generate_info_changed({
-      preferences = { ["stse.turnOffIndicatorLight"] = false }
+      preferences = { ["stse.turnOffIndicatorLight"] = true }
     }))
     test.socket.zigbee:__expect_send({ mock_parent_device.id,
       cluster_base.write_manufacturer_specific_attribute(mock_parent_device, 0x0006,

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
@@ -100,7 +100,7 @@ end
 local function device_info_changed(driver, device, event, args)
   local preferences = device.preferences
   local old_preferences = args.old_st_store.preferences
-  local value_map = { [true] = 0x01,[false] = 0x00 }
+  local value_map = { [true] = 0x00,[false] = 0x01 }
   if preferences ~= nil then
     local id = "stse.turnOffIndicatorLight"
     local old_value = old_preferences[id]


### PR DESCRIPTION
Because the APP page displays "Turn off indicator light" , so when "true", it should be closed