### PR TITLE
Change the TOTEM device profile

### DIFF
--- a/drivers/SmartThings/zigbee-lock/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-lock/fingerprints.yml
@@ -124,6 +124,17 @@ zigbeeManufacturer:
     manufacturer:
     model: E261-KR0B0Z0-HA
     deviceProfileName: lock-battery
+  # TOTEM
+  - id: TOTEM/H60/H90
+    deviceLabel: TOTEM Door Lock
+    manufacturer: TOTEM
+    model: H60/H90
+    deviceProfileName: lock-battery
+  - id: TOTEM/P30
+    deviceLabel: TOTEM Door Lock
+    manufacturer: TOTEM
+    model: P30
+    deviceProfileName: lock-battery
 zigbeeGeneric:
   - id: "genericLock"
     deviceLabel: Zigbee Lock

--- a/drivers/SmartThings/zigbee-lock/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-lock/fingerprints.yml
@@ -129,12 +129,12 @@ zigbeeManufacturer:
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: H60/H90
-    deviceProfileName: base-lock
+    deviceProfileName: totem-lock
   - id: TOTEM/P30
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: P30
-    deviceProfileName: base-lock
+    deviceProfileName: totem-lock
 zigbeeGeneric:
   - id: "genericLock"
     deviceLabel: Zigbee Lock

--- a/drivers/SmartThings/zigbee-lock/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-lock/fingerprints.yml
@@ -129,12 +129,12 @@ zigbeeManufacturer:
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: H60/H90
-    deviceProfileName: lock-battery
+    deviceProfileName: base-lock
   - id: TOTEM/P30
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: P30
-    deviceProfileName: lock-battery
+    deviceProfileName: base-lock
 zigbeeGeneric:
   - id: "genericLock"
     deviceLabel: Zigbee Lock

--- a/drivers/SmartThings/zigbee-lock/profiles/totem-lock.yml
+++ b/drivers/SmartThings/zigbee-lock/profiles/totem-lock.yml
@@ -1,0 +1,12 @@
+name: totem-lock
+components:
+- id: main
+  capabilities:
+  - id: lock
+    version: 1
+  - id: battery
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock

--- a/tools/localizations/cn.csv
+++ b/tools/localizations/cn.csv
@@ -61,3 +61,4 @@ Aqara Wireless Mini Switch T1,Aqara 无线开关 T1
 "Aqara Smart Wall Switch H1 EU (With Neutral, Double Rocker)",Aqara智能墙壁开关H1 EU (零火线双键版)
 "Aqara Smart Wall Switch H1 EU (No Neutral, Single Rocker)",Aqara智能墙壁开关H1 EU (单火线单键版)
 "Aqara Smart Wall Switch H1 EU (No Neutral, Double Rocker)",Aqara智能墙壁开关H1 EU (单火线双键版)
+"TOTEM Door Lock",TOTEM智能门锁


### PR DESCRIPTION
As we tested, the TOTEM door lock, including H60, H90 and P30, does not support the 'lockCodes' and the 'firmwareUpdate' capabilities. 
For such consideration, we adjusted the files as follows:
1. Create a new profile named 'totem-lock'
2. Change the fingerprints of the three types of TOTEM door locks from 'base-lock' to 'totem-lock'.