### PR TITLE
matter-button: Change category for icon

### DIFF
--- a/drivers/SmartThings/matter-button/profiles/button-battery.yml
+++ b/drivers/SmartThings/matter-button/profiles/button-battery.yml
@@ -11,4 +11,4 @@ components:
       - id: refresh
         version: 1
     categories:
-    - name: RemoteController
+    - name: Button

--- a/drivers/SmartThings/matter-button/profiles/button.yml
+++ b/drivers/SmartThings/matter-button/profiles/button.yml
@@ -9,4 +9,4 @@ components:
       - id: refresh
         version: 1
     categories:
-    - name: RemoteController
+    - name: Button


### PR DESCRIPTION
The icon for the RemoteController category is not a button icon. This commit changes the category for the single button profile among the matter-button profiles from RemoteController to Button.