### PR TITLE
Remove Device (Matter Window Covering) ZM25M-Matter-Roller-Motor

### DIFF
--- a/drivers/SmartThings/matter-window-covering/fingerprints.yml
+++ b/drivers/SmartThings/matter-window-covering/fingerprints.yml
@@ -26,12 +26,6 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xFF15
     deviceProfileName: window-covering
-  - id: "5020/65535"
-    deviceLabel: Zemismart ZM25M Matter Roller Motor
-    vendorId: 0x139C
-    productId: 0xFFFF
-    deviceProfileName: window-covering
-
 matterGeneric:
   - id: "windowcovering"
     deviceLabel: Matter Window Covering


### PR DESCRIPTION
This PR is to remove a fingerprint for a Zemismart Roller Motor. This device has open certification bugs, and was previously merged with other devices that passed. 

Please see the certification ticket for more information. 