### PR TITLE
New Device (Matter Switch) Eve Energy Outdoor 006B

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -25,6 +25,11 @@ matterManufacturer:
     vendorId: 0x130A
     productId: 0x69
     deviceProfileName: power-energy-powerConsumption
+  - id: "4874/107"
+    deviceLabel: Eve Energy Outdoor
+    vendorId: 0x130A
+    productId: 0x006B
+    deviceProfileName: power-energy-powerConsumption
 
 #GE
   - id: "4921/177"


### PR DESCRIPTION
This is a PR for a new WWST Certification request for an Eve Outdoor Device Model Number:  20ECM8301. The Product ID is: 006B. 