### PR TITLE
new device (Matter Window Covering): WWST Cert request to add the Zemismart MT25B, MT82, MT25A, ZM25M

### DIFF
--- a/drivers/SmartThings/matter-window-covering/fingerprints.yml
+++ b/drivers/SmartThings/matter-window-covering/fingerprints.yml
@@ -10,7 +10,7 @@ matterManufacturer:
     deviceLabel: Zemismart MT25B Roller Motor
     vendorId: 0x139C
     productId: 0xFF60
-    deviceProfileName: window-covering-battery
+    deviceProfileName: window-covering 
   - id: "5020/65296"
     deviceLabel: Zemismart MT82 Smart Curtain
     vendorId: 0x139C

--- a/drivers/SmartThings/matter-window-covering/fingerprints.yml
+++ b/drivers/SmartThings/matter-window-covering/fingerprints.yml
@@ -5,7 +5,17 @@ matterManufacturer:
     vendorId: 0x130A
     productId: 0x55
     deviceProfileName: window-covering-battery
-
+#Zemismart
+  - id: "5020/65376"
+    deviceLabel: Zemismart MT25B Roller Motor
+    vendorId: 0x139C
+    productId: 0xFF60
+    deviceProfileName: window-covering-battery
+  - id: "5020/65296"
+    deviceLabel: Zemismart MT82 Smart Curtain
+    vendorId: 0x139C
+    productId: 0xFF10
+    deviceProfileName: window-covering
 matterGeneric:
   - id: "windowcovering"
     deviceLabel: Matter Window Covering

--- a/drivers/SmartThings/matter-window-covering/fingerprints.yml
+++ b/drivers/SmartThings/matter-window-covering/fingerprints.yml
@@ -16,6 +16,16 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xFF10
     deviceProfileName: window-covering
+  - id: "5020/65301"
+    deviceLabel: Zemismart MT25A Thread Roller Motor
+    vendorId: 0x139C
+    productId: 0xFF15
+    deviceProfileName: window-covering
+  - id: "5020/65535"
+    deviceLabel: Zemismart ZM25M Matter Roller Motor
+    vendorId: 0x139C
+    productId: 0xFFFF
+    deviceProfileName: window-covering
 matterGeneric:
   - id: "windowcovering"
     deviceLabel: Matter Window Covering


### PR DESCRIPTION
This PR is to add the fingerprint for two new Matter WWST Certification requests. 

I reviewed the product pages for the MT25B and MT82 devices. I believe that the MT25B device supports battery, and have fingerprinted that device to the window-covering-battery profile that supports the battery capability. I am following up with PSM to see if this adjustment should be made. 