### PR TITLE
New Device (Matter Switch) Eve Energy Switzerland 0x006A

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -25,6 +25,11 @@ matterManufacturer:
     vendorId: 0x130A
     productId: 0x69
     deviceProfileName: power-energy-powerConsumption
+  - id: "4874/106"
+    deviceLabel: Eve Energy Switzerland
+    vendorId: 0x130A
+    productId: 0x006A
+    deviceProfileName: power-energy-powerConsumption
 
 #GE
   - id: "4921/177"


### PR DESCRIPTION
This is a new WWST Certification Request for the Eve Energy Switzerland ModelNumber: 20ECL1301. The Matter Product ID for this device is 0x006A. 