### PR TITLE
Use component_to_endpoint to get default endpoint

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/init.lua
@@ -247,8 +247,8 @@ local function handle_temperature_setpoint(driver, device, cmd)
     return
   end
 
-  local ENDPOINT = 1
-  device:send(clusters.TemperatureControl.commands.SetTemperature(device, ENDPOINT, utils.round(value * 100.0), nil))
+  local endpoint_id = device:component_to_endpoint(cmd.component)
+  device:send(clusters.TemperatureControl.commands.SetTemperature(device, endpoint_id, utils.round(value * 100.0), nil))
 end
 
 local matter_driver_template = {

--- a/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
@@ -208,10 +208,10 @@ local function handle_dishwasher_mode(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_dishwasher_mode mode: %s", cmd.args.mode))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   for i, mode in ipairs(dishwasherModeSupportedModes) do
     if cmd.args.mode == mode then
-      device:send(clusters.DishwasherMode.commands.ChangeToMode(device, ENDPOINT, i - 1))
+      device:send(clusters.DishwasherMode.commands.ChangeToMode(device, endpoint_id, i - 1))
       return
     end
   end
@@ -221,10 +221,10 @@ local function handle_temperature_level(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_temperature_level: %s", cmd.args.temperatureLevel))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
-      device:send(clusters.TemperatureControl.commands.SetTemperature(device, ENDPOINT, nil, i - 1))
+      device:send(clusters.TemperatureControl.commands.SetTemperature(device, endpoint_id, nil, i - 1))
       return
     end
   end

--- a/drivers/SmartThings/matter-appliance/src/matter-laundry-washer/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-laundry-washer/init.lua
@@ -220,10 +220,10 @@ local function handle_laundry_washer_mode(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_laundry_washer_mode[%s] mode: %s", cmd.component, cmd.args.mode))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   for i, mode in ipairs(laundryWasherModeSupportedModes) do
     if cmd.args.mode == mode then
-      device:send(clusters.LaundryWasherMode.commands.ChangeToMode(device, ENDPOINT, i - 1))
+      device:send(clusters.LaundryWasherMode.commands.ChangeToMode(device, endpoint_id, i - 1))
       return
     end
   end
@@ -233,10 +233,10 @@ local function handle_temperature_level(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_temperature_level: %s", cmd.args.temperatureLevel))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
-      device:send(clusters.TemperatureControl.commands.SetTemperature(device, ENDPOINT, nil, i - 1))
+      device:send(clusters.TemperatureControl.commands.SetTemperature(device, endpoint_id, nil, i - 1))
       return
     end
   end
@@ -246,10 +246,10 @@ local function handle_laundry_washer_spin_speed(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_laundry_washer_spin_speed spinSpeed: %s", cmd.args.spinSpeed))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   for i, spinSpeed in ipairs(laundryWasherControlsSpinSpeeds) do
     if cmd.args.spinSpeed == spinSpeed then
-      device:send(clusters.LaundryWasherControls.attributes.SpinSpeedCurrent:write(device, ENDPOINT, i - 1))
+      device:send(clusters.LaundryWasherControls.attributes.SpinSpeedCurrent:write(device, endpoint_id, i - 1))
       return
     end
   end
@@ -259,10 +259,10 @@ local function handle_laundry_washer_rinse_mode(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_laundry_washer_rinse_mode rinseMode: %s", cmd.args.rinseMode))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   for clusterVal, capabilityVal in pairs(LAUNDRY_WASHER_RINSE_MODE_MAP) do
     if cmd.args.rinseMode == capabilityVal.NAME then
-      device:send(clusters.LaundryWasherControls.attributes.NumberOfRinses:write(device, ENDPOINT, clusterVal))
+      device:send(clusters.LaundryWasherControls.attributes.NumberOfRinses:write(device, endpoint_id, clusterVal))
       break
     end
   end

--- a/drivers/SmartThings/matter-rvc/src/init.lua
+++ b/drivers/SmartThings/matter-rvc/src/init.lua
@@ -292,12 +292,12 @@ local function handle_robot_cleaner_mode(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_robot_cleaner_mode component: %s, mode: %s", cmd.component, cmd.args.mode))
 
-  local ENDPOINT = 1
+  local endpoint_id = device:component_to_endpoint(cmd.component)
   if cmd.component == "runMode" then
     local supported_modes = get_field_labels_of_supported_modes(device, RVC_RUN_MODE_SUPPORTED_MODES) or {}
     for i, mode in ipairs(supported_modes) do
       if cmd.args.mode == mode then
-        device:send(clusters.RvcRunMode.commands.ChangeToMode(device, ENDPOINT, i - 1))
+        device:send(clusters.RvcRunMode.commands.ChangeToMode(device, endpoint_id, i - 1))
         return
       end
     end
@@ -305,7 +305,7 @@ local function handle_robot_cleaner_mode(driver, device, cmd)
     local supported_modes = get_field_labels_of_supported_modes(device, RVC_CLEAN_MODE_SUPPORTED_MODES) or {}
     for i, mode in ipairs(supported_modes) do
       if cmd.args.mode == mode then
-        device:send(clusters.RvcCleanMode.commands.ChangeToMode(device, ENDPOINT, i - 1))
+        device:send(clusters.RvcCleanMode.commands.ChangeToMode(device, endpoint_id, i - 1))
         return
       end
     end


### PR DESCRIPTION
Currently, the endpoint is hardcoded to the matter default endpoint (1) for some of the appliance device types. This is the default assumption for simple single component devices. However, we should use the `component_to_endpoint` function instead for more robust endpoint handling. In these cases, `component_to_endpoint` will essentially call `find_default_endpoint` and return the first nonzero endpoint on the matter device. In many cases it could be 1, but this change will make the endpoint handling more generic.