### PR TITLE
BUG2-1182-fix: hide non functional attribute update 

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -74,7 +74,7 @@ end
 
 local function device_added(driver, device)
   device:emit_event(
-    capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"})
+    capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, {visibility = {displayed = false}})
   )
 end
 

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -390,6 +390,7 @@ test.register_coroutine_test(
           component_id = "main",
           attribute_id = "supportedWindowShadeCommands",
           state = {value = {"open", "close", "pause"}},
+          visibility = {displayed = false}
         },
       }
     )

--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
@@ -166,8 +166,8 @@ local function do_configure(self, device)
 end
 
 local function device_added(driver, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }))
-  device:emit_event(deviceInitialization.supportedInitializedState({ "notInitialized", "initializing", "initialized" }))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
+  device:emit_event(deviceInitialization.supportedInitializedState({ "notInitialized", "initializing", "initialized" }, {visibility = {displayed = false}}))
   device:emit_event(capabilities.windowShadeLevel.shadeLevel(0))
   device:emit_event(capabilities.windowShade.windowShade.closed())
   device:emit_event(deviceInitialization.initializedState.notInitialized())

--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/roller-shade/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/roller-shade/init.lua
@@ -92,7 +92,7 @@ local function device_info_changed(driver, device, event, args)
 end
 
 local function device_added(driver, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
   device:emit_event(capabilities.windowShadeLevel.shadeLevel(0))
   device:emit_event(capabilities.windowShade.windowShade.closed())
   device:emit_event(initializedStateWithGuide.initializedStateWithGuide.notInitialized())

--- a/drivers/SmartThings/zigbee-window-treatment/src/hanssem/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/hanssem/init.lua
@@ -187,7 +187,7 @@ end
 -------------------- Lifecycle Handlers -------------------
 
 local function device_added(driver, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"}, {visibility = {displayed = false}}))
   if getLatestLevel(device) == 0 then
     emit_event_final_position(device, getLatestLevel(device))
     device.thread:call_with_delay(3, function(d)

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
@@ -86,14 +86,15 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
-        capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }))
+        capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
     )
     test.socket.capability:__expect_send({
       mock_device.id,
       {
         capability_id = "stse.deviceInitialization", component_id = "main",
         attribute_id = "supportedInitializedState",
-        state = { value = { "notInitialized", "initializing", "initialized" } }
+        state = { value = { "notInitialized", "initializing", "initialized" } },
+        visibility = { displayed = false }
       }
     })
     test.socket.capability:__expect_send(

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
@@ -72,7 +72,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
-        capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }))
+        capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0))

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_hanssem.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_hanssem.lua
@@ -86,7 +86,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__expect_send(
-        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }))
+        mock_device:generate_test_message("main", capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
       )
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closed()))


### PR DESCRIPTION
Some blind drivers have exposed unnecessary information to history. (bug2-1182)
modify the aqara and hansem blind drivers not to show some events
(for supportedWindowShadeCommands, supportedInitializedState)