### PR TITLE
Fix run_driver_tests.py UnicodeDecodeError

### DIFF
--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
@@ -71,7 +71,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "|")
+      build_motion_status_message(mock_device, "\x7C")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
@@ -85,7 +85,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "~")
+      build_motion_status_message(mock_device, "\x7E")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.active()))
@@ -99,7 +99,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "X")
+      build_motion_status_message(mock_device, "\x58")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(70)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
@@ -113,7 +113,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "Z")
+      build_motion_status_message(mock_device, "\x5A")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(70)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.active()))
@@ -127,7 +127,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "½")
+      build_motion_status_message(mock_device, "\xBD")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.lqi(50)))
@@ -140,7 +140,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "¿")
+      build_motion_status_message(mock_device, "\xBF")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.active()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.lqi(50)))
@@ -153,7 +153,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "0")
+      build_motion_status_message(mock_device, "\x30")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(0)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))


### PR DESCRIPTION
I accidentally discovered that smartsense test run failed due to decode error.
The root cause is that our script use wrong encoding to open file.

This test script is "ISO-8859" encoding which includes "0xBD" which UTF-8 doesn't support.
```
❯ file test_smartsense_motion_sensor.lua
test_smartsense_motion_sensor.lua: ISO-8859 text
```

By default python3 uses UTF-8 to open file. That is we our script can't run smartsense test.

Import chardet lib to detect encoding format automatically to fix this issue.