### PR TITLE
newdevice (Z-wave Lock): Philips  DDL240X-15HZW

### DIFF
--- a/drivers/SmartThings/zwave-lock/fingerprints.yml
+++ b/drivers/SmartThings/zwave-lock/fingerprints.yml
@@ -294,6 +294,13 @@ zwaveManufacturer:
     productType: 0x0001
     productId: 0x0001
     deviceProfileName: base-lock
+  # Philips
+  - id: "541/2307/212"
+    deviceLabel: Philips
+    manufacturerId: 0x021D
+    productId: 0x00D4
+    productType: 0x0903
+    deviceProfileName: base-lock
   # TLJ
   - id: "TLJ"
     deviceLabel: TLJ Door Lock


### PR DESCRIPTION
This is a WWST Certification request for a new Z-Wave Lock that supports lock codes. 