### PR TITLE
Matter Window Covering: add missing parameter

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -68,7 +68,7 @@ local function info_changed(driver, device, event, args)
   else
     -- Something else has changed info (SW update, reinterview, etc.), so
     -- try updating profile as needed
-    match_profile()
+    match_profile(device)
   end
 end
 

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -497,4 +497,14 @@ test.register_coroutine_test(
   { test_init = test_init_mains_powered }
 )
 
+test.register_coroutine_test(
+  "InfoChanged event checks for new profile match if device has changed (i.e. through reinterview or SW update)",
+  function()
+    test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed({}))
+    mock_device:expect_metadata_update({
+      profile = "window-covering-battery",
+    })
+  end
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
The "device" parameter was missing in the match_profile() call on infoChanged. This would cause the infoChanged event to error and not check for a new profile match.

Added unit test to explicitly test this case.

cherry-pick of changes in https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1101