### PR TITLE
Add line numbers to failure outputs for non-ci test script

### DIFF
--- a/tools/run_driver_tests.py
+++ b/tools/run_driver_tests.py
@@ -73,7 +73,14 @@ def run_tests(verbosity_level, filter, junit, coverage_files):
             if m is not None:
                 test_title = line
                 in_progress_test_name = m.group(1)
-                test_case = junit_xml.TestCase(in_progress_test_name)
+                test_name_regex = re.compile(in_progress_test_name)
+                line_number = None
+                with open(test_file, 'r') as search_file:
+                    for idx, line in enumerate(search_file, 1):
+                        if test_name_regex.search(line) :
+                            line_number = idx
+                            break
+                test_case = junit_xml.TestCase(in_progress_test_name, line=line_number)
                 test_count += 1
             elif re.search("PASSED", line) is not None:
                 test_done = True
@@ -84,7 +91,8 @@ def run_tests(verbosity_level, filter, junit, coverage_files):
             elif re.search("FAILED", line) is not None:
                 test_done = True
                 test_status = line
-                failure_files[test_file].append(in_progress_test_name)
+                failure_string = f"{in_progress_test_name} [line {test_case.line}]"
+                failure_files[test_file].append(failure_string)
                 if "traceback" in test_case.stdout:
                     test_case.add_error_info(line, test_case.stdout)
                 else:


### PR DESCRIPTION
This change adds line number output to failure reports from the non-ci `run_driver_tests.py` script. This script doesn't run in CI/CD but can be useful for local development since it can take the `--filter` arg, which lets developers run groups of tests at once with JUnit reports.

Adding the line numbers to the `stdout` report is a QoL improvement for devs to jump to tests quickly; I've even been able to create a problem matcher for the output in VS Code now.

This also adds the line number of the test to the JUnit XML.

The `run_driver_tests_p.py` script that runs in CI/CD is unmodified.

Previous output example:

```console
Unit test failures in /home/dstephen/Developer/Workspaces/SmartThings/git/SmartThingsEdgeDrivers/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua:
    Configure should configure all necessary attributes
```

Output with these changes example:
```console
Unit test failures in /home/dstephen/Developer/Workspaces/SmartThings/git/SmartThingsEdgeDrivers/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua:
    Configure should configure all necessary attributes [line 63]
```