### PR TITLE
Matter Switch: refresh child devices on added event

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -339,9 +339,18 @@ local function info_changed(driver, device, event, args)
   end
 end
 
+local function device_added(driver, device)
+  -- refresh child devices to get initial attribute state in case child device
+  -- was created after the initial subscription report
+  if device.network_type == device_lib.NETWORK_TYPE_CHILD then
+    handle_refresh(driver, device)
+  end
+end
+
 local matter_driver_template = {
   lifecycle_handlers = {
     init = device_init,
+    added = device_added,
     removed = device_removed,
     infoChanged = info_changed
   },

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child.lua
@@ -219,4 +219,13 @@ test.register_message_test(
   }
 )
 
+test.register_coroutine_test(
+  "Added should call refresh for child devices", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    test.socket.device_lifecycle:__queue_receive({ mock_children[child1_ep].id, "added" })
+    local req = clusters.OnOff.attributes.OnOff:read(mock_children[child1_ep])
+    test.socket.matter:__expect_send({mock_device.id, req})
+  end
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
There is a race condition where sometimes the initial subscription report will be handled before child devices are done being created. In this case, the child devices will not recieve the initial value of the attribute, and will appear as just "connected" or "waiting for device to update" until they are  manually refreshed or the state is physically toggled on the device.