### PR TITLE
 Matter Switch: Set switchLevel range to 1-100 for light matter profiles

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-2000K-7000K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-2000K-7000K.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
   - id: colorControl

--- a/drivers/SmartThings/matter-switch/profiles/light-level-ColorTemperature-1500-9000k.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-ColorTemperature-1500-9000k.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
     config:

--- a/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: colorTemperature
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level.yml
@@ -6,6 +6,10 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+    config:
+      values:
+        - key: "level.value"
+          range: [1, 100]
   - id: firmwareUpdate
     version: 1
   - id: refresh


### PR DESCRIPTION
Updating the "light" matter profiles in the matter switch driver to set the supported range of switchLevel to 1-100 to resolve CHAD-12814. Devices supporting the lighting feature support a minimum value of 1, however, MinLevel is an optional attribute, so currently devices that do not supply this value may use a range of 0-100 even though 0 is not supported.