### PR TITLE
Update profile category to TempHumiditySensor where appropriate

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
@@ -13,7 +13,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: Thermostat
+  - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-battery.yml
@@ -15,7 +15,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: HumiditySensor
+  - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure.yml
@@ -13,7 +13,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: HumiditySensor
+  - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: Thermostat
+  - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
@@ -13,7 +13,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: MultiFunctionalSensor
+  - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: MultiFunctionalSensor
+  - name: TempHumiditySensor
 preferences:
   - preferenceId: tempOffset
     explicit: true

--- a/drivers/SmartThings/zwave-sensor/profiles/humidity-temperature-battery.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/humidity-temperature-battery.yml
@@ -15,4 +15,4 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: MultiFunctionalSensor
+  - name: TempHumiditySensor


### PR DESCRIPTION
Updates certain profiles to use the new TempHumiditySensor category.

Includes the following profiles: 

### Matter
drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-battery.yml
drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure.yml
drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml

### Zigbee
drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml

Note: drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery-aqara.yml was updated here: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1398

### Z-Wave
drivers/SmartThings/zwave-sensor/profiles/humidity-temperature-battery.yml

