### PR TITLE
SmartSense Multi: Fix handling of large negative threeAxis values

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/multi-sensor/multi_utils.lua
+++ b/drivers/SmartThings/zigbee-contact/src/multi-sensor/multi_utils.lua
@@ -138,7 +138,7 @@ multi_utils.convert_to_signedInt16 = function(byte1, byte2)
   local finalValue
   local swapped = (byte2 << 8) | byte1
   local sign_mask = 0x8000
-  local int16mask = 0xFF
+  local int16mask = 0xFFFF
   local isNegative = (swapped & sign_mask) >> 15
 
   if(isNegative == 1) then

--- a/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
@@ -336,26 +336,74 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(1050, -3, 9)",
+    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(1050, 3, 9)",
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_three_axis_report_message(mock_device, "\x1A\x04\xFD\xFF\x09\x00")
+        build_three_axis_report_message(mock_device, "\x1A\x04\x03\x00\x09\x00")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
-      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({1050, -3, 9})) )
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({1050, 3, 9})) )
     end
 )
 
 test.register_coroutine_test(
-    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(1123,-130,-24)",
+    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(-1050, -3, -9)",
     function()
       test.socket.zigbee:__queue_receive({
         mock_device.id,
-        build_three_axis_report_message(mock_device, "\x63\x04\x7E\xFF\xE8\xFF")
+        build_three_axis_report_message(mock_device, "\xE6\xFB\xFD\xFF\xF7\xFF")
       })
       test.socket.capability:__set_channel_ordering("relaxed")
-      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({1123, -130, -24})) )
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({-1050, -3, -9})) )
+    end
+)
+
+test.register_coroutine_test(
+    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(10, 1020, 7)",
+    function()
+      test.socket.zigbee:__queue_receive({
+        mock_device.id,
+        build_three_axis_report_message(mock_device, "\x0A\x00\xFC\x03\x07\x00")
+      })
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({10, 1020, 7})) )
+    end
+)
+
+test.register_coroutine_test(
+    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(-10, -1020, -7)",
+    function()
+      test.socket.zigbee:__queue_receive({
+        mock_device.id,
+        build_three_axis_report_message(mock_device, "\xF6\xFF\x04\xFC\xF9\xFF")
+      })
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({-10, -1020, -7})) )
+    end
+)
+
+test.register_coroutine_test(
+    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(116, 4, 1003)",
+    function()
+      test.socket.zigbee:__queue_receive({
+        mock_device.id,
+        build_three_axis_report_message(mock_device, "\x74\x00\x04\x00\xEB\x03")
+      })
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({116, 4, 1003})) )
+    end
+)
+
+test.register_coroutine_test(
+    "Report from cluster 0xFC03, command 0x05 should be handled as: threeAxis(-116, -4, -1003)",
+    function()
+      test.socket.zigbee:__queue_receive({
+        mock_device.id,
+        build_three_axis_report_message(mock_device, "\x8C\xFF\xFC\xFF\x15\xFC")
+      })
+      test.socket.capability:__set_channel_ordering("relaxed")
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({-116, -4, -1003})) )
     end
 )
 


### PR DESCRIPTION
The `convert_to_signedInt16` function had a bug preventing it from handling large negative threeAxis values. This would impact the garage door handling since in the typical orientation the sensor will report approximately -1000 for the Z axis when the door is open.

https://smartthings.atlassian.net/browse/CHAD-13097