### PR TITLE
chore: restore verbose Hue logs

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco/contact.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/contact.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 local socket = require "cosock".socket
 local st_utils = require "st.utils"
 

--- a/drivers/SmartThings/philips-hue/src/disco/light.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/light.lua
@@ -49,7 +49,7 @@ local function join_light(driver, light, device_service_info, parent_device_id, 
     parent_assigned_child_key = parent_assigned_child_key
   }
 
-  log.debug(true, st_utils.stringify_table(st_metadata, "light create", true))
+  log.debug(st_utils.stringify_table(st_metadata, "light create", true))
   st_metadata_callback(driver, st_metadata)
   -- rate limit ourself.
   socket.sleep(0.1)

--- a/drivers/SmartThings/philips-hue/src/disco/motion.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/motion.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 local socket = require "cosock".socket
 local st_utils = require "st.utils"
 

--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -1,5 +1,5 @@
 local capabilities = require "st.capabilities"
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
 ---@type fun(val: table, name: string?, multi_line: boolean?): string
@@ -131,7 +131,7 @@ function AttributeEmitters.emit_button_attribute_events(button_device, button_in
   end
 
   if button_info.power_state and type(button_info.power_state.battery_level) == "number" then
-    log.debug(true, "emit power")
+    log.debug("emit power")
     button_device:emit_event(
       capabilities.battery.battery(
         st_utils.clamp_value(button_info.power_state.battery_level, 0, 100)
@@ -186,12 +186,12 @@ function AttributeEmitters.emit_contact_sensor_attribute_events(sensor_device, s
   end
 
   if sensor_info.power_state  and type(sensor_info.power_state.battery_level) == "number" then
-    log.debug(true, "emit power")
+    log.debug("emit power")
     sensor_device:emit_event(capabilities.battery.battery(st_utils.clamp_value(sensor_info.power_state.battery_level, 0, 100)))
   end
 
   if sensor_info.tamper_reports then
-    log.debug(true, "emit tamper")
+    log.debug("emit tamper")
     local tampered = false
     for _, tamper in ipairs(sensor_info.tamper_reports) do
       if tamper.state == "tampered" then
@@ -208,7 +208,7 @@ function AttributeEmitters.emit_contact_sensor_attribute_events(sensor_device, s
   end
 
   if sensor_info.contact_report then
-    log.debug(true, "emit contact")
+    log.debug("emit contact")
     if sensor_info.contact_report.state == "contact" then
       sensor_device:emit_event(capabilities.contactSensor.contact.closed())
     else
@@ -224,12 +224,12 @@ function AttributeEmitters.emit_motion_sensor_attribute_events(sensor_device, se
   end
 
   if sensor_info.power_state  and type(sensor_info.power_state.battery_level) == "number" then
-    log.debug(true, "emit power")
+    log.debug("emit power")
     sensor_device:emit_event(capabilities.battery.battery(st_utils.clamp_value(sensor_info.power_state.battery_level, 0, 100)))
   end
 
   if sensor_info.temperature and sensor_info.temperature.temperature_valid then
-    log.debug(true, "emit temp")
+    log.debug("emit temp")
     sensor_device:emit_event(capabilities.temperatureMeasurement.temperature({
       value = sensor_info.temperature.temperature,
       unit = "C"
@@ -237,7 +237,7 @@ function AttributeEmitters.emit_motion_sensor_attribute_events(sensor_device, se
   end
 
   if sensor_info.light and sensor_info.light.light_level_valid then
-    log.debug(true, "emit light")
+    log.debug("emit light")
     -- From the Hue docs: Light level in 10000*log10(lux) +1
     local raw_light_level = sensor_info.light.light_level
     -- Convert from the Hue value to lux
@@ -246,7 +246,7 @@ function AttributeEmitters.emit_motion_sensor_attribute_events(sensor_device, se
   end
 
   if sensor_info.motion and sensor_info.motion.motion_valid then
-    log.debug(true, "emit motion")
+    log.debug("emit motion")
     if sensor_info.motion.motion then
       sensor_device:emit_event(capabilities.motionSensor.motion.active())
     else
@@ -259,19 +259,19 @@ end
 ---@param light_repr table
 function AttributeEmitters.emit_light_attribute_events(light_device, light_repr)
   if light_device == nil or (light_device and light_device.id == nil) then
-    log.warn(true, "Tried to emit light status event for device that has been deleted")
+    log.warn("Tried to emit light status event for device that has been deleted")
     return
   end
   local success, maybe_err = pcall(_emit_light_events_inner, light_device, light_repr)
   if not success then
-    log.error_with({ hub_logs = true, on = true }, string.format("Failed to invoke emit light status handler. Reason: %s", maybe_err))
+    log.error_with({ hub_logs = true }, string.format("Failed to invoke emit light status handler. Reason: %s", maybe_err))
   end
 end
 
 local function noop_event_emitter(device, ...)
   local label = (device and device.label) or "Unknown Device Name"
   local device_type = (device and device:get_field(Fields.DEVICE_TYPE)) or "Unknown Device Type"
-  log.warn(true, string.format("Tried to find attribute event emitter for device [%s] of unsupported type [%s], ignoring", label, device_type))
+  log.warn(string.format("Tried to find attribute event emitter for device [%s] of unsupported type [%s], ignoring", label, device_type))
 end
 
 function AttributeEmitters.emitter_for_device_type(device_type)

--- a/drivers/SmartThings/philips-hue/src/handlers/commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/commands.lua
@@ -1,5 +1,5 @@
 local capabilities = require "st.capabilities"
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local Consts = require "consts"

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/bridge.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/bridge.lua
@@ -1,5 +1,5 @@
 local cosock = require "cosock"
-local log = require "logjam"
+local log = require "log"
 
 local Discovery = require "disco"
 local Fields = require "fields"

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local refresh_handler = require("handlers.commands").refresh_handler

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local Discovery = require "disco"
@@ -88,7 +88,7 @@ function LifecycleHandlers.device_added(driver, device, ...)
       local bridge_id = parent_bridge and parent_bridge:get_field(Fields.BRIDGE_ID)
 
       if not (bridge_ip and bridge_id and resource_state_known and (Discovery.api_keys[bridge_id or {}] or key)) then
-        log.warn(true,
+        log.warn(
           "Found \"stray\" bulb without associated Hue Bridge. Waiting to see if a bridge becomes available.")
         driver.stray_device_tx:send({
           type = StrayDeviceHelper.MessageTypes.NewStrayDevice,

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 local refresh_handler = require("handlers.commands").refresh_handler
 local st_utils = require "st.utils"
 

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local refresh_handler = require("handlers.commands").refresh_handler

--- a/drivers/SmartThings/philips-hue/src/handlers/migration_handlers/bridge.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/migration_handlers/bridge.lua
@@ -1,5 +1,5 @@
 local cosock = require "cosock"
-local log = require "logjam"
+local log = require "log"
 
 local Discovery = require "disco"
 local HueApi = require "hue.api"

--- a/drivers/SmartThings/philips-hue/src/handlers/migration_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/migration_handlers/light.lua
@@ -1,5 +1,5 @@
 local capabilities = require "st.capabilities"
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local Discovery = require "disco"

--- a/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
@@ -1,5 +1,5 @@
 local cosock = require "cosock"
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local Fields = require "fields"

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -2,7 +2,7 @@ local cosock = require "cosock"
 local channel = require "cosock.channel"
 
 local json = require "st.json"
-local log = require "logjam"
+local log = require "log"
 local RestClient = require "lunchbox.rest"
 local st_utils = require "st.utils"
 

--- a/drivers/SmartThings/philips-hue/src/hue_debug/init.lua
+++ b/drivers/SmartThings/philips-hue/src/hue_debug/init.lua
@@ -11,7 +11,7 @@ local lazy_handlers = utils.lazy_handler_loader("handlers")
 local hue_debug = {}
 
 local _log = function(msg)
-  log.debug(true, "*****>> " .. msg)
+  log.debug("*****>> " .. msg)
 end
 
 local function _setup_delayed_bridges(template, delay_time)

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -67,6 +67,6 @@ hue:call_with_delay(3, Discovery.do_mdns_scan, "Philips Hue mDNS Initial Scan")
 local MDNS_SCAN_INTERVAL_SECONDS = 600
 hue:call_on_schedule(MDNS_SCAN_INTERVAL_SECONDS, Discovery.do_mdns_scan, "Philips Hue mDNS Scan Task")
 
-log.info(true, "Starting Hue driver")
+log.info("Starting Hue driver")
 hue:run()
-log.warn(true, "Hue driver exiting")
+log.warn("Hue driver exiting")

--- a/drivers/SmartThings/philips-hue/src/lunchbox/sse/eventsource.lua
+++ b/drivers/SmartThings/philips-hue/src/lunchbox/sse/eventsource.lua
@@ -5,7 +5,7 @@ local ssl = require "cosock.ssl"
 ---@type fun(sock: table, config: table?): table?, string?
 ssl.wrap = ssl.wrap
 
-local log = require "logjam"
+local log = require "log"
 local util = require "lunchbox.util"
 local Request = require "luncheon.request"
 local Response = require "luncheon.response"

--- a/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
+++ b/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
@@ -1,5 +1,5 @@
 local cosock = require "cosock"
-local log = require "logjam"
+local log = require "log"
 local st_utils = require "st.utils"
 
 local Discovery = require "disco"

--- a/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
@@ -1,5 +1,5 @@
 local cosock = require "cosock"
-local log = require "logjam"
+local log = require "log"
 local json = require "st.json"
 local st_utils = require "st.utils"
 
@@ -154,7 +154,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
           -- events.
           if event.type == "update" then
             for _, update_data in ipairs(event.data) do
-              log.debug(true, "Received update event with type " .. update_data.type)
+              log.debug("Received update event with type " .. update_data.type)
               local resource_ids = {}
               if update_data.type == "zigbee_connectivity" and update_data.owner ~= nil then
                 for rid, rtype in pairs(driver.services_for_device_rid[update_data.owner.rid] or {}) do
@@ -170,7 +170,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
                 table.insert(resource_ids, update_data.id)
               end
               for _, resource_id in ipairs(resource_ids) do
-                log.debug(true, string.format("Looking for device record for %s", resource_id))
+                log.debug(string.format("Looking for device record for %s", resource_id))
                 local child_device = driver.hue_identifier_to_device_record[resource_id]
                 if child_device ~= nil and child_device.id ~= nil then
                   if update_data.type == "zigbee_connectivity" then
@@ -178,7 +178,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
                     attribute_emitters.connectivity_update(child_device, update_data)
                   else
                     local device_type = utils.determine_device_type(child_device)
-                    log.debug(true, st_utils.stringify_table({device_type = device_type, update_data}, "updating", true))
+                    log.debug(st_utils.stringify_table({device_type = device_type, update_data}, "updating", true))
                     attribute_emitters.emitter_for_device_type(device_type)(child_device, update_data)
                   end
                 end

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -1,4 +1,4 @@
-local log = require "logjam"
+local log = require "log"
 
 local Fields = require "fields"
 local HueDeviceTypes = require "hue_device_types"


### PR DESCRIPTION
We silenced some logging (both driver only and hubcore) because the driver was very chatty, but with the new release, we need to restore it.