### PR TITLE
[CHAD-12999] fix (Zigbee Lock): Ignore unknown status for sds lock

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
@@ -30,8 +30,6 @@ local function handle_lock_state(driver, device, value, zb_rx)
     device:emit_event(Lock.lock.locked())
   elseif value.value == DoorLock.attributes.LockState.UNLOCKED then
     device:emit_event(Lock.lock.unlocked())
-  else
-    device:emit_event(Lock.lock.unknown())
   end
 end
 
@@ -52,7 +50,7 @@ local function unlock_cmd_handler(driver, device, command)
 end
 
 local function lock_cmd_handler(driver, device, command)
-  --do nothing in lock command handler
+  -- do nothing in lock command handler
 end
 
 local refresh = function(driver, device, cmd)

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
@@ -112,6 +112,18 @@ test.register_message_test(
 )
 
 test.register_message_test(
+    "Not Fully Locked status reporting should not be handled",
+    {
+      {
+        channel = "zigbee",
+        direction = "receive",
+        message = { mock_device.id, DoorLock.attributes.LockState:build_test_attr_report(mock_device,
+                                                                                         DoorLockState.NOT_FULLY_LOCKED) }
+      }
+    }
+)
+
+test.register_message_test(
     "Lock operation event reporting should be handled",
     {
       {


### PR DESCRIPTION
https://smartthings.atlassian.net/browse/CHAD-12999
