### PR TITLE
Danfoss Ally Radiator Thermostat models eTRV0101 and eTRV0103

### DIFF
--- a/drivers/SmartThings/zigbee-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-thermostat/fingerprints.yml
@@ -22,7 +22,7 @@ zigbeeManufacturer:
   - id: "Danfoss/eTRV0101"
     deviceLabel: Danfoss Thermostat
     manufacturer: Danfoss
-    model: eTRV0103
+    model: eTRV0101
     deviceProfileName: thermostat-popp-danfoss
   - id: "Danfoss/eTRV0103"
     deviceLabel: Danfoss Thermostat

--- a/drivers/SmartThings/zigbee-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-thermostat/fingerprints.yml
@@ -19,6 +19,11 @@ zigbeeManufacturer:
     manufacturer: Danfoss
     model: eTRV0100
     deviceProfileName: thermostat-popp-danfoss
+  - id: "Danfoss/eTRV0103"
+    deviceLabel: Danfoss Ally Thermostat
+    manufacturer: Danfoss
+    model: eTRV0103
+    deviceProfileName: thermostat-popp-danfoss
   - id: "D5X84YU/eT093WRO"
     deviceLabel: POPP Smart Thermostat (Zigbee)
     manufacturer: D5X84YU

--- a/drivers/SmartThings/zigbee-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-thermostat/fingerprints.yml
@@ -19,8 +19,13 @@ zigbeeManufacturer:
     manufacturer: Danfoss
     model: eTRV0100
     deviceProfileName: thermostat-popp-danfoss
+  - id: "Danfoss/eTRV0101"
+    deviceLabel: Danfoss Thermostat
+    manufacturer: Danfoss
+    model: eTRV0103
+    deviceProfileName: thermostat-popp-danfoss
   - id: "Danfoss/eTRV0103"
-    deviceLabel: Danfoss Ally Thermostat
+    deviceLabel: Danfoss Thermostat
     manufacturer: Danfoss
     model: eTRV0103
     deviceProfileName: thermostat-popp-danfoss

--- a/drivers/SmartThings/zigbee-thermostat/src/danfoss/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/danfoss/init.lua
@@ -3,7 +3,8 @@ local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 local PowerConfiguration = clusters.PowerConfiguration
 
 local DANFOSS_THERMOSTAT_FINGERPRINTS = {
-  { mfr = "Danfoss", model = "eTRV0100" }
+  { mfr = "Danfoss", model = "eTRV0100" },
+  { mfr = "Danfoss", model = "eTRV0103" }
 }
 
 local is_danfoss_thermostat = function(opts, driver, device)

--- a/drivers/SmartThings/zigbee-thermostat/src/danfoss/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/danfoss/init.lua
@@ -4,6 +4,7 @@ local PowerConfiguration = clusters.PowerConfiguration
 
 local DANFOSS_THERMOSTAT_FINGERPRINTS = {
   { mfr = "Danfoss", model = "eTRV0100" },
+  { mfr = "Danfoss", model = "eTRV0101" },
   { mfr = "Danfoss", model = "eTRV0103" }
 }
 


### PR DESCRIPTION
Adds two new Danfoss Ally Radiator Thermostat model numbers eTRV0101 and eTRV0103 with the same profile as eTRV0100.