### PR TITLE
Z-Wave Switch: lazy load sub drivers

### DIFF
--- a/drivers/SmartThings/zwave-switch/src/aeon-smart-strip/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/aeon-smart-strip/init.lua
@@ -40,7 +40,8 @@ local POWER_UNIT_WATT = "W"
 local function can_handle_aeon_smart_strip(opts, driver, device, ...)
   for _, fingerprint in ipairs(AEON_SMART_STRIP_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("aeon-smart-strip")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/aeotec-smart-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/aeotec-smart-switch/init.lua
@@ -24,7 +24,10 @@ local FINGERPRINTS = {
 
 local function can_handle(opts, driver, device, ...)
   for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, nil, fingerprint.prodId) then return true end
+    if device:id_match(fingerprint.mfr, nil, fingerprint.prodId) then
+      local subdriver = require("aeotec-smart-switch")
+      return true, subdriver
+    end
   end
   return false
 end

--- a/drivers/SmartThings/zwave-switch/src/dawon-smart-plug/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/dawon-smart-plug/init.lua
@@ -31,7 +31,8 @@ local DAWON_SMART_PLUG_FINGERPRINTS = {
 local function can_handle_dawon_smart_plug(opts, driver, device, ...)
   for _, fingerprint in ipairs(DAWON_SMART_PLUG_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("dawon-smart-plug")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/dawon-wall-smart-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/dawon-wall-smart-switch/init.lua
@@ -41,7 +41,8 @@ local DAWON_WALL_SMART_SWITCH_FINGERPRINTS = {
 local function can_handle_dawon_wall_smart_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(DAWON_WALL_SMART_SWITCH_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("dawon-wall-smart-switch")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/eaton-5-scene-keypad/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/eaton-5-scene-keypad/init.lua
@@ -111,7 +111,8 @@ end
 local function can_handle_eaton_5_scene_keypad(opts, driver, device, ...)
   for _, fingerprint in ipairs(EATON_5_SCENE_KEYPAD_FINGERPRINT) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("eaton-5-scene-keypad")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/eaton-accessory-dimmer/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/eaton-accessory-dimmer/init.lua
@@ -31,7 +31,8 @@ local EATON_ACCESSORY_DIMMER_FINGERPRINTS = {
 local function can_handle_eaton_accessory_dimmer(opts, driver, device, ...)
   for _, fingerprint in ipairs(EATON_ACCESSORY_DIMMER_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("eaton-accessory-dimmer")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/eaton-anyplace-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/eaton-anyplace-switch/init.lua
@@ -25,7 +25,8 @@ local EATON_ANYPLACE_SWITCH_FINGERPRINTS = {
 local function can_handle_eaton_anyplace_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(EATON_ANYPLACE_SWITCH_FINGERPRINTS) do
     if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
+      local subdriver = require("eaton-anyplace-switch")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/ecolink-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/ecolink-switch/init.lua
@@ -27,7 +27,8 @@ local ECOLINK_FINGERPRINTS = {
 local function can_handle_ecolink(opts, driver, device, ...)
   for _, fingerprint in ipairs(ECOLINK_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("ecolink-switch")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/fibaro-double-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/fibaro-double-switch/init.lua
@@ -43,7 +43,8 @@ local FIBARO_DOUBLE_SWITCH_FINGERPRINTS = {
 local function can_handle_fibaro_double_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(FIBARO_DOUBLE_SWITCH_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("fibaro-double-switch")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/fibaro-single-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/fibaro-single-switch/init.lua
@@ -37,7 +37,8 @@ local FIBARO_SINGLE_SWITCH_FINGERPRINTS = {
 local function can_handle_fibaro_single_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(FIBARO_SINGLE_SWITCH_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("fibaro-single-switch")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/fibaro-wall-plug-us/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/fibaro-wall-plug-us/init.lua
@@ -20,7 +20,8 @@ local FIBARO_WALL_PLUG_FINGERPRINTS = {
 local function can_handle_fibaro_wall_plug(opts, driver, device, ...)
   for _, fingerprint in ipairs(FIBARO_WALL_PLUG_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("fibaro-wall-plug-us")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/init.lua
@@ -103,6 +103,19 @@ local function switch_multilevel_stop_level_change_handler(driver, device, cmd)
   device:send(SwitchMultilevel:Get({}))
 end
 
+local function lazy_load_if_possible(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+
+  -- version 9 will include the lazy loading functions
+  if version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end
+
 -------------------------------------------------------------------------------------------
 -- Register message handlers and run driver
 -------------------------------------------------------------------------------------------
@@ -130,25 +143,25 @@ local driver_template = {
     }
   },
   sub_drivers = {
-    require("eaton-accessory-dimmer"),
-    require("inovelli-LED"),
-    require("dawon-smart-plug"),
-    require("inovelli-2-channel-smart-plug"),
-    require("zwave-dual-switch"),
-    require("eaton-anyplace-switch"),
-    require("fibaro-wall-plug-us"),
-    require("dawon-wall-smart-switch"),
-    require("zooz-power-strip"),
-    require("aeon-smart-strip"),
-    require("qubino-switches"),
-    require("fibaro-double-switch"),
-    require("fibaro-single-switch"),
-    require("eaton-5-scene-keypad"),
-    require("ecolink-switch"),
-    require("multi-metering-switch"),
-    require("zooz-zen-30-dimmer-relay"),
-    require("multichannel-device"),
-    require("aeotec-smart-switch")
+    lazy_load_if_possible("eaton-accessory-dimmer"),
+    lazy_load_if_possible("inovelli-LED"),
+    lazy_load_if_possible("dawon-smart-plug"),
+    lazy_load_if_possible("inovelli-2-channel-smart-plug"),
+    lazy_load_if_possible("zwave-dual-switch"),
+    lazy_load_if_possible("eaton-anyplace-switch"),
+    lazy_load_if_possible("fibaro-wall-plug-us"),
+    lazy_load_if_possible("dawon-wall-smart-switch"),
+    lazy_load_if_possible("zooz-power-strip"),
+    lazy_load_if_possible("aeon-smart-strip"),
+    lazy_load_if_possible("qubino-switches"),
+    lazy_load_if_possible("fibaro-double-switch"),
+    lazy_load_if_possible("fibaro-single-switch"),
+    lazy_load_if_possible("eaton-5-scene-keypad"),
+    lazy_load_if_possible("ecolink-switch"),
+    lazy_load_if_possible("multi-metering-switch"),
+    lazy_load_if_possible("zooz-zen-30-dimmer-relay"),
+    lazy_load_if_possible("multichannel-device"),
+    lazy_load_if_possible("aeotec-smart-switch")
   },
   lifecycle_handlers = {
     init = device_init,

--- a/drivers/SmartThings/zwave-switch/src/inovelli-2-channel-smart-plug/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-2-channel-smart-plug/init.lua
@@ -38,7 +38,8 @@ local INOVELLI_2_CHANNEL_SMART_PLUG_FINGERPRINTS = {
 local function can_handle_inovelli_2_channel_smart_plug(opts, driver, device, ...)
   for _, fingerprint in ipairs(INOVELLI_2_CHANNEL_SMART_PLUG_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("inovelli-2-channel-smart-plug")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/inovelli-LED/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/inovelli-LED/init.lua
@@ -84,7 +84,8 @@ local function can_handle_inovelli_led(opts, driver, device, ...)
     {INOVELLI_LZW31SN_PRODUCT_TYPE, INOVELLI_LZW31_PRODUCT_TYPE},
     INOVELLI_DIMMER_PRODUCT_ID
   ) then
-    return true
+    local subdriver = require("inovelli-LED")
+    return true, subdriver
   end
   return false
 end

--- a/drivers/SmartThings/zwave-switch/src/multi-metering-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/multi-metering-switch/init.lua
@@ -47,7 +47,8 @@ local MULTI_METERING_SWITCH_FINGERPRINTS = {
 local function can_handle_multi_metering_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(MULTI_METERING_SWITCH_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("multi-metering-switch")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/multichannel-device/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/multichannel-device/init.lua
@@ -28,7 +28,11 @@ local map_device_class_to_profile = {
 }
 
 local function can_handle_multichannel_device(opts, driver, device, ...)
-  return device:supports_capability(capabilities.zwMultichannel)
+  if device:supports_capability(capabilities.zwMultichannel) then
+    local subdriver = require("multichannel-device")
+    return true, subdriver
+  end
+  return false
 end
 
 local function find_child(device, src_channel)

--- a/drivers/SmartThings/zwave-switch/src/qubino-switches/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/qubino-switches/init.lua
@@ -52,7 +52,11 @@ local function getDeviceProfile(device, isTemperatureSensorOnboard)
 end
 
 local function can_handle_qubino_flush_relay(opts, driver, device, cmd, ...)
-  return device:id_match(constants.QUBINO_MFR)
+  if device:id_match(constants.QUBINO_MFR) then
+    local subdriver = require("qubino-switches")
+    return true, subdriver
+  end
+  return false
 end
 
 local function add_temperature_sensor_if_needed(device)

--- a/drivers/SmartThings/zwave-switch/src/zooz-power-strip/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zooz-power-strip/init.lua
@@ -27,7 +27,8 @@ local ZOOZ_POWER_STRIP_FINGERPRINTS = {
 local function can_handle_zooz_power_strip(opts, driver, device, ...)
   for _, fingerprint in ipairs(ZOOZ_POWER_STRIP_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("zooz-power-strip")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zooz-zen-30-dimmer-relay/init.lua
@@ -77,7 +77,8 @@ local ZOOZ_ZEN_30_DIMMER_RELAY_FINGERPRINTS = {
 local function can_handle_zooz_zen_30_dimmer_relay_double_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(ZOOZ_ZEN_30_DIMMER_RELAY_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("zooz-zen-30-dimmer-relay")
+      return true, subdriver
     end
   end
   return false

--- a/drivers/SmartThings/zwave-switch/src/zwave-dual-switch/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/zwave-dual-switch/init.lua
@@ -41,7 +41,8 @@ local ZWAVE_DUAL_SWITCH_FINGERPRINTS = {
 local function can_handle_zwave_dual_switch(opts, driver, device, ...)
   for _, fingerprint in ipairs(ZWAVE_DUAL_SWITCH_FINGERPRINTS) do
     if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
+      local subdriver = require("zwave-dual-switch")
+      return true, subdriver
     end
   end
   return false


### PR DESCRIPTION
Adds the ability to lazy load sub drivers. Sub driver that are not currently used by the driver will be "lazy loaded", meaning just a smaller version of the sub driver will be loaded until a device joins that requires the entire sub driver, at which point all the sub driver handlers will be loaded. Given the high number of sub drivers in the zwave-switch driver, this should provide a good amount of memory savings in cases where many of the sub drivers go unused.

Note, this will only work with the latest lua libs changes, so the lazy loading is only activated after an API version check.