### PR TITLE
Addition of 'setSaturation' and 'setHue' logic for Philips Hue Lights

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -166,6 +166,28 @@ local function do_color_action(driver, device, args)
   end
 end
 
+-- Function to allow changes to "setHue" attribute to Philips Hue light devices
+---@param driver HueDriver
+---@param device HueChildDevice
+local function do_setHue_action(driver, device, args)
+
+  -- Use existing 'saturation' value for device or set to 0 and pass arg values to function 'do_color_action'
+  local currentSaturation = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.saturation.NAME) or 0
+  args.args.color.saturation = currentSaturation
+  do_color_action(driver, device, args)
+end
+
+-- Function to allow changes to "setSaturation" attribute to Philips Hue light devices
+---@param driver HueDriver
+---@param device HueChildDevice
+local function do_setSaturation_action(driver, device, args)
+
+  -- Use existing 'hue' value for device or set to 0 and pass arg values to function 'do_color_action'
+  local currentHue = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.hue.NAME) or 0
+  args.args.color.hue = currentHue
+  do_color_action(driver, device, args)
+end
+
 function handlers.kelvin_to_mirek(kelvin) return 1000000 / kelvin end
 
 function handlers.mirek_to_kelvin(mirek) return 1000000 / mirek end
@@ -247,6 +269,20 @@ end
 function handlers.set_color_temp_handler(driver, device, args)
   do_color_temp_action(driver, device, args)
 end
+
+---@param driver HueDriver
+---@param device HueChildDevice
+function handlers.set_color_hue_handler(driver, device, args)
+  do_setHue_action(driver, device, args)
+end
+
+
+---@param driver HueDriver
+---@param device HueChildDevice
+function handlers.set_color_saturation_handler(driver, device, args)
+  do_setSaturation_action(driver, device, args)
+end
+
 
 ---@param driver HueDriver
 ---@param light_device HueChildDevice

--- a/drivers/SmartThings/philips-hue/src/handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers.lua
@@ -172,8 +172,11 @@ end
 local function do_setHue_action(driver, device, args)
 
   -- Use existing 'saturation' value for device or set to 0 and pass arg values to function 'do_color_action'
-  local currentSaturation = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.saturation.NAME) or 0
-  args.args.color.saturation = currentSaturation
+  local currentSaturation = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.saturation.NAME, 0)
+  args.args.color = {
+    hue = args.args.hue,
+    saturation = currentSaturation
+  }
   do_color_action(driver, device, args)
 end
 
@@ -183,8 +186,11 @@ end
 local function do_setSaturation_action(driver, device, args)
 
   -- Use existing 'hue' value for device or set to 0 and pass arg values to function 'do_color_action'
-  local currentHue = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.hue.NAME) or 0
-  args.args.color.hue = currentHue
+  local currentHue = device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.hue.NAME, 0)
+  args.args.color = {
+    hue = currentHue,
+    saturation = args.args.saturation
+  }
   do_color_action(driver, device, args)
 end
 
@@ -272,14 +278,14 @@ end
 
 ---@param driver HueDriver
 ---@param device HueChildDevice
-function handlers.set_color_hue_handler(driver, device, args)
+function handlers.set_hue_handler(driver, device, args)
   do_setHue_action(driver, device, args)
 end
 
 
 ---@param driver HueDriver
 ---@param device HueChildDevice
-function handlers.set_color_saturation_handler(driver, device, args)
+function handlers.set_saturation_handler(driver, device, args)
   do_setSaturation_action(driver, device, args)
 end
 

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -70,6 +70,8 @@ local switch_on_handler = safe_wrap_handler(handlers.switch_on_handler)
 local switch_off_handler = safe_wrap_handler(handlers.switch_off_handler)
 local switch_level_handler = safe_wrap_handler(handlers.switch_level_handler)
 local set_color_handler = safe_wrap_handler(handlers.set_color_handler)
+local set_color_hue_handler = safe_wrap_handler(handlers.set_color_hue_handler)
+local set_color_saturation_handler = safe_wrap_handler(handlers.set_color_saturation_handler)
 local set_color_temp_handler = safe_wrap_handler(handlers.set_color_temp_handler)
 
 ---@param light_device HueChildDevice
@@ -1509,6 +1511,8 @@ local hue = Driver("hue",
       },
       [capabilities.colorControl.ID] = {
         [capabilities.colorControl.commands.setColor.NAME] = set_color_handler,
+        [capabilities.colorControl.commands.setHue.NAME] = set_color_hue_handler,
+        [capabilities.colorControl.commands.setSaturation.NAME] = set_color_saturation_handler,
       },
       [capabilities.colorTemperature.ID] = {
         [capabilities.colorTemperature.commands.setColorTemperature.NAME] = set_color_temp_handler,

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -70,8 +70,8 @@ local switch_on_handler = safe_wrap_handler(handlers.switch_on_handler)
 local switch_off_handler = safe_wrap_handler(handlers.switch_off_handler)
 local switch_level_handler = safe_wrap_handler(handlers.switch_level_handler)
 local set_color_handler = safe_wrap_handler(handlers.set_color_handler)
-local set_color_hue_handler = safe_wrap_handler(handlers.set_color_hue_handler)
-local set_color_saturation_handler = safe_wrap_handler(handlers.set_color_saturation_handler)
+local set_hue_handler = safe_wrap_handler(handlers.set_hue_handler)
+local set_saturation_handler = safe_wrap_handler(handlers.set_saturation_handler)
 local set_color_temp_handler = safe_wrap_handler(handlers.set_color_temp_handler)
 
 ---@param light_device HueChildDevice
@@ -1511,8 +1511,8 @@ local hue = Driver("hue",
       },
       [capabilities.colorControl.ID] = {
         [capabilities.colorControl.commands.setColor.NAME] = set_color_handler,
-        [capabilities.colorControl.commands.setHue.NAME] = set_color_hue_handler,
-        [capabilities.colorControl.commands.setSaturation.NAME] = set_color_saturation_handler,
+        [capabilities.colorControl.commands.setHue.NAME] = set_hue_handler,
+        [capabilities.colorControl.commands.setSaturation.NAME] = set_saturation_handler,
       },
       [capabilities.colorTemperature.ID] = {
         [capabilities.colorTemperature.commands.setColorTemperature.NAME] = set_color_temp_handler,


### PR DESCRIPTION
## Description

Addition of 'setSaturation' and 'setHue' logic for Philips Hue Lights. The motvation towards this addition comes from the use of some clients that use setHue and setSaturation instead of setColor.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have fully and thoroughly tested my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings