### PR TITLE
matter-appliance: Improve refrigerator driver

### DIFF
--- a/drivers/SmartThings/matter-appliance/profiles/refrigerator-freezer.yml
+++ b/drivers/SmartThings/matter-appliance/profiles/refrigerator-freezer.yml
@@ -16,7 +16,19 @@ components:
   capabilities:
   - id: mode # Refrigerator And Temperature Controlled Cabinet Mode
     version: 1
+  - id: temperatureSetpoint # Temperature Control / TN
+    version: 1
+    config:
+      values:
+        - key: "temperatureSetpoint.value"
+          range: [ 0, 100 ]
   - id: temperatureMeasurement # Temperature Measurement
+    version: 1
+  categories:
+  - name: Refrigerator
+- id: refrigeratorTemperatureLevel # First endpoint's Temperature Control
+  capabilities:
+  - id: mode # Temperature Control / TL
     version: 1
   categories:
   - name: Refrigerator
@@ -24,7 +36,19 @@ components:
   capabilities:
   - id: mode # Refrigerator And Temperature Controlled Cabinet Mode
     version: 1
+  - id: temperatureSetpoint # Temperature Control / TN
+    version: 1
+    config:
+      values:
+        - key: "temperatureSetpoint.value"
+          range: [ 0, 100 ]
   - id: temperatureMeasurement # Temperature Measurement
+    version: 1
+  categories:
+  - name: Refrigerator
+- id: freezerTemperatureLevel # Second endpoint's Temperature Control
+  capabilities:
+  - id: mode # Temperature Control / TL
     version: 1
   categories:
   - name: Refrigerator

--- a/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
@@ -68,6 +68,9 @@ local function device_added(driver, device)
       end
     end
   end
+
+  table.sort(cabinet_eps)
+
   if #cabinet_eps > 1 then
     endpointToComponentMap = { -- This is just a guess for now
       [cabinet_eps[1]] = "refrigerator",


### PR DESCRIPTION
IOTE-3354
IOTE-3544

* Sometimes, device.endpoints loop is not working sequentially.
* Adding optional capability to make a superset profile (related to MTR-619)