### PR TITLE
Busted tests for Hue driver + Bugfix for migrated lights

### DIFF
--- a/drivers/SmartThings/philips-hue/run_specs.sh
+++ b/drivers/SmartThings/philips-hue/run_specs.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export LUA_PATH="./test/spec/?.lua;./test/spec/?/init.lua;./src/?.lua;./src/?/init.lua;$LUA_LIBS/?.lua;$LUA_LIBS/?/init.lua;;"
+
+~/.luarocks/bin/busted -C 'src' -m "$LUA_PATH" -k -v './test/spec'

--- a/drivers/SmartThings/philips-hue/src/test/spec/device_faker.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/device_faker.lua
@@ -1,0 +1,47 @@
+local utils = require "utils"
+local lazy_fakers = utils.lazy_handler_loader("fakers")
+
+local st_utils = require "st.utils"
+
+local test_helpers = require "test_helpers"
+
+local fake_device_mt = {
+  set_field = function(device, key, val, _opts) (device.fields or {})[key] = val end,
+  get_field = function(device, key) return (device.fields or {})[key] end
+}
+fake_device_mt.__index = fake_device_mt
+
+---Make a fake device
+---@param args table args for the faker
+---@param bridge_info table? the hue bridge info for the faker to pull from, will be randomly generated if absent
+---@return table fake_device faked device
+---@return HueBridgeInfo bridge_info the bridge info used for this fake device
+local function device_faker(args, bridge_info)
+  local faker = string.format("%s_faker", args.device_type)
+  bridge_info = bridge_info or test_helpers.random_bridge_info()
+  args.bridge_key = args.bridge_key or test_helpers.random_hue_bridge_key()
+
+  local faked_device = lazy_fakers[faker](args, bridge_info)
+  assert(faked_device, string.format("No faking available for device type %s", args.device_type))
+
+  faked_device.label = args.name or "Fake Hue Device"
+  if args.migrated == true and type(args.data) == "table" then
+    faked_device.data = faked_device.data or {}
+    for k, v in pairs(args.data) do
+      rawset(faked_device.data, k, v)
+    end
+  end
+
+  if type(args.fields) == "table" then
+    faked_device.fields = faked_device.fields or {}
+    for k, v in pairs(args.fields) do
+      rawset(faked_device.fields, k, v)
+    end
+  end
+
+  faked_device.id = args.id or st_utils.generate_uuid_v4()
+
+  return setmetatable(faked_device, fake_device_mt), bridge_info
+end
+
+return device_faker

--- a/drivers/SmartThings/philips-hue/src/test/spec/fakers/bridge_faker.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/fakers/bridge_faker.lua
@@ -1,0 +1,30 @@
+local spec_utils = require "test_helpers"
+
+local function make_edge_device(_faker_args, bridge_info)
+  return {
+    device_network_id = bridge_info.mac or spec_utils.random_mac_address(),
+    label = bridge_info.name or "Philips Hue Bridge",
+    model = bridge_info.modelid or "BSB002"
+  }
+end
+
+local function make_migrated_device(faker_args, bridge_info)
+  local bridge = make_edge_device(faker_args, bridge_info)
+  bridge.data = {
+    ip = bridge_info.ip or spec_utils.random_private_ip_address(),
+    mac = bridge.device_network_id,
+    username = faker_args.bridge_key
+  }
+
+  return bridge
+end
+
+return function(faker_args, bridge_info)
+  bridge_info = bridge_info or {}
+  faker_args.name = faker_args.name or "Fake Hue Bridge"
+  if faker_args.migrated == true then
+    return make_migrated_device(faker_args, bridge_info)
+  else
+    return make_edge_device(faker_args, bridge_info)
+  end
+end

--- a/drivers/SmartThings/philips-hue/src/test/spec/fakers/driver_faker.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/fakers/driver_faker.lua
@@ -1,0 +1,55 @@
+local fake_driver_mt = {}
+fake_driver_mt.__index = fake_driver_mt
+
+function fake_driver_mt:get_device_info(device_id)
+  return self.devices[device_id]
+end
+
+local function driver_faker(faker_args)
+  faker_args = faker_args or {}
+  faker_args.bridges = faker_args.bridges or {}
+  faker_args.child_devices = faker_args.child_devices or {}
+
+  local fake_driver = { devices = {} }
+  fake_driver.datastore = faker_args.datastore or {}
+  fake_driver.datastore.bridge_netinfo = fake_driver.datastore.bridge_netinfo or {}
+  fake_driver.datastore.dni_to_device_id = fake_driver.datastore.dni_to_device_id or {}
+  fake_driver.datastore.api_keys = fake_driver.datastore.api_keys or {}
+
+  fake_driver._bridges = {}
+  fake_driver._child_devices = {}
+
+  for _, bridge_details in ipairs(faker_args.bridges) do
+    local device = bridge_details.device
+    local bridge_netinfo = bridge_details.info
+    local api_key = bridge_details.key
+
+    fake_driver.devices[device.id] = device
+
+    if bridge_details.add_info_to_datastore == true then
+      fake_driver.datastore.bridge_netinfo[device.device_network_id] = bridge_netinfo
+    end
+
+    if bridge_details.map_dni_to_device then
+      fake_driver.datastore.dni_to_device_id[device.device_network_id] = device.id
+    end
+
+    if bridge_details.add_key_to_datastore then
+      fake_driver.datastore.api_keys[device.device_network_id] = api_key
+    end
+
+    fake_driver._bridges[bridge_netinfo] = device
+  end
+
+  for _, child_details in ipairs(faker_args.child_devices) do
+    local device = child_details.device
+    local parent_bridge = fake_driver._bridges[child_details.parent_bridge_info]
+
+    device.parent_device_id = parent_bridge.id
+    fake_driver.devices[device.id] = device
+  end
+
+  return setmetatable(fake_driver, fake_driver_mt)
+end
+
+return driver_faker

--- a/drivers/SmartThings/philips-hue/src/test/spec/fakers/light_faker.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/fakers/light_faker.lua
@@ -1,0 +1,43 @@
+local st_utils = require "st.utils"
+
+local function make_migrated_device(faker_args, bridge_info)
+  local device_network_id = faker_args.dni or st_utils.generate_uuid_v4()
+  local v1_bulb_id = faker_args.v1_bulb_id or math.random(255)
+  local pack = string.format("%s/%d", bridge_info.bridgeid, v1_bulb_id)
+  return {
+    parent_assigned_child_key = pack,
+    device_network_id = device_network_id,
+    data = {
+      ip = bridge_info.ip,
+      mac = bridge_info.mac,
+      username = faker_args.bridge_key,
+      bulbId = v1_bulb_id
+    }
+  }
+end
+
+local function make_edge_device(faker_args, bridge_info)
+  local hue_id = faker_args.hue_id or st_utils.generate_uuid_v4()
+  local device_network_id = faker_args.dni or st_utils.generate_uuid_v4()
+
+  local parent_assigned_child_key
+  if faker_args.uuid_only_parent_assigned_key == true then
+    parent_assigned_child_key = hue_id
+  else
+    parent_assigned_child_key = string.format("light:%s", hue_id)
+  end
+
+  return {
+    parent_assigned_child_key = parent_assigned_child_key,
+    device_network_id = device_network_id
+  }
+end
+
+return function(faker_args, bridge_info)
+  faker_args.name = faker_args.name or "Fake Hue Bulb"
+  if faker_args.migrated == true then
+    return make_migrated_device(faker_args, bridge_info)
+  else
+    return make_edge_device(faker_args, bridge_info)
+  end
+end

--- a/drivers/SmartThings/philips-hue/src/test/spec/test_helpers/init.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/test_helpers/init.lua
@@ -1,0 +1,133 @@
+---@class spec_utils
+local test_helpers = {}
+
+local private_cidr_strings = {
+  ["192.168.0.0/16"] = true,
+  ["172.16.0.0/12"] = true,
+  ["10.0.0.0/8"] = true
+}
+
+---Generate a random IP address for the given CIDR string
+---@param cidr_string string? Optional, must be a CIDR string identifying one of the three private network spaces. Defaults to "192.168.0.0/16"
+---@return string ip a random IP address.
+function test_helpers.random_private_ip_address(cidr_string)
+  cidr_string = cidr_string or "192.168.0.0/16"
+
+  local valid_strings = {}
+  for k, _ in pairs(private_cidr_strings) do
+    table.insert(valid_strings, k)
+  end
+
+  assert(
+    private_cidr_strings[cidr_string],
+    "CIDR string is not a valid private network string, must be one of %s, %s, or %s",
+    table.unpack(valid_strings)
+  )
+  if cidr_string == "172.16.0.0/12" then
+    return string.format(
+      "172.%d.%d.%d",
+      math.random(16, 31),
+      math.random(255),
+      math.random(255)
+    )
+  end
+
+  if cidr_string == "10.0.0.1/8" then
+    return string.format(
+      "10.%d.%d.%d",
+      math.random(255),
+      math.random(255),
+      math.random(255)
+    )
+  end
+
+  return string.format(
+    "192.168.%d.%d",
+    math.random(255),
+    math.random(255)
+  )
+end
+
+---Generate a random MAC address
+---@param separator string? Optional, separator to use in between MAC address segments. Can be '.', ':', '-', or ''. Defaults to ':'
+---@param cisco_format boolean? if true, use 3 segments of 4 hex characters instead of 6 segments of 2 characters.
+---@return string mac Random MAC address.
+function test_helpers.random_mac_address(separator, cisco_format)
+  separator = separator or ':'
+  assert(
+    separator == '.' or
+    separator == ':' or
+    separator == '-' or
+    separator == '',
+    "Invalid separator for random mac addr: " .. tostring(separator)
+  )
+  local segments = {}
+
+  local num_segments
+  if cisco_format == true then
+    num_segments = 3
+  else
+    num_segments = 6
+  end
+
+  local chars_per_segment
+  if cisco_format == true then
+    chars_per_segment = 4
+  else
+    chars_per_segment = 2
+  end
+
+  local function make_segment()
+    local segment = ""
+    for _ = 1, chars_per_segment do
+      segment = segment .. string.format("%x", math.random(0xF))
+    end
+
+    return segment
+  end
+
+  for i = 1, num_segments do
+    table.insert(segments, i, make_segment())
+  end
+
+  return table.concat(segments, separator):upper()
+end
+
+
+---Generate a random Hue Application Key/"username"
+---@param len number? Number between 10 and 40 for the desired length of the application key. Selected randomly from the range if omitted.
+---@return string key the hue application key
+function test_helpers.random_hue_bridge_key(len)
+  local charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-_"
+  len = (type(len) == "number" and len > 10 and len) or math.random(10, 40)
+
+  local key = ""
+  for i=1,len do
+    key = key .. charset:sub(math.random(1, #charset), 1)
+  end
+  return key
+end
+
+---Generate partiall random Hue Bridge Info
+---@param override_info HueBridgeInfo? Optional, overrides for the generated fields; can be a partial table.
+---@return HueBridgeInfo bridge_info
+function test_helpers.random_bridge_info(override_info)
+  override_info = override_info or {}
+  local mac_addr = override_info.mac_addr or test_helpers.random_mac_address(':', false)
+
+  return {
+    name = override_info.name or "Philips Hue",
+    datastoreversion = override_info.datastoreversion or "166",
+    swversion = override_info.swversion or "1963089030",
+    apiversion = override_info.apiversion or "1.63.0",
+    mac = mac_addr,
+    bridge_id = mac_addr:upper():gsub(':', ''),
+    factorynew = override_info.factoryenw or false,
+    replacesbridgeid = override_info.replacesbridgeid or false,
+    modelid = override_info.modelid or "BSB002",
+    starterkitid = override_info.starterkitid or "",
+    ip = override_info.ip or test_helpers.random_private_ip_address()
+  }
+end
+
+return test_helpers

--- a/drivers/SmartThings/philips-hue/src/test/spec/unit/utils_spec.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/unit/utils_spec.lua
@@ -1,0 +1,666 @@
+describe("utility functions", function()
+  local Fields
+  local HueDeviceTypes
+  local st_utils
+  local utils
+
+  setup(function()
+    Fields = require "fields"
+    HueDeviceTypes = require "hue_device_types"
+    utils = require "utils"
+    st_utils = require "st.utils"
+  end)
+
+  describe("that handle raw data will handle their input correctly:", function()
+    local test_mac_addr
+    local test_cisco_mac_addr
+    local test_hue_uuid
+
+    before_each(function()
+      test_mac_addr = "CA:FE:C0:FF:EE:00"
+      test_cisco_mac_addr = "CAFE.C0FF.EE00"
+      test_hue_uuid = st_utils.generate_uuid_v4()
+    end)
+
+    it("is_hue_id_string accepts a UUIDv4", function()
+      assert.True(utils.is_hue_id_string(test_hue_uuid), string.format("Failed with value %s", test_hue_uuid))
+    end)
+    it("is_hue_id_string rejects strings that aren't a UUIDv4", function()
+      assert.False(utils.is_hue_id_string("foo"))
+    end)
+    it("is_hue_id_string rejects values that aren't strings", function()
+      assert.False(utils.is_hue_id_string(42))
+      assert.False(utils.is_hue_id_string(nil))
+      assert.False(utils.is_hue_id_string(true))
+      assert.False(utils.is_hue_id_string(false))
+      assert.False(utils.is_hue_id_string({ "foo" }))
+      assert.False(utils.is_hue_id_string({ test_hue_uuid }))
+      assert.False(utils.is_hue_id_string(print))
+      assert.False(utils.is_hue_id_string())
+    end)
+    it("is_valid_mac_addr_string accepts normal MAC address with colon separators", function()
+      assert.True(utils.is_valid_mac_addr_string(test_mac_addr), string.format("Failed with value %s", test_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_mac_addr)),
+        string.format("Failed with value %s", test_mac_addr))
+    end)
+    it("is_valid_mac_addr_string accepts normal MAC address with hyphen separators", function()
+      test_mac_addr = string.gsub(test_mac_addr, ':', '-')
+      assert.True(utils.is_valid_mac_addr_string(test_mac_addr), string.format("Failed with value %s", test_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_mac_addr)),
+        string.format("Failed with value %s", test_mac_addr))
+    end)
+    it("is_valid_mac_addr_string accepts normal MAC address with dot separators", function()
+      test_mac_addr = string.gsub(test_mac_addr, ':', '.')
+      assert.True(utils.is_valid_mac_addr_string(test_mac_addr), string.format("Failed with value %s", test_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_mac_addr)),
+        string.format("Failed with value %s", test_mac_addr))
+    end)
+    it("is_valid_mac_addr_string accepts Cisco MAC address with dot separators", function()
+      assert.True(utils.is_valid_mac_addr_string(test_cisco_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_cisco_mac_addr)),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+    end)
+    it("is_valid_mac_addr_string accepts Cisco MAC address with colon separators", function()
+      test_cisco_mac_addr = string.gsub(test_cisco_mac_addr, '%.', ':')
+      assert.True(utils.is_valid_mac_addr_string(test_cisco_mac_addr),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_cisco_mac_addr)),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+    end)
+    it("is_valid_mac_addr_string accepts Cisco MAC address with hyphen separators", function()
+      test_cisco_mac_addr = string.gsub(test_cisco_mac_addr, '%.', '-')
+      assert.True(utils.is_valid_mac_addr_string(test_cisco_mac_addr),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_cisco_mac_addr)),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+    end)
+    it("is_valid_mac_addr_string accepts MAC addresses with no separators", function()
+      test_mac_addr = string.gsub(test_mac_addr, ':', '')
+      assert.True(utils.is_valid_mac_addr_string(test_mac_addr), string.format("Failed with value %s", test_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_mac_addr)),
+        string.format("Failed with value %s", test_mac_addr))
+
+      test_cisco_mac_addr = string.gsub(test_cisco_mac_addr, '%.', '')
+      assert.True(utils.is_valid_mac_addr_string(test_cisco_mac_addr),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+      assert.True(utils.is_valid_mac_addr_string(string.lower(test_cisco_mac_addr)),
+        string.format("Failed with value %s", test_cisco_mac_addr))
+    end)
+  end)
+
+  describe("that handle devices will handle their metadata correctly:", function()
+    local driver_faker
+    local device_faker
+
+    setup(function()
+      driver_faker = require "fakers.driver_faker"
+      device_faker = require "device_faker"
+    end)
+
+    it("parse_parent_assigned_child_key parses an Edge Light", function()
+      local hue_id = st_utils.generate_uuid_v4()
+      local fake_light = device_faker {
+        migrated = false,
+        device_type = HueDeviceTypes.LIGHT,
+        hue_id = hue_id
+      }
+      local _, rid, rtype = assert.True(utils.parse_parent_assigned_key(fake_light))
+      assert.are.equal(hue_id, rid)
+      assert.are.equal(HueDeviceTypes.LIGHT, rtype)
+    end)
+
+    it("parse_parent_assigned_key does NOT parse migrated child light", function()
+      local fake_light = device_faker {
+        migrated = true,
+        device_type = HueDeviceTypes.LIGHT
+      }
+      assert.False(utils.parse_parent_assigned_key(fake_light))
+    end)
+
+    it("parse_parent_assigned_key does NOT parse migrated child light", function()
+      local fake_light = device_faker {
+        migrated = true,
+        device_type = HueDeviceTypes.LIGHT
+      }
+      assert.False(utils.parse_parent_assigned_key(fake_light))
+    end)
+
+    it("get_hue_rid gets the rid from the RESOURCE_ID field", function()
+      local hue_id = st_utils.generate_uuid_v4()
+      local fake_light = device_faker {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = true,
+        fields = {
+          [Fields.RESOURCE_ID] = hue_id
+        }
+      }
+
+      assert.are.equal(hue_id, utils.get_hue_rid(fake_light))
+
+      hue_id = st_utils.generate_uuid_v4()
+      fake_light = device_faker {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = false,
+        fields = {
+          [Fields.RESOURCE_ID] = hue_id
+        }
+      }
+
+      assert.are.equal(hue_id, utils.get_hue_rid(fake_light))
+    end)
+
+    it("get_hue_rid gets the rid from the parent-assigned key of a non-migrated light", function()
+      local hue_id = st_utils.generate_uuid_v4()
+      local fake_light = device_faker {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = false,
+        hue_id = hue_id
+      }
+
+      assert.are.equal(hue_id, utils.get_hue_rid(fake_light))
+    end)
+
+    it("get_hue_rid fails to get the rid of a migrated light without a RESOURCE_ID field", function()
+      local hue_id = st_utils.generate_uuid_v4()
+      local fake_light = device_faker {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = true,
+        hue_id = hue_id
+      }
+
+      local _, err_msg = assert.is_nil(utils.get_hue_rid(fake_light))
+      assert.String(err_msg)
+    end)
+
+    it(
+      "determine_device_type gets the device type of a non-migrated light WITH the type in the parent-assigned child key",
+      function()
+        local hue_id = st_utils.generate_uuid_v4()
+        local fake_light = device_faker {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = false,
+          hue_id = hue_id,
+          uuid_only_parent_assigned_key = false
+        }
+
+        local expected_parent_assigned_child_key = string.format("light:%s", hue_id)
+        assert.are.same(expected_parent_assigned_child_key, fake_light.parent_assigned_child_key)
+
+        local rtype, err_msg = assert(utils.determine_device_type(fake_light))
+        assert.are.same(HueDeviceTypes.LIGHT, rtype)
+        assert.is_nil(err_msg)
+      end)
+
+    it(
+      "determine_device_type gets the device type of a non-migrated light WITHOUT the type in the parent-assigned child key",
+      function()
+        local hue_id = st_utils.generate_uuid_v4()
+        local fake_light = device_faker {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = false,
+          hue_id = hue_id,
+          uuid_only_parent_assigned_key = true
+        }
+
+        local expected_parent_assigned_child_key = hue_id
+        assert.are.same(expected_parent_assigned_child_key, fake_light.parent_assigned_child_key)
+
+        local rtype, err_msg = assert(utils.determine_device_type(fake_light))
+        assert.are.same(HueDeviceTypes.LIGHT, rtype)
+        assert.is_nil(err_msg)
+      end)
+
+    it("determine_device_type gets the device type of a migrated light", function()
+      local fake_light = device_faker {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = true,
+      }
+
+      local rtype, err_msg = assert(utils.determine_device_type(fake_light))
+      assert.are.same(HueDeviceTypes.LIGHT, rtype)
+      assert.is_nil(err_msg)
+    end)
+
+    it("determine_device_type gets the device type of a migrated bridge", function()
+      local fake_bridge = device_faker {
+        device_type = HueDeviceTypes.BRIDGE,
+        migrated = true,
+      }
+
+      local rtype, err_msg = assert(utils.determine_device_type(fake_bridge))
+      assert.are.same(HueDeviceTypes.BRIDGE, rtype)
+      assert.is_nil(err_msg)
+    end)
+
+    it("determine_device_type gets the device type of a non-migrated light", function()
+      local fake_light = device_faker {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = false,
+      }
+
+      local rtype, err_msg = assert(utils.determine_device_type(fake_light))
+      assert.are.same(HueDeviceTypes.LIGHT, rtype)
+      assert.is_nil(err_msg)
+    end)
+
+    it("determine_device_type gets the device type of a non-migrated bridge", function()
+      local fake_bridge = device_faker {
+        device_type = HueDeviceTypes.BRIDGE,
+        migrated = false,
+      }
+
+      local rtype, err_msg = assert(utils.determine_device_type(fake_bridge))
+      assert.are.same(HueDeviceTypes.BRIDGE, rtype)
+      assert.is_nil(err_msg)
+    end)
+
+    it("is_bridge returns true for a migrated bridge without DEVICE_TYPE field set, with cached bridge info", function()
+      local bridge_faker_args = {
+        device_type = HueDeviceTypes.BRIDGE,
+        migrated = true,
+      }
+      local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+      local fake_driver = driver_faker {
+        bridges = {
+          {
+            device = fake_bridge,
+            info = bridge_info,
+            key = bridge_faker_args.bridge_key,
+            add_info_to_datastore = true,
+            add_key_to_datastore = true,
+            map_dni_to_device = true
+          }
+        }
+      }
+
+      assert.True(utils.is_bridge(fake_driver, fake_bridge))
+    end)
+
+    it("is_bridge returns true for a migrated bridge without DEVICE_TYPE field set, without cached bridge info",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = true,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+              add_info_to_datastore = false,
+              add_key_to_datastore = false,
+              map_dni_to_device = false
+            }
+          }
+        }
+
+        assert.True(utils.is_bridge(fake_driver, fake_bridge))
+      end)
+
+    it("is_bridge returns true for a non-migrated bridge without DEVICE_TYPE field set, with cached bridge info",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = true,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+              add_info_to_datastore = true,
+              add_key_to_datastore = true,
+              map_dni_to_device = true
+            }
+          }
+        }
+
+        assert.True(utils.is_bridge(fake_driver, fake_bridge))
+      end)
+
+    it("is_bridge returns true for a non-migrated bridge without DEVICE_TYPE field set, without cached bridge info",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = true,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+              add_info_to_datastore = false,
+              add_key_to_datastore = false,
+              map_dni_to_device = false
+            }
+          }
+        }
+
+        assert.True(utils.is_bridge(fake_driver, fake_bridge))
+      end)
+
+    it("is_bridge returns false for a migrated light without DEVICE_TYPE field set, with cached bridge info", function()
+      local light_faker_args = {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = true,
+      }
+      local fake_light, _ = device_faker(light_faker_args)
+
+      local fake_driver = driver_faker {}
+
+      assert.False(utils.is_bridge(fake_driver, fake_light))
+    end)
+
+    it("is_bridge returns false for a migrated light without DEVICE_TYPE field set, without cached bridge info",
+      function()
+        local light_faker_args = {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = true,
+        }
+        local fake_light, _ = device_faker(light_faker_args)
+
+        local fake_driver = driver_faker {}
+
+        assert.False(utils.is_bridge(fake_driver, fake_light))
+      end)
+
+    it("is_bridge returns false for a non-migrated light without DEVICE_TYPE field set, with cached bridge info",
+      function()
+        local light_faker_args = {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = false,
+        }
+        local fake_light, _ = device_faker(light_faker_args)
+
+        local fake_driver = driver_faker {}
+
+        assert.False(utils.is_bridge(fake_driver, fake_light))
+      end)
+
+    it("is_bridge returns false for a non-migrated light without DEVICE_TYPE field set, without cached bridge info",
+      function()
+        local light_faker_args = {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = false,
+        }
+        local fake_light, _ = device_faker(light_faker_args)
+
+        local fake_driver = driver_faker {}
+
+        assert.False(utils.is_bridge(fake_driver, fake_light))
+      end)
+
+    it("is_edge_bridge and is_dth_bridge behave as expected for a migrated bridge", function()
+      local bridge_faker_args = {
+        device_type = HueDeviceTypes.BRIDGE,
+        migrated = true,
+      }
+      local fake_bridge, _ = device_faker(bridge_faker_args)
+
+      assert.True(utils.is_dth_bridge(fake_bridge))
+      assert.False(utils.is_edge_bridge(fake_bridge))
+    end)
+
+    it("is_edge_bridge and is_dth_bridge behave as expected for a non-migrated bridge", function()
+      local bridge_faker_args = {
+        device_type = HueDeviceTypes.BRIDGE,
+        migrated = false,
+      }
+      local fake_bridge, _ = device_faker(bridge_faker_args)
+
+      assert.True(utils.is_edge_bridge(fake_bridge))
+      assert.False(utils.is_dth_bridge(fake_bridge))
+    end)
+
+    it("is_dth_light behaves as expected for a migrated light", function()
+      local light_faker_args = {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = true,
+      }
+      local fake_bridge, _ = device_faker(light_faker_args)
+
+      assert.True(utils.is_dth_light(fake_bridge))
+    end)
+
+    it("is_dth_light behaves as expected for a non-migrated light", function()
+      local light_faker_args = {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = false,
+      }
+      local fake_bridge, _ = device_faker(light_faker_args)
+
+      assert.False(utils.is_dth_light(fake_bridge))
+    end)
+
+    it("get_hue_bridge_for_device returns the passed in bridge for a migrated bridge when bridge info is not cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = true,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+            }
+          }
+        }
+
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_bridge))
+      end)
+
+    it("get_hue_bridge_for_device returns the passed in bridge for a non-migrated bridge when bridge info is not cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = false,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+            }
+          }
+        }
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_bridge))
+      end)
+
+    it("get_hue_bridge_for_device returns the passed in bridge for a migrated bridge when bridge info is cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = true,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+              add_info_to_datastore = true,
+              add_key_to_datastore = true,
+              map_dni_to_device = true
+            }
+          }
+        }
+
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_bridge))
+      end)
+
+    it("get_hue_bridge_for_device returns the passed in bridge for a non-migrated bridge when bridge info is cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = false,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+              add_info_to_datastore = true,
+              add_key_to_datastore = true,
+              map_dni_to_device = true
+            }
+          }
+        }
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_bridge))
+      end)
+
+    it("get_hue_bridge_for_device returns the parent bridge for a migrated light when bridge info is not cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = true,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+        local light_faker_args = {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = true
+        }
+        local fake_light = device_faker(light_faker_args, bridge_info)
+
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+            }
+          },
+          child_devices = {
+            {
+              device = fake_light,
+              parent_bridge_info = bridge_info
+            }
+          }
+        }
+
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_light))
+      end)
+
+    it("get_hue_bridge_for_device returns the parent bridge for a non-migrated light when bridge info is not cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = false,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+        local light_faker_args = {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = false
+        }
+        local fake_light = device_faker(light_faker_args, bridge_info)
+
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+            }
+          },
+          child_devices = {
+            {
+              device = fake_light,
+              parent_bridge_info = bridge_info
+            }
+          }
+        }
+
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_light))
+      end)
+
+    it("get_hue_bridge_for_device returns the parent bridge for a migrated light when bridge info is cached", function()
+      local bridge_faker_args = {
+        device_type = HueDeviceTypes.BRIDGE,
+        migrated = true,
+      }
+      local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+      local light_faker_args = {
+        device_type = HueDeviceTypes.LIGHT,
+        migrated = true
+      }
+      local fake_light = device_faker(light_faker_args, bridge_info)
+
+      local fake_driver = driver_faker {
+        bridges = {
+          {
+            device = fake_bridge,
+            info = bridge_info,
+            key = bridge_faker_args.bridge_key,
+            add_info_to_datastore = true,
+            add_key_to_datastore = true,
+            map_dni_to_device = true
+          }
+        },
+        child_devices = {
+          {
+            device = fake_light,
+            parent_bridge_info = bridge_info
+          }
+        }
+      }
+
+      assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_light))
+    end)
+
+    it("get_hue_bridge_for_device returns the parent bridge for a non-migrated light when bridge info is cached",
+      function()
+        local bridge_faker_args = {
+          device_type = HueDeviceTypes.BRIDGE,
+          migrated = false,
+        }
+        local fake_bridge, bridge_info = device_faker(bridge_faker_args)
+
+        local light_faker_args = {
+          device_type = HueDeviceTypes.LIGHT,
+          migrated = false
+        }
+        local fake_light = device_faker(light_faker_args, bridge_info)
+
+        local fake_driver = driver_faker {
+          bridges = {
+            {
+              device = fake_bridge,
+              info = bridge_info,
+              key = bridge_faker_args.bridge_key,
+              add_info_to_datastore = true,
+              add_key_to_datastore = true,
+              map_dni_to_device = true
+            }
+          },
+          child_devices = {
+            {
+              device = fake_light,
+              parent_bridge_info = bridge_info
+            }
+          }
+        }
+
+        assert.are.same(fake_bridge, utils.get_hue_bridge_for_device(fake_driver, fake_light))
+      end)
+  end)
+end)

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -283,7 +283,7 @@ end
 function utils.is_bridge(driver, device)
   return (device:get_field(Fields.DEVICE_TYPE) == "bridge")
       or (driver.datastore.bridge_netinfo[device.device_network_id] ~= nil)
-      or utils.is_edge_bridge(device) or utils.is_dth_light(device)
+      or utils.is_edge_bridge(device) or utils.is_dth_bridge(device)
       or (device.parent_assigned_child_key == nil)
 end
 


### PR DESCRIPTION
We don't run Busted tests in CI, but the Hue driver is now very testable after the recent refactor. The ability to write integration tests for LAN Drivers is still forthcoming, but we're also going to be accumulating unit tests for Hue going forward as well.

We keep the `spec` folder as a sibling to the `src` folder so that it doesn't get included in the driver package, so care should be taken when setting up the LUA PATH to run these tests.

We also fix a bug that was reported by some community users, the presence of which was validated by and is also now covered by the new specs.

## For Reviewers

The PR is broken up in to two commits. The first commits are all of the new Busted work. The second commit is the bugfix.