### PR TITLE
Harman-Luxury Improve device update communications

### DIFF
--- a/drivers/SmartThings/harman-luxury/src/api/nsdk.lua
+++ b/drivers/SmartThings/harman-luxury/src/api/nsdk.lua
@@ -88,7 +88,12 @@ local function handleReply(func_name, u, sink, code, valLocationFunc)
     end
     return nil, err
   else -- UNKNOWN VALUE
-    local err = string.format("Error in %s: Unknown return value: code: %s, sink: %s", func_name, code, sink)
+    local err
+    if string.find(code, "timeout") then
+      err = string.format("Error in %s: Connection timeout", func_name)
+    else
+      err = string.format("Error in %s: Unknown return value: code: %s, sink: %s", func_name, code, sink)
+    end
     log.error(err)
     return nil, err
   end

--- a/drivers/SmartThings/harman-luxury/src/constants.lua
+++ b/drivers/SmartThings/harman-luxury/src/constants.lua
@@ -10,7 +10,7 @@ local Constants = {
   -- intervals constants (in seconds)
   UPDATE_INTERVAL = 1,
   HEALTH_CHEACK_INTERVAL = 10,
-  HTTP_TIMEOUT = 10,
+  HTTP_TIMEOUT = 5,
 
   -- discovery constants
   SERVICE_TYPE = "_sue-st._tcp",


### PR DESCRIPTION
Reduced the thread responsible to poll updates from the device from one per device to a single one for the whole driver. This will help with stability when a user has a lot of devices (Harman Luxury devices in particular) connected to their hub.
Moreover, the HTTP timeout time was reduced and a timeout error will now has its own error message.