### PR TITLE
Change the category of humidity sensor from GenericSensor to HumiditySensor.

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/humidity-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/humidity-battery.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: GenericSensor
+  - name: HumiditySensor
 preferences:
   - preferenceId: humidityOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/humidity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/humidity.yml
@@ -9,7 +9,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: GenericSensor
+  - name: HumiditySensor
 preferences:
   - preferenceId: humidityOffset
     explicit: true


### PR DESCRIPTION
Currently, it's displayed as a default image because the category of the humidity sensor is a GenericSensor.
To support the humidity Image, change the category of humidity sensor from GenericSensor to HumiditySensor.