### PR TITLE
Matter Window Covering: add comment to deprecate window-covering-profile

### DIFF
--- a/drivers/SmartThings/matter-window-covering/profiles/window-covering-profile.yml
+++ b/drivers/SmartThings/matter-window-covering/profiles/window-covering-profile.yml
@@ -1,3 +1,4 @@
+# deprecated - please use window-covering-battery instead
 name: window-covering-profile
 components:
 - id: main


### PR DESCRIPTION
This profile was intentionally duplicated here: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1091#issuecomment-1830284489
Adding a comment so it is clear that `window-covering-battery` should be used instead and that this profile should be deprecated.