### PR TITLE
Matter-Switch: Limit reads subscriptions

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 local capabilities = require "st.capabilities"
-local im = require "st.matter.interaction_model"
 local log = require "log"
 local clusters = require "st.matter.clusters"
 local MatterDriver = require "st.matter.driver"
@@ -39,7 +38,6 @@ local SWITCH_INITIALIZED = "__switch_intialized"
 -- in the device table for devices that joined prior to this transition, and it
 -- will not be set for new devices.
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
-local BOUNDS_CHECKED = "__bounds_checked"
 local COLOR_TEMP_BOUND_RECEIVED = "__colorTemp_bound_received"
 local COLOR_TEMP_MIN = "__color_temp_min"
 local COLOR_TEMP_MAX = "__color_temp_max"
@@ -213,22 +211,6 @@ local function device_init(driver, device)
     device:set_endpoint_to_component_fn(endpoint_to_component)
     device:set_find_child(find_child)
     device:subscribe()
-
-    if not device:get_field(BOUNDS_CHECKED) then
-      local limit_read = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
-      if device:supports_capability(capabilities.colorTemperature) then
-        limit_read:merge(clusters.ColorControl.attributes.ColorTempPhysicalMinMireds:read())
-        limit_read:merge(clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds:read())
-      end
-      if device:supports_capability(capabilities.switchLevel) then
-        limit_read:merge(clusters.LevelControl.attributes.MinLevel:read())
-        limit_read:merge(clusters.LevelControl.attributes.MaxLevel:read())
-      end
-      if #limit_read.info_blocks ~= 0 then
-        device:send(limit_read)
-      end
-      device:set_field(BOUNDS_CHECKED, true)
-    end
   end
 end
 
@@ -540,7 +522,9 @@ local matter_driver_template = {
       clusters.OnOff.attributes.OnOff
     },
     [capabilities.switchLevel.ID] = {
-      clusters.LevelControl.attributes.CurrentLevel
+      clusters.LevelControl.attributes.CurrentLevel,
+      clusters.LevelControl.attributes.MaxLevel,
+      clusters.LevelControl.attributes.MinLevel,
     },
     [capabilities.colorControl.ID] = {
       clusters.ColorControl.attributes.CurrentHue,
@@ -550,6 +534,8 @@ local matter_driver_template = {
     },
     [capabilities.colorTemperature.ID] = {
       clusters.ColorControl.attributes.ColorTemperatureMireds,
+      clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+      clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
     },
     [capabilities.illuminanceMeasurement.ID] = {
       clusters.IlluminanceMeasurement.attributes.MeasuredValue

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -79,17 +79,18 @@ local function test_init()
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LevelControl.attributes.CurrentLevel,
+    clusters.LevelControl.attributes.MaxLevel,
+    clusters.LevelControl.attributes.MinLevel,
     clusters.ColorControl.attributes.CurrentHue,
     clusters.ColorControl.attributes.CurrentSaturation,
     clusters.ColorControl.attributes.CurrentX,
     clusters.ColorControl.attributes.CurrentY,
     clusters.ColorControl.attributes.ColorTemperatureMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
     clusters.IlluminanceMeasurement.attributes.MeasuredValue,
     clusters.OccupancySensing.attributes.Occupancy
   }
-  -- Set __bounds_checked to bypass the setpoint limit reads so they do not need
-  -- to be checked in the init function.
-  mock_device:set_field("__bounds_checked", true, {persist = true})
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -80,11 +80,15 @@ local mock_device_no_hue_sat = test.mock_device.build_test_matter_device({
 local cluster_subscribe_list = {
   clusters.OnOff.attributes.OnOff,
   clusters.LevelControl.attributes.CurrentLevel,
+  clusters.LevelControl.attributes.MaxLevel,
+  clusters.LevelControl.attributes.MinLevel,
   clusters.ColorControl.attributes.CurrentHue,
   clusters.ColorControl.attributes.CurrentSaturation,
   clusters.ColorControl.attributes.CurrentX,
   clusters.ColorControl.attributes.CurrentY,
   clusters.ColorControl.attributes.ColorTemperatureMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
 }
 
 local function test_init()
@@ -96,13 +100,6 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-  local limit_read = clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds:read()
-  limit_read:merge(clusters.ColorControl.attributes.ColorTempPhysicalMinMireds:read())
-  limit_read:merge(clusters.LevelControl.attributes.MaxLevel:read())
-  limit_read:merge(clusters.LevelControl.attributes.MinLevel:read())
-  test.socket.matter:__expect_send({mock_device.id, limit_read})
-
   test.mock_device.add_test_device(mock_device)
 
   subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_no_hue_sat)
@@ -112,13 +109,6 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({mock_device_no_hue_sat.id, subscribe_request})
-
-  limit_read = clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds:read()
-  limit_read:merge(clusters.ColorControl.attributes.ColorTempPhysicalMinMireds:read())
-  limit_read:merge(clusters.LevelControl.attributes.MaxLevel:read())
-  limit_read:merge(clusters.LevelControl.attributes.MinLevel:read())
-  test.socket.matter:__expect_send({mock_device_no_hue_sat.id, limit_read})
-
   test.mock_device.add_test_device(mock_device_no_hue_sat)
 end
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -98,11 +98,12 @@ local function test_init()
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LevelControl.attributes.CurrentLevel,
+    clusters.LevelControl.attributes.MaxLevel,
+    clusters.LevelControl.attributes.MinLevel,
     clusters.ColorControl.attributes.ColorTemperatureMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
   }
-  -- Set __bounds_checked to bypass the setpoint limit reads so they do not need
-  -- to be checked in the init function.
-  mock_device:set_field("__bounds_checked", true, {persist = true})
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then


### PR DESCRIPTION
Subscribe to min/max color temperature and min/max switch level attributes rather than reading them during device init. This is to resolve an issue identified while investigating `InteractionQueueFull` spikes in the exception reports, where onboarding a large number of devices resulted in more attributes being read than the maximum number of attributes per read interaction (9). These attribute reads were split into multiple read requests, which exceeded the maximum number of concurrent requests (5), causing the remaining requests to be dropped.

Utilizing subscriptions for these attributes rather than manually querying the device will take advantage of the current optimizations for subscription requests and avoid this issue.