### PR TITLE
changed MA AVRs profile name to a more user friendly name

### DIFF
--- a/drivers/SmartThings/harman-luxury/profiles/jbl-ma-avr-series.yaml
+++ b/drivers/SmartThings/harman-luxury/profiles/jbl-ma-avr-series.yaml
@@ -1,4 +1,4 @@
-name: maX10
+name: jbl-ma-avr-series
 components:
 - id: main
   capabilities:

--- a/drivers/SmartThings/harman-luxury/src/devices.lua
+++ b/drivers/SmartThings/harman-luxury/src/devices.lua
@@ -29,22 +29,22 @@ local devices_model_info = {
     model = "L42ms",
   },
   [SetupID.MA510] = {
-    profile = "maX10",
+    profile = "jbl-ma-avr-series",
     manufacturer = "JBL",
     model = "MA510",
   },
   [SetupID.MA710] = {
-    profile = "maX10",
+    profile = "jbl-ma-avr-series",
     manufacturer = "JBL",
     model = "MA710",
   },
   [SetupID.MA7100HP] = {
-    profile = "maX10",
+    profile = "jbl-ma-avr-series",
     manufacturer = "JBL",
     model = "MA7100HP",
   },
   [SetupID.MA9100HP] = {
-    profile = "maX10",
+    profile = "jbl-ma-avr-series",
     manufacturer = "JBL",
     model = "MA9100HP",
   },


### PR DESCRIPTION
Trying to change the Device Name as this is not user friendly, as can be seen below:
![image](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/assets/141163075/90ead282-0bd3-477b-a44d-7e2aa3b8fa98)
