### PR TITLE
Add fingerprints of TOTEM Door Lock for SmartThingsEdgeDriver

### DIFF
--- a/drivers/SmartThings/zigbee-lock/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-lock/fingerprints.yml
@@ -124,6 +124,17 @@ zigbeeManufacturer:
     manufacturer:
     model: E261-KR0B0Z0-HA
     deviceProfileName: lock-battery
+  # TOTEM
+  - id: TOTEM/H60/H90
+    deviceLabel: TOTEM Door Lock
+    manufacturer: TOTEM
+    model: H60/H90
+    deviceProfileName: lock-battery
+  - id: TOTEM/P30
+    deviceLabel: TOTEM Door Lock
+    manufacturer: TOTEM
+    model: P30
+    deviceProfileName: lock-battery
 zigbeeGeneric:
   - id: "genericLock"
     deviceLabel: Zigbee Lock

--- a/drivers/SmartThings/zigbee-lock/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-lock/fingerprints.yml
@@ -129,12 +129,12 @@ zigbeeManufacturer:
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: H60/H90
-    deviceProfileName: lock-battery
+    deviceProfileName: base-lock
   - id: TOTEM/P30
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: P30
-    deviceProfileName: lock-battery
+    deviceProfileName: base-lock
 zigbeeGeneric:
   - id: "genericLock"
     deviceLabel: Zigbee Lock

--- a/tools/localizations/cn.csv
+++ b/tools/localizations/cn.csv
@@ -61,3 +61,4 @@ Aqara Wireless Mini Switch T1,Aqara 无线开关 T1
 "Aqara Smart Wall Switch H1 EU (With Neutral, Double Rocker)",Aqara智能墙壁开关H1 EU (零火线双键版)
 "Aqara Smart Wall Switch H1 EU (No Neutral, Single Rocker)",Aqara智能墙壁开关H1 EU (单火线单键版)
 "Aqara Smart Wall Switch H1 EU (No Neutral, Double Rocker)",Aqara智能墙壁开关H1 EU (单火线双键版)
+"TOTEM Door Lock",TOTEM智能门锁


### PR DESCRIPTION
The fingerprints of TOTEM Door Lock have already existed in the DTH(SmartThings Public). 
I tried to manage to migrate the fingerprints from DTH to Edge Driver.

Zigbee Device ID: "TOTEM H60/H90" & "TOTEM P30"