### PR TITLE
New Device (Matter Switch) Zemismart ZM606-3

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2124,6 +2124,11 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xD003
     deviceProfileName: light-color-level
+  - id: "5020/43825"
+    deviceLabel: Zemismart WiFi Smart Switch
+    vendorId: 0x139C
+    productId: 0xAB31
+    deviceProfileName: switch-binary
 
 
 #Bridge devices need manufacturer specific fingerprints until


### PR DESCRIPTION
This PR is for a WWST Certification request to add the Zemismart ZM606-3 device. According to the DCL it has a  device type of 0x103. 


Here is the VID and the PID for this device

- vendorId: 0x139C
- productId: 0xAB31