### PR TITLE
Remove history of the Supported list

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
@@ -84,7 +84,8 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
   device:set_field(SUPPORTED_TEMPERATURE_LEVELS, supportedTemperatureLevels, {persist = true})
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels))
+  local event = capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function dishwasher_supported_modes_attr_handler(driver, device, ib, response)
@@ -96,7 +97,8 @@ local function dishwasher_supported_modes_attr_handler(driver, device, ib, respo
     table.insert(supportedDishwasherModes, mode.elements.label.value)
   end
   device:set_field(SUPPORTED_DISHWASHER_MODES, supportedDishwasherModes, { persist = true })
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(supportedDishwasherModes))
+  local event = capabilities.mode.supportedModes(supportedDishwasherModes, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function dishwasher_mode_attr_handler(driver, device, ib, response)
@@ -174,7 +176,8 @@ local function operational_state_accepted_command_list_attr_handler(driver, devi
       table.insert(accepted_command_list, OPERATIONAL_STATE_COMMAND_MAP[accepted_command_id])
     end
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.supportedCommands(accepted_command_list))
+  local event = capabilities.operationalState.supportedCommands(accepted_command_list, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function operational_state_attr_handler(driver, device, ib, response)

--- a/drivers/SmartThings/matter-appliance/src/matter-laundry-washer/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-laundry-washer/init.lua
@@ -95,7 +95,8 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
   device:set_field(SUPPORTED_TEMPERATURE_LEVELS, supportedTemperatureLevels, {persist = true})
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels))
+  local event = capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function laundry_washer_supported_modes_attr_handler(driver, device, ib, response)
@@ -107,10 +108,10 @@ local function laundry_washer_supported_modes_attr_handler(driver, device, ib, r
     log.info(string.format("Inserting supported washer mode: %s", mode.elements.label.value))
     table.insert(supportedLaundryWasherModes, mode.elements.label.value)
   end
-
   local component = device.profile.components["main"]
   device:set_field(SUPPORTED_LAUNDRY_WASHER_MODES, supportedLaundryWasherModes, {persist = true})
-  device:emit_component_event(component, capabilities.mode.supportedModes(supportedLaundryWasherModes))
+  local event = capabilities.mode.supportedModes(supportedLaundryWasherModes, {visibility = {displayed = false}})
+  device:emit_component_event(component, event)
 end
 
 local function laundry_washer_mode_attr_handler(driver, device, ib, response)
@@ -136,7 +137,8 @@ local function laundry_washer_controls_spin_speeds_attr_handler(driver, device, 
     table.insert(supportedLaundryWasherSpinSpeeds, spinSpeed.value)
   end
   device:set_field(SUPPORTED_LAUNDRY_WASHER_SPIN_SPEEDS, supportedLaundryWasherSpinSpeeds, {persist = true})
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherSpinSpeed.supportedSpinSpeeds(supportedLaundryWasherSpinSpeeds))
+  local event = capabilities.laundryWasherSpinSpeed.supportedSpinSpeeds(supportedLaundryWasherSpinSpeeds, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function laundry_washer_controls_spin_speed_current_attr_handler(driver, device, ib, response)
@@ -171,7 +173,8 @@ local function laundry_washer_controls_supported_rinses_attr_handler(driver, dev
     table.insert(supportedLaundryWasherRinses, LAUNDRY_WASHER_RINSE_MODE_MAP[numberOfRinses.value].NAME)
   end
   device:set_field(SUPPORTED_LAUNDRY_WASHER_RINSES, supportedLaundryWasherRinses, {persist = true})
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.laundryWasherRinseMode.supportedRinseModes(supportedLaundryWasherRinses))
+  local event = capabilities.laundryWasherRinseMode.supportedRinseModes(supportedLaundryWasherRinses, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function operational_state_accepted_command_list_attr_handler(driver, device, ib, response)
@@ -186,7 +189,8 @@ local function operational_state_accepted_command_list_attr_handler(driver, devi
       table.insert(accepted_command_list, OPERATIONAL_STATE_COMMAND_MAP[accepted_command_id])
     end
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.supportedCommands(accepted_command_list))
+  local event = capabilities.operationalState.supportedCommands(accepted_command_list, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function operational_state_attr_handler(driver, device, ib, response)

--- a/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
@@ -166,7 +166,8 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
   device:set_field(SUPPORTED_TEMPERATURE_LEVEL, supportedTemperatureLevels, { persist = true })
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels))
+  local event = capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function refrigerator_tcc_supported_modes_attr_handler(driver, device, ib, response)
@@ -180,7 +181,8 @@ local function refrigerator_tcc_supported_modes_attr_handler(driver, device, ib,
   end
   supportedRefrigeratorTccModesMap[ib.endpoint_id] = supportedRefrigeratorTccModes
   device:set_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP, supportedRefrigeratorTccModesMap, {persist = true})
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.mode.supportedModes(supportedRefrigeratorTccModes))
+  local event = capabilities.mode.supportedModes(supportedRefrigeratorTccModes, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function refrigerator_tcc_mode_attr_handler(driver, device, ib, response)

--- a/drivers/SmartThings/matter-rvc/src/init.lua
+++ b/drivers/SmartThings/matter-rvc/src/init.lua
@@ -160,9 +160,9 @@ local function rvc_run_mode_supported_mode_attr_handler(driver, device, ib, resp
     clusters.RvcRunMode.types.ModeTag.IDLE,
     current_mode
   )
-
   local component = device.profile.components["runMode"]
-  device:emit_component_event(component, capabilities.mode.supportedModes(labels_of_supported_modes))
+  local event = capabilities.mode.supportedModes(labels_of_supported_modes, {visibility = {displayed = false}})
+  device:emit_component_event(component, event)
 end
 
 local function rvc_run_mode_current_mode_attr_handler(driver, device, ib, response)
@@ -186,7 +186,8 @@ local function rvc_run_mode_current_mode_attr_handler(driver, device, ib, respon
         clusters.RvcRunMode.types.ModeTag.IDLE,
         mode
       )
-      device:emit_component_event(component, capabilities.mode.supportedModes(filtered_labels))
+      local event = capabilities.mode.supportedModes(filtered_labels, {visibility = {displayed = false}})
+      device:emit_component_event(component, event)
 
       -- State Machine Rules 2. RVC Clean Mode - Mode Change Restrictions
       local is_idle = is_idle_mode(device, RVC_RUN_MODE_SUPPORTED_MODES, i, clusters.RvcRunMode.types.ModeTag.IDLE)
@@ -197,9 +198,11 @@ local function rvc_run_mode_current_mode_attr_handler(driver, device, ib, respon
           clusters.RvcCleanMode.ID,
           clusters.RvcCleanMode.attributes.SupportedModes.ID,
           response)
-        device:emit_component_event(component, capabilities.mode.supportedModes(labels_of_rvc_clean_mode))
+        local event = capabilities.mode.supportedModes(labels_of_rvc_clean_mode, {visibility = {displayed = false}})
+        device:emit_component_event(component, event)
       else
-        device:emit_component_event(component, capabilities.mode.supportedModes({}))
+        local event = capabilities.mode.supportedModes({}, {visibility = {displayed = false}})
+        device:emit_component_event(component, event)
       end
       break
     end
@@ -211,7 +214,8 @@ local function rvc_clean_mode_supported_mode_attr_handler(driver, device, ib, re
   local labels_of_supported_modes = get_field_labels_of_supported_modes(device, RVC_CLEAN_MODE_SUPPORTED_MODES)
 
   local component = device.profile.components["cleanMode"]
-  device:emit_component_event(component, capabilities.mode.supportedModes(labels_of_supported_modes))
+  local event = capabilities.mode.supportedModes(labels_of_supported_modes, {visibility = {displayed = false}})
+  device:emit_component_event(component, event)
 end
 
 local function rvc_clean_mode_current_mode_attr_handler(driver, device, ib, response)

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -349,7 +349,8 @@ local function system_mode_handler(driver, device, ib, response)
     end
     -- if we get here, then the reported mode was not in our mode map
     table.insert(sm, THERMOSTAT_MODE_MAP[ib.data.value].NAME)
-    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.thermostatMode.supportedThermostatModes(sm))
+    local event = capabilities.thermostatMode.supportedThermostatModes(sm, {visibility = {displayed = false}})
+    device:emit_event_for_endpoint(ib.endpoint_id, event)
   end
 end
 
@@ -383,7 +384,8 @@ local function sequence_of_operation_handler(driver, device, ib, response)
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.cool.NAME)
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.heat.NAME)
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.thermostatMode.supportedThermostatModes(supported_modes))
+  local event = capabilities.thermostatMode.supportedThermostatModes(supported_modes, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function min_deadband_limit_handler(driver, device, ib, response)
@@ -473,7 +475,8 @@ local function fan_mode_sequence_handler(driver, device, ib, response)
         "high"
       }
     end
-    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airConditionerFanMode.supportedAcFanModes(supportedAcFanModes))
+    local event = capabilities.airConditionerFanMode.supportedAcFanModes(supportedAcFanModes, {visibility = {displayed = false}})
+    device:emit_event_for_endpoint(ib.endpoint_id, event)
   elseif device:supports_capability_by_id(capabilities.airPurifierFanMode.ID) then
     -- Air Purifier
     local supportedAirPurifierFanModes
@@ -517,7 +520,8 @@ local function fan_mode_sequence_handler(driver, device, ib, response)
         capabilities.airPurifierFanMode.airPurifierFanMode.high.NAME
       }
     end
-    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airPurifierFanMode.supportedAirPurifierFanModes(supportedAirPurifierFanModes))
+    local event = capabilities.airPurifierFanMode.supportedAirPurifierFanModes(supportedAirPurifierFanModes, {visibility = {displayed = false}})
+    device:emit_event_for_endpoint(ib.endpoint_id, event)
   else
     -- Thermostat
     -- Our thermostat fan mode control is probably not granular enough to handle the supported modes here well
@@ -525,10 +529,14 @@ local function fan_mode_sequence_handler(driver, device, ib, response)
     if ib.data.value >= clusters.FanControl.attributes.FanModeSequence.OFF_LOW_MED_HIGH_AUTO and
       ib.data.value <= clusters.FanControl.attributes.FanModeSequence.OFF_ON_AUTO then
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.thermostatFanMode.supportedThermostatFanModes(
-        {capabilities.thermostatFanMode.thermostatFanMode.auto.NAME, capabilities.thermostatFanMode.thermostatFanMode.on.NAME}))
+        {capabilities.thermostatFanMode.thermostatFanMode.auto.NAME, capabilities.thermostatFanMode.thermostatFanMode.on.NAME},
+        {visibility = {displayed = false}}
+      ))
     else
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.thermostatFanMode.supportedThermostatFanModes(
-        {capabilities.thermostatFanMode.thermostatFanMode.on.NAME}))
+        {capabilities.thermostatFanMode.thermostatFanMode.on.NAME},
+        {visibility = {displayed = false}}
+      ))
     end
   end
 end
@@ -548,7 +556,8 @@ local function wind_support_handler(driver, device, ib, response)
       table.insert(supported_wind_modes, wind_mode.NAME)
     end
   end
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.windMode.supportedWindModes(supported_wind_modes))
+  local event = capabilities.windMode.supportedWindModes(supported_wind_modes, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
 end
 
 local function wind_setting_handler(driver, device, ib, response)


### PR DESCRIPTION
Currently, The supportedXXX of mode and temperature level capability is updated to history. but It should be modified not to be updated.
