### PR TITLE
Skip processing Hue Bridges as deletion candidates + some static analysis cleanup

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -253,14 +253,17 @@ function HueDiscovery.search_bridge_for_supported_devices(driver, bridge_id, api
 
   if do_delete then
     for _, device in ipairs(driver:get_devices()) do ---@cast device HueDevice
+      -- We're only interested in processing child/non-bridge devices here.
+      if utils.is_bridge(driver, device) then goto continue end
       local not_known_to_bridge = device_is_joined_to_bridge[device:get_field(Fields.HUE_DEVICE_ID) or ""]
       local parent_device_id = device.parent_device_id or device:get_field(Fields.PARENT_DEVICE_ID) or ""
       local parent_bridge_device = driver:get_device_info(parent_device_id)
       local is_child_of_bridge = parent_bridge_device and (parent_bridge_device:get_field(Fields.BRIDGE_ID) == bridge_id)
-      if is_child_of_bridge and not not_known_to_bridge then
+      if parent_bridge_device and is_child_of_bridge and not not_known_to_bridge then
         device.log.info(string.format("Device is no longer joined to Hue Bridge %q, deleting", parent_bridge_device.label))
         driver:do_hue_light_delete(device)
       end
+      ::continue::
     end
   end
 end

--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -5,7 +5,7 @@ local mdns = require "st.mdns"
 local net_utils = require "st.net_utils"
 local st_utils = require "st.utils"
 
-local Fields = require "hue.fields"
+local Fields = require "fields"
 local HueApi = require "hue.api"
 local utils = require "utils"
 
@@ -94,8 +94,8 @@ function HueDiscovery.scan_bridge_and_update_devices(driver, bridge_id)
   end
 
   local known_bridge_device = known_identifier_to_device_map[bridge_id]
-  if known_bridge_device and known_bridge_device:get_field(Fields.API_KEY) then
-    HueDiscovery.api_keys[bridge_id] = known_bridge_device:get_field(Fields.API_KEY)
+  if known_bridge_device and known_bridge_device:get_field(HueApi.APPLICATION_KEY_HEADER) then
+    HueDiscovery.api_keys[bridge_id] = known_bridge_device:get_field(HueApi.APPLICATION_KEY_HEADER)
   end
 
   HueDiscovery.search_bridge_for_supported_devices(driver, bridge_id, HueDiscovery.disco_api_instances[bridge_id],
@@ -116,8 +116,8 @@ discovered_bridge_callback = function(driver, bridge_ip, bridge_id, known_identi
   if driver.ignored_bridges[bridge_id] then return end
 
   local known_bridge_device = known_identifier_to_device_map[bridge_id]
-  if known_bridge_device and known_bridge_device:get_field(Fields.API_KEY) then
-    HueDiscovery.api_keys[bridge_id] = known_bridge_device:get_field(Fields.API_KEY)
+  if known_bridge_device and known_bridge_device:get_field(HueApi.APPLICATION_KEY_HEADER) then
+    HueDiscovery.api_keys[bridge_id] = known_bridge_device:get_field(HueApi.APPLICATION_KEY_HEADER)
   end
 
   if known_bridge_device ~= nil
@@ -283,7 +283,7 @@ end
 ---@param bridge_id string
 ---@param resource_id string
 ---@param device_info table
----@param known_identifier_to_device_map table<string,boolean>
+---@param known_identifier_to_device_map table<string,HueDevice>
 process_discovered_light = function(driver, bridge_id, resource_id, device_info, known_identifier_to_device_map)
   local api_instance = HueDiscovery.disco_api_instances[bridge_id]
   if not api_instance then

--- a/drivers/SmartThings/philips-hue/src/fields.lua
+++ b/drivers/SmartThings/philips-hue/src/fields.lua
@@ -1,4 +1,3 @@
-local APPLICATION_KEY_HEADER = require "hue.api".APPLICATION_KEY_HEADER
 --- Table of constants used to index in to device store fields
 --- @class Fields
 --- @field IPV4 string the ipV4 address of a Hue bridge
@@ -14,7 +13,6 @@ local Fields = {
   _ADDED = "added",
   _INIT = "init",
   _REFRESH_AFTER_INIT = "force_refresh",
-  API_KEY = APPLICATION_KEY_HEADER,
   BRIDGE_API = "bridge_api",
   BRIDGE_ID = "bridgeid",
   BRIDGE_SW_VERSION = "swversion",

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -1,4 +1,4 @@
-local Fields = require "hue.fields"
+local Fields = require "fields"
 local HueApi = require "hue.api"
 local HueColorUtils = require "hue.cie_utils"
 local log = require "log"
@@ -7,6 +7,9 @@ local utils = require "utils"
 local cosock = require "cosock"
 local capabilities = require "st.capabilities"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: table, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local handlers = {}
 

--- a/drivers/SmartThings/philips-hue/src/hue/types.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/types.lua
@@ -1,3 +1,5 @@
+--- @meta
+
 --- Hue Bridge Info as returned by the unauthenticated API endpoint `/api/config`
 --- @class HueBridgeInfo
 --- @field public name string
@@ -23,21 +25,30 @@
 --- @field public update_bridge_netinfo fun(self: HueDriver, bridge_id: string, bridge_info: HueBridgeInfo)
 --- @field public emit_light_status_events fun(light_device: HueChildDevice, light: table)
 --- @field public get_device_by_dni fun(self: HueDriver, device_network_id: string, force_refresh?: boolean): HueDevice|nil
---- @field private _lights_pending_refresh table<string,HueChildDevice>
+--- @field public do_hue_light_delete fun(self: HueDriver, light_device: HueDevice)
+--- @field public get_device_info fun(self: HueDriver, device_id: string, force_refresh: boolean?): HueDevice?
+--- @field public check_hue_repr_for_capability_support fun(hue_repr: table, capability_id: string): boolean
+--- @field public _lights_pending_refresh table<string,HueChildDevice>
 
 --- @class HueDevice:st.Device
 --- @field public label string
 --- @field public id string
 --- @field public device_network_id string
+--- @field public parent_device_id string
+--- @field public parent_assigned_child_key string?
+--- @field public manufacturer string
+--- @field public model string
+--- @field public vendor_provided_label string
 --- @field public data table|nil migration data for a migrated device
 --- @field public log table device-scoped logging module
+--- @field public profile table
 --- @field public get_field fun(self: HueDevice, key: string):any
 --- @field public set_field fun(self: HueDevice, key: string, value: any, args?: table)
 --- @field public emit_event fun(self: HueDevice, event: any)
+--- @field public supports_capability_by_id fun(self: HueDevice, capability_id: string, component: string?): boolean
 
 --- @class HueBridgeDevice:HueDevice
 --- @field public device_network_id string
 
 --- @class HueChildDevice:HueDevice
---- @field public parent_device_id string
 --- @field public parent_assigned_child_key string

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -40,8 +40,6 @@ local utils = require "utils"
 local syncCapabilityId = "samsungim.hueSyncMode"
 local hueSyncMode = capabilities[syncCapabilityId]
 
-local api_version = require("version").api
-
 local StrayDeviceMessageTypes = {
   FoundBridge = "FOUND_BRIDGE",
   NewStrayLight = "NEW_STRAY_LIGHT",
@@ -717,12 +715,7 @@ local function do_bridge_network_init(driver, bridge_device, bridge_url, api_key
 
       local bridge_api = bridge_device:get_field(Fields.BRIDGE_API)
       cosock.spawn(function()
-        -- auto-add/auto-delete is only supported with newer lua libs. We do a conditional
-        -- check in the delete routine, but we try to avoid doing it at all here with an
-        -- additional defensive check against the Lua Libs API version.
-        if api_version >= 9 then
-          Discovery.scan_bridge_and_update_devices(driver, bridge_device:get_field(Fields.BRIDGE_ID))
-        end
+        Discovery.scan_bridge_and_update_devices(driver, bridge_device:get_field(Fields.BRIDGE_ID))
         local child_device_map = {}
         local children = bridge_device:get_child_list()
         bridge_device.log.debug(string.format("Scanning connectivity of %s child devices", #children))

--- a/drivers/SmartThings/philips-hue/src/lunchbox/rest.lua
+++ b/drivers/SmartThings/philips-hue/src/lunchbox/rest.lua
@@ -1,9 +1,16 @@
+---@class ChunkedResponse : Response
+---@field package _received_body boolean
+---@field package _parsed_headers boolean
+---@field public new fun(status_code: number, socket: table?): ChunkedResponse
+---@field public fill_body fun(self: ChunkedResponse): string?
+---@field public append_body fun(self: ChunkedResponse, next_chunk_body: string): ChunkedResponse
+
 local socket = require "cosock.socket"
 
 local utils = require "utils"
 local lb_utils = require "lunchbox.util"
 local Request = require "luncheon.request"
-local Response = require "luncheon.response"
+local Response = require "luncheon.response"  --[[@as ChunkedResponse]]
 
 local api_version = require("version").api
 
@@ -43,9 +50,15 @@ local function reconnect(client)
   return connect(client)
 end
 
+---comment
+---@param client RestClient
+---@param request Request
+---@return integer? bytes_sent
+---@return string? err_msg
+---@return integer idx
 local function send_request(client, request)
   if client.socket == nil then
-    return nil, "no socket available"
+    return nil, "no socket available", 0
   end
   local payload = request:serialize()
 
@@ -63,7 +76,7 @@ local function parse_chunked_response(original_response, sock)
     EXPECTING_BODY_CHUNK = "ExpectingBodyChunk",
   }
 
-  local full_response = Response.new(original_response.status, nil)
+  local full_response = Response.new(original_response.status, nil)  --[[@as ChunkedResponse]]
 
   for header in original_response.headers:iter() do full_response.headers:append_chunk(header) end
 
@@ -144,7 +157,7 @@ local function handle_response(sock)
   if initial_recv ~= nil then
     local headers = initial_recv:get_headers()
 
-    if headers:get_one("Transfer-Encoding") == "chunked" then
+    if headers and headers:get_one("Transfer-Encoding") == "chunked" then
       local response, err = parse_chunked_response(initial_recv, sock)
       if err ~= nil then
         return nil, err
@@ -162,12 +175,12 @@ end
 
 local function execute_request(client, request, retry_fn)
   if not client._active then
-    return nil, "Called `execute request` on a terminated REST Client"
+    return nil, "Called `execute request` on a terminated REST Client", nil
   end
 
   if client.socket == nil then
     local success, err = connect(client)
-    if not success then return nil, err end
+    if not success then return nil, err, nil end
   end
 
   local should_retry = retry_fn
@@ -179,7 +192,7 @@ local function execute_request(client, request, retry_fn)
   -- send output
   local _bytes_sent, send_err, _idx = nil, nil, 0
   -- recv output
-  local response, recv_err, _partial = nil, nil, nil
+  local response, recv_err, partial = nil, nil, nil
   -- return values
   local ret, err = nil, nil
 
@@ -206,7 +219,7 @@ local function execute_request(client, request, retry_fn)
         current_state = RestCallStates.COMPLETE
       end
     elseif current_state == RestCallStates.RECEIVE then
-      response, recv_err, _partial = handle_response(client.socket)
+      response, recv_err, partial = handle_response(client.socket)
 
       if not recv_err then
         ret = response
@@ -242,7 +255,7 @@ local function execute_request(client, request, retry_fn)
     end
   until current_state == RestCallStates.COMPLETE
 
-  return ret, err
+  return ret, err, partial
 end
 
 ---@class RestClient
@@ -257,7 +270,6 @@ function RestClient.one_shot_get(full_url, additional_headers, socket_builder)
   local client = RestClient.new(url_table.scheme .. "://" .. url_table.host, socket_builder)
   local ret, err = client:get(url_table.path, additional_headers)
   client:shutdown()
-  client = nil
   return ret, err
 end
 
@@ -266,7 +278,6 @@ function RestClient.one_shot_post(full_url, body, additional_headers, socket_bui
   local client = RestClient.new(url_table.scheme .. "://" .. url_table.host, socket_builder)
   local ret, err = client:post(url_table.path, body, additional_headers)
   client:shutdown()
-  client = nil
   return ret, err
 end
 

--- a/drivers/SmartThings/philips-hue/src/utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils.lua
@@ -1,3 +1,4 @@
+local Fields = require "fields"
 local log = require "log"
 ---@module 'utils'
 local utils = {}
@@ -39,7 +40,7 @@ end
 ---@param device HueDevice
 ---@return boolean
 function utils.is_edge_light(device)
-  return device.parent_assigned_child_key and #device.parent_assigned_child_key > MAC_ADDRESS_STR_LEN and
+  return device.parent_assigned_child_key ~= nil and #device.parent_assigned_child_key > MAC_ADDRESS_STR_LEN and
       not (device.data and device.data.username and device.data.bulbId)
 end
 
@@ -147,8 +148,8 @@ function utils.labeled_socket_builder(label)
       )
       sock, err =
           ssl.wrap(sock, { mode = "client", protocol = "any", verify = "none", options = "all" })
-      if err ~= nil then
-        return nil, "SSL wrap error: " .. err
+      if not sock or err ~= nil then
+        return nil, (err and "SSL wrap error: " .. err) or "Unexpected nil socket returned from ssl.wrap"
       end
       log.info(
         string.format(


### PR DESCRIPTION
This removes the API version guard on the auto add/delete scan during
event stream connection and instead skips to the next element in the
iterator if it detects that the current iteration target is a device
record that represents a bridge.

We do this because we *do* want the auto-add/auto-delete routine to
run on older firmware, as the delete function does feature detection
on the lua libs and uses `device:offline()` as a fallback. Plus, auto
add will work on all firmware versions, so this is the better UX all
around.

We also address some static analysis lints from the Lua Language Server
VS Code plugin.

Most of these are just refining/augmenting gradual typing to quiet the
IDE warnings, but there were a few places that we were missing nil
checks or otherwise had other potential bugs that got addressed here.