### PR TITLE
Fix the repair task for unlinked bridges

### DIFF
--- a/drivers/SmartThings/philips-hue/src/utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils.lua
@@ -28,7 +28,6 @@ function utils.is_nan(number)
   return tostring(number) == tostring(0 / 0)
 end
 
-
 --- Attempts an exhaustive check of all the ways a device
 --- can indicate that it represents a Hue Bridge.
 ---@param driver HueDriver
@@ -36,9 +35,9 @@ end
 ---@return boolean is_bridge true if the device record represents a Hue Bridge
 function utils.is_bridge(driver, device)
   return (device:get_field(Fields.DEVICE_TYPE) == "bridge")
-    or (driver.datastore.bridge_netinfo[device.device_network_id] ~= nil)
-    or utils.is_edge_bridge(device) or utils.is_dth_light(device)
-    or (device.parent_assigned_child_key == nil)
+      or (driver.datastore.bridge_netinfo[device.device_network_id] ~= nil)
+      or utils.is_edge_bridge(device) or utils.is_dth_light(device)
+      or (device.parent_assigned_child_key == nil)
 end
 
 --- Only checked during `added` callback, or as a later


### PR DESCRIPTION
Sometimes a data loss event can occur that prevents the Bridge
Application Key from being persisted in the Edge Driver Datastore.

This coroutine broke at some point during a refactor, unsure when, but
this commit restores the functionality that would let a user re-link
their bridge in the event that they're aware that this is what has
happened.