### PR TITLE
Matter Switch: add Zemismart ZM606-6 fingerprint

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2144,6 +2144,11 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xAB04
     deviceProfileName: switch-binary
+  - id: "5020/43777"
+    deviceLabel: Zemismart WiFi Smart Switch
+    vendorId: 0x139C
+    productId: 0xAB01
+    deviceProfileName: switch-binary
 
 
 #Bridge devices need manufacturer specific fingerprints until


### PR DESCRIPTION
This PR is for a WWST Certification request to add the Zemismart ZM606-6 device. According to the DCL it has a device type of 0x103.