### PR TITLE
Don't log stse.detectionFrequency changelog in ST App history

### DIFF
--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/aqara/init.lua
@@ -60,7 +60,7 @@ end
 
 local function write_attr_res_handler(driver, device, zb_rx)
   local value = device:get_field(FREQUENCY_PREF) or FREQUENCY_DEFAULT_VALUE
-  device:emit_event(detectionFrequency.detectionFrequency(value))
+  device:emit_event(detectionFrequency.detectionFrequency(value, {visibility = {displayed = false}}))
 end
 
 local function device_init(driver, device)
@@ -76,7 +76,7 @@ end
 
 local function added_handler(self, device)
   device:emit_event(capabilities.illuminanceMeasurement.illuminance(0))
-  device:emit_event(detectionFrequency.detectionFrequency(FREQUENCY_DEFAULT_VALUE))
+  device:emit_event(detectionFrequency.detectionFrequency(FREQUENCY_DEFAULT_VALUE, {visibility = {displayed = false}}))
   device:emit_event(capabilities.battery.battery(100))
 
   device:send(cluster_base.write_manufacturer_specific_attribute(device, PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID,

--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor_aqara.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor_aqara.lua
@@ -62,7 +62,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       capabilities.illuminanceMeasurement.illuminance(0)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
-      detectionFrequency.detectionFrequency(FREQUENCY_DEFAULT_VALUE)))
+      detectionFrequency.detectionFrequency(FREQUENCY_DEFAULT_VALUE, {visibility = {displayed = false}})))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
 
     test.socket.zigbee:__expect_send({ mock_device.id,

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/init.lua
@@ -43,7 +43,7 @@ local function write_attr_res_handler(driver, device, zb_rx)
     -- for unoccupied timer
     device:set_field(aqara_utils.PREF_FREQUENCY_KEY, value, { persist = true })
     -- update ui
-    device:emit_event(detectionFrequency.detectionFrequency(value))
+    device:emit_event(detectionFrequency.detectionFrequency(value, {visibility = {displayed = false}}))
   elseif key == PREF_SENSITIVITY_KEY then
     -- sensitivity adjustment
 
@@ -80,7 +80,7 @@ end
 
 local function added_handler(self, device)
   device:emit_event(capabilities.motionSensor.motion.inactive())
-  device:emit_event(detectionFrequency.detectionFrequency(aqara_utils.PREF_FREQUENCY_VALUE_DEFAULT))
+  device:emit_event(detectionFrequency.detectionFrequency(aqara_utils.PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}}))
   device:emit_event(sensitivityAdjustment.sensitivityAdjustment.Medium())
   device:emit_event(capabilities.battery.battery(100))
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
@@ -63,7 +63,7 @@ local function write_attr_res_handler(driver, device, zb_rx)
     -- for unoccupied timer
     device:set_field(aqara_utils.PREF_FREQUENCY_KEY, value, { persist = true })
     -- update ui
-    device:emit_event(detectionFrequency.detectionFrequency(value))
+    device:emit_event(detectionFrequency.detectionFrequency(value, {visibility = {displayed = false}}))
   end
 end
 
@@ -80,7 +80,7 @@ end
 local function added_handler(self, device)
   device:emit_event(capabilities.motionSensor.motion.inactive())
   device:emit_event(capabilities.illuminanceMeasurement.illuminance(0))
-  device:emit_event(detectionFrequency.detectionFrequency(aqara_utils.PREF_FREQUENCY_VALUE_DEFAULT))
+  device:emit_event(detectionFrequency.detectionFrequency(aqara_utils.PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}}))
   device:emit_event(capabilities.battery.battery(100))
 
   device:send(cluster_base.write_manufacturer_specific_attribute(device, aqara_utils.PRIVATE_CLUSTER_ID,

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
@@ -64,7 +64,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       capabilities.motionSensor.motion.inactive()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
-      detectionFrequency.detectionFrequency(PREF_FREQUENCY_VALUE_DEFAULT)))
+      detectionFrequency.detectionFrequency(PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}})))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       sensitivityAdjustment.sensitivityAdjustment.Medium()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
@@ -65,7 +65,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       capabilities.illuminanceMeasurement.illuminance(0)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
-      detectionFrequency.detectionFrequency(PREF_FREQUENCY_VALUE_DEFAULT)))
+      detectionFrequency.detectionFrequency(PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}})))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
 
     test.socket.zigbee:__expect_send({ mock_device.id,


### PR DESCRIPTION
Fix PLM P240314-06959

There is a problem about the unit translation of "stse.detectionFrequency" in ST App history.
Since "stse.detectionFrequency" history is not critical, ignore it first as a workaround.