### PR TITLE
Fix the battery check in matter-thermostat, look for feature map

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -118,7 +118,7 @@ local function do_configure(driver, device)
   local thermo_eps = device:get_endpoints(clusters.Thermostat.ID)
   local fan_eps = device:get_endpoints(clusters.FanControl.ID)
   local humidity_eps = device:get_endpoints(clusters.RelativeHumidityMeasurement.ID)
-  local battery_eps = device:get_endpoints(clusters.PowerSource.ID)
+  local battery_eps = device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
   local profile_name = "thermostat"
   --Note: we have not encountered thermostats with multiple endpoints that support the Thermostat cluster
   if #thermo_eps == 1 then

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -37,7 +37,7 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = 1,
       clusters = {
         {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = clusters.PowerSource.types.PowerSourceFeature.BATTERY},
         {
           cluster_id = clusters.Thermostat.ID,
           cluster_revision=5,
@@ -70,7 +70,7 @@ local mock_device_simple = test.mock_device.build_test_matter_device({
     {
       endpoint_id = 1,
       clusters = {
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = clusters.PowerSource.types.PowerSourceFeature.BATTERY},
         {
           cluster_id = clusters.Thermostat.ID,
           cluster_revision=5,

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -42,7 +42,7 @@ local mock_device = test.mock_device.build_test_matter_device({
           cluster_type="SERVER",
           feature_map=35, -- Heat, Cool, and Auto features.
         },
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = clusters.PowerSource.types.PowerSourceFeature.BATTERY},
       }
     }
   }


### PR DESCRIPTION
This was just looking for the presence of the power source cluster whereas the correct check would be to look for the battery feature map bit in that cluster. 