### PR TITLE
Fixup unit test for 51 wakeup notification bugfix

### DIFF
--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
@@ -21,7 +21,6 @@ local t_utils = require "integration_test.utils"
 local Battery = (require "st.zwave.CommandClass.Battery")({ version=1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version=5 })
-local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version=1 })
 local Notification = (require "st.zwave.CommandClass.Notification")({ version=4 })
 
@@ -159,19 +158,6 @@ test.register_coroutine_test(
         Configuration:Set({parameter_number=32, size=2, configuration_value=4320})
       )
     )
-    test.socket.zwave:__expect_send(
-      zw_test_utils.zwave_test_build_send_command(
-        mock_device,
-        SensorBinary:Get({sensor_type = SensorBinary.sensor_type.FREEZE})
-      )
-    )
-    test.socket.zwave:__expect_send(
-      zw_test_utils.zwave_test_build_send_command(
-        mock_device,
-        SensorBinary:Get({sensor_type = SensorBinary.sensor_type.SMOKE})
-      )
-    )
-
   end
 )
 


### PR DESCRIPTION
This fixes unit tests when using the v8 lua libs that were just released. The fix removes what were extra refresh commands due to a bug that was present in the v6 lua libs.