### PR TITLE
Matter Switch: use parent-child for multi switch devices

### DIFF
--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -22,6 +22,7 @@ local clusters = require "st.matter.clusters"
 local cluster_base = require "st.matter.cluster_base"
 local utils = require "st.utils"
 local data_types = require "st.matter.data_types"
+local device_lib = require "st.device"
 
 local EVE_MANUFACTURER_ID = 0x130A
 local PRIVATE_CLUSTER_ID = 0x130AFC01
@@ -41,7 +42,9 @@ local REPORT_TIMEOUT = (15 * 60) -- Report the value each 15 minutes
 -------------------------------------------------------------------------------------
 
 local function is_eve_energy_products(opts, driver, device)
-  if device.manufacturer_info.vendor_id == EVE_MANUFACTURER_ID then
+  -- this sub driver does not support child devices
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
+     device.manufacturer_info.vendor_id == EVE_MANUFACTURER_ID then
     return true
   end
 

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -32,6 +32,7 @@ local COLOR_TEMPERATURE_MIRED_MIN = CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN
 
 local SWITCH_INITIALIZED = "__switch_intialized"
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
+local AGGREGATOR_DEVICE_TYPE_ID = 0x000E
 local detect_matter_thing
 
 local function convert_huesat_st_to_matter(val)
@@ -121,7 +122,7 @@ end
 local function detect_bridge(device)
   for _, ep in ipairs(device.endpoints) do
     for _, dt in ipairs(ep.device_types) do
-      if dt.device_type_id == 0x000E then -- look for aggregator type
+      if dt.device_type_id == AGGREGATOR_DEVICE_TYPE_ID then
         return true
       end
     end

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -17,6 +17,7 @@ local log = require "log"
 local clusters = require "st.matter.clusters"
 local MatterDriver = require "st.matter.driver"
 local utils = require "st.utils"
+local device_lib = require "st.device"
 
 local MOST_RECENT_TEMP = "mostRecentTemp"
 local RECEIVED_X = "receivedX"
@@ -29,9 +30,8 @@ local COLOR_TEMPERATURE_KELVIN_MIN = 1
 local COLOR_TEMPERATURE_MIRED_MAX = CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MIN
 local COLOR_TEMPERATURE_MIRED_MIN = CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MAX
 
+local SWITCH_INITIALIZED = "__switch_intialized"
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
--- New profiles need to be added for devices that have more switch endpoints
-local MAX_MULTI_SWITCH_EPS = 7
 local detect_matter_thing
 
 local function convert_huesat_st_to_matter(val)
@@ -44,46 +44,47 @@ end
 --- and supports the OnOff cluster. This is done to bypass the
 --- BRIDGED_NODE_DEVICE_TYPE on bridged devices
 local function find_default_endpoint(device, component)
-  local res = device.MATTER_DEFAULT_ENDPOINT
   local eps = device:get_endpoints(clusters.OnOff.ID)
   table.sort(eps)
   for _, v in ipairs(eps) do
     if v ~= 0 then --0 is the matter RootNode endpoint
-      res = v
-      break
+      return v
     end
   end
   device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
-  return res
+  return device.MATTER_DEFAULT_ENDPOINT
 end
 
-local function initialize_switch(device)
+local function initialize_switch(driver, device)
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
   table.sort(switch_eps)
-  local component_map = {}
 
-  -- For switch devices, the profile components follow the naming convention "switch%d",
-  -- with the exception of "main" being the first component. Each component will then map
-  -- to the next lowest endpoint that hasn't been mapped yet.
-  -- Additionally, since we do not support bindings at the moment, we only want to count
-  -- On/Off clusters that have been implemented as server. This can be removed when we have
+  -- Since we do not support bindings at the moment, we only want to count On/Off
+  -- clusters that have been implemented as server. This can be removed when we have
   -- support for bindings.
   local num_server_eps = 0
+  local main_endpoint = find_default_endpoint(device)
   for _, ep in ipairs(switch_eps) do
     if device:supports_server_cluster(clusters.OnOff.ID, ep) then
-      num_server_eps = num_server_eps + 1;
-      if num_server_eps == 1 then
-        component_map["main"] = ep
-      else
-        component_map[string.format("switch%d", num_server_eps)] = ep
+      num_server_eps = num_server_eps + 1
+      if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
+        local name = string.format("%s %d", device.label, num_server_eps)
+        driver:try_create_device(
+          {
+            type = "EDGE_CHILD",
+            label = name,
+            profile = "switch-binary",
+            parent_device_id = device.id,
+            parent_assigned_child_key = string.format("%d", ep),
+            vendor_provided_label = name
+          }
+        )
       end
     end
   end
 
-  device:set_field(COMPONENT_TO_ENDPOINT_MAP, component_map, {persist = true})
-  -- Note: This profile switching is needed because of shortcoming in the generic fingerprints
-  -- where devices with multiple endpoints with the same device type cannot be detected
-  -- Also, the case where num_server_eps == 1 is a workaround for devices that have the On/Off
+  device:set_field(SWITCH_INITIALIZED, true)
+  -- The case where num_server_eps == 1 is a workaround for devices that have the On/Off
   -- Light Switch device type but implement the On Off cluster as server (which is against the spec
   -- for this device type). By default, we do not support On/Off Light Switch because by spec these
   -- devices need bindings to work correctly (On/Off cluster is client in this case), so this device type
@@ -92,15 +93,6 @@ local function initialize_switch(device)
   -- is a workaround for those devices.
   if num_server_eps == 1 and detect_matter_thing(device) == true then
     device:try_update_metadata({profile = "switch-binary"})
-  elseif num_server_eps > 1 then
-    device:try_update_metadata({profile = string.format("switch-%d", math.min(num_server_eps, MAX_MULTI_SWITCH_EPS))})
-  end
-  if num_server_eps > MAX_MULTI_SWITCH_EPS then
-    error(string.format(
-      "Matter multi switch device will have limited function. Profile doesn't exist with %d components, max is %d",
-      num_server_eps,
-      MAX_MULTI_SWITCH_EPS
-    ))
   end
 end
 
@@ -119,19 +111,27 @@ local function endpoint_to_component(device, ep)
        return component
     end
   end
-  log.warn_with({hub_logs = true}, string.format("Device has more than supported number of switches (max %d), mapping excess endpoint to main component", MAX_MULTI_SWITCH_EPS))
   return "main"
 end
 
+local function find_child(parent, ep_id)
+  return parent:get_child_by_parent_assigned_key(string.format("%d", ep_id))
+end
+
 local function device_init(driver, device)
-  log.info_with({hub_logs=true}, "device init")
-  if not device:get_field(COMPONENT_TO_ENDPOINT_MAP) then
-    -- create endpoint to component map and switch profile as needed
-    initialize_switch(device)
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
+    -- initialize_switch will create parent-child devices as needed for multi-switch devices.
+    -- However, we want to maintain support for existing MCD devices, so do not initialize
+    -- device if it has already been previously initialized as an MCD device.
+    if not device:get_field(COMPONENT_TO_ENDPOINT_MAP) and not device:get_field(SWITCH_INITIALIZED) then
+      -- create child devices as needed for multi-switch devices
+      initialize_switch(driver, device)
+    end
+    device:set_component_to_endpoint_fn(component_to_endpoint)
+    device:set_endpoint_to_component_fn(endpoint_to_component)
+    device:set_find_child(find_child)
+    device:subscribe()
   end
-  device:set_component_to_endpoint_fn(component_to_endpoint)
-  device:set_endpoint_to_component_fn(endpoint_to_component)
-  device:subscribe()
 end
 
 local function device_removed(driver, device)
@@ -264,7 +264,7 @@ end
 local function temp_attr_handler(driver, device, ib, response)
   if ib.data.value ~= nil then
     if (ib.data.value < COLOR_TEMPERATURE_MIRED_MIN or ib.data.value > COLOR_TEMPERATURE_MIRED_MAX) then
-      device.log.warn_with({hub_logs = true}, "Device reported color temperature %d mired outside of supported capability range", ib.data.value)
+      device.log.warn_with({hub_logs = true}, string.format("Device reported color temperature %d mired outside of supported capability range", ib.data.value))
       return
     end
     local temp = utils.round(CONVERSION_CONSTANT/ib.data.value)

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -38,7 +38,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         { cluster_id = clusters.Basic.ID, cluster_type = "SERVER" },
       },
       device_types = {
-        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+        { device_type_id = 0x0016, device_type_revision = 1 } -- RootNode
       }
     },
     {
@@ -56,6 +56,9 @@ local mock_device = test.mock_device.build_test_matter_device({
           cluster_revision = 1,
           feature_map = 0, --u32 bitmap
         }
+      },
+      device_types = {
+        { device_type_id = 0x010A, device_type_revision = 1 } -- On/Off Plug
       }
     }
   }

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
@@ -1,0 +1,85 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+
+local clusters = require "st.matter.clusters"
+
+-- This is to make sure that any device with the "Aggregator" device type
+-- is not profile switched from a bridge, even if there are other endpoints
+-- present. This is due to an issue on the hub where sometimes the endpoints
+-- are not filtered out properly.
+local mock_bridge = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("matter-bridge.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x000E, device_type_revision = 1} -- Aggregator
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = clusters.OnOff.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 0, --u32 bitmap
+        },
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
+      }
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {
+          cluster_id = clusters.OnOff.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 0, --u32 bitmap
+        },
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
+      }
+    }
+  }
+})
+
+local function test_init_mock_bridge()
+  test.socket.matter:__set_channel_ordering("relaxed")
+  test.mock_device.add_test_device(mock_bridge)
+end
+
+test.register_coroutine_test(
+  "Profile should not change for devices with aggregator device type (bridges)",
+  function()
+  end,
+  { test_init = test_init_mock_bridge }
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -50,7 +50,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
       },
       device_types = {
-        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
       }
     }
   }
@@ -69,6 +69,9 @@ local mock_device_no_hue_sat = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
         {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
       }
     }
   }

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -34,7 +34,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
       }
     },
     {
@@ -48,6 +48,9 @@ local mock_device = test.mock_device.build_test_matter_device({
         },
         {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 31},
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
       }
     }
   }

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
@@ -31,7 +31,7 @@ local mock_3switch = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
       }
     },
     {
@@ -40,7 +40,7 @@ local mock_3switch = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
       }
     },
     {
@@ -49,7 +49,7 @@ local mock_3switch = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
       }
     },
     {
@@ -58,7 +58,7 @@ local mock_3switch = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
       }
     },
   }

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
@@ -16,9 +16,10 @@ local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 
 local clusters = require "st.matter.clusters"
+local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
 
 local mock_3switch = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("light-binary.yml"),
+  profile = t_utils.get_profile_definition("switch-3.yml"),
   manufacturer_info = {
     vendor_id = 0x0000,
     product_id = 0x0000,
@@ -64,7 +65,7 @@ local mock_3switch = test.mock_device.build_test_matter_device({
 })
 
 local mock_2switch = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("light-binary.yml"),
+  profile = t_utils.get_profile_definition("switch-2.yml"),
   manufacturer_info = {
     vendor_id = 0x0000,
     product_id = 0x0000,
@@ -100,8 +101,9 @@ local mock_2switch = test.mock_device.build_test_matter_device({
   }
 })
 
+
 local mock_3switch_non_sequential = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("light-binary.yml"),
+  profile = t_utils.get_profile_definition("switch-3.yml"),
   manufacturer_info = {
     vendor_id = 0x0000,
     product_id = 0x0000,
@@ -147,6 +149,8 @@ local mock_3switch_non_sequential = test.mock_device.build_test_matter_device({
 })
 
 local function test_init_mock_3switch()
+  local component_map = {main = 1, switch2 = 2, switch3 = 3}
+  mock_3switch:set_field(COMPONENT_TO_ENDPOINT_MAP, component_map, {persist = true})
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
   }
@@ -154,10 +158,11 @@ local function test_init_mock_3switch()
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_3switch)
   test.socket.matter:__expect_send({mock_3switch.id, subscribe_request})
   test.mock_device.add_test_device(mock_3switch)
-  mock_3switch:expect_metadata_update({ profile = "switch-3" })
 end
 
 local function test_init_mock_2switch()
+  local component_map = {main = 1, switch2 = 2}
+  mock_2switch:set_field(COMPONENT_TO_ENDPOINT_MAP, component_map, {persist = true})
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
   }
@@ -165,10 +170,11 @@ local function test_init_mock_2switch()
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_2switch)
   test.socket.matter:__expect_send({mock_2switch.id, subscribe_request})
   test.mock_device.add_test_device(mock_2switch)
-  mock_2switch:expect_metadata_update({ profile = "switch-2" })
 end
 
 local function test_init_mock_3switch_non_sequential()
+  local component_map = {main = 10, switch2 = 14, switch3 = 15}
+  mock_3switch_non_sequential:set_field(COMPONENT_TO_ENDPOINT_MAP, component_map, {persist = true})
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
   }
@@ -176,7 +182,6 @@ local function test_init_mock_3switch_non_sequential()
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_3switch_non_sequential)
   test.socket.matter:__expect_send({mock_3switch_non_sequential.id, subscribe_request})
   test.mock_device.add_test_device(mock_3switch_non_sequential)
-  mock_3switch_non_sequential:expect_metadata_update({ profile = "switch-3" })
 end
 
 -- The custom "test_init" function also checks that the appropriate profile is switched on init

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child.lua
@@ -1,0 +1,222 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local capabilities = require "st.capabilities"
+
+local clusters = require "st.matter.clusters"
+
+local child_profile = t_utils.get_profile_definition("switch-binary.yml")
+local parent_ep = 10
+local child1_ep = 20
+local child2_ep = 30
+
+local mock_device = test.mock_device.build_test_matter_device({
+  label = "Matter Switch",
+  profile = t_utils.get_profile_definition("switch-binary.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = parent_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+      }
+    },
+    {
+      endpoint_id = child1_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+      }
+    },
+    {
+      endpoint_id = child2_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+      }
+    },
+  }
+})
+
+local mock_children = {}
+for i, endpoint in ipairs(mock_device.endpoints) do
+  if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
+    local child_data = {
+      profile = child_profile,
+      device_network_id = string.format("%s:%d", mock_device.id, endpoint.endpoint_id),
+      parent_device_id = mock_device.id,
+      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+    }
+    mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
+
+local function test_init()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
+  test.mock_device.add_test_device(mock_device)
+  for _, child in pairs(mock_children) do
+    test.mock_device.add_test_device(child)
+  end
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 2",
+    profile = "switch-binary",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = string.format("%d", child1_ep)
+  })
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 3",
+    profile = "switch-binary",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = string.format("%d", child2_ep)
+  })
+end
+
+test.set_test_init_function(test_init)
+
+test.register_message_test(
+  "Parent device: switch capability should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.OnOff.server.commands.On(mock_device, parent_ep)
+      },
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, parent_ep, true)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  }
+)
+
+test.register_message_test(
+  "First child device: switch capability switch should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[child1_ep].id,
+        { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.OnOff.server.commands.On(mock_device, child1_ep)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, child1_ep, true)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child1_ep]:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  }
+)
+
+test.register_message_test(
+  "Second child device: switch capability should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[child2_ep].id,
+        { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.OnOff.server.commands.On(mock_device, child2_ep)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, child2_ep, true)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  }
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child.lua
@@ -37,7 +37,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
       }
     },
     {
@@ -46,7 +46,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
       }
     },
     {
@@ -55,7 +55,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
       }
     },
     {
@@ -64,7 +64,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
       },
       device_types = {
-        device_type_id = 0x0100, device_type_revision = 2, -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
       }
     },
   }


### PR DESCRIPTION
Updates matter switch driver to use parent-child for multi switch devices rather than multi-component devices. Along with these changes, we will check for matter bridge devices before attempting a profile switch to prevent bridge devices from incorrectly switching to MCD switch profiles.