### PR TITLE
fix(hue): Address various nil field index issues

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco.lua
@@ -262,7 +262,7 @@ function HueDiscovery.search_bridge_for_supported_devices(driver, bridge_id, api
       local parent_device_id = device.parent_device_id or device:get_field(Fields.PARENT_DEVICE_ID) or ""
       local parent_bridge_device = driver:get_device_info(parent_device_id)
       local is_child_of_bridge = parent_bridge_device and (parent_bridge_device:get_field(Fields.BRIDGE_ID) == bridge_id)
-      if parent_bridge_device and is_child_of_bridge and not not_known_to_bridge then
+      if parent_bridge_device and is_child_of_bridge and not not_known_to_bridge and device.id then
         device.log.info(string.format("Device is no longer joined to Hue Bridge %q, deleting", parent_bridge_device.label))
         driver:do_hue_light_delete(device)
       end


### PR DESCRIPTION
The majority of these fixes are concurrency races:

Due to Hue's heavy usage of additional Cosock coroutines, it can be the
case that functions that have been passed references to device records
will be operating on a device record for a deleted device. This can cause
unexpected nil index errors and crashes.

We attempt to minimize that here with heuristics; in particular, a device
that has been deleted will return `nil` for *any* of its table keys. So
we check a field that we *know* a device record should have, its `.id` field.

We wrap all handlers in a closure that does a sanity check on the status of
the device record using this heuristic, and we wrap the handler itself in a
pcall.

We also address some one-off locations where nil field indexes can occur
for other reasons, and introduce some additional defensiveness around other
places where we've observed nil index crashes in crash metrics.
