### PR TITLE
Matter Lock: handle COTA even if profile doesn't have lock codes

### DIFF
--- a/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
@@ -231,7 +231,11 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.lockAlarm.alarm.clear())
     )
-end
+    local req = clusters.DoorLock.attributes.MaxPINCodeLength:read(mock_device, 1)
+    req:merge(clusters.DoorLock.attributes.MinPINCodeLength:read(mock_device, 1))
+    req:merge(clusters.DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device, 1))
+    test.socket.matter:__expect_send({mock_device.id, req})
+  end
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -70,6 +70,7 @@ local function test_init()
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+  test.socket.matter:__expect_send({mock_device.id, DoorLock.attributes.RequirePINforRemoteOperation:read(device, 10)})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -70,7 +70,7 @@ local function test_init()
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
-  test.socket.matter:__expect_send({mock_device.id, DoorLock.attributes.RequirePINforRemoteOperation:read(device, 10)})
+  test.socket.matter:__expect_send({mock_device.id, DoorLock.attributes.RequirePINforRemoteOperation:read(mock_device, 10)})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
@@ -1,0 +1,333 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- Mock out globals
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+test.add_package_capability("lockAlarm.yml")
+local t_utils = require "integration_test.utils"
+local json = require "st.json"
+local clusters = require "st.matter.clusters"
+local DoorLock = clusters.DoorLock
+local types = DoorLock.types
+
+local mock_device_record = {
+  profile = t_utils.get_profile_definition("lock-lockalarm-nobattery.yml"),
+  manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
+  endpoints = {
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 10,
+      clusters = {
+        {
+          cluster_id = DoorLock.ID,
+          cluster_type = "SERVER",
+          feature_map = 0x0181, -- PIN & USR & COTA
+        },
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+      },
+    },
+  },
+}
+local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
+
+local function test_init()
+  local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
+  subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
+  test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+  test.socket.matter:__expect_send({mock_device.id, DoorLock.attributes.RequirePINforRemoteOperation:read(mock_device, 10)})
+  test.mock_device.add_test_device(mock_device)
+end
+
+test.set_test_init_function(test_init)
+
+local test_credential_data = "12345678"
+
+local function expect_kick_off_cota_process(device)
+  test.socket.device_lifecycle:__queue_receive({ device.id, "added" })
+  test.socket.capability:__expect_send(
+    device:generate_test_message("main", capabilities.lockAlarm.alarm.clear())
+  )
+  local req = DoorLock.attributes.MaxPINCodeLength:read(device, 10)
+  req:merge(DoorLock.attributes.MinPINCodeLength:read(device, 10))
+  req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(device, 10))
+  req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(device, 10))
+  test.socket.matter:__expect_send({device.id, req})
+  test.wait_for_events()
+
+  test.socket.matter:__queue_receive({
+    device.id,
+    DoorLock.attributes.NumberOfPINUsersSupported:build_test_report_data(device, 10, 16),
+  })
+
+  -- The creation of advance timers, advancing time, and waiting for events
+  -- is done to ensure a correct order of operations and allow for all the
+  -- `call_with_delay(0, ...)` calls to execute at the correct time.
+  test.wait_for_events()
+  test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+
+  test.socket.matter:__queue_receive(
+    {
+      device.id,
+      DoorLock.attributes.RequirePINforRemoteOperation:build_test_report_data(
+        device, 10, true
+      ),
+    }
+  )
+  test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+  test.mock_time.advance_time(1) --trigger remote pin handling
+  test.wait_for_events()
+  device:set_field("cotaCred", test_credential_data, {persist = true}) --overwrite random cred for test expectation
+  test.timer.__create_and_queue_test_time_advance_timer(3, "oneshot")
+
+  test.socket.matter:__expect_send(
+    {
+      device.id,
+      DoorLock.server.commands.SetCredential(
+        device, 10, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      ),
+    }
+  )
+  test.mock_time.advance_time(1) --trigger set_cota_credential
+  test.wait_for_events()
+end
+
+test.register_coroutine_test(
+  "Added should kick off cota cred process", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+  end
+)
+
+test.register_coroutine_test(
+  "UnlockDoor uses cota cred when present", function()
+    test.socket.capability:__queue_receive(
+      {mock_device.id, {capability = capabilities.lock.ID, command = "unlock", args = {}}}
+    )
+    local lock_utils = require "lock_utils"
+    mock_device:set_field(lock_utils.COTA_CRED, "1111")
+    test.socket.matter:__expect_send({
+        mock_device.id,
+        clusters.DoorLock.server.commands.UnlockDoor(mock_device, 10, "1111"),
+      })
+  end
+)
+
+test.register_coroutine_test(
+  "LockDoor uses cota cred when present", function()
+    test.socket.capability:__queue_receive(
+      {mock_device.id, {capability = capabilities.lock.ID, command = "lock", args = {}}}
+    )
+    local lock_utils = require "lock_utils"
+    mock_device:set_field(lock_utils.COTA_CRED, "1111")
+    test.socket.matter:__expect_send({
+        mock_device.id,
+        clusters.DoorLock.server.commands.LockDoor(mock_device, 10, "1111"),
+      })
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for OCCUPIED credential index requests next_credential_index", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 10,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 10, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for OCCUPIED credential index no space, but need full search", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 10,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 10, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 10,
+        DoorLock.types.DlStatus.OCCUPIED,
+        1,  --user_index
+        nil --next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 10, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential for DUPLICATE credential index generates new credential and retries", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+    test.timer.__create_and_queue_test_time_advance_timer(4, "oneshot")
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 10,
+        DoorLock.types.DlStatus.DUPLICATE,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.wait_for_events()
+    local new_credential_data = "87654321"
+    mock_device:set_field("cotaCred", new_credential_data, {persist = true})
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 10, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = 1}
+        ), -- credential
+        new_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+    test.mock_time.advance_time(2)
+  end
+)
+
+test.register_coroutine_test(
+  "SetCredential FAILURE requests next_credential_index if available", function()
+    test.socket.matter:__set_channel_ordering("relaxed")
+    expect_kick_off_cota_process(mock_device)
+
+    local next_credential_index = 6
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+        mock_device, 10,
+        DoorLock.types.DlStatus.FAILURE,
+        1, --user_index
+        next_credential_index
+      ),
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.SetCredential(
+        mock_device, 10, -- endpoint
+        DoorLock.types.DlDataOperationType.ADD, -- operation_type
+        DoorLock.types.DlCredential(
+          {credential_type = DoorLock.types.DlCredentialType.PIN, credential_index = next_credential_index}
+        ), -- credential
+        test_credential_data, -- credential_data
+        nil, -- user_index
+        DoorLock.types.DlUserStatus.OCCUPIED_ENABLED, -- user_status
+        DoorLock.types.DlUserType.REMOTE_ONLY_USER -- user_type
+      )
+    })
+  end
+)
+
+-- test.register_coroutine_test(
+--   "Delay setting COTA cred if another cred is already being set.", function()
+--   end
+-- )
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
@@ -320,9 +320,9 @@ test.register_coroutine_test(
   end
 )
 
--- test.register_coroutine_test(
---   "Delay setting COTA cred if another cred is already being set.", function()
---   end
--- )
+test.register_coroutine_test(
+  "Delay setting COTA cred if another cred is already being set.", function()
+  end
+)
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
@@ -30,10 +30,8 @@ local test = require "integration_test"
 local capabilities = require "st.capabilities"
 test.add_package_capability("lockAlarm.yml")
 local t_utils = require "integration_test.utils"
-local json = require "st.json"
 local clusters = require "st.matter.clusters"
 local DoorLock = clusters.DoorLock
-local types = DoorLock.types
 
 local mock_device_record = {
   profile = t_utils.get_profile_definition("lock-lockalarm-nobattery.yml"),

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
@@ -323,9 +323,9 @@ test.register_coroutine_test(
   end
 )
 
--- test.register_coroutine_test(
---   "Delay setting COTA cred if another cred is already being set.", function()
---   end
--- )
+test.register_coroutine_test(
+  "Delay setting COTA cred if another cred is already being set.", function()
+  end
+)
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota_no_lock_codes_profile.lua
@@ -34,7 +34,7 @@ local clusters = require "st.matter.clusters"
 local DoorLock = clusters.DoorLock
 
 local mock_device_record = {
-  profile = t_utils.get_profile_definition("lock-lockalarm-nobattery.yml"),
+  profile = t_utils.get_profile_definition("lock-nocodes-notamper.yml"),
   manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
   endpoints = {
     {
@@ -63,7 +63,7 @@ local mock_device = test.mock_device.build_test_matter_device(mock_device_record
 
 local function test_init()
   local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
-  subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
+  subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
   test.socket.matter:__expect_send({mock_device.id, DoorLock.attributes.RequirePINforRemoteOperation:read(mock_device, 10)})
   test.mock_device.add_test_device(mock_device)
@@ -75,9 +75,6 @@ local test_credential_data = "12345678"
 
 local function expect_kick_off_cota_process(device)
   test.socket.device_lifecycle:__queue_receive({ device.id, "added" })
-  test.socket.capability:__expect_send(
-    device:generate_test_message("main", capabilities.lockAlarm.alarm.clear())
-  )
   local req = DoorLock.attributes.MaxPINCodeLength:read(device, 10)
   req:merge(DoorLock.attributes.MinPINCodeLength:read(device, 10))
   req:merge(DoorLock.attributes.NumberOfPINUsersSupported:read(device, 10))
@@ -323,9 +320,9 @@ test.register_coroutine_test(
   end
 )
 
-test.register_coroutine_test(
-  "Delay setting COTA cred if another cred is already being set.", function()
-  end
-)
+-- test.register_coroutine_test(
+--   "Delay setting COTA cred if another cred is already being set.", function()
+--   end
+-- )
 
 test.run_registered_tests()


### PR DESCRIPTION
Fixes regression introduced by: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1413