### PR TITLE
New Device (Z-Wave Thermostat) Mco Home Water Heating Thermostat

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/zwave-thermostat/fingerprints.yml
@@ -86,6 +86,12 @@ zwaveManufacturer:
     manufacturerId: 0x0002
     productType: 0x0005
     deviceProfileName: thermostat-heating-battery
+  - id: "95/1810/20738"
+    deviceLabel: Water Heating Thermostat
+    manufacturerId: 0x005F
+    productId: 0x5102
+    productType: 0x0712
+    deviceProfileName: thermostat-temperature-temperaturealarm
 zwaveGeneric:
   - id: "GenericBatteryThermostat"
     deviceLabel: Z-Wave Battery Thermostat


### PR DESCRIPTION
This is a WWST Certification request to add the MCO Home Z-Wave thermostat ModelNumber: MH7H-WH. 

Here is a link to the product page https://www.mcohome.com/MH7H-WH-MH7H-EH-PG3894186