### PR TITLE
Matter Switch: improve child device profile support

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -38,6 +38,20 @@ local SWITCH_INITIALIZED = "__switch_intialized"
 -- will not be set for new devices.
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
 local AGGREGATOR_DEVICE_TYPE_ID = 0x000E
+local ON_OFF_LIGHT_DEVICE_TYPE_ID = 0x0100
+local DIMMABLE_LIGHT_DEVICE_TYPE_ID = 0x0101
+local COLOR_TEMP_LIGHT_DEVICE_TYPE_ID = 0x010C
+local EXTENDED_COLOR_LIGHT_DEVICE_TYPE_ID = 0x010D
+local ON_OFF_PLUG_DEVICE_TYPE_ID = 0x010A
+local DIMMABLE_PLUG_DEVICE_TYPE_ID = 0x010B
+local device_type_profile_map = {
+  [ON_OFF_LIGHT_DEVICE_TYPE_ID] = "light-binary",
+  [DIMMABLE_LIGHT_DEVICE_TYPE_ID] = "light-level",
+  [COLOR_TEMP_LIGHT_DEVICE_TYPE_ID] = "light-level-colorTemperature",
+  [EXTENDED_COLOR_LIGHT_DEVICE_TYPE_ID] = "light-color-level",
+  [ON_OFF_PLUG_DEVICE_TYPE_ID] = "plug-binary",
+  [DIMMABLE_PLUG_DEVICE_TYPE_ID] = "plug-level"
+}
 local detect_matter_thing
 
 local function convert_huesat_st_to_matter(val)
@@ -61,6 +75,26 @@ local function find_default_endpoint(device, component)
   return device.MATTER_DEFAULT_ENDPOINT
 end
 
+local function assign_child_profile(device, child_ep)
+  local profile
+  for _, ep in ipairs(device.endpoints) do
+    if ep.endpoint_id == child_ep then
+      -- Some devices report multiple device types which are a subset of
+      -- a superset device type (For example, Dimmable Light is a superset of
+      -- On/Off light). This mostly applies to the four light types, so we will want
+      -- to match the profile for the superset device type. This can be done by
+      -- matching to the device type with the highest ID
+      local id = 0
+      for _, dt in ipairs(ep.device_types) do
+        id = math.max(id, dt.device_type_id)
+      end
+      profile = device_type_profile_map[id]
+    end
+  end
+  -- default to "switch-binary" if no profile is found
+  return profile or "switch-binary"
+end
+
 local function initialize_switch(driver, device)
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
   table.sort(switch_eps)
@@ -75,11 +109,12 @@ local function initialize_switch(driver, device)
       num_server_eps = num_server_eps + 1
       if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
         local name = string.format("%s %d", device.label, num_server_eps)
+        local child_profile = assign_child_profile(device, ep)
         driver:try_create_device(
           {
             type = "EDGE_CHILD",
             label = name,
-            profile = "switch-binary",
+            profile = child_profile,
             parent_device_id = device.id,
             parent_assigned_child_key = string.format("%d", ep),
             vendor_provided_label = name
@@ -288,7 +323,8 @@ local function temp_attr_handler(driver, device, ib, response)
       return
     end
     local temp = utils.round(CONVERSION_CONSTANT/ib.data.value)
-    local most_recent_temp = device:get_field(MOST_RECENT_TEMP)
+    local temp_device = find_child(device, ib.endpoint_id) or device
+    local most_recent_temp = temp_device:get_field(MOST_RECENT_TEMP)
     -- this is to avoid rounding errors from the round-trip conversion of Kelvin to mireds
     if most_recent_temp ~= nil and
       most_recent_temp <= utils.round(CONVERSION_CONSTANT/(ib.data.value - 1)) and

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -1,4 +1,4 @@
--- Copyright 2023 SmartThings
+-- Copyright 2024 SmartThings
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -17,15 +17,17 @@ local t_utils = require "integration_test.utils"
 local capabilities = require "st.capabilities"
 
 local clusters = require "st.matter.clusters"
+local TRANSITION_TIME = 0
+local OPTIONS_MASK = 0x01
+local OPTIONS_OVERRIDE = 0x01
 
-local child_profile = t_utils.get_profile_definition("switch-binary.yml")
 local parent_ep = 10
 local child1_ep = 20
 local child2_ep = 30
 
 local mock_device = test.mock_device.build_test_matter_device({
   label = "Matter Switch",
-  profile = t_utils.get_profile_definition("switch-binary.yml"),
+  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
   manufacturer_info = {
     vendor_id = 0x0000,
     product_id = 0x0000,
@@ -53,28 +55,37 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = child1_ep,
       clusters = {
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
       },
       device_types = {
-        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
+        {device_type_id = 0x0100, device_type_revision = 2}, -- On/Off Light
+        {device_type_id = 0x0101, device_type_revision = 2} -- Dimmable Light
       }
     },
     {
       endpoint_id = child2_ep,
       clusters = {
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
       },
       device_types = {
-        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
+        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
       }
     },
   }
 })
 
+local child_profiles = {
+  [child1_ep] = t_utils.get_profile_definition("light-level.yml"),
+  [child2_ep] = t_utils.get_profile_definition("light-color-level.yml")
+}
+
 local mock_children = {}
 for i, endpoint in ipairs(mock_device.endpoints) do
   if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
     local child_data = {
-      profile = child_profile,
+      profile = child_profiles[endpoint.endpoint_id],
       device_network_id = string.format("%s:%d", mock_device.id, endpoint.endpoint_id),
       parent_device_id = mock_device.id,
       parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
@@ -86,8 +97,15 @@ end
 local function test_init()
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
+    clusters.LevelControl.attributes.CurrentLevel,
+    clusters.ColorControl.attributes.ColorTemperatureMireds,
   }
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 
   test.mock_device.add_test_device(mock_device)
@@ -98,7 +116,7 @@ local function test_init()
   mock_device:expect_device_create({
     type = "EDGE_CHILD",
     label = "Matter Switch 2",
-    profile = "switch-binary",
+    profile = "light-level",
     parent_device_id = mock_device.id,
     parent_assigned_child_key = string.format("%d", child1_ep)
   })
@@ -106,7 +124,7 @@ local function test_init()
   mock_device:expect_device_create({
     type = "EDGE_CHILD",
     label = "Matter Switch 3",
-    profile = "switch-binary",
+    profile = "light-color-level",
     parent_device_id = mock_device.id,
     parent_assigned_child_key = string.format("%d", child2_ep)
   })
@@ -219,13 +237,154 @@ test.register_message_test(
   }
 )
 
-test.register_coroutine_test(
-  "Added should call refresh for child devices", function()
-    test.socket.matter:__set_channel_ordering("relaxed")
-    test.socket.device_lifecycle:__queue_receive({ mock_children[child1_ep].id, "added" })
-    local req = clusters.OnOff.attributes.OnOff:read(mock_children[child1_ep])
-    test.socket.matter:__expect_send({mock_device.id, req})
-  end
+test.register_message_test(
+  "Current level reports should generate appropriate events",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.LevelControl.server.attributes.CurrentLevel:build_test_report_data(mock_device, child1_ep, 50)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child1_ep]:generate_test_message("main", capabilities.switchLevel.level(math.floor((50 / 254.0 * 100) + 0.5)))
+    },
+  }
+)
+
+test.register_message_test(
+  "Set color temperature should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[child2_ep].id,
+        { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {1800} }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, child2_ep, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToColorTemperature:build_test_command_response(mock_device, child2_ep)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, child2_ep, 556)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.colorTemperature.colorTemperature(1800))
+    },
+  }
+)
+
+test.register_message_test(
+  "X and Y color values should report hue and saturation once both have been received",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, child2_ep, 15091)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, child2_ep, 21547)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.colorControl.hue(50))
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.colorControl.saturation(72))
+    }
+  }
+)
+
+test.register_message_test(
+  "Set color command should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[child2_ep].id,
+        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 72 } } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToColor(mock_device, child2_ep, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToColor:build_test_command_response(mock_device, child2_ep)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, child2_ep, 15091)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, child2_ep, 21547)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.colorControl.hue(50))
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.colorControl.saturation(72))
+    }
+  }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -1,0 +1,231 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local capabilities = require "st.capabilities"
+
+local clusters = require "st.matter.clusters"
+
+local child_profile = t_utils.get_profile_definition("plug-binary.yml")
+local parent_ep = 10
+local child1_ep = 20
+local child2_ep = 30
+
+local mock_device = test.mock_device.build_test_matter_device({
+  label = "Matter Switch",
+  profile = t_utils.get_profile_definition("plug-binary.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = parent_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
+      }
+    },
+    {
+      endpoint_id = child1_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
+      }
+    },
+    {
+      endpoint_id = child2_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
+      }
+    },
+  }
+})
+
+local mock_children = {}
+for i, endpoint in ipairs(mock_device.endpoints) do
+  if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
+    local child_data = {
+      profile = child_profile,
+      device_network_id = string.format("%s:%d", mock_device.id, endpoint.endpoint_id),
+      parent_device_id = mock_device.id,
+      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+    }
+    mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
+
+local function test_init()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
+  test.mock_device.add_test_device(mock_device)
+  for _, child in pairs(mock_children) do
+    test.mock_device.add_test_device(child)
+  end
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 2",
+    profile = "plug-binary",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = string.format("%d", child1_ep)
+  })
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 3",
+    profile = "plug-binary",
+    parent_device_id = mock_device.id,
+    parent_assigned_child_key = string.format("%d", child2_ep)
+  })
+end
+
+test.set_test_init_function(test_init)
+
+test.register_message_test(
+  "Parent device: switch capability should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.OnOff.server.commands.On(mock_device, parent_ep)
+      },
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, parent_ep, true)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  }
+)
+
+test.register_message_test(
+  "First child device: switch capability switch should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[child1_ep].id,
+        { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.OnOff.server.commands.On(mock_device, child1_ep)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, child1_ep, true)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child1_ep]:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  }
+)
+
+test.register_message_test(
+  "Second child device: switch capability should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[child2_ep].id,
+        { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.OnOff.server.commands.On(mock_device, child2_ep)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, child2_ep, true)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[child2_ep]:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  }
+)
+
+test.register_coroutine_test(
+  "Added should call refresh for child devices", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_children[child1_ep].id, "added" })
+    local req = clusters.OnOff.attributes.OnOff:read(mock_children[child1_ep])
+    test.socket.matter:__expect_send({mock_device.id, req})
+  end
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
Child device profiles will now be determined dynamically based on the device type of the child device endpoint. This will improve support for multi-devices.