### PR TITLE
New Device(Matter Switch) Cync Bulbs 1.01.060 and Outdoor Plug

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -77,6 +77,11 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0xAC
     deviceProfileName: plug-binary
+  - id: "4921/111"
+    deviceLabel: Cync Outdoor Plug
+    vendorId: 0x1339
+    productId: 0x006F
+    deviceProfileName: plug-binary
 
 #Nanoleaf
   - id: "Nanoleaf NL53"

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -22,47 +22,47 @@ matterManufacturer:
     deviceProfileName: power-energy-powerConsumption
 
 #GE
-  - id: 4921/177
+  - id: "4921/177"
     deviceLabel: Cync Full Color 2 Inch Wafer
     vendorId: 0x1339
     productId: 0x00B1
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/44
+  - id: "4921/44"
     deviceLabel: Cync Full Color 3 Inch Puck
     vendorId: 0x1339
     productId: 0x002C
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/174
+  - id: "4921/174"
     deviceLabel: Cync Full Color 4 Inch Wafer
     vendorId: 0x1339
     productId: 0x00AE
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/180
+  - id: "4921/180"
     deviceLabel: Cync 4 Inch High Ceiling Wafer
     vendorId: 0x1339
     productId: 0x00B4
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/175
+  - id: "4921/175"
     deviceLabel: Cync Full Color 6 Inch Wafer
     vendorId: 0x1339
     productId: 0x00AF
     deviceProfileName: light-color-level-2000K-7000K  
-  - id: 4921/181
+  - id: "4921/181"
     deviceLabel: Cync 6 Inch High Ceiling Wafer
     vendorId: 0x1339
     productId: 0x00B5
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/41
+  - id: "4921/41"
     deviceLabel: Cync Full Color Undercabinet 12 Inch
     vendorId: 0x1339
     productId: 0x0029
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/42
+  - id: "4921/42"
     deviceLabel: Cync Full Color Undercabinet 18 Inch
     vendorId: 0x1339
     productId: 0x002A
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/43
+  - id: "4921/43"
     deviceLabel: Cync Full Color Undercabinet 24 Inch
     vendorId: 0x1339
     productId: 0x002B

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -22,6 +22,51 @@ matterManufacturer:
     deviceProfileName: power-energy-powerConsumption
 
 #GE
+  - id: 4921/177
+    deviceLabel: Cync Full Color 2 Inch Wafer
+    vendorId: 0x1339
+    productId: 0x00B1
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/44
+    deviceLabel: Cync Full Color 3 Inch Puck
+    vendorId: 0x1339
+    productId: 0x002C
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/174
+    deviceLabel: Cync Full Color 4 Inch Wafer
+    vendorId: 0x1339
+    productId: 0x00AE
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/180
+    deviceLabel: Cync 4 Inch High Ceiling Wafer
+    vendorId: 0x1339
+    productId: 0x00B4
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/175
+    deviceLabel: Cync Full Color 6 Inch Wafer
+    vendorId: 0x1339
+    productId: 0x00AF
+    deviceProfileName: light-color-level-2000K-7000K  
+  - id: 4921/181
+    deviceLabel: Cync 6 Inch High Ceiling Wafer
+    vendorId: 0x1339
+    productId: 0x00B5
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/41
+    deviceLabel: Cync Full Color Undercabinet 12 Inch
+    vendorId: 0x1339
+    productId: 0x0029
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/42
+    deviceLabel: Cync Full Color Undercabinet 18 Inch
+    vendorId: 0x1339
+    productId: 0x002A
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/43
+    deviceLabel: Cync Full Color Undercabinet 24 Inch
+    vendorId: 0x1339
+    productId: 0x002B
+    deviceProfileName: light-color-level-2000K-7000K
   - id: "GELightingSavant/Bulb/A19"
     deviceLabel: Cync Full Color A19
     vendorId: 0x1339


### PR DESCRIPTION
This PR was created to break out devices from this original PR. https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1186/files

This PR contains 9 GE Cync Bulbs for Matter WWST Certification that have a device firmware version of 1.01.060 currently and 1 Cync Outdoor Plug