### PR TITLE
Beta release expedite: Disable hue light controls when in sync mode

### DIFF
--- a/drivers/SmartThings/philips-hue/profiles/legacy-color.yml
+++ b/drivers/SmartThings/philips-hue/profiles/legacy-color.yml
@@ -6,10 +6,6 @@ components:
     version: 1
   - id: switchLevel
     version: 1
-    config:
-      values:
-        - key: "level.value"
-          range: [ 1, 100 ]
   - id: colorControl
     version: 1
   - id: samsungim.hueSyncMode
@@ -18,3 +14,6 @@ components:
     version: 1
   categories:
   - name: Light
+metadata:
+  mnmn: SmartThingsEdge
+  vid: philips-legacy-color

--- a/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-ambiance.yml
@@ -6,19 +6,14 @@ components:
     version: 1
   - id: switchLevel
     version: 1
-    config:
-      values:
-        - key: "level.value"
-          range: [ 1, 100 ]
   - id: colorTemperature
     version: 1
-    config:
-      values:
-        - key: "colorTemperature.value"
-          range: [ 2200, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh
     version: 1
   categories:
   - name: Light
+metadata:
+  mnmn: SmartThingsEdge
+  vid: philips-white-ambiance

--- a/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white-and-color-ambiance.yml
@@ -6,21 +6,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
-    config:
-      values:
-        - key: "level.value"
-          range: [ 1, 100 ]
   - id: colorControl
     version: 1
   - id: colorTemperature
     version: 1
-    config:
-      values:
-        - key: "colorTemperature.value"
-          range: [ 2000, 6500 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh
     version: 1
   categories:
   - name: Light
+metadata:
+  mnmn: SmartThingsEdge
+  vid: philips-white-and-color-ambiance

--- a/drivers/SmartThings/philips-hue/profiles/white.yml
+++ b/drivers/SmartThings/philips-hue/profiles/white.yml
@@ -6,13 +6,12 @@ components:
     version: 1
   - id: switchLevel
     version: 1
-    config:
-      values:
-        - key: "level.value"
-          range: [ 1, 100 ]
   - id: samsungim.hueSyncMode
     version: 1
   - id: refresh
     version: 1
   categories:
   - name: Light
+metadata:
+  mnmn: SmartThingsEdge
+  vid: philips-white


### PR DESCRIPTION
This PR is to hot-release the profile changes to Hue for improved Sync support that landed in #1144.

`DO NOT MERGE` label is being held until other scheduled Tuesday deploys go out across the platform to mitigate load.