### PR TITLE
[CHAD-12631] fix(zigbee-button): Adding exception case of manufacturer information for IKEA button

### DIFF
--- a/drivers/SmartThings/zigbee-button/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-button/fingerprints.yml
@@ -44,6 +44,11 @@ zigbeeManufacturer:
     manufacturer: KE
     model: TRADFRI open/close remote
     deviceProfileName: two-buttons-battery
+  - id: "02KE/TRADFRIopenclose"
+    deviceLabel: IKEA Remote Control
+    manufacturer: "\x02KE"
+    model: TRADFRI open/close remote
+    deviceProfileName: two-buttons-battery
   - id: "CentraLite/3450-L"
     deviceLabel: Iris Remote Control
     manufacturer: CentraLite


### PR DESCRIPTION
Jira : https://smartthings.atlassian.net/browse/CHAD-12631