### PR TITLE
Adding an option to remove support Aqara Illuminance Sensor without "T1" in the name for CN translations

### DIFF
--- a/tools/localizations/cn.csv
+++ b/tools/localizations/cn.csv
@@ -41,6 +41,7 @@ Aqara Door and Window Sensor T1, Aqara 门窗传感器T1
 Aqara Temperature and Humidity Sensor T1, Aqara温湿度传感器 T1
 Aqara Water Leak Sensor, Aqara 水浸传感器 T1
 Aqara Illuminance Sensor T1, Aqara 光照传感器T1
+Aqara Illuminance Sensor, Aqara 光照传感器
 Aqara Presence Sensor FP1, Aqara 人体存在传感器FP1
 Aqara Smart Dimmer Controller T1 Pro, Aqara 双色温驱动器 T1 Pro
 Aqara Single Switch Module T1 (With Neutral), Aqara 单路控制器T1 (零火版)


### PR DESCRIPTION
Adding per Xianguo.qi to remove "T1" from the name