### PR TITLE
Add a Dimmer Switch in Matter fingerprints

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2191,6 +2191,11 @@ matterGeneric:
     deviceTypes:
       - id: 0x010B # Dimmable Plug-in Unit
     deviceProfileName: plug-level
+  - id: "matter/dimmer/switch"
+    deviceLabel: Matter Dimmer Switch
+    deviceTypes:
+      - id: 0x0104 # Dimmer Switch
+    deviceProfileName: switch-level
 
 matterThing:
   - id: SmartThings/MatterThing


### PR DESCRIPTION
Add to fingerprints to use Matter switch-level profile that is already registered.
  IOTE-3863, IOTE-3757