### PR TITLE
new feature (Z-Wave Switch): Aeotech Heavy Duty ZW078

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -898,6 +898,12 @@ zwaveManufacturer:
     manufacturerId: 0x010F
     productType: 0x0102
     deviceProfileName: fibaro-dimmer-2
+  - id: "881/259/78"
+    deviceLabel: "Heavy Duty Smart Switch"
+    manufacturerId: 0x371
+    productId: 0x4E
+    productType: 0x103
+    deviceProfileName: "metering-switch"
 zwaveGeneric:
   - id: "GenericSwitch/1"
     deviceLabel: Switch


### PR DESCRIPTION
This is for a WWST Certification submission for the Aeotech Heavy Duty ZW078 device. Information on this device can be found here, https://aeotec.com/products/aeoteo-heavy-duty-switch/ and there are additional technical specs on the product available as well. 