### PR TITLE
Hotfix: Revert auto-add/auto-delete on 0.47 hubs

### DIFF
--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -37,6 +37,8 @@ local utils = require "utils"
 local syncCapabilityId = "samsungim.hueSyncMode"
 local hueSyncMode = capabilities[syncCapabilityId]
 
+local api_version = require("version").api
+
 local StrayDeviceMessageTypes = {
   FoundBridge = "FOUND_BRIDGE",
   NewStrayLight = "NEW_STRAY_LIGHT",
@@ -712,7 +714,12 @@ local function do_bridge_network_init(driver, bridge_device, bridge_url, api_key
 
       local bridge_api = bridge_device:get_field(Fields.BRIDGE_API)
       cosock.spawn(function()
-        Discovery.scan_bridge_and_update_devices(driver, bridge_device:get_field(Fields.BRIDGE_ID))
+        -- auto-add/auto-delete is only supported with newer lua libs. We do a conditional
+        -- check in the delete routine, but we try to avoid doing it at all here with an
+        -- additional defensive check against the Lua Libs API version.
+        if api_version >= 9 then
+          Discovery.scan_bridge_and_update_devices(driver, bridge_device:get_field(Fields.BRIDGE_ID))
+        end
         local child_device_map = {}
         local children = bridge_device:get_child_list()
         bridge_device.log.debug(string.format("Scanning connectivity of %s child devices", #children))


### PR DESCRIPTION
This change puts an API Version guard around the call that performs the auto-add/auto-delete scan at startup, which is causing a crash on 0.47 TV's due to an issue with looking up non-existent UUID's.

We believe the root of the issue is that the non-existent UUID lookup is related to trying to look up the Hub UUID as the parent of the bridge, but because this is a pretty gnarly issue we're going to roll back while we're confirming our suspicion.