### PR TITLE
change JBL MA AVRs category to Receiver

### DIFF
--- a/drivers/SmartThings/harman-luxury/profiles/maX10.yaml
+++ b/drivers/SmartThings/harman-luxury/profiles/maX10.yaml
@@ -23,7 +23,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: Speaker
+  - name: Receiver
 preferences:
 - preferenceId: certifiedpreferences.doNotDisturbPlayback
   explicit: true


### PR DESCRIPTION
As told by @Seong-Yeol-Park eCode, AVRs like the ones this profile represent should be under the `Receiver` category instead of `Speaker`.