### PR TITLE
Matter Switch: Add Aqara LED Light Bulb T1 fingerprint

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1884,6 +1884,13 @@ matterManufacturer:
     productId: 0x228F
     deviceProfileName: light-color-level-2200K-6500K
 
+#Aqara
+  - id: "Aqara LED Light Bulb T1"
+    deviceLabel: Aqara LED Light Bulb T1
+    vendorId: 0x115F
+    productName: Aqara LED Light Bulb T1
+    deviceProfileName: light-level-colorTemperature-2710k-6500k
+
 #Bridge devices need manufacturer specific fingerprints until
 #bridge support is released to all hubs. This is because of the way generic
 #fingerprints work for bridges joined prior to hubs being able to support them


### PR DESCRIPTION
Adds the fingerprint for the Aqara LED Light Bulb T1, correctly using the "productName" field for a bridged device fingerprint.