### PR TITLE
Fix unit tests with supportedModes visibility

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
@@ -145,7 +145,7 @@ test.register_message_test(
         capabilities.airPurifierFanMode.airPurifierFanMode.low.NAME,
         capabilities.airPurifierFanMode.airPurifierFanMode.medium.NAME,
         capabilities.airPurifierFanMode.airPurifierFanMode.high.NAME
-      }))
+      }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -162,7 +162,7 @@ test.register_message_test(
         capabilities.airPurifierFanMode.airPurifierFanMode.off.NAME,
         capabilities.airPurifierFanMode.airPurifierFanMode.low.NAME,
         capabilities.airPurifierFanMode.airPurifierFanMode.high.NAME
-      }))
+      }, {visibility={displayed=false}}))
     },
   }
 )
@@ -324,7 +324,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.windMode.supportedWindModes(supportedFanWind))
+      message = mock_device:generate_test_message("main", capabilities.windMode.supportedWindModes(supportedFanWind, {visibility={displayed=false}}))
     },
     {
       channel = "matter",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
@@ -157,7 +157,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.windMode.supportedWindModes(supportedFanWind))
+      message = mock_device:generate_test_message("main", capabilities.windMode.supportedWindModes(supportedFanWind, {visibility={displayed=false}}))
     },
     {
       channel = "matter",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -275,7 +275,7 @@ test.register_message_test(
 		{
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"emergency heat"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"emergency heat"}, {visibility={displayed=false}}))
     },
   }
 )
@@ -295,7 +295,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat"}, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -308,7 +308,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "heat"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "heat"}, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -321,7 +321,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}, {visibility={displayed=false}}))
     },
   }
 )
@@ -340,7 +340,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat"}, {visibility={displayed=false}}))
     },
 		{
       channel = "matter",
@@ -358,7 +358,7 @@ test.register_message_test(
 		{
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat", "emergency heat"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat", "emergency heat"}, {visibility={displayed=false}}))
     }
   }
 )
@@ -425,7 +425,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({"on"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({"on"}, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -438,7 +438,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({"auto", "on"}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.supportedThermostatFanModes({"auto", "on"}, {visibility={displayed=false}}))
     },
   }
 )

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
@@ -286,7 +286,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "emergency heat" }))
+        capabilities.thermostatMode.supportedThermostatModes({ "emergency heat" }, {visibility={displayed=false}}))
     },
   }
 )
@@ -308,7 +308,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat" }))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -322,7 +322,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat" }))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -336,7 +336,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto",  "cool" }))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto",  "cool" }, {visibility={displayed=false}}))
     },
   }
 )
@@ -356,7 +356,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat" }))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -375,7 +375,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat", "emergency heat" }))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat", "emergency heat" }, {visibility={displayed=false}}))
     }
   }
 )
@@ -443,7 +443,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatFanMode.supportedThermostatFanModes({ "on" }))
+        capabilities.thermostatFanMode.supportedThermostatFanModes({ "on" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -457,7 +457,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatFanMode.supportedThermostatFanModes({ "auto", "on" }))
+        capabilities.thermostatFanMode.supportedThermostatFanModes({ "auto", "on" }, {visibility={displayed=false}}))
     },
   }
 )


### PR DESCRIPTION
Fixes some unit tests that were broken by the changes in this commit: e372124dddaf1d44ddedb08b3fb18fd261cfb2ea.

These changes were intentional, but the unit tests were not updated to reflect the changes.