### PR TITLE
New Device (Matter Switch) Legrand Smart Lights Plug

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -139,7 +139,12 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x006F
     deviceProfileName: plug-binary
-
+#Legrand
+  - id: "4129/3"
+    deviceLabel: Smart Lights Smart Plug
+    vendorId: 0x1021
+    productId: 0x0003
+    deviceProfileName: plug-binary
 #Lifx
   - id: "5155/169"
     deviceLabel: LIFX Color (A21)


### PR DESCRIPTION
This is a WWST certification request for a New Device from Legrand, for a Smart Lights Smart Plug that uses the plug-binary profile, and according to the DCL has a Device Type ID of x10A