### PR TITLE
audio TTS fix on samsung speakers

### DIFF
--- a/drivers/SmartThings/samsung-audio/README.md
+++ b/drivers/SmartThings/samsung-audio/README.md
@@ -1,0 +1,15 @@
+# Samsung-Audio integration documentation
+
+The purpose of this readme is to document the behavior of various samsung lan speaker devices,
+since during the development of the driver there have been some weird behavior.
+The document will also explain any mitigations the driver makes to provide a
+consistent integration despite the weird behavior.
+
+## Device testing notes
+
+Audio Speaker Device shows some wierd behavior while responding to various commands. Due to non uniform response by devices, device state mismatch can be
+observed sometimes in the ST app.
+
+## Samsung Audio TTS Notification
+
+Currently, Audio TTS notification is played with certain non expected behaviors. For example, when the speakers are in paused state, the notification plays but the queued music resumes playing. Similarly, when speakers are in mute state, it will unmute and play the notification but the speakers will remain unmuted after this. 

--- a/drivers/SmartThings/samsung-audio/README.md
+++ b/drivers/SmartThings/samsung-audio/README.md
@@ -7,7 +7,7 @@ consistent integration despite the weird behavior.
 
 ## Device testing notes
 
-Audio Speaker Device shows some wierd behavior while responding to various commands. Due to non uniform response by devices, device state mismatch can be
+Audio Speaker Device shows some weird behavior while responding to various commands. Due to non uniform response by devices, device state mismatch can be
 observed sometimes in the ST app.
 
 ## Samsung Audio TTS Notification

--- a/drivers/SmartThings/samsung-audio/src/command.lua
+++ b/drivers/SmartThings/samsung-audio/src/command.lua
@@ -349,27 +349,6 @@ function Command.getPlayStatus(ip)
   return response_map
 end
 
---- Return err code from xml handler or nil if it doesn't exist
-local get_resp = function(response_map)
-  if response_map ~= nil and
-      response_map.handler_res~= nil and
-      response_map.handler_res.root ~= nil and
-      response_map.handler_res.root.UIC ~= nil and
-      response_map.handler_res.root.UIC.response ~=nil then
-      return {
-        method = response_map.handler_res.root.UIC.method,
-        err_code= response_map.handler_res.root.UIC.response.errCode
-      }
-  else
-    log.trace("errorCode not found")
-    return {
-      method = nil,
-      err_code = nil
-    }
-  end
-
-end
-
 local format_streaming_path = function(uri)
   return "/UIC?cmd=%3Cpwron%3Eon%3C/pwron%3E%3Cname%3ESetUrlPlayback%3C/name%3E%3Cp%20type=%22cdata%22%20name=%22url%22%20val=%22empty%22%3E%3C![CDATA[" .. uri .. "]]%3E%3C/p%3E%3Cp%20type=%22dec%22%20name=%22buffersize%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22seektime%22%20val=%220%22/%3E%3Cp%20type=%22dec%22%20name=%22resume%22%20val=%221%22/%3E"
 end
@@ -388,22 +367,7 @@ function Command.play_streaming_uri(ip, uri)
   log.trace("Triggering UPnP Command Request for [Audio Notification -> SetUrlPlayback]")
   local response_map = nil
   if ip then
-    local path = format_streaming_path(uri)
-    local url = format_url(ip, path)
-    log.trace(string.format("Final Notification Command URL for making Audio Notification http request = %s", url))
-    response_map = handle_http_request(ip, url)
-    --- Adding extra debug logs in case some issue comes in future
-    log.debug("Response Map table with https: ", utils.stringify_table(response_map))
-    local resp = get_resp(response_map)
-    log.debug("resp method and error code : ", utils.stringify_table(resp))
-    if resp.method == "ErrorEvent" then
-      log.info(string.format("Recieved error code %s",resp.err_code))
-      response_map= fallback_to_http(ip,uri)
-    end
-    if resp.method == "PausePlaybackEvent" then
-      log.info(string.format("Recieved error code %s",resp.err_code))
-      response_map= fallback_to_http(ip,uri)
-    end
+    response_map = fallback_to_http(ip, uri)
   end
   return response_map
 end

--- a/drivers/SmartThings/samsung-audio/src/handlers.lua
+++ b/drivers/SmartThings/samsung-audio/src/handlers.lua
@@ -136,7 +136,11 @@ end
 
 function CapabilityHandlers.handle_audio_notification(driver, device, cmd)
   local ip = device:get_field("ip")
-  -- Audio Notification working fine when checked through routine. Need to confirm later for any issue whether ST app expect any emit_event here
+  local mute_status = command.getMute(ip)
+  if mute_status.muted ~= "off" then
+     --unmute before playig notification
+     command.unmute(ip)
+  end
   command.play_streaming_uri(ip, cmd.args.uri)
 end
 


### PR DESCRIPTION
Ticket: https://smartthings.atlassian.net/browse/BEE-4280

Currently, the notification could only be played with 'http' method. In order to make the TTS work uniformly, direct fallback method has been adopted to make it work without fail.