### PR TITLE
Update default profile for smoke-co-alarm device type

### DIFF
--- a/drivers/SmartThings/matter-sensor/fingerprints.yml
+++ b/drivers/SmartThings/matter-sensor/fingerprints.yml
@@ -126,4 +126,4 @@ matterGeneric:
     deviceLabel: Matter Smoke/CO Alarm
     deviceTypes:
       - id: 0x0076
-    deviceProfileName: smoke-co
+    deviceProfileName: smoke-co-temp-humidity-comeas


### PR DESCRIPTION
If the default profile is not super-set with all capabilities and profile is changed by the try_update_metadata function, the driver cannot read the value of the capability that was not in the default profile. 
It seems that these capabilities are not loaded, so the driver cannot find it.