### PR TITLE
Adding Zemismart Inline Module ZME2 Device

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1927,7 +1927,7 @@ matterManufacturer:
     productId: 0x228F
     deviceProfileName: light-color-level-2200K-6500K
 #Zemismart
-  - id: 5020/61154
+  - id: "5020/61154"
     deviceLabel: Zemismart Inline Module
     vendorId: 0x139C
     productId: 0xEEE2

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1926,7 +1926,12 @@ matterManufacturer:
     vendorId: 0x100b
     productId: 0x228F
     deviceProfileName: light-color-level-2200K-6500K
-
+#Zemismart
+  - id: 5020/61154
+    deviceLabel: Zemismart Inline Module
+    vendorId: 0x139C
+    productId: 0xEEE2
+    deviceProfileName: switch-binary
 
 #Bridge devices need manufacturer specific fingerprints until
 #bridge support is released to all hubs. This is because of the way generic


### PR DESCRIPTION
This is a fingerprint addition for the Zemismart Inline Module ZME2 Device. 

This will be a parent child Matter Device. 

The switch-binary profile was selected to support this device. 

We know that this device according to the DCL is 0x0103, and based on when the device joined in SRPOL this device supports the On/Off Cluster as a BOTH a client and as a server. 

