### PR TITLE
New Device (Matter Window Covering)Duc Blinds with Smartwings

### DIFF
--- a/drivers/SmartThings/matter-window-covering/fingerprints.yml
+++ b/drivers/SmartThings/matter-window-covering/fingerprints.yml
@@ -1,4 +1,10 @@
 matterManufacturer:
+#Duc
+  - id: "5151/4097"
+    deviceLabel: DUC Blinds with SMARTWINGS
+    vendorId: 0x141F
+    productId: 0x1001
+    deviceProfileName: window-covering-battery
 #Eve
   - id: "Eve MotionBlinds"
     deviceLabel: Eve MotionBlinds


### PR DESCRIPTION
This is a new WWST Certification Request for a Matter Window Covering device, Duc Blinds with SmartWings. The Device Type ID is X1001.