### PR TITLE
New Device (Matter Switch) NanoLeaf Smart Holiday String Lights

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -226,6 +226,11 @@ matterManufacturer:
     deviceLabel: Essentials Outdoor Lights
     vendorId: 0x115A
     productId: 0x0049
+    deviceProfileName: light-color-level-2700K-6500K
+  - id: "4442/71"
+    deviceLabel: Smart Holiday String Lights
+    vendorId: 0x115A
+    productId: 0x0047
     deviceProfileName: light-color-level-2700K-6500K  
 #SONOFF
   - id: "SONOFF MINIR4M"


### PR DESCRIPTION
This PR is for a WWST CxS Submission for the following Matter Device 

Nanoleaf - Smart Holiday String Lights
VID: 4442 (0x115a)
PID:  71 (0x47)

According to the DCL this device has a device type = 10d

