### PR TITLE
(Hue/Sonos) Use new Luncheon features if available

### DIFF
--- a/drivers/SmartThings/philips-hue/src/lunchbox/rest.lua
+++ b/drivers/SmartThings/philips-hue/src/lunchbox/rest.lua
@@ -5,6 +5,8 @@ local lb_utils = require "lunchbox.util"
 local Request = require "luncheon.request"
 local Response = require "luncheon.response"
 
+local api_version = require("version").api
+
 local RestCallStates = {
   SEND = "Send",
   RECEIVE = "Receive",
@@ -129,6 +131,11 @@ local function parse_chunked_response(original_response, sock)
 end
 
 local function handle_response(sock)
+  if api_version >= 9 then
+    local response, err = Response.tcp_source(sock)
+    if err or (not response) then return response, (err or "unknown error") end
+    return response, response:fill_body()
+  end
   -- called select right before passing in so we receive immediately
   local initial_recv, initial_err, partial = Response.source(function() return sock:receive('*l') end)
 

--- a/drivers/SmartThings/sonos/src/lunchbox/rest.lua
+++ b/drivers/SmartThings/sonos/src/lunchbox/rest.lua
@@ -6,6 +6,8 @@ local utils = require "utils"
 local Request = require "luncheon.request"
 local Response = require "luncheon.response"
 
+local api_version = require("version").api
+
 local RestCallStates = {
   SEND = "Send",
   RECEIVE = "Receive",
@@ -132,6 +134,11 @@ local function parse_chunked_response(original_response, sock)
 end
 
 local function handle_response(sock)
+  if api_version >= 9 then
+    local response, err = Response.tcp_source(sock)
+    if err or (not response) then return response, (err or "unknown error") end
+    return response, response:fill_body()
+  end
   -- called select right before passing in so we receive immediately
   local initial_recv, initial_err, partial = Response.source(function() return sock:receive('*l') end)
 


### PR DESCRIPTION
The next Lua Libs release will include an update to the vendored dep Luncheon which has built-in support for chunked transfer encodings.

Previous versions of Luncheon did not support chunked transfer so we had to roll our own in order to handle large REST API responses.

We branch on the reported lua libs API version, using Luncheon directly if it's available, otherwise we continue to use the existing parsing.

Supercedes: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1148
Co-authored-by: Robert Masen <robert.masen@smartthings.com>