### PR TITLE
Include embedded config for profiles using temperatureAlarm

### DIFF
--- a/drivers/SmartThings/matter-appliance/profiles/dishwasher-tl.yml
+++ b/drivers/SmartThings/matter-appliance/profiles/dishwasher-tl.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: temperatureAlarm
     version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+            - heat
   - id: operationalState
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-appliance/profiles/dishwasher-tn-tl.yml
+++ b/drivers/SmartThings/matter-appliance/profiles/dishwasher-tn-tl.yml
@@ -20,6 +20,13 @@ components:
     version: 1
   - id: temperatureAlarm
     version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+            - heat
   - id: operationalState
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-appliance/profiles/dishwasher-tn.yml
+++ b/drivers/SmartThings/matter-appliance/profiles/dishwasher-tn.yml
@@ -18,6 +18,13 @@ components:
     version: 1
   - id: temperatureAlarm
     version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+            - heat
   - id: operationalState
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-appliance/profiles/dishwasher.yml
+++ b/drivers/SmartThings/matter-appliance/profiles/dishwasher.yml
@@ -12,6 +12,13 @@ components:
     version: 1
   - id: temperatureAlarm
     version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+            - heat
   - id: operationalState
     version: 1
   - id: firmwareUpdate


### PR DESCRIPTION
The temperatureAlarm capability supports four enum values: freeze, cleared, heat, and rateOfRise. Currently, all driver profiles that support this capability exclude rateOfRise since it is unused and will come up in automations if not excluded, and it is the same case for these dishwasher profiles. Since this enum is not used in the dishwasher subdriver, it should be excluded just as is done in other driver profiles.