### PR TITLE
Matter Switch: add Zemismart ZM606-3 fingerprint

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -2139,6 +2139,11 @@ matterManufacturer:
     vendorId: 0x139C
     productId: 0xAB31
     deviceProfileName: switch-binary
+  - id: "5020/43780"
+    deviceLabel: Zemismart WiFi Smart Switch
+    vendorId: 0x139C
+    productId: 0xAB04
+    deviceProfileName: switch-binary
 
 
 #Bridge devices need manufacturer specific fingerprints until


### PR DESCRIPTION
This PR is for a WWST Certification request to add the Zemismart ZM606-3 device. According to the DCL it has a device type of 0x103.