### PR TITLE
[Eve]: Support for Eve Energy Outlet

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -20,6 +20,11 @@ matterManufacturer:
     vendorId: 0x130A
     productId: 0x5E
     deviceProfileName: power-energy-powerConsumption
+  - id: "Eve/Energy/OutletUS"
+    deviceLabel: Eve Energy Outlet
+    vendorId: 0x130A
+    productId: 0x69
+    deviceProfileName: power-energy-powerConsumption
 
 #GE
   - id: "GELightingSavant/Bulb/A19"

--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -251,18 +251,20 @@ end
 -------------------------------------------------------------------------------------
 
 local function device_init(driver, device)
-  if not device:get_field(COMPONENT_TO_ENDPOINT_MAP) and
-      not device:get_field(SWITCH_INITIALIZED) then
-    -- create child devices as needed for multi-switch devices
-    initialize_switch(driver, device)
-  end
-  device:set_component_to_endpoint_fn(component_to_endpoint)
-  device:set_endpoint_to_component_fn(endpoint_to_component)
-  device:set_find_child(find_child)
-  device:subscribe()
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
+    if not device:get_field(COMPONENT_TO_ENDPOINT_MAP) and
+        not device:get_field(SWITCH_INITIALIZED) then
+      -- create child devices as needed for multi-switch devices
+      initialize_switch(driver, device)
+    end
+    device:set_component_to_endpoint_fn(component_to_endpoint)
+    device:set_endpoint_to_component_fn(endpoint_to_component)
+    device:set_find_child(find_child)
+    device:subscribe()
 
-  create_poll_schedule(device)
-  create_poll_report_schedule(device)
+    create_poll_schedule(device)
+    create_poll_report_schedule(device)
+  end
 end
 
 local function device_added(driver, device)

--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -24,6 +24,9 @@ local utils = require "st.utils"
 local data_types = require "st.matter.data_types"
 local device_lib = require "st.device"
 
+local SWITCH_INITIALIZED = "__switch_intialized"
+local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
+
 local EVE_MANUFACTURER_ID = 0x130A
 local PRIVATE_CLUSTER_ID = 0x130AFC01
 
@@ -49,7 +52,7 @@ local REPORT_TIMEOUT = (15 * 60) -- Report the value each 15 minutes
 local function is_eve_energy_products(opts, driver, device)
   -- this sub driver does not support child devices
   if device.network_type == device_lib.NETWORK_TYPE_MATTER and
-     device.manufacturer_info.vendor_id == EVE_MANUFACTURER_ID then
+      device.manufacturer_info.vendor_id == EVE_MANUFACTURER_ID then
     return true
   end
 
@@ -86,6 +89,11 @@ local function requestData(device)
 end
 
 local function create_poll_schedule(device)
+  -- the poll schedule is only needed for devices that support powerConsumption
+  if not device:supports_capability(capabilities.powerConsumptionReport) then
+    return
+  end
+
   local poll_timer = device:get_field(RECURRING_POLL_TIMER)
   if poll_timer ~= nil then
     return
@@ -110,6 +118,11 @@ end
 
 
 local function create_poll_report_schedule(device)
+  -- the poll schedule is only needed for devices that support powerConsumption
+  if not device:supports_capability(capabilities.powerConsumptionReport) then
+    return
+  end
+
   -- The powerConsumption report needs to be updated at least every 15 minutes in order to be included in SmartThings Energy
   local timer = device.thread:call_on_schedule(REPORT_TIMEOUT, function()
     local current_time = os.time()
@@ -151,33 +164,70 @@ end
 --- device does not have endpoint ids in sequential order from 1
 --- In this case the function returns the lowest endpoint value that isn't 0
 local function find_default_endpoint(device, component)
-  local res = device.MATTER_DEFAULT_ENDPOINT
-  local eps = device:get_endpoints(nil)
+  local eps = device:get_endpoints(clusters.OnOff.ID)
   table.sort(eps)
   for _, v in ipairs(eps) do
     if v ~= 0 then --0 is the matter RootNode endpoint
-      res = v
-      break
+      return v
     end
   end
   device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead",
     device.MATTER_DEFAULT_ENDPOINT))
-  return res
+  return device.MATTER_DEFAULT_ENDPOINT
 end
 
-local function component_to_endpoint(device, component_id)
-  -- Assumes matter endpoint layout is sequentional starting at 1.
-  local ep_num = component_id:match("switch(%d)")
-  return ep_num and tonumber(ep_num) or find_default_endpoint(device, component_id)
+local function initialize_switch(driver, device)
+  local switch_eps = device:get_endpoints(clusters.OnOff.ID)
+  table.sort(switch_eps)
+
+  -- Since we do not support bindings at the moment, we only want to count On/Off
+  -- clusters that have been implemented as server. This can be removed when we have
+  -- support for bindings.
+  local num_server_eps = 0
+  local main_endpoint = find_default_endpoint(device)
+  for _, ep in ipairs(switch_eps) do
+    if device:supports_server_cluster(clusters.OnOff.ID, ep) then
+      num_server_eps = num_server_eps + 1
+      if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
+        local name = string.format("%s %d", device.label, num_server_eps)
+        driver:try_create_device(
+          {
+            type = "EDGE_CHILD",
+            label = name,
+            profile = "plug-binary",
+            parent_device_id = device.id,
+            parent_assigned_child_key = string.format("%d", ep),
+            vendor_provided_label = name
+          }
+        )
+      end
+    end
+  end
+
+  device:try_update_metadata({ profile = "power-energy-powerConsumption-only" })
+  device:set_field(SWITCH_INITIALIZED, true)
+end
+
+local function component_to_endpoint(device, component)
+  local map = device:get_field(COMPONENT_TO_ENDPOINT_MAP) or {}
+  if map[component] then
+    return map[component]
+  end
+  return find_default_endpoint(device, component)
 end
 
 local function endpoint_to_component(device, ep)
-  local switch_comp = string.format("switch%d", ep)
-  if device.profile.components[switch_comp] ~= nil then
-    return switch_comp
-  else
-    return "main"
+  local map = device:get_field(COMPONENT_TO_ENDPOINT_MAP) or {}
+  for component, endpoint in pairs(map) do
+    if endpoint == ep then
+      return component
+    end
   end
+  return "main"
+end
+
+local function find_child(parent, ep_id)
+  return parent:get_child_by_parent_assigned_key(string.format("%d", ep_id))
 end
 
 
@@ -186,9 +236,14 @@ end
 -------------------------------------------------------------------------------------
 
 local function device_init(driver, device)
-  log.info_with({ hub_logs = true }, "device init")
+  if not device:get_field(COMPONENT_TO_ENDPOINT_MAP) and
+      not device:get_field(SWITCH_INITIALIZED) then
+    -- create child devices as needed for multi-switch devices
+    initialize_switch(driver, device)
+  end
   device:set_component_to_endpoint_fn(component_to_endpoint)
   device:set_endpoint_to_component_fn(endpoint_to_component)
+  device:set_find_child(find_child)
   device:subscribe()
 
   create_poll_schedule(device)
@@ -245,16 +300,21 @@ local function on_off_attr_handler(driver, device, ib, response)
   if ib.data.value then
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switch.switch.on())
 
-    create_poll_schedule(device)
+    -- the poll schedule is only needed for devices that support powerConsumption
+    if device:supports_capability(capabilities.powerConsumptionReport) then
+      create_poll_schedule(device)
+    end
   else
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switch.switch.off())
 
-    -- We want to prevent to read the power reports of the device if the device is off
-    -- We set here the power to 0 before the read is skipped so that the power is correctly displayed and not using a stale value
-    device:emit_event(capabilities.powerMeter.power({ value = 0, unit = "W" }))
+    if device:supports_capability(capabilities.powerConsumptionReport) then
+      -- We want to prevent to read the power reports of the device if the device is off
+      -- We set here the power to 0 before the read is skipped so that the power is correctly displayed and not using a stale value
+      device:emit_event(capabilities.powerMeter.power({ value = 0, unit = "W" }))
 
-    -- Stop the timer when the device is off
-    delete_poll_schedule(device)
+      -- Stop the timer when the device is off
+      delete_poll_schedule(device)
+    end
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -17,7 +17,6 @@
 -------------------------------------------------------------------------------------
 
 local capabilities = require "st.capabilities"
-local log = require "log"
 local clusters = require "st.matter.clusters"
 local cluster_base = require "st.matter.cluster_base"
 local utils = require "st.utils"

--- a/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/eve-energy/init.lua
@@ -204,7 +204,6 @@ local function initialize_switch(driver, device)
     end
   end
 
-  device:try_update_metadata({ profile = "power-energy-powerConsumption-only" })
   device:set_field(SWITCH_INITIALIZED, true)
 end
 


### PR DESCRIPTION
- Add Eve Energy Outlet fingerprint
- Only create the polls (create_poll_schedule and create_poll_report_schedule) if the device supports capabilities.powerConsumptionReport
- When the device is initialized, create child devices with the profile plug-binary for each additional outlet
- Update component_to_endpoint, endpoint_to_component and find_child to support multiple children
- Each time an oulet is turned on or off, store the value in a dictionary
- If one of the outlet is on, we should create the poll to monitor the power consumption
- If all the outlet are off, we should delete the poll