### PR TITLE
Store local variables by using set/get_field api

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
@@ -32,8 +32,8 @@ local OPERATIONAL_STATE_COMMAND_MAP = {
   [clusters.OperationalState.commands.Resume.ID] = "resume",
 }
 
-local supportedTemperatureLevels = {}
-local dishwasherModeSupportedModes = {}
+local SUPPORTED_TEMPERATURE_LEVELS = "__supported_temperature_levels"
+local SUPPORTED_DISHWASHER_MODES = "__supported_dishwasher_modes"
 
 local function device_init(driver, device)
   device:subscribe()
@@ -60,6 +60,7 @@ local function selected_temperature_level_attr_handler(driver, device, ib, respo
   device.log.info_with({ hub_logs = true },
     string.format("selected_temperature_level_attr_handler: %s", ib.data.value))
 
+  local supportedTemperatureLevels = device:get_field(SUPPORTED_TEMPERATURE_LEVELS)
   local temperatureLevel = ib.data.value
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if i - 1 == temperatureLevel then
@@ -78,30 +79,33 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
   device.log.info_with({ hub_logs = true },
     string.format("supported_temperature_levels_attr_handler: %s", ib.data.elements))
 
-  supportedTemperatureLevels = {}
+  local supportedTemperatureLevels = {}
   for _, tempLevel in ipairs(ib.data.elements) do
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
+  device:set_field(SUPPORTED_TEMPERATURE_LEVELS, supportedTemperatureLevels, {persist = true})
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels))
 end
 
 local function dishwasher_supported_modes_attr_handler(driver, device, ib, response)
-  dishwasherModeSupportedModes = {}
+  local supportedDishwasherModes = {}
   for _, mode in ipairs(ib.data.elements) do
     if version.api < 10 then
       clusters.DishwasherMode.types.ModeOptionStruct:augment_type(mode)
     end
-    table.insert(dishwasherModeSupportedModes, mode.elements.label.value)
+    table.insert(supportedDishwasherModes, mode.elements.label.value)
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(dishwasherModeSupportedModes))
+  device:set_field(SUPPORTED_DISHWASHER_MODES, supportedDishwasherModes, { persist = true })
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(supportedDishwasherModes))
 end
 
 local function dishwasher_mode_attr_handler(driver, device, ib, response)
   device.log.info_with({ hub_logs = true },
     string.format("dishwasher_mode_attr_handler mode: %s", ib.data.value))
 
+  local supportedDishwasherModes = device:get_field(SUPPORTED_DISHWASHER_MODES)
   local currentMode = ib.data.value
-  for i, mode in ipairs(dishwasherModeSupportedModes) do
+  for i, mode in ipairs(supportedDishwasherModes) do
     if i - 1 == currentMode then
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.mode(mode))
       break
@@ -209,7 +213,8 @@ local function handle_dishwasher_mode(driver, device, cmd)
     string.format("handle_dishwasher_mode mode: %s", cmd.args.mode))
 
   local endpoint_id = device:component_to_endpoint(cmd.component)
-  for i, mode in ipairs(dishwasherModeSupportedModes) do
+  local supportedDishwasherModes =device:get_field(SUPPORTED_DISHWASHER_MODES)
+  for i, mode in ipairs(supportedDishwasherModes) do
     if cmd.args.mode == mode then
       device:send(clusters.DishwasherMode.commands.ChangeToMode(device, endpoint_id, i - 1))
       return
@@ -222,6 +227,7 @@ local function handle_temperature_level(driver, device, cmd)
     string.format("handle_temperature_level: %s", cmd.args.temperatureLevel))
 
   local endpoint_id = device:component_to_endpoint(cmd.component)
+  local supportedTemperatureLevels =device:get_field(SUPPORTED_TEMPERATURE_LEVELS)
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
       device:send(clusters.TemperatureControl.commands.SetTemperature(device, endpoint_id, nil, i - 1))

--- a/drivers/SmartThings/matter-appliance/src/matter-laundry-washer/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-laundry-washer/init.lua
@@ -41,10 +41,10 @@ local OPERATIONAL_STATE_COMMAND_MAP = {
   [clusters.OperationalState.commands.Resume.ID] = "resume",
 }
 
-local supportedTemperatureLevels = {}
-local laundryWasherModeSupportedModes = {}
-local laundryWasherControlsSpinSpeeds = {}
-local laundryWasherControlsSupportedRinses = {}
+local SUPPORTED_TEMPERATURE_LEVELS = "__supported_temperature_levels"
+local SUPPORTED_LAUNDRY_WASHER_MODES = "__supported_laundry_washer_modes"
+local SUPPORTED_LAUNDRY_WASHER_SPIN_SPEEDS = "__supported_laundry_spin_speeds"
+local SUPPORTED_LAUNDRY_WASHER_RINSES = "__supported_laundry_washer_rinses"
 
 local function device_init(driver, device)
   device:subscribe()
@@ -71,6 +71,7 @@ local function selected_temperature_level_attr_handler(driver, device, ib, respo
   device.log.info_with({ hub_logs = true },
     string.format("selected_temperature_level_attr_handler: %s", ib.data.value))
 
+  local supportedTemperatureLevels = device:get_field(SUPPORTED_TEMPERATURE_LEVELS)
   local temperatureLevel = ib.data.value
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if i - 1 == temperatureLevel then
@@ -89,37 +90,37 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
   device.log.info_with({ hub_logs = true },
     string.format("supported_temperature_levels_attr_handler: %s", ib.data.elements))
 
-  supportedTemperatureLevels = {}
+  local supportedTemperatureLevels = {}
   for _, tempLevel in ipairs(ib.data.elements) do
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
+  device:set_field(SUPPORTED_TEMPERATURE_LEVELS, supportedTemperatureLevels, {persist = true})
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels))
 end
 
 local function laundry_washer_supported_modes_attr_handler(driver, device, ib, response)
-  laundryWasherModeSupportedModes = {}
+  local supportedLaundryWasherModes = {}
   for _, mode in ipairs(ib.data.elements) do
     if version.api < 10 then
       clusters.LaundryWasherMode.types.ModeOptionStruct:augment_type(mode)
     end
     log.info(string.format("Inserting supported washer mode: %s", mode.elements.label.value))
-    table.insert(laundryWasherModeSupportedModes, mode.elements.label.value)
+    table.insert(supportedLaundryWasherModes, mode.elements.label.value)
   end
-  -- TODO: Create laundryWasherSpinSpeed
-  -- device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(laundryWasherModeSupportedModes))
+
   local component = device.profile.components["main"]
-  device:emit_component_event(component, capabilities.mode.supportedModes(laundryWasherModeSupportedModes))
+  device:set_field(SUPPORTED_LAUNDRY_WASHER_MODES, supportedLaundryWasherModes, {persist = true})
+  device:emit_component_event(component, capabilities.mode.supportedModes(supportedLaundryWasherModes))
 end
 
 local function laundry_washer_mode_attr_handler(driver, device, ib, response)
   device.log.info_with({ hub_logs = true },
     string.format("laundry_washer_mode_attr_handler currentMode: %s", ib.data.value))
 
+  local supportedLaundryWasherModes = device:get_field(SUPPORTED_LAUNDRY_WASHER_MODES)
   local currentMode = ib.data.value
-  for i, mode in ipairs(laundryWasherModeSupportedModes) do
+  for i, mode in ipairs(supportedLaundryWasherModes) do
     if i - 1 == currentMode then
-      -- TODO: Create laundryWasherSpinSpeed
-      -- device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.mode(mode))
       local component = device.profile.components["main"]
       device:emit_component_event(component, capabilities.mode.mode(mode))
       return
@@ -129,20 +130,22 @@ local function laundry_washer_mode_attr_handler(driver, device, ib, response)
 end
 
 local function laundry_washer_controls_spin_speeds_attr_handler(driver, device, ib, response)
-  laundryWasherControlsSpinSpeeds = {}
+  local supportedLaundryWasherSpinSpeeds = {}
   for _, spinSpeed in ipairs(ib.data.elements) do
     log.info(string.format("Inserting supported spin speed mode: %s", spinSpeed.value))
-    table.insert(laundryWasherControlsSpinSpeeds, spinSpeed.value)
+    table.insert(supportedLaundryWasherSpinSpeeds, spinSpeed.value)
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherSpinSpeed.supportedSpinSpeeds(laundryWasherControlsSpinSpeeds))
+  device:set_field(SUPPORTED_LAUNDRY_WASHER_SPIN_SPEEDS, supportedLaundryWasherSpinSpeeds, {persist = true})
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherSpinSpeed.supportedSpinSpeeds(supportedLaundryWasherSpinSpeeds))
 end
 
 local function laundry_washer_controls_spin_speed_current_attr_handler(driver, device, ib, response)
   device.log.info_with({ hub_logs = true },
     string.format("laundry_washer_controls_spin_speed_current_attr_handler spinSpeedCurrent: %s", ib.data.value))
 
+  local supportedLaundryWasherSpinSpeeds = device:get_field(SUPPORTED_LAUNDRY_WASHER_SPIN_SPEEDS)
   local spinSpeedCurrent = ib.data.value
-  for i, spinSpeed in ipairs(laundryWasherControlsSpinSpeeds) do
+  for i, spinSpeed in ipairs(supportedLaundryWasherSpinSpeeds) do
     if i - 1 == spinSpeedCurrent then
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherSpinSpeed.spinSpeed(spinSpeed))
       return
@@ -162,12 +165,13 @@ local function laundry_washer_controls_supported_rinses_attr_handler(driver, dev
   device.log.info_with({ hub_logs = true },
     string.format("laundry_washer_controls_supported_rinses_attr_handler: %s", ib.data.elements))
 
-  laundryWasherControlsSupportedRinses = {}
+  local supportedLaundryWasherRinses = {}
   for _, numberOfRinses in ipairs(ib.data.elements) do
     device.log.info_with({ hub_logs = true }, string.format("numberOfRinses: %s => %s", numberOfRinses.value, LAUNDRY_WASHER_RINSE_MODE_MAP[numberOfRinses.value].NAME))
-    table.insert(laundryWasherControlsSupportedRinses, LAUNDRY_WASHER_RINSE_MODE_MAP[numberOfRinses.value].NAME)
+    table.insert(supportedLaundryWasherRinses, LAUNDRY_WASHER_RINSE_MODE_MAP[numberOfRinses.value].NAME)
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherRinseMode.supportedRinseModes(laundryWasherControlsSupportedRinses))
+  device:set_field(SUPPORTED_LAUNDRY_WASHER_RINSES, supportedLaundryWasherRinses, {persist = true})
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherRinseMode.supportedRinseModes(supportedLaundryWasherRinses))
 end
 
 local function operational_state_accepted_command_list_attr_handler(driver, device, ib, response)
@@ -221,7 +225,8 @@ local function handle_laundry_washer_mode(driver, device, cmd)
     string.format("handle_laundry_washer_mode[%s] mode: %s", cmd.component, cmd.args.mode))
 
   local endpoint_id = device:component_to_endpoint(cmd.component)
-  for i, mode in ipairs(laundryWasherModeSupportedModes) do
+  local supportedLaundryWasherModes = device:get_field(SUPPORTED_LAUNDRY_WASHER_MODES)
+  for i, mode in ipairs(supportedLaundryWasherModes) do
     if cmd.args.mode == mode then
       device:send(clusters.LaundryWasherMode.commands.ChangeToMode(device, endpoint_id, i - 1))
       return
@@ -234,6 +239,7 @@ local function handle_temperature_level(driver, device, cmd)
     string.format("handle_temperature_level: %s", cmd.args.temperatureLevel))
 
   local endpoint_id = device:component_to_endpoint(cmd.component)
+  local supportedTemperatureLevels = device:get_field(SUPPORTED_TEMPERATURE_LEVELS)
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
       device:send(clusters.TemperatureControl.commands.SetTemperature(device, endpoint_id, nil, i - 1))
@@ -247,7 +253,8 @@ local function handle_laundry_washer_spin_speed(driver, device, cmd)
     string.format("handle_laundry_washer_spin_speed spinSpeed: %s", cmd.args.spinSpeed))
 
   local endpoint_id = device:component_to_endpoint(cmd.component)
-  for i, spinSpeed in ipairs(laundryWasherControlsSpinSpeeds) do
+  local supportedLaundryWasherSpinSpeeds = device:get_field(SUPPORTED_LAUNDRY_WASHER_SPIN_SPEEDS)
+  for i, spinSpeed in ipairs(supportedLaundryWasherSpinSpeeds) do
     if cmd.args.spinSpeed == spinSpeed then
       device:send(clusters.LaundryWasherControls.attributes.SpinSpeedCurrent:write(device, endpoint_id, i - 1))
       return

--- a/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
@@ -29,14 +29,14 @@ end
 local REFRIGERATOR_DEVICE_TYPE_ID = 0x0070
 local TEMPERATURE_CONTROLLED_CABINET_DEVICE_TYPE_ID = 0x0071
 
-local SUPPORTED_TEMP_LEVEL = "__supported_temperature_levels"
 local setpoint_limit_device_field = {
   MIN_TEMP = "MIN_TEMP",
   MAX_TEMP = "MAX_TEMP",
 }
 
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
-local refrigeratorTccModeSupportedModesMap = {}
+local SUPPORTED_TEMPERATURE_LEVEL = "__supported_temperature_levels"
+local SUPPORTED_REFRIGERATOR_TCC_MODES_MAP = "__supported_refrigerator_tcc_modes_map"
 
 local function endpoint_to_component(device, ep)
   local map = device:get_field(COMPONENT_TO_ENDPOINT_MAP) or {}
@@ -144,8 +144,8 @@ local function selected_temperature_level_attr_handler(driver, device, ib, respo
     string.format("selected_temperature_level_attr_handler: %s", ib.data.value))
 
   local temperatureLevel = ib.data.value
-  local stl = device:get_field(SUPPORTED_TEMP_LEVEL)
-  for i, tempLevel in ipairs(stl) do
+  local supportedTemperatureLevels = device:get_field(SUPPORTED_TEMPERATURE_LEVEL)
+  for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if i - 1 == temperatureLevel then
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.temperatureLevel(tempLevel))
       break
@@ -159,35 +159,38 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
     device.log.warn_with({ hub_logs = true }, string.format("Device does not support TEMPERATURE_LEVEL feature"))
     return
   end
-  local stl = {}
+  local supportedTemperatureLevels = {}
   for _, tempLevel in ipairs(ib.data.elements) do
     log.info_with({ hub_logs = true },
       string.format("supported_temperature_levels_attr_handler: %s", tempLevel.value))
-    table.insert(stl, tempLevel.value)
+    table.insert(supportedTemperatureLevels, tempLevel.value)
   end
-  device:set_field(SUPPORTED_TEMP_LEVEL, stl, { persist = true })
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(stl))
+  device:set_field(SUPPORTED_TEMPERATURE_LEVEL, supportedTemperatureLevels, { persist = true })
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels))
 end
 
 local function refrigerator_tcc_supported_modes_attr_handler(driver, device, ib, response)
-  local refrigeratorTccModeSupportedModes = {}
+  local supportedRefrigeratorTccModesMap = device:get_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP) or {}
+  local supportedRefrigeratorTccModes = {}
   for _, mode in ipairs(ib.data.elements) do
     if version.api < 10 then
       clusters.RefrigeratorAndTemperatureControlledCabinetMode.types.ModeOptionStruct:augment_type(mode)
     end
-    table.insert(refrigeratorTccModeSupportedModes, mode.elements.label.value)
+    table.insert(supportedRefrigeratorTccModes, mode.elements.label.value)
   end
-  refrigeratorTccModeSupportedModesMap[ib.endpoint_id] = refrigeratorTccModeSupportedModes
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(refrigeratorTccModeSupportedModes))
+  supportedRefrigeratorTccModesMap[ib.endpoint_id] = supportedRefrigeratorTccModes
+  device:set_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP, supportedRefrigeratorTccModesMap, {persist = true})
+  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(supportedRefrigeratorTccModes))
 end
 
 local function refrigerator_tcc_mode_attr_handler(driver, device, ib, response)
   device.log.info_with({ hub_logs = true },
     string.format("refrigerator_tcc_mode_attr_handler currentMode: %s", ib.data.value))
 
+  local supportedRefrigeratorTccModesMap = device:get_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP)
+  local supportedRefrigeratorTccModes = supportedRefrigeratorTccModesMap[ib.endpoint_id] or {}
   local currentMode = ib.data.value
-  local refrigeratorTccModeSupportedModes = refrigeratorTccModeSupportedModesMap[ib.endpoint_id] or {}
-  for i, mode in ipairs(refrigeratorTccModeSupportedModes) do
+  for i, mode in ipairs(supportedRefrigeratorTccModes) do
     if i - 1 == currentMode then
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.mode(mode))
       break
@@ -223,8 +226,9 @@ local function handle_refrigerator_tcc_mode(driver, device, cmd)
     string.format("handle_refrigerator_tcc_mode mode: %s", cmd.args.mode))
 
   local ep = component_to_endpoint(device, cmd.component)
-  local refrigeratorTccModeSupportedModes = refrigeratorTccModeSupportedModesMap[ep] or {}
-  for i, mode in ipairs(refrigeratorTccModeSupportedModes) do
+  local supportedRefrigeratorTccModesMap = device:get_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP)
+  local supportedRefrigeratorTccModes = supportedRefrigeratorTccModesMap[ep] or {}
+  for i, mode in ipairs(supportedRefrigeratorTccModes) do
     if cmd.args.mode == mode then
       device:send(clusters.RefrigeratorAndTemperatureControlledCabinetMode.commands.ChangeToMode(device, ep, i - 1))
       return
@@ -270,8 +274,8 @@ local function handle_temperature_level(driver, device, cmd)
   device.log.info_with({ hub_logs = true },
     string.format("handle_temperature_level: %s(%d)", cmd.args.temperatureLevel, ep))
 
-  local stl = device:get_field(SUPPORTED_TEMP_LEVEL)
-  for i, tempLevel in ipairs(stl) do
+  local supportedTemperatureLevels = device:get_field(SUPPORTED_TEMPERATURE_LEVEL)
+  for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
       device:send(clusters.TemperatureControl.commands.SetTemperature(device, ep, nil, i - 1))
       return


### PR DESCRIPTION
If two or more same application device types are connected, a conflict occurs in the list supported by the mode or temperature level. This patch is for fixing this part.