### PR TITLE
fix Aqara Wireless Button E1 reonboarding issue

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/aqara/init.lua
@@ -82,29 +82,34 @@ local function device_init(driver, device)
 end
 
 local function added_handler(self, device)
-    if device:get_model() == "lumi.remote.b1acn02" then
-      device:send(cluster_base.write_manufacturer_specific_attribute(device,
-      PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID_T1, MFG_CODE, data_types.Uint8, 1))
-    elseif device:get_model() == "lumi.remote.acn003" then
-      device:send(cluster_base.write_manufacturer_specific_attribute(device,
-      PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID_E1, MFG_CODE, data_types.Uint8, 2))
-    end
-    -- when the wireless switch T1 accesses the network, the gateway sends
-    -- private attribute 0009 to make the device no longer distinguish
-    -- between the standard gateway and the aqara gateway.
-    -- When wireless switch E1 is connected to the network, the gateway sends
-    -- private attribute 0125 to enable the device to send double-click and long-press packets.
     device:emit_event(capabilities.button.supportedButtonValues({"pushed","held","double"}, {visibility = { displayed = false }}))
     device:emit_event(capabilities.button.numberOfButtons({value = 1}))
     device:emit_event(capabilities.button.button.pushed({state_change = false}))
     device:emit_event(capabilities.battery.battery(100))
 end
 
+local function do_configure(driver, device)
+  device:configure()
+  if device:get_model() == "lumi.remote.b1acn02" then
+    device:send(cluster_base.write_manufacturer_specific_attribute(device,
+    PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID_T1, MFG_CODE, data_types.Uint8, 1))
+  elseif device:get_model() == "lumi.remote.acn003" then
+    device:send(cluster_base.write_manufacturer_specific_attribute(device,
+    PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID_E1, MFG_CODE, data_types.Uint8, 2))
+  end
+  -- when the wireless switch T1 accesses the network, the gateway sends
+  -- private attribute 0009 to make the device no longer distinguish
+  -- between the standard gateway and the aqara gateway.
+  -- When wireless switch E1 is connected to the network, the gateway sends
+  -- private attribute 0125 to enable the device to send double-click and long-press packets.
+end
+
 local aqara_wireless_switch_handler = {
     NAME = "Aqara Wireless Switch Handler",
     lifecycle_handlers = {
       init = device_init,
-      added = added_handler
+      added = added_handler,
+      doConfigure = do_configure
     },
     zigbee_handlers = {
       attr = {

--- a/drivers/SmartThings/zigbee-button/src/test/test_SLED_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_SLED_button.lua
@@ -1,0 +1,100 @@
+-- Copyright 2024 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+local test = require "integration_test"
+local clusters = require "st.zigbee.zcl.clusters"
+local t_utils = require "integration_test.utils"
+local zigbee_test_utils = require "integration_test.zigbee_test_utils"
+local capabilities = require "st.capabilities"
+
+local Level = clusters.Level
+local OnOff = clusters.OnOff
+local ColorControl = clusters.ColorControl
+local button_attr = capabilities.button.button
+
+local mock_device = test.mock_device.build_test_zigbee_device(
+  {
+    profile = t_utils.get_profile_definition("SLED-three-buttons.yml"),
+    zigbee_endpoints = {
+      [1] = {
+        id = 1,
+        manufacturer = "Samsung Electronics",
+        model = "SAMSUNG-ITM-Z-005",
+        server_clusters = {0x0001, 0x0006, 0x0008, 0x0300}
+      }
+    }
+  }
+)
+
+zigbee_test_utils.prepare_zigbee_env_info()
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
+  zigbee_test_utils.init_noop_health_check_timer()
+end
+
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+  "Reported button should be handled: pushed true",
+  function()
+    test.socket.zigbee:__queue_receive({ mock_device.id, OnOff.server.commands.On.build_test_rx(mock_device) })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("button1", button_attr.pushed({ state_change = true }))
+    )
+    test.wait_for_events()
+    test.socket.zigbee:__queue_receive({ mock_device.id, OnOff.server.commands.Off.build_test_rx(mock_device) })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("button2", button_attr.pushed({ state_change = true }))
+    )
+    test.wait_for_events()
+    test.socket.zigbee:__queue_receive({ mock_device.id, OnOff.server.commands.Toggle.build_test_rx(mock_device) })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("button3", button_attr.pushed({ state_change = true }))
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Reported button should be handled: held true",
+  function()
+    test.wait_for_events()
+    test.socket.zigbee:__queue_receive({ mock_device.id, Level.server.commands.MoveWithOnOff.build_test_rx(mock_device, 0x00, 0x00) })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("button1", button_attr.held({ state_change = true }))
+    )
+    test.socket.zigbee:__queue_receive({ mock_device.id, Level.server.commands.Move.build_test_rx(mock_device, 0x00, 0x00) })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("button2", button_attr.held({ state_change = true }))
+    )
+    test.wait_for_events()
+    test.socket.zigbee:__queue_receive({ mock_device.id, ColorControl.server.commands.MoveToColorTemperature.build_test_rx(mock_device, 0x00, 0x00) })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("button3", button_attr.held({ state_change = true }))
+    )
+    test.wait_for_events()
+  end
+)
+
+test.register_coroutine_test(
+  "Handle doConfigure lifecycle",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__expect_send({
+        mock_device.id,
+        zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+      })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-button/src/test/test_wallhero_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_wallhero_button.lua
@@ -315,7 +315,8 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", button_attr.pushed({ state_change = true }))
     )
     test.wait_for_events()
-
+    test.socket.zigbee:__queue_receive({ mock_device.id, zigbee_test_utils.build_custom_command_id(mock_device, Scenes.ID, Scenes.server.commands.RecallScene.ID, 0x0000, "\x05\x00\x00\x00\x05\x00", 0x1F) })
+    test.wait_for_events()
   end
 )
 


### PR DESCRIPTION
This is a fix for STSE-2620. Added Test Coverage, but wallhero coverage may not be up to 90%. The function that did not coverage is init function. I cannot access by test using virtual devices.