### PR TITLE
new device (Matter Switch): Nanoleaf NL71 Holiday String Lights

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -59,6 +59,11 @@ matterManufacturer:
     vendorId: 0x115a
     productId: 0x44
     deviceProfileName: light-color-level-2700K-6500K
+  - id: "Nanoleaf NL71"
+    deviceLabel: Essentials Smart Holiday String Lights
+    vendorId: 0x115a
+    productId: 0x771
+    deviceProfileName: light-color-level-2700K-6500K
 #SONOFF
   - id: "SONOFF MINIR4M"
     deviceLabel: Smart Plug-in Unit

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -59,9 +59,9 @@ matterManufacturer:
     vendorId: 0x115a
     productId: 0x44
     deviceProfileName: light-color-level-2700K-6500K
-  - id: "Nanoleaf NL71"
-    deviceLabel: Essentials Smart Holiday String Lights
-    vendorId: 0x115a
+  - id: "4442/1809"
+    deviceLabel: Smart Holiday String Lights
+    vendorId: 0x115A
     productId: 0x771
     deviceProfileName: light-color-level-2700K-6500K
 #SONOFF


### PR DESCRIPTION
This is a new WWST Matter device certification request for the Nanoleaf Smart Holiday String Lights  NL71. 