### PR TITLE
New Device (Matter Switch) Zemismart LED Strip Driver

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2076,6 +2076,11 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xEEE2
     deviceProfileName: switch-binary
+  - id: "5020/53251"
+    deviceLabel: Zemismart Led Light Strip Driver
+    vendorId: 0x139C
+    productId: 0xD003
+    deviceProfileName: light-color-level-2000K-7000K
 
 #Bridge devices need manufacturer specific fingerprints until
 #bridge support is released to all hubs. This is because of the way generic


### PR DESCRIPTION
This PR is for a WWST Certification request, to add a fingerprint for the Zemismart LED Strip Driver device:
Vendor ID	5020 (0x139c)  
Product ID	53251 (0xd003)

According to the DCL the device type of this is 10D

