### PR TITLE
Change the totem device profile

### DIFF
--- a/drivers/SmartThings/zigbee-lock/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-lock/fingerprints.yml
@@ -129,12 +129,12 @@ zigbeeManufacturer:
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: H60/H90
-    deviceProfileName: base-lock
+    deviceProfileName: lock-battery
   - id: TOTEM/P30
     deviceLabel: TOTEM Door Lock
     manufacturer: TOTEM
     model: P30
-    deviceProfileName: base-lock
+    deviceProfileName: lock-battery
 zigbeeGeneric:
   - id: "genericLock"
     deviceLabel: Zigbee Lock


### PR DESCRIPTION
Hi, @lelandblue @greens.
After the discussion between us and the TOTEM manufacturer, the TOTEM door lock, including H60, H90 and P30 does not support the 'lockCodes' and the 'firmwareUpdate' capabilities.
For this consideration, we adjusted the files as follows:

1. Create a new profile named 'totem-lock'
2. Change the fingerprints of the three types of TOTEM door locks from 'base-lock' to 'totem-lock'.

WWST link: https://smartthings.atlassian.net/browse/WWST-8010
PIOT link: https://smartthings.atlassian.net/browse/PIOT-139
