### PR TITLE
Refactor discovery for addition of new device types

### DIFF
--- a/drivers/SmartThings/philips-hue/PROGRESS.md
+++ b/drivers/SmartThings/philips-hue/PROGRESS.md
@@ -8,10 +8,10 @@ Tracking TODOs for this refactor in this file; this is mostly to allow for creat
 
 #### Tasks
 
-- [ ] Convert supported resources map to a map of handlers instead of boolean
-- [ ] Move handlers to their own file
-- [ ] Rename the "light_state_disco_cache" key to be service type agnostic
-- [ ] Update the `discovered_device_callback` function to allow for other device types
+- [x] Convert supported resources map to a map of handlers instead of boolean ✅ 2024-04-16
+- [x] Move handlers to their own file ✅ 2024-04-16
+- [x] Rename the "light_state_disco_cache" key to be service type agnostic ✅ 2024-04-16
+- [x] Update the `discovered_device_callback` function to allow for other device types ✅ 2024-04-16
 
 ### Capability Handlers
 

--- a/drivers/SmartThings/philips-hue/src/disco/light_disco.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/light_disco.lua
@@ -1,0 +1,88 @@
+local log = require "log"
+local socket = require "cosock".socket
+local st_utils = require "st.utils"
+
+local M = {}
+
+---@param driver HueDriver
+---@param bridge_id string
+---@param api_instance PhilipsHueApi
+---@param resource_id string
+---@param device_info table
+---@param device_state_disco_cache table<string, table>
+---@param known_identifier_to_device_map table<string,HueDevice>
+function M.process_discovered_light(driver, bridge_id, api_instance, resource_id, device_info, device_state_disco_cache, known_identifier_to_device_map)
+  local light_resource, err, _ = api_instance:get_light_by_id(resource_id)
+  if err ~= nil or not light_resource then
+    log.error_with({ hub_logs = true },
+      string.format("Error getting light info for %s: %s", device_info.product_data.product_name,
+        (err or "unexpected nil in error position")))
+    return
+  end
+
+  if light_resource.errors and #light_resource.errors > 0 then
+    log.error_with({ hub_logs = true }, "Errors found in API response:")
+    for idx, err in ipairs(light_resource.errors) do
+      log.error_with({ hub_logs = true }, st_utils.stringify_table(err, "Error " .. idx, true))
+    end
+    return
+  end
+
+  for _, light in ipairs(light_resource.data or {}) do
+    local profile_ref
+
+    if light.color then
+      if light.color_temperature then
+        profile_ref = "white-and-color-ambiance"
+      else
+        profile_ref = "legacy-color"
+      end
+    elseif light.color_temperature then
+      profile_ref = "white-ambiance" -- all color temp products support `white` (dimming)
+    elseif light.dimming then
+      profile_ref = "white"          -- `white` refers to dimmable and includes filament bulbs
+    else
+      log.warn(
+        string.format(
+          "Light resource [%s] does not seem to be A White/White-Ambiance/White-Color-Ambiance device, currently unsupported"
+          ,
+          resource_id
+        )
+      )
+      goto continue
+    end
+
+    local bridge_device = known_identifier_to_device_map[bridge_id]
+
+    local create_device_msg = {
+      type = "EDGE_CHILD",
+      label = light.metadata.name,
+      vendor_provided_label = device_info.product_data.product_name,
+      profile = profile_ref,
+      manufacturer = device_info.product_data.manufacturer_name,
+      model = device_info.product_data.model_id,
+      parent_device_id = bridge_device.id,
+      parent_assigned_child_key = light.id,
+    }
+
+    device_state_disco_cache[light.id] = {
+      hue_provided_name = light.metadata.name,
+      id = light.id,
+      on = light.on,
+      color = light.color,
+      dimming = light.dimming,
+      color_temperature = light.color_temperature,
+      mode = light.mode,
+      parent_device_id = bridge_device.id,
+      hue_device_id = light.owner.rid,
+      hue_device_data = device_info
+    }
+
+    driver:try_create_device(create_device_msg)
+    -- rate limit ourself.
+    socket.sleep(0.1)
+    ::continue::
+  end
+end
+
+return M

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -469,7 +469,7 @@ local function migrate_light(driver, device, parent_device_id, hue_light_descrip
   local api_instance = (bridge_device and bridge_device:get_field(Fields.BRIDGE_API))
       or (bridge_device and Discovery.disco_api_instances[bridge_device.device_network_id])
   local light_resource = hue_light_description or
-      Discovery.light_state_disco_cache[(device:get_field(Fields.RESOURCE_ID))]
+      Discovery.device_state_disco_cache[(device:get_field(Fields.RESOURCE_ID))]
 
   if not (api_instance and bridge_device and bridge_device:get_field(Fields._INIT)
         and driver.joined_bridges[bridge_id] and light_resource) then
@@ -593,7 +593,7 @@ light_added = function(driver, device, parent_device_id, resource_id)
   local child_key = device.parent_assigned_child_key
   local device_light_resource_id = resource_id or child_key
 
-  local light_info_known = (Discovery.light_state_disco_cache[device_light_resource_id] ~= nil)
+  local light_info_known = (Discovery.device_state_disco_cache[device_light_resource_id] ~= nil)
   if not light_info_known then
     log.info(
       string.format("Querying device info for parent of %s", (device.label or device.id or "unknown device")))
@@ -659,7 +659,7 @@ light_added = function(driver, device, parent_device_id, resource_id)
 
     for _, light in ipairs(light_resource.data or {}) do
       if device_light_resource_id == light.id then
-        Discovery.light_state_disco_cache[light.id] = {
+        Discovery.device_state_disco_cache[light.id] = {
           hue_provided_name = light.metadata.name,
           id = light.id,
           on = light.on,
@@ -696,7 +696,7 @@ light_added = function(driver, device, parent_device_id, resource_id)
     return
   end
 
-  local light_info = Discovery.light_state_disco_cache[device_light_resource_id]
+  local light_info = Discovery.device_state_disco_cache[device_light_resource_id]
   local minimum_dimming = 2
 
   if light_info.dimming and light_info.dimming.min_dim_level then minimum_dimming = light_info.dimming.min_dim_level end
@@ -976,7 +976,7 @@ local function do_bridge_network_init(driver, bridge_device, bridge_url, api_key
                     parent_assigned_child_key = add_data.id,
                   }
 
-                  Discovery.light_state_disco_cache[add_data.id] = {
+                  Discovery.device_state_disco_cache[add_data.id] = {
                     hue_provided_name = add_data.metadata.name,
                     id = add_data.id,
                     on = add_data.on,
@@ -1231,7 +1231,7 @@ cosock.spawn(function()
 
     for light_dni, light_device in pairs(strays) do
       local light_rid = stray_dni_to_rid[light_dni]
-      local cached_light_description = Discovery.light_state_disco_cache[light_rid]
+      local cached_light_description = Discovery.device_state_disco_cache[light_rid]
       if cached_light_description then
         table.insert(dnis_to_remove, light_dni)
         migrate_light(driver, light_device, bridge_device_uuid, cached_light_description)
@@ -1337,10 +1337,10 @@ cosock.spawn(function()
                   hue_device_id = light.owner.rid,
                   hue_device_data = device_data
                 }
-                if not Discovery.light_state_disco_cache[light.id] then
+                if not Discovery.device_state_disco_cache[light.id] then
                   log.info(string.format("Caching previously unknown light service description for %s",
                     device_data.metadata.name))
-                  Discovery.light_state_disco_cache[light.id] = light_resource_description
+                  Discovery.device_state_disco_cache[light.id] = light_resource_description
                 end
               end
             end


### PR DESCRIPTION
This is mostly a structural refactor as opposed to a functional one, but there are subtle changes.

First, we refactored the discovery module in to a directory, as we're going to be breaking the file up. The first extraction here is moving the handler for processing a discovered light in to its own file.

Next, we changed some names of some variables where it was assumed that we were working with lights; this is purely a comprehension/readability refactor.

The only functional change made here was a modification to the `supported_resource_types` mapping, which was originally just a map of booleans. This is now a map from a resource type to a handler function. In this case, we import the handler function from the new file mentioned above.