### PR TITLE
New Device (Matter Switch) Cync Indoor Plug CPLGSTDBLW1MS

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -169,6 +169,11 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x006B
     deviceProfileName: light-color-level-2000K-7000K
+  - id: "4921/64"
+    deviceLabel: Cync Indoor Plug
+    vendorId: 0x1339
+    productId: 0x0040
+    deviceProfileName: plug-binary
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug


### PR DESCRIPTION
This device is pursuing WWST Certification. It is not published in the DCL, however on the CSA website this[ information was available](https://csa-iot.org/csa_product/cync-indoor-plug-3/). 

When I looked at the PICS documents for this device, in the on/off cluster test plan I see "Level Control for Lighting Matter_App_Clusters_1.5.4. O true". I concluded based on that information that this device supports Level Control and therefor the SwitchLevel capability withen the `deviceProfileName: plug-level`.