### PR TITLE
Fix a part of mis-implementation for window covering device type

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -155,8 +155,8 @@ local function current_pos_handler(driver, device, ib, response)
       else
         device:emit_event_for_endpoint(ib.endpoint_id, capabilities.windowShade.windowShade.unknown())
       end
+      device:set_field(EVENT_STATE, WindowCoveringEventEnum.NO_EVENT)
     end
-    device:set_field(EVENT_STATE, WindowCoveringEventEnum.NO_EVENT)
   else
     device:set_field(EVENT_STATE, WindowCoveringEventEnum.CURRENT_POSITION_EVENT)
   end
@@ -186,6 +186,7 @@ local function current_status_handler(driver, device, ib, response)
       else
         device:emit_event_for_endpoint(ib.endpoint_id, attr.partially_open())
       end
+      device:set_field(IS_MOVING, false)
     elseif state == 1 then -- opening
       device:emit_event_for_endpoint(ib.endpoint_id, attr.opening())
     elseif state == 2 then -- closing
@@ -203,8 +204,8 @@ local function current_status_handler(driver, device, ib, response)
       device:set_field(IS_MOVING, true)
     else
       device:set_field(IS_MOVING, false)
+      device:set_field(EVENT_STATE, WindowCoveringEventEnum.OPERATIONAL_STATE_EVENT)
     end
-    device:set_field(EVENT_STATE, WindowCoveringEventEnum.OPERATIONAL_STATE_EVENT)
   end
 end
 


### PR DESCRIPTION
Previously, the window covering driver was modified because the windowshade value was sometimes wrong.
And there was a part of mis-implementation.
So the issue was reported as below.
https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/issues/1436

This is a patch that fix the issue.