### PR TITLE
Matter Sensor: resubscribe on profile switch

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
@@ -129,6 +129,11 @@ local function info_changed(self, device, event, args)
       end
     end
   end
+
+  -- resubscribe to new attributes as needed if a profile switch occured
+  if device.profile.id ~= args.old_st_store.profile.id then
+    device:subscribe()
+  end
 end
 
 -- Matter Handlers --


### PR DESCRIPTION
Resubscribe whenever there is a profile switch so that new attributes can be subscribed to if the new profile includes new capabilities.