### PR TITLE
fix an issue of Fan device type sending command

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -225,8 +225,8 @@ end
 local function component_to_endpoint(device, component_name)
   -- Use the find_default_endpoint function to return the first endpoint that
   -- supports a given cluster.
-  if device:supports_capability(capabilities.airPurifierFanMode) then
-    -- Fan Control is mandatory for the Air Purifier device type
+  if device:supports_capability(capabilities.airPurifierFanMode) or device:supports_capability(capabilities.airConditionerFanMode) then
+    -- Fan Control is mandatory for the Air Purifier device type and Air Conditioner device type
     return find_default_endpoint(device, clusters.FanControl.ID)
   else
     -- Thermostat is mandatory for Thermostat and Room AC device type


### PR DESCRIPTION
Issue Description: We onboarding Yeelight Fan(bridged device) device to ST App, but we are unable to control device by sending fan mode or speed.

Problem Analysis: Upon reviewing the logs, it was found that the command send to a wrong endpoint (endpoint 0 for the yeelight bridge instead of endpoint 68 for the yeelight fan). It was caused by the local function  "component_to_endpoint" in matter-thermostat/init.lua 158. We revised the edge driver by adding an "elseif" statement for returning Fan device type related endpoint. (As per Matter Device Library Spec, there are 3 device type in HVAC, including Thermostat, Fan and Air Purifier. However, It should be noted that the Fan device is currently absent from the function "component_to_endpoint".)