### PR TITLE
New Devices (Matter Switch) Nanoleaf Indoor and Outdoor Lights

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -203,6 +203,16 @@ matterManufacturer:
     vendorId: 0x115A
     productId: 0x711
     deviceProfileName: light-color-level-2700K-6500K
+ - id: "4442/72"
+    deviceLabel: Essentials Indoor Lights
+    vendorId: 0x115A
+    productId: 0x0048
+    deviceProfileName: light-color-level-2700K-6500K
+  - id: "4442/73"
+    deviceLabel: Essentials Outdoor Lights
+    vendorId: 0x115A
+    productId: 0x0049
+    deviceProfileName: light-color-level-2700K-6500K  
 #SONOFF
   - id: "SONOFF MINIR4M"
     deviceLabel: Smart Plug-in Unit


### PR DESCRIPTION
This PR is to add two devices to WWST Certification. They will be Certified by Simularity. 

In the DCL the two devices are:

Nanoleaf Indoor Lights
VID:4442 (0x115a)
PID: 72 (0x48)
Device ID: 269 (0x10d)

Nanoleaf Outdoor Lights
VID:4442 (0x115a)
73 (0x49)
Device ID: 269 (0x10d)
