### PR TITLE
Zigbee Lock: Add lock command handler for sds doorlock

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
@@ -51,6 +51,10 @@ local function unlock_cmd_handler(driver, device, command)
           "\x10\x04\x31\x32\x33\x35"))
 end
 
+local function lock_cmd_handler(driver, device, command)
+  --do nothing in lock command handler
+end
+
 local refresh = function(driver, device, cmd)
   -- do nothing in refresh capability handler
 end
@@ -95,7 +99,8 @@ local samsung_sds_driver = {
       [capabilities.refresh.commands.refresh.NAME] = refresh
     },
     [capabilities.lock.ID] = {
-      [capabilities.lock.commands.unlock.NAME] = unlock_cmd_handler
+      [capabilities.lock.commands.unlock.NAME] = unlock_cmd_handler,
+      [capabilities.lock.commands.lock.NAME] = lock_cmd_handler
     }
   },
   lifecycle_handlers = {

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
@@ -1350,6 +1350,19 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
+    "Handle Lock cmd",
+    function()
+      test.socket.capability:__queue_receive(
+          {
+            mock_device.id,
+            { capability = "lock", component = "main", command = "lock", args = {} }
+          }
+      )
+      test.wait_for_events()
+    end
+)
+
+test.register_coroutine_test(
     "Device added function handler",
     function()
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added"})


### PR DESCRIPTION
override lock command handler from the sds lock
detailed description is here
https://smartthings.atlassian.net/browse/CHAD-12444
