### PR TITLE
Move write_manufacturer_specific_attribute from added to doConfigure event

### DIFF
--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/init.lua
@@ -83,7 +83,10 @@ local function added_handler(self, device)
   device:emit_event(detectionFrequency.detectionFrequency(aqara_utils.PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}}))
   device:emit_event(sensitivityAdjustment.sensitivityAdjustment.Medium())
   device:emit_event(capabilities.battery.battery(100))
+end
 
+local function do_configure(self, device)
+  device:configure()
   device:send(cluster_base.write_manufacturer_specific_attribute(device, aqara_utils.PRIVATE_CLUSTER_ID,
     aqara_utils.PRIVATE_ATTRIBUTE_ID,
     aqara_utils.MFG_CODE, data_types.Uint8, 1))
@@ -92,7 +95,8 @@ end
 local aqara_high_precision_motion_handler = {
   NAME = "Aqara High Precision Motion Handler",
   lifecycle_handlers = {
-    added = added_handler
+    added = added_handler,
+    doConfigure = do_configure
   },
   capability_handlers = {
     [sensitivityAdjustment.ID] = {

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
@@ -82,7 +82,10 @@ local function added_handler(self, device)
   device:emit_event(capabilities.illuminanceMeasurement.illuminance(0))
   device:emit_event(detectionFrequency.detectionFrequency(aqara_utils.PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}}))
   device:emit_event(capabilities.battery.battery(100))
+end
 
+local function do_configure(self, device)
+  device:configure()
   device:send(cluster_base.write_manufacturer_specific_attribute(device, aqara_utils.PRIVATE_CLUSTER_ID,
     aqara_utils.PRIVATE_ATTRIBUTE_ID,
     aqara_utils.MFG_CODE, data_types.Uint8, 1))
@@ -101,7 +104,8 @@ local aqara_motion_handler = {
   NAME = "Aqara Motion Handler",
   lifecycle_handlers = {
     init = device_init,
-    added = added_handler
+    added = added_handler,
+    doConfigure = do_configure
   },
   capability_handlers = {
     [detectionFrequency.ID] = {

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
@@ -69,11 +69,26 @@ test.register_coroutine_test(
       sensitivityAdjustment.sensitivityAdjustment.Medium()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       capabilities.battery.battery(100)))
+  end
+)
 
+test.register_coroutine_test(
+  "Handle doConfigure lifecycle",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, PowerConfiguration.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      PowerConfiguration.attributes.BatteryVoltage:configure_reporting(mock_device, 30, 3600, 1)
+    })
     test.socket.zigbee:__expect_send({ mock_device.id,
       cluster_base.write_manufacturer_specific_attribute(mock_device, PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID, MFG_CODE
         ,
         data_types.Uint8, 1) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
@@ -67,11 +67,26 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       detectionFrequency.detectionFrequency(PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}})))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
+  end
+)
 
+test.register_coroutine_test(
+  "Handle doConfigure lifecycle",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, PowerConfiguration.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      PowerConfiguration.attributes.BatteryVoltage:configure_reporting(mock_device, 30, 3600, 1)
+    })
     test.socket.zigbee:__expect_send({ mock_device.id,
       cluster_base.write_manufacturer_specific_attribute(mock_device, PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID, MFG_CODE
         ,
         data_types.Uint8, 1) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
 )
 


### PR DESCRIPTION
fix issue that motion detection doesn't work after reonboarding

When reonboard Aqara sensors when device card remain, added event
will not be called, synced with Aqara team, they suggest us to move
write_manufacturer_specific_attribute from added to doConfigure event