### PR TITLE
New Devices (Matter Switch) Zemismart Multiple Devices

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2081,7 +2081,7 @@ matterManufacturer:
     productId: 0xEEE2
     deviceProfileName: switch-binary
   - id: "5020/53249"
-    deviceLabel: Zemismart downlight
+    deviceLabel: Zemismart Downlight
     vendorId: 0x139C
     productId: 0xD001
     deviceProfileName: light-color-level

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2086,7 +2086,7 @@ matterManufacturer:
     productId: 0xD001
     deviceProfileName: light-color-level
   - id: "5020/53250"
-    deviceLabel: Zemismart bulb
+    deviceLabel: Zemismart Bulb
     vendorId: 0x139C
     productId: 0xD002
     deviceProfileName: light-color-level

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2091,7 +2091,7 @@ matterManufacturer:
     productId: 0xD002
     deviceProfileName: light-color-level
   - id: "5020/53251"
-    deviceLabel: Zemismart Led Light Strip Driver
+    deviceLabel: Zemismart LED Light Strip Driver
     vendorId: 0x139C
     productId: 0xD003
     deviceProfileName: light-color-level

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2080,6 +2080,22 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xEEE2
     deviceProfileName: switch-binary
+  - id: "5020/53249"
+    deviceLabel: Zemismart downlight
+    vendorId: 0x139C
+    productId: 0xD001
+    deviceProfileName: light-color-level
+  - id: "5020/53250"
+    deviceLabel: Zemismart bulb
+    vendorId: 0x139C
+    productId: 0xD002
+    deviceProfileName: light-color-level
+  - id: "5020/53251"
+    deviceLabel: Zemismart Led Light Strip Driver
+    vendorId: 0x139C
+    productId: 0xD003
+    deviceProfileName: light-color-level
+
 
 #Bridge devices need manufacturer specific fingerprints until
 #bridge support is released to all hubs. This is because of the way generic


### PR DESCRIPTION
This is a WWST Cert Request, two of the three devices will be CxS. 

From the Matter DCL, here is additional information:

Device 1
Vendor ID | 5020 (0x139c)
Product ID | 53249 (0xd001)
Device Type ID | 269 (0x10d)

Device 2
Vendor ID | 5020 (0x139c)
Product ID | 53250 (0xd002)
Device Type ID | 269 (0x10d)

Device 3
Vendor ID | 5020 (0x139c)
Product ID | 53251 (0xd003)
Device Type ID | 269 (0x10d)




