### PR TITLE
Hotfix: Revert matter lock changes and move aqara to sub driver

### DIFF
--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -21,4 +21,4 @@ matterGeneric:
     deviceLabel: Matter Door Lock
     deviceTypes:
       - id: 0x000A # Door Lock
-    deviceProfileName: lock-lockalarm
+    deviceProfileName: base-lock

--- a/drivers/SmartThings/matter-lock/src/aqara-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/aqara-lock/init.lua
@@ -1,0 +1,147 @@
+-- Copyright 2024 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local capabilities = require "st.capabilities"
+local clusters = require "st.matter.clusters"
+local device_lib = require "st.device"
+
+local DoorLock = clusters.DoorLock
+local AQARA_MANUFACTURER_ID = 0x115f
+local U200_PRODUCT_ID = 0x2802
+
+local function is_aqara_products(opts, driver, device)
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
+      device.manufacturer_info.vendor_id == AQARA_MANUFACTURER_ID and
+      device.manufacturer_info.product_id == U200_PRODUCT_ID then
+        return true
+  end
+  return false
+end
+
+local function find_default_endpoint(device, cluster)
+  local res = device.MATTER_DEFAULT_ENDPOINT
+  local eps = device:get_endpoints(cluster)
+  table.sort(eps)
+  for _, v in ipairs(eps) do
+    if v ~= 0 then --0 is the matter RootNode endpoint
+      return v
+    end
+  end
+  device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
+  return res
+end
+
+local function component_to_endpoint(device, component_name)
+  return find_default_endpoint(device, clusters.DoorLock.ID)
+end
+
+local function device_init(driver, device)
+  device:set_component_to_endpoint_fn(component_to_endpoint)
+  device:subscribe()
+ end
+
+local function device_added(driver, device)
+  device:emit_event(capabilities.lockAlarm.alarm.clear())
+end
+
+local function lock_state_handler(driver, device, ib, response)
+  local LockState = DoorLock.attributes.LockState
+  local attr = capabilities.lock.lock
+  local LOCK_STATE = {
+    [LockState.NOT_FULLY_LOCKED] = attr.unknown(),
+    [LockState.LOCKED] = attr.locked(),
+    [LockState.UNLOCKED] = attr.unlocked(),
+  }
+
+  if ib.data.value ~= nil then
+    device:emit_event(LOCK_STATE[ib.data.value])
+  else
+    device:emit_event(LOCK_STATE[LockState.NOT_FULLY_LOCKED])
+  end
+end
+
+local function alarm_event_handler(driver, device, ib, response)
+  local DlAlarmCode = DoorLock.types.DlAlarmCode
+  local alarm_code = ib.data.elements.alarm_code
+  if alarm_code.value == DlAlarmCode.LOCK_JAMMED then
+    device:emit_event(capabilities.lockAlarm.alarm.unableToLockTheDoor())
+  elseif alarm_code.value == DlAlarmCode.LOCK_FACTORY_RESET then
+    device:emit_event(capabilities.lockAlarm.alarm.lockFactoryReset())
+  elseif alarm_code.value == DlAlarmCode.WRONG_CODE_ENTRY_LIMIT then
+    device:emit_event(capabilities.lockAlarm.alarm.attemptsExceeded())
+  elseif alarm_code.value == DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED then
+    device:emit_event(capabilities.lockAlarm.alarm.damaged())
+  elseif alarm_code.value == DlAlarmCode.DOOR_FORCED_OPEN then
+    device:emit_event(capabilities.lockAlarm.alarm.forcedOpeningAttempt())
+  end
+end
+
+local function handle_refresh(driver, device, command)
+  local req = DoorLock.attributes.LockState:read(device)
+  device:send(req)
+end
+
+local function handle_lock(driver, device, command)
+  local ep = device:component_to_endpoint(command.component)
+  device:send(DoorLock.server.commands.LockDoor(device, ep))
+end
+
+local function handle_unlock(driver, device, command)
+  local ep = device:component_to_endpoint(command.component)
+  device:send(DoorLock.server.commands.UnlockDoor(device, ep))
+end
+
+local aqara_lock_handler = {
+  NAME = "Aqara Lock Handler",
+  lifecycle_handlers = {
+    init = device_init,
+    added = device_added,
+  },
+  matter_handlers = {
+    attr = {
+      [DoorLock.ID] = {
+        [DoorLock.attributes.LockState.ID] = lock_state_handler
+      },
+    },
+    event = {
+      [DoorLock.ID] = {
+        [DoorLock.events.DoorLockAlarm.ID] = alarm_event_handler
+      },
+    },
+  },
+  subscribed_attributes = {
+    [capabilities.lock.ID] = {DoorLock.attributes.LockState}
+  },
+  subscribed_events = {
+    [capabilities.lockAlarm.ID] = {
+      DoorLock.events.DoorLockAlarm
+    },
+  },
+  capability_handlers = {
+    [capabilities.lock.ID] = {
+      [capabilities.lock.commands.lock.NAME] = handle_lock,
+      [capabilities.lock.commands.unlock.NAME] = handle_unlock,
+    },
+    [capabilities.refresh.ID] = {
+      [capabilities.refresh.commands.refresh.NAME] = handle_refresh
+    },
+  },
+  supported_capabilities = {
+    capabilities.lock,
+    capabilities.lockAlarm
+  },
+  can_handle = is_aqara_products
+}
+
+return aqara_lock_handler

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -110,8 +110,8 @@ local function num_pin_users_handler(driver, device, ib, response)
   device:emit_event(capabilities.lockCodes.maxCodes(ib.data.value, {visibility = {displayed = false}}))
 end
 
-local function require_remote_pin_handler(driver, device, ib, response)
-  if ib.data.value then
+local function apply_cota_credentials_if_absent(device)
+  if not device:get_field(lock_utils.COTA_CRED) then
     --Process after all other info blocks have been dispatched to ensure MaxPINCodeLength has been processed
     device.thread:call_with_delay(0, function(t)
       generate_cota_cred_for_device(device)
@@ -121,6 +121,12 @@ local function require_remote_pin_handler(driver, device, ib, response)
         set_cota_credential(device, INITIAL_COTA_INDEX)
       end)
     end)
+  end
+end
+
+local function require_remote_pin_handler(driver, device, ib, response)
+  if ib.data.value then
+    apply_cota_credentials_if_absent(device)
   else
     device:set_field(lock_utils.COTA_CRED, false, {persist = true})
   end
@@ -292,24 +298,10 @@ end
 local function alarm_event_handler(driver, device, ib, response)
   local DlAlarmCode = DoorLock.types.DlAlarmCode
   local alarm_code = ib.data.elements.alarm_code
-  if device:supports_capability(capabilities.lockAlarm) then
-    if alarm_code.value == DlAlarmCode.LOCK_JAMMED then
-      device:emit_event(capabilities.lockAlarm.alarm.unableToLockTheDoor())
-    elseif alarm_code.value == DlAlarmCode.LOCK_FACTORY_RESET then
-      device:emit_event(capabilities.lockAlarm.alarm.lockFactoryReset())
-    elseif alarm_code.value == DlAlarmCode.WRONG_CODE_ENTRY_LIMIT then
-      device:emit_event(capabilities.lockAlarm.alarm.attemptsExceeded())
-    elseif alarm_code.value == DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED then
-      device:emit_event(capabilities.lockAlarm.alarm.damaged())
-    elseif alarm_code.value == DlAlarmCode.DOOR_FORCED_OPEN then
-      device:emit_event(capabilities.lockAlarm.alarm.forcedOpeningAttempt())
-    end
-  elseif device:supports_capability(capabilities.tamperAlert) then
-    if alarm_code.value == DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED or alarm_code.value
-      == DlAlarmCode.WRONG_CODE_ENTRY_LIMIT or alarm_code.value == DlAlarmCode.FORCED_USER
-      or alarm_code.value == DlAlarmCode.DOOR_FORCED_OPEN then
-      device:emit_event(capabilities.tamperAlert.tamper.detected())
-    end
+  if alarm_code.value == DlAlarmCode.FRONT_ESCEUTCHEON_REMOVED or alarm_code.value
+    == DlAlarmCode.WRONG_CODE_ENTRY_LIMIT or alarm_code.value == DlAlarmCode.FORCED_USER
+    or alarm_code.value == DlAlarmCode.DOOR_FORCED_OPEN then
+    device:emit_event(capabilities.tamperAlert.tamper.detected())
   end
 end
 
@@ -384,9 +376,7 @@ end
 local function handle_refresh(driver, device, command)
   -- Note: no endpoint specified indicates a wildcard endpoint
   local req = DoorLock.attributes.LockState:read(device)
-  if device:supports_capability(capabilities.battery) then
-    req:merge(PowerSource.attributes.BatPercentRemaining:read(device))
-  end
+  req:merge(PowerSource.attributes.BatPercentRemaining:read(device))
   device:send(req)
 end
 
@@ -519,13 +509,26 @@ end
 local function device_init(driver, device)
   device:set_component_to_endpoint_fn(component_to_endpoint)
   device:subscribe()
+
+  -- check if we have a missing COTA credential. Only run this if it has not been run before (i.e. in device added),
+  -- because there is a delay built into the COTA process and we do not want to start two COTA generations at the same time
+  -- in the event this was triggered on add.
+  if not device:get_field(lock_utils.COTA_READ_INITIALIZED) or not device:get_field(lock_utils.COTA_CRED) then
+    local eps = device:get_endpoints(DoorLock.ID, {feature_bitmap = DoorLock.types.DoorLockFeature.CREDENTIALSOTA | DoorLock.types.DoorLockFeature.PIN_CREDENTIALS})
+    if #eps == 0 then
+      device.log.debug("Device will not require PIN for remote operation")
+      device:set_field(lock_utils.COTA_CRED, false, {persist = true})
+    else
+      device:send(DoorLock.attributes.RequirePINforRemoteOperation:read(device, eps[1]))
+      device:set_field(lock_utils.COTA_READ_INITIALIZED, true, {persist = true})
+    end
+  end
  end
 
 local function device_added(driver, device)
   --Note: May want to write OperatingMode to NORMAL, to attempt to ensure remote operation works
   --Note: May want to write RequirePINForRemoteOperation, to avoid cota cases if possible.
   device:emit_event(capabilities.tamperAlert.tamper.clear())
-  device:emit_event(capabilities.lockAlarm.alarm.clear())
   local eps = device:get_endpoints(DoorLock.ID, {feature_bitmap = DoorLock.types.DoorLockFeature.PIN_CREDENTIALS})
   if #eps == 0 then
     if device:supports_capability_by_id(capabilities.tamperAlert.ID) then
@@ -534,9 +537,7 @@ local function device_added(driver, device)
     else
       device.log.debug("Device supports neither lock codes nor tamper. Unable to switch profile.")
     end
-  -- some devices may have lock codes functionality, but may not support it in their profile
-  -- intentionally, so only run this if device supports lockCodes in profile.
-  elseif device:supports_capability(capabilities.lockCodes) then
+  else
     local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
     req:merge(DoorLock.attributes.MaxPINCodeLength:read(device, eps[1]))
     req:merge(DoorLock.attributes.MinPINCodeLength:read(device, eps[1]))
@@ -554,6 +555,7 @@ local function device_added(driver, device)
       device:set_field(lock_utils.COTA_CRED, false, {persist = true})
     else
       req:merge(DoorLock.attributes.RequirePINforRemoteOperation:read(device, eps[1]))
+      device:set_field(lock_utils.COTA_READ_INITIALIZED, true, {persist = true})
     end
     device:send(req)
   end
@@ -616,6 +618,9 @@ local matter_lock_driver = {
     capabilities.lockCodes,
     capabilities.tamperAlert,
     capabilities.battery,
+  },
+  sub_drivers = {
+    require("aqara-lock"),
   },
   lifecycle_handlers = {init = device_init, added = device_added},
 }

--- a/drivers/SmartThings/matter-lock/src/lock_utils.lua
+++ b/drivers/SmartThings/matter-lock/src/lock_utils.lua
@@ -24,7 +24,8 @@ local lock_utils = {
   COTA_CRED = "cotaCred",
   COTA_CODE_NAME = "ST Remote Operation Code",
   COTA_CRED_INDEX = "cotaCredIndex",
-  NONFUNCTIONAL = "nonFunctional"
+  NONFUNCTIONAL = "nonFunctional",
+  COTA_READ_INITIALIZED = "cotaReadInitialized"
 }
 local capabilities = require "st.capabilities"
 local json = require "st.json"

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -70,6 +70,7 @@ local function test_init()
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+  test.socket.matter:__expect_send({mock_device.id, DoorLock.attributes.RequirePINforRemoteOperation:read(mock_device, 10)})
   test.mock_device.add_test_device(mock_device)
 end
 


### PR DESCRIPTION
Cherry pick matter lock aqara hotfix to beta
Revert Aqara matter-lock changes and move them to sub driver

This reverts commit d0a77c936e3ea9e7dfbf99220f3f0fa63051754b. 
This reverts commit 1f1df0610a47daca75913b0323774ef91a197f34. 
Add back profiles and fixes after moving Aqara to sub driver Add COTA recovery logic on init