### PR TITLE
Apply new TempHumiditySensor category to Aqara Temperature Humidity Sensor

### DIFF
--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery-aqara.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery-aqara.yml
@@ -13,7 +13,7 @@ components:
       - id: refresh
         version: 1
     categories:
-      - name: Thermostat
+      - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true


### PR DESCRIPTION
new device category - TempHumiditySensor have been prepared.
So it's better to apply TempHumiditySensor category to Aqara Temperature Humidity Sensor.

![image](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/assets/100197321/0edd987b-66c8-46a7-a14e-791293d1681b)

