### PR TITLE
Cherry Pick: Matter Thermostat extend Air Quality Sensor

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-aqs-co2-tvoc-meas-co2-radon-level.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-aqs-co2-tvoc-meas-co2-radon-level.yml
@@ -1,0 +1,43 @@
+name: air-purifier-hepa-ac-aqs-co2-tvoc-meas-co2-radon-level
+components:
+- id: main
+  label: Main
+  capabilities:
+  - id: airPurifierFanMode
+    version: 1
+  - id: fanSpeedPercent
+    version: 1
+  - id: airQualityHealthConcern
+    version: 1
+  - id: carbonDioxideHealthConcern
+    version: 1
+  - id: carbonDioxideMeasurement
+    version: 1
+  - id: radonHealthConcern
+    version: 1
+  - id: tvocMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: AirPurifier
+- id: hepaFilter
+  label: Hepa Filter
+  capabilities:
+  - id: filterState
+    version: 1
+  - id: filterStatus
+    version: 1
+  categories:
+  - name: AirPurifier
+- id: activatedCarbonFilter
+  label: Activated Carbon Filter
+  capabilities:
+  - id: filterState
+    version: 1
+  - id: filterStatus
+    version: 1
+  categories:
+  - name: AirPurifier

--- a/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
@@ -1,0 +1,61 @@
+name: air-purifier-hepa-ac-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level
+components:
+- id: main
+  label: Main
+  capabilities:
+  - id: airPurifierFanMode
+    version: 1
+  - id: fanSpeedPercent
+    version: 1
+  - id: windMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: dustSensor
+    version: 1
+  - id: formaldehydeMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: airQualityHealthConcern
+    version: 1
+  - id: dustHealthConcern
+    version: 1
+  - id: fineDustHealthConcern
+    version: 1
+  - id: formaldehydeHealthConcern
+    version: 1
+  - id: nitrogenDioxideHealthConcern
+    version: 1
+  - id: tvocHealthConcern
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: AirPurifier
+- id: hepaFilter
+  label: Hepa Filter
+  capabilities:
+  - id: filterState
+    version: 1
+  - id: filterStatus
+    version: 1
+  categories:
+  - name: AirPurifier
+- id: activatedCarbonFilter
+  label: Activated Carbon Filter
+  capabilities:
+  - id: filterState
+    version: 1
+  - id: filterStatus
+    version: 1
+  categories:
+  - name: AirPurifier

--- a/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-aqs.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-aqs.yml
@@ -1,0 +1,26 @@
+name: air-purifier-hepa-aqs
+components:
+- id: main
+  label: Main
+  capabilities:
+  - id: airQualityHealthConcern
+    version: 1
+  - id: airPurifierFanMode
+    version: 1
+  - id: fanSpeedPercent
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: AirPurifier
+- id: hepaFilter
+  label: Hepa filter
+  capabilities:
+  - id: filterState
+    version: 1
+  - id: filterStatus
+    version: 1
+  categories:
+  - name: AirPurifier

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/init.lua
@@ -1,0 +1,59 @@
+local cluster_base = require "st.matter.cluster_base"
+local AirQualityServerAttributes = require "AirQuality.server.attributes"
+local AirQualityTypes = require "AirQuality.types"
+
+local AirQuality = {}
+
+AirQuality.ID = 0x005B
+AirQuality.NAME = "AirQuality"
+AirQuality.server = {}
+AirQuality.client = {}
+AirQuality.server.attributes = AirQualityServerAttributes:set_parent_cluster(AirQuality)
+AirQuality.types = AirQualityTypes
+
+function AirQuality:get_attribute_by_id(attr_id)
+  local attr_id_map = {
+    [0x0000] = "AirQuality",
+    [0xFFF9] = "AcceptedCommandList",
+    [0xFFFA] = "EventList",
+    [0xFFFB] = "AttributeList",
+  }
+  local attr_name = attr_id_map[attr_id]
+  if attr_name ~= nil then
+    return self.attributes[attr_name]
+  end
+  return nil
+end
+
+-- Attribute Mapping
+AirQuality.attribute_direction_map = {
+  ["AirQuality"] = "server",
+  ["AcceptedCommandList"] = "server",
+  ["EventList"] = "server",
+  ["AttributeList"] = "server",
+}
+
+AirQuality.FeatureMap = AirQuality.types.Feature
+
+function AirQuality.are_features_supported(feature, feature_map)
+  if (AirQuality.FeatureMap.bits_are_valid(feature)) then
+    return (feature & feature_map) == feature
+  end
+  return false
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = AirQuality.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, AirQuality.NAME))
+  end
+  return AirQuality[direction].attributes[key]
+end
+AirQuality.attributes = {}
+setmetatable(AirQuality.attributes, attribute_helper_mt)
+
+setmetatable(AirQuality, {__index = cluster_base})
+
+return AirQuality
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/AcceptedCommandList.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/AcceptedCommandList.lua
@@ -1,0 +1,75 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local AcceptedCommandList = {
+  ID = 0xFFF9,
+  NAME = "AcceptedCommandList",
+  base_type = require "st.matter.data_types.Array",
+  element_type = require "st.matter.data_types.Uint32",
+}
+
+function AcceptedCommandList:augment_type(data_type_obj)
+  for i, v in ipairs(data_type_obj.elements) do
+    data_type_obj.elements[i] = data_types.validate_or_build_type(v, AcceptedCommandList.element_type)
+  end
+end
+
+function AcceptedCommandList:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function AcceptedCommandList:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function AcceptedCommandList:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function AcceptedCommandList:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function AcceptedCommandList:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function AcceptedCommandList:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(AcceptedCommandList, {__call = AcceptedCommandList.new_value, __index = AcceptedCommandList.base_type})
+return AcceptedCommandList
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/AirQuality.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/AirQuality.lua
@@ -1,0 +1,68 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local AirQuality = {
+  ID = 0x0000,
+  NAME = "AirQuality",
+  base_type = require "AirQuality.types.AirQualityEnum",
+}
+
+function AirQuality:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+  self:augment_type(o)
+  return o
+end
+
+function AirQuality:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function AirQuality:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function AirQuality:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function AirQuality:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+  self:augment_type(data)
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function AirQuality:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(AirQuality, {__call = AirQuality.new_value, __index = AirQuality.base_type})
+return AirQuality
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/AttributeList.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/AttributeList.lua
@@ -1,0 +1,75 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local AttributeList = {
+  ID = 0xFFFB,
+  NAME = "AttributeList",
+  base_type = require "st.matter.data_types.Array",
+  element_type = require "st.matter.data_types.Uint32",
+}
+
+function AttributeList:augment_type(data_type_obj)
+  for i, v in ipairs(data_type_obj.elements) do
+    data_type_obj.elements[i] = data_types.validate_or_build_type(v, AttributeList.element_type)
+  end
+end
+
+function AttributeList:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function AttributeList:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function AttributeList:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function AttributeList:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function AttributeList:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function AttributeList:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(AttributeList, {__call = AttributeList.new_value, __index = AttributeList.base_type})
+return AttributeList
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/EventList.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/EventList.lua
@@ -1,0 +1,75 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local EventList = {
+  ID = 0xFFFA,
+  NAME = "EventList",
+  base_type = require "st.matter.data_types.Array",
+  element_type = require "st.matter.data_types.Uint32",
+}
+
+function EventList:augment_type(data_type_obj)
+  for i, v in ipairs(data_type_obj.elements) do
+    data_type_obj.elements[i] = data_types.validate_or_build_type(v, EventList.element_type)
+  end
+end
+
+function EventList:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function EventList:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function EventList:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function EventList:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function EventList:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function EventList:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(EventList, {__call = EventList.new_value, __index = EventList.base_type})
+return EventList
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("AirQuality.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local AirQualityServerAttributes = {}
+
+function AirQualityServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(AirQualityServerAttributes, attr_mt)
+
+return AirQualityServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/types/AirQualityEnum.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/types/AirQualityEnum.lua
@@ -1,0 +1,45 @@
+local data_types = require "st.matter.data_types"
+local UintABC = require "st.matter.data_types.base_defs.UintABC"
+
+local AirQualityEnum = {}
+-- Note: the name here is intentionally set to Uint8 to maintain backwards compatibility
+-- with how types were handled in api < 10.
+local new_mt = UintABC.new_mt({NAME = "Uint8", ID = data_types.name_to_id_map["Uint8"]}, 1)
+new_mt.__index.pretty_print = function(self)
+  local name_lookup = {
+    [self.UNKNOWN] = "UNKNOWN",
+    [self.GOOD] = "GOOD",
+    [self.FAIR] = "FAIR",
+    [self.MODERATE] = "MODERATE",
+    [self.POOR] = "POOR",
+    [self.VERY_POOR] = "VERY_POOR",
+    [self.EXTREMELY_POOR] = "EXTREMELY_POOR",
+  }
+  return string.format("%s: %s", self.field_name or self.NAME, name_lookup[self.value] or string.format("%d", self.value))
+end
+new_mt.__tostring = new_mt.__index.pretty_print
+
+new_mt.__index.UNKNOWN  = 0x00
+new_mt.__index.GOOD  = 0x01
+new_mt.__index.FAIR  = 0x02
+new_mt.__index.MODERATE  = 0x03
+new_mt.__index.POOR  = 0x04
+new_mt.__index.VERY_POOR  = 0x05
+new_mt.__index.EXTREMELY_POOR  = 0x06
+
+AirQualityEnum.UNKNOWN  = 0x00
+AirQualityEnum.GOOD  = 0x01
+AirQualityEnum.FAIR  = 0x02
+AirQualityEnum.MODERATE  = 0x03
+AirQualityEnum.POOR  = 0x04
+AirQualityEnum.VERY_POOR  = 0x05
+AirQualityEnum.EXTREMELY_POOR  = 0x06
+
+AirQualityEnum.augment_type = function(cls, val)
+  setmetatable(val, new_mt)
+end
+
+setmetatable(AirQualityEnum, new_mt)
+
+return AirQualityEnum
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/types/Feature.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/types/Feature.lua
@@ -1,0 +1,120 @@
+local data_types = require "st.matter.data_types"
+local UintABC = require "st.matter.data_types.base_defs.UintABC"
+
+local Feature = {}
+local new_mt = UintABC.new_mt({NAME = "Feature", ID = data_types.name_to_id_map["Uint32"]}, 4)
+
+Feature.BASE_MASK = 0xFFFF
+Feature.FAIR = 0x0001
+Feature.MODERATE = 0x0002
+Feature.VERY_POOR = 0x0004
+Feature.EXTREMELY_POOR = 0x0008
+
+Feature.mask_fields = {
+  BASE_MASK = 0xFFFF,
+  FAIR = 0x0001,
+  MODERATE = 0x0002,
+  VERY_POOR = 0x0004,
+  EXTREMELY_POOR = 0x0008,
+}
+
+Feature.is_fair_set = function(self)
+  return (self.value & self.FAIR) ~= 0
+end
+
+Feature.set_fair = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.FAIR
+  else
+    self.value = self.FAIR
+  end
+end
+
+Feature.unset_fair = function(self)
+  self.value = self.value & (~self.FAIR & self.BASE_MASK)
+end
+
+Feature.is_moderate_set = function(self)
+  return (self.value & self.MODERATE) ~= 0
+end
+
+Feature.set_moderate = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.MODERATE
+  else
+    self.value = self.MODERATE
+  end
+end
+
+Feature.unset_moderate = function(self)
+  self.value = self.value & (~self.MODERATE & self.BASE_MASK)
+end
+
+Feature.is_very_poor_set = function(self)
+  return (self.value & self.VERY_POOR) ~= 0
+end
+
+Feature.set_very_poor = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.VERY_POOR
+  else
+    self.value = self.VERY_POOR
+  end
+end
+
+Feature.unset_very_poor = function(self)
+  self.value = self.value & (~self.VERY_POOR & self.BASE_MASK)
+end
+
+Feature.is_extremely_poor_set = function(self)
+  return (self.value & self.EXTREMELY_POOR) ~= 0
+end
+
+Feature.set_extremely_poor = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.EXTREMELY_POOR
+  else
+    self.value = self.EXTREMELY_POOR
+  end
+end
+
+Feature.unset_extremely_poor = function(self)
+  self.value = self.value & (~self.EXTREMELY_POOR & self.BASE_MASK)
+end
+
+function Feature.bits_are_valid(feature)
+  local max =
+    Feature.FAIR |
+    Feature.MODERATE |
+    Feature.VERY_POOR |
+    Feature.EXTREMELY_POOR
+  if (feature <= max) and (feature >= 1) then
+    return true
+  else
+    return false
+  end
+end
+
+Feature.mask_methods = {
+  is_fair_set = Feature.is_fair_set,
+  set_fair = Feature.set_fair,
+  unset_fair = Feature.unset_fair,
+  is_moderate_set = Feature.is_moderate_set,
+  set_moderate = Feature.set_moderate,
+  unset_moderate = Feature.unset_moderate,
+  is_very_poor_set = Feature.is_very_poor_set,
+  set_very_poor = Feature.set_very_poor,
+  unset_very_poor = Feature.unset_very_poor,
+  is_extremely_poor_set = Feature.is_extremely_poor_set,
+  set_extremely_poor = Feature.set_extremely_poor,
+  unset_extremely_poor = Feature.unset_extremely_poor,
+}
+
+Feature.augment_type = function(cls, val)
+  setmetatable(val, new_mt)
+end
+
+setmetatable(Feature, new_mt)
+
+return Feature
+

--- a/drivers/SmartThings/matter-thermostat/src/AirQuality/types/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/AirQuality/types/init.lua
@@ -1,0 +1,15 @@
+local types_mt = {}
+types_mt.__types_cache = {}
+types_mt.__index = function(self, key)
+  if types_mt.__types_cache[key] == nil then
+    types_mt.__types_cache[key] = require("AirQuality.types." .. key)
+  end
+  return types_mt.__types_cache[key]
+end
+
+local AirQualityTypes = {}
+
+setmetatable(AirQualityTypes, types_mt)
+
+return AirQualityTypes
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local CarbonDioxideConcentrationMeasurementServerAttributes = require "CarbonDioxideConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local CarbonDioxideConcentrationMeasurement = {}
+
+CarbonDioxideConcentrationMeasurement.ID = 0x040D
+CarbonDioxideConcentrationMeasurement.NAME = "CarbonDioxideConcentrationMeasurement"
+CarbonDioxideConcentrationMeasurement.server = {}
+CarbonDioxideConcentrationMeasurement.client = {}
+CarbonDioxideConcentrationMeasurement.server.attributes = CarbonDioxideConcentrationMeasurementServerAttributes:set_parent_cluster(CarbonDioxideConcentrationMeasurement)
+CarbonDioxideConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function CarbonDioxideConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function CarbonDioxideConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+CarbonDioxideConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+CarbonDioxideConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function CarbonDioxideConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = CarbonDioxideConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, CarbonDioxideConcentrationMeasurement.NAME))
+  end
+  return CarbonDioxideConcentrationMeasurement[direction].attributes[key]
+end
+CarbonDioxideConcentrationMeasurement.attributes = {}
+setmetatable(CarbonDioxideConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(CarbonDioxideConcentrationMeasurement, {__index = cluster_base})
+
+return CarbonDioxideConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonDioxideConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("CarbonDioxideConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local CarbonDioxideConcentrationMeasurementServerAttributes = {}
+
+function CarbonDioxideConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(CarbonDioxideConcentrationMeasurementServerAttributes, attr_mt)
+
+return CarbonDioxideConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local CarbonMonoxideConcentrationMeasurementServerAttributes = require "CarbonMonoxideConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local CarbonMonoxideConcentrationMeasurement = {}
+
+CarbonMonoxideConcentrationMeasurement.ID = 0x040C
+CarbonMonoxideConcentrationMeasurement.NAME = "CarbonMonoxideConcentrationMeasurement"
+CarbonMonoxideConcentrationMeasurement.server = {}
+CarbonMonoxideConcentrationMeasurement.client = {}
+CarbonMonoxideConcentrationMeasurement.server.attributes = CarbonMonoxideConcentrationMeasurementServerAttributes:set_parent_cluster(CarbonMonoxideConcentrationMeasurement)
+CarbonMonoxideConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function CarbonMonoxideConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function CarbonMonoxideConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+CarbonMonoxideConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+CarbonMonoxideConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function CarbonMonoxideConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = CarbonMonoxideConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, CarbonMonoxideConcentrationMeasurement.NAME))
+  end
+  return CarbonMonoxideConcentrationMeasurement[direction].attributes[key]
+end
+CarbonMonoxideConcentrationMeasurement.attributes = {}
+setmetatable(CarbonMonoxideConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(CarbonMonoxideConcentrationMeasurement, {__index = cluster_base})
+
+return CarbonMonoxideConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/CarbonMonoxideConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("CarbonMonoxideConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local CarbonMonoxideConcentrationMeasurementServerAttributes = {}
+
+function CarbonMonoxideConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(CarbonMonoxideConcentrationMeasurementServerAttributes, attr_mt)
+
+return CarbonMonoxideConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/init.lua
@@ -1,0 +1,108 @@
+local cluster_base = require "st.matter.cluster_base"
+local ConcentrationMeasurementServerAttributes = require "ConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurementTypes = require "ConcentrationMeasurement.types"
+
+local ConcentrationMeasurement = {}
+
+ConcentrationMeasurement.ID = 0x040C
+ConcentrationMeasurement.NAME = "CarbonMonoxideConcentrationMeasurement"
+ConcentrationMeasurement.server = {}
+ConcentrationMeasurement.client = {}
+ConcentrationMeasurement.server.attributes = ConcentrationMeasurementServerAttributes:set_parent_cluster(ConcentrationMeasurement)
+ConcentrationMeasurement.types = ConcentrationMeasurementTypes
+
+function ConcentrationMeasurement:get_attribute_by_id(attr_id)
+  local attr_id_map = {
+    [0x0000] = "MeasuredValue",
+    [0x0001] = "MinMeasuredValue",
+    [0x0002] = "MaxMeasuredValue",
+    [0x0003] = "PeakMeasuredValue",
+    [0x0004] = "PeakMeasuredValueWindow",
+    [0x0005] = "AverageMeasuredValue",
+    [0x0006] = "AverageMeasuredValueWindow",
+    [0x0007] = "Uncertainty",
+    [0x0008] = "MeasurementUnit",
+    [0x0009] = "MeasurementMedium",
+    [0x000A] = "LevelValue",
+    [0xFFF9] = "AcceptedCommandList",
+    [0xFFFA] = "EventList",
+    [0xFFFB] = "AttributeList",
+  }
+  local attr_name = attr_id_map[attr_id]
+  if attr_name ~= nil then
+    return self.attributes[attr_name]
+  end
+  return nil
+end
+
+function ConcentrationMeasurement:get_server_command_by_id(command_id)
+  local server_id_map = {
+  }
+  if server_id_map[command_id] ~= nil then
+    return self.server.commands[server_id_map[command_id]]
+  end
+  return nil
+end
+
+ConcentrationMeasurement.attribute_direction_map = {
+  ["MeasuredValue"] = "server",
+  ["MinMeasuredValue"] = "server",
+  ["MaxMeasuredValue"] = "server",
+  ["PeakMeasuredValue"] = "server",
+  ["PeakMeasuredValueWindow"] = "server",
+  ["AverageMeasuredValue"] = "server",
+  ["AverageMeasuredValueWindow"] = "server",
+  ["Uncertainty"] = "server",
+  ["MeasurementUnit"] = "server",
+  ["MeasurementMedium"] = "server",
+  ["LevelValue"] = "server",
+  ["AcceptedCommandList"] = "server",
+  ["EventList"] = "server",
+  ["AttributeList"] = "server",
+}
+
+ConcentrationMeasurement.command_direction_map = {
+}
+
+ConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function ConcentrationMeasurement.are_features_supported(feature, feature_map)
+  if (ConcentrationMeasurement.FeatureMap.bits_are_valid(feature)) then
+    return (feature & feature_map) == feature
+  end
+  return false
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = ConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, ConcentrationMeasurement.NAME))
+  end
+  return ConcentrationMeasurement[direction].attributes[key]
+end
+ConcentrationMeasurement.attributes = {}
+setmetatable(ConcentrationMeasurement.attributes, attribute_helper_mt)
+
+local command_helper_mt = {}
+command_helper_mt.__index = function(self, key)
+  local direction = ConcentrationMeasurement.command_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown command %s on cluster %s", key, ConcentrationMeasurement.NAME))
+  end
+  return ConcentrationMeasurement[direction].commands[key]
+end
+ConcentrationMeasurement.commands = {}
+setmetatable(ConcentrationMeasurement.commands, command_helper_mt)
+
+local event_helper_mt = {}
+event_helper_mt.__index = function(self, key)
+  return ConcentrationMeasurement.server.events[key]
+end
+ConcentrationMeasurement.events = {}
+setmetatable(ConcentrationMeasurement.events, event_helper_mt)
+
+setmetatable(ConcentrationMeasurement, {__index = cluster_base})
+
+return ConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,70 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+  self:augment_type(o)
+  return o
+end
+
+function LevelValue:read(device, endpoint_id, cluster_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    nil --event_id
+  )
+end
+
+
+function LevelValue:subscribe(device, endpoint_id, cluster_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    nil --event_id
+  )
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status,
+  cluster_id
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+  self:augment_type(data)
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function LevelValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,70 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function MeasuredValue:read(device, endpoint_id, cluster_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    nil --event_id
+  )
+end
+
+
+function MeasuredValue:subscribe(device, endpoint_id, cluster_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    nil --event_id
+  )
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status,
+  cluster_id
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,69 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+  self:augment_type(o)
+  return o
+end
+
+function MeasurementUnit:read(device, endpoint_id, cluster_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    nil --event_id
+  )
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id, cluster_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    nil --event_id
+  )
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status,
+  cluster_id
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+  self:augment_type(data)
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    cluster_id,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("ConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local ConcentrationMeasurementServerAttributes = {}
+
+function ConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(ConcentrationMeasurementServerAttributes, attr_mt)
+
+return ConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/Feature.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/Feature.lua
@@ -1,0 +1,164 @@
+local data_types = require "st.matter.data_types"
+local UintABC = require "st.matter.data_types.base_defs.UintABC"
+
+local Feature = {}
+local new_mt = UintABC.new_mt({NAME = "Feature", ID = data_types.name_to_id_map["Uint32"]}, 4)
+
+Feature.BASE_MASK = 0xFFFF
+Feature.NUMERIC_MEASUREMENT = 0x0001
+Feature.LEVEL_INDICATION = 0x0002
+Feature.MEDIUM_LEVEL = 0x0004
+Feature.CRITICAL_LEVEL = 0x0008
+Feature.PEAK_MEASUREMENT = 0x0010
+Feature.AVERAGE_MEASUREMENT = 0x0020
+
+Feature.mask_fields = {
+  BASE_MASK = 0xFFFF,
+  NUMERIC_MEASUREMENT = 0x0001,
+  LEVEL_INDICATION = 0x0002,
+  MEDIUM_LEVEL = 0x0004,
+  CRITICAL_LEVEL = 0x0008,
+  PEAK_MEASUREMENT = 0x0010,
+  AVERAGE_MEASUREMENT = 0x0020,
+}
+
+Feature.is_numeric_measurement_set = function(self)
+  return (self.value & self.NUMERIC_MEASUREMENT) ~= 0
+end
+
+Feature.set_numeric_measurement = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.NUMERIC_MEASUREMENT
+  else
+    self.value = self.NUMERIC_MEASUREMENT
+  end
+end
+
+Feature.unset_numeric_measurement = function(self)
+  self.value = self.value & (~self.NUMERIC_MEASUREMENT & self.BASE_MASK)
+end
+
+Feature.is_level_indication_set = function(self)
+  return (self.value & self.LEVEL_INDICATION) ~= 0
+end
+
+Feature.set_level_indication = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.LEVEL_INDICATION
+  else
+    self.value = self.LEVEL_INDICATION
+  end
+end
+
+Feature.unset_level_indication = function(self)
+  self.value = self.value & (~self.LEVEL_INDICATION & self.BASE_MASK)
+end
+
+Feature.is_medium_level_set = function(self)
+  return (self.value & self.MEDIUM_LEVEL) ~= 0
+end
+
+Feature.set_medium_level = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.MEDIUM_LEVEL
+  else
+    self.value = self.MEDIUM_LEVEL
+  end
+end
+
+Feature.unset_medium_level = function(self)
+  self.value = self.value & (~self.MEDIUM_LEVEL & self.BASE_MASK)
+end
+
+Feature.is_critical_level_set = function(self)
+  return (self.value & self.CRITICAL_LEVEL) ~= 0
+end
+
+Feature.set_critical_level = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.CRITICAL_LEVEL
+  else
+    self.value = self.CRITICAL_LEVEL
+  end
+end
+
+Feature.unset_critical_level = function(self)
+  self.value = self.value & (~self.CRITICAL_LEVEL & self.BASE_MASK)
+end
+
+Feature.is_peak_measurement_set = function(self)
+  return (self.value & self.PEAK_MEASUREMENT) ~= 0
+end
+
+Feature.set_peak_measurement = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.PEAK_MEASUREMENT
+  else
+    self.value = self.PEAK_MEASUREMENT
+  end
+end
+
+Feature.unset_peak_measurement = function(self)
+  self.value = self.value & (~self.PEAK_MEASUREMENT & self.BASE_MASK)
+end
+
+Feature.is_average_measurement_set = function(self)
+  return (self.value & self.AVERAGE_MEASUREMENT) ~= 0
+end
+
+Feature.set_average_measurement = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.AVERAGE_MEASUREMENT
+  else
+    self.value = self.AVERAGE_MEASUREMENT
+  end
+end
+
+Feature.unset_average_measurement = function(self)
+  self.value = self.value & (~self.AVERAGE_MEASUREMENT & self.BASE_MASK)
+end
+
+function Feature.bits_are_valid(feature)
+  local max =
+    Feature.NUMERIC_MEASUREMENT |
+    Feature.LEVEL_INDICATION |
+    Feature.MEDIUM_LEVEL |
+    Feature.CRITICAL_LEVEL |
+    Feature.PEAK_MEASUREMENT |
+    Feature.AVERAGE_MEASUREMENT
+  if (feature <= max) and (feature >= 1) then
+    return true
+  else
+    return false
+  end
+end
+
+Feature.mask_methods = {
+  is_numeric_measurement_set = Feature.is_numeric_measurement_set,
+  set_numeric_measurement = Feature.set_numeric_measurement,
+  unset_numeric_measurement = Feature.unset_numeric_measurement,
+  is_level_indication_set = Feature.is_level_indication_set,
+  set_level_indication = Feature.set_level_indication,
+  unset_level_indication = Feature.unset_level_indication,
+  is_medium_level_set = Feature.is_medium_level_set,
+  set_medium_level = Feature.set_medium_level,
+  unset_medium_level = Feature.unset_medium_level,
+  is_critical_level_set = Feature.is_critical_level_set,
+  set_critical_level = Feature.set_critical_level,
+  unset_critical_level = Feature.unset_critical_level,
+  is_peak_measurement_set = Feature.is_peak_measurement_set,
+  set_peak_measurement = Feature.set_peak_measurement,
+  unset_peak_measurement = Feature.unset_peak_measurement,
+  is_average_measurement_set = Feature.is_average_measurement_set,
+  set_average_measurement = Feature.set_average_measurement,
+  unset_average_measurement = Feature.unset_average_measurement,
+}
+
+Feature.augment_type = function(cls, val)
+  setmetatable(val, new_mt)
+end
+
+setmetatable(Feature, new_mt)
+
+return Feature
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/LevelValueEnum.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/LevelValueEnum.lua
@@ -1,0 +1,39 @@
+local data_types = require "st.matter.data_types"
+local UintABC = require "st.matter.data_types.base_defs.UintABC"
+
+local LevelValueEnum = {}
+-- Note: the name here is intentionally set to Uint8 to maintain backwards compatibility
+-- with how types were handled in api < 10.
+local new_mt = UintABC.new_mt({NAME = "Uint8", ID = data_types.name_to_id_map["Uint8"]}, 1)
+new_mt.__index.pretty_print = function(self)
+  local name_lookup = {
+    [self.UNKNOWN] = "UNKNOWN",
+    [self.LOW] = "LOW",
+    [self.MEDIUM] = "MEDIUM",
+    [self.HIGH] = "HIGH",
+    [self.CRITICAL] = "CRITICAL",
+  }
+  return string.format("%s: %s", self.field_name or self.NAME, name_lookup[self.value] or string.format("%d", self.value))
+end
+new_mt.__tostring = new_mt.__index.pretty_print
+
+new_mt.__index.UNKNOWN  = 0x00
+new_mt.__index.LOW  = 0x01
+new_mt.__index.MEDIUM  = 0x02
+new_mt.__index.HIGH  = 0x03
+new_mt.__index.CRITICAL  = 0x04
+
+LevelValueEnum.UNKNOWN  = 0x00
+LevelValueEnum.LOW  = 0x01
+LevelValueEnum.MEDIUM  = 0x02
+LevelValueEnum.HIGH  = 0x03
+LevelValueEnum.CRITICAL  = 0x04
+
+LevelValueEnum.augment_type = function(cls, val)
+  setmetatable(val, new_mt)
+end
+
+setmetatable(LevelValueEnum, new_mt)
+
+return LevelValueEnum
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/MeasurementUnitEnum.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/MeasurementUnitEnum.lua
@@ -1,0 +1,48 @@
+local data_types = require "st.matter.data_types"
+local UintABC = require "st.matter.data_types.base_defs.UintABC"
+
+local MeasurementUnitEnum = {}
+-- Note: the name here is intentionally set to Uint8 to maintain backwards compatibility
+-- with how types were handled in api < 10.
+local new_mt = UintABC.new_mt({NAME = "Uint8", ID = data_types.name_to_id_map["Uint8"]}, 1)
+new_mt.__index.pretty_print = function(self)
+  local name_lookup = {
+    [self.PPM] = "PPM",
+    [self.PPB] = "PPB",
+    [self.PPT] = "PPT",
+    [self.MGM3] = "MGM3",
+    [self.UGM3] = "UGM3",
+    [self.NGM3] = "NGM3",
+    [self.PM3] = "PM3",
+    [self.BQM3] = "BQM3",
+  }
+  return string.format("%s: %s", self.field_name or self.NAME, name_lookup[self.value] or string.format("%d", self.value))
+end
+new_mt.__tostring = new_mt.__index.pretty_print
+
+new_mt.__index.PPM  = 0x00
+new_mt.__index.PPB  = 0x01
+new_mt.__index.PPT  = 0x02
+new_mt.__index.MGM3  = 0x03
+new_mt.__index.UGM3  = 0x04
+new_mt.__index.NGM3  = 0x05
+new_mt.__index.PM3  = 0x06
+new_mt.__index.BQM3  = 0x07
+
+MeasurementUnitEnum.PPM  = 0x00
+MeasurementUnitEnum.PPB  = 0x01
+MeasurementUnitEnum.PPT  = 0x02
+MeasurementUnitEnum.MGM3  = 0x03
+MeasurementUnitEnum.UGM3  = 0x04
+MeasurementUnitEnum.NGM3  = 0x05
+MeasurementUnitEnum.PM3  = 0x06
+MeasurementUnitEnum.BQM3  = 0x07
+
+MeasurementUnitEnum.augment_type = function(cls, val)
+  setmetatable(val, new_mt)
+end
+
+setmetatable(MeasurementUnitEnum, new_mt)
+
+return MeasurementUnitEnum
+

--- a/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/ConcentrationMeasurement/types/init.lua
@@ -1,0 +1,15 @@
+local types_mt = {}
+types_mt.__types_cache = {}
+types_mt.__index = function(self, key)
+  if types_mt.__types_cache[key] == nil then
+    types_mt.__types_cache[key] = require("ConcentrationMeasurement.types." .. key)
+  end
+  return types_mt.__types_cache[key]
+end
+
+local ConcentrationMeasurementTypes = {}
+
+setmetatable(ConcentrationMeasurementTypes, types_mt)
+
+return ConcentrationMeasurementTypes
+

--- a/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local FormaldehydeConcentrationMeasurementServerAttributes = require "FormaldehydeConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local FormaldehydeConcentrationMeasurement = {}
+
+FormaldehydeConcentrationMeasurement.ID = 0x042B
+FormaldehydeConcentrationMeasurement.NAME = "FormaldehydeConcentrationMeasurement"
+FormaldehydeConcentrationMeasurement.server = {}
+FormaldehydeConcentrationMeasurement.client = {}
+FormaldehydeConcentrationMeasurement.server.attributes = FormaldehydeConcentrationMeasurementServerAttributes:set_parent_cluster(FormaldehydeConcentrationMeasurement)
+FormaldehydeConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function FormaldehydeConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function FormaldehydeConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+FormaldehydeConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+FormaldehydeConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function FormaldehydeConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = FormaldehydeConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, FormaldehydeConcentrationMeasurement.NAME))
+  end
+  return FormaldehydeConcentrationMeasurement[direction].attributes[key]
+end
+FormaldehydeConcentrationMeasurement.attributes = {}
+setmetatable(FormaldehydeConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(FormaldehydeConcentrationMeasurement, {__index = cluster_base})
+
+return FormaldehydeConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/FormaldehydeConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("FormaldehydeConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local FormaldehydeConcentrationMeasurementServerAttributes = {}
+
+function FormaldehydeConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(FormaldehydeConcentrationMeasurementServerAttributes, attr_mt)
+
+return FormaldehydeConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local NitrogenDioxideConcentrationMeasurementServerAttributes = require "NitrogenDioxideConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local NitrogenDioxideConcentrationMeasurement = {}
+
+NitrogenDioxideConcentrationMeasurement.ID = 0x0413
+NitrogenDioxideConcentrationMeasurement.NAME = "NitrogenDioxideConcentrationMeasurement"
+NitrogenDioxideConcentrationMeasurement.server = {}
+NitrogenDioxideConcentrationMeasurement.client = {}
+NitrogenDioxideConcentrationMeasurement.server.attributes = NitrogenDioxideConcentrationMeasurementServerAttributes:set_parent_cluster(NitrogenDioxideConcentrationMeasurement)
+NitrogenDioxideConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function NitrogenDioxideConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function NitrogenDioxideConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+NitrogenDioxideConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+NitrogenDioxideConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function NitrogenDioxideConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = NitrogenDioxideConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, NitrogenDioxideConcentrationMeasurement.NAME))
+  end
+  return NitrogenDioxideConcentrationMeasurement[direction].attributes[key]
+end
+NitrogenDioxideConcentrationMeasurement.attributes = {}
+setmetatable(NitrogenDioxideConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(NitrogenDioxideConcentrationMeasurement, {__index = cluster_base})
+
+return NitrogenDioxideConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/NitrogenDioxideConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("NitrogenDioxideConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local NitrogenDioxideConcentrationMeasurementServerAttributes = {}
+
+function NitrogenDioxideConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(NitrogenDioxideConcentrationMeasurementServerAttributes, attr_mt)
+
+return NitrogenDioxideConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local OzoneConcentrationMeasurementServerAttributes = require "OzoneConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local OzoneConcentrationMeasurement = {}
+
+OzoneConcentrationMeasurement.ID = 0x0415
+OzoneConcentrationMeasurement.NAME = "OzoneConcentrationMeasurement"
+OzoneConcentrationMeasurement.server = {}
+OzoneConcentrationMeasurement.client = {}
+OzoneConcentrationMeasurement.server.attributes = OzoneConcentrationMeasurementServerAttributes:set_parent_cluster(OzoneConcentrationMeasurement)
+OzoneConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function OzoneConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function OzoneConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+OzoneConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+OzoneConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function OzoneConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = OzoneConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, OzoneConcentrationMeasurement.NAME))
+  end
+  return OzoneConcentrationMeasurement[direction].attributes[key]
+end
+OzoneConcentrationMeasurement.attributes = {}
+setmetatable(OzoneConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(OzoneConcentrationMeasurement, {__index = cluster_base})
+
+return OzoneConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/OzoneConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("OzoneConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local OzoneConcentrationMeasurementServerAttributes = {}
+
+function OzoneConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(OzoneConcentrationMeasurementServerAttributes, attr_mt)
+
+return OzoneConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local Pm10ConcentrationMeasurementServerAttributes = require "Pm10ConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local Pm10ConcentrationMeasurement = {}
+
+Pm10ConcentrationMeasurement.ID = 0x042D
+Pm10ConcentrationMeasurement.NAME = "Pm10ConcentrationMeasurement"
+Pm10ConcentrationMeasurement.server = {}
+Pm10ConcentrationMeasurement.client = {}
+Pm10ConcentrationMeasurement.server.attributes = Pm10ConcentrationMeasurementServerAttributes:set_parent_cluster(Pm10ConcentrationMeasurement)
+Pm10ConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function Pm10ConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function Pm10ConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+Pm10ConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+Pm10ConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function Pm10ConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = Pm10ConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, Pm10ConcentrationMeasurement.NAME))
+  end
+  return Pm10ConcentrationMeasurement[direction].attributes[key]
+end
+Pm10ConcentrationMeasurement.attributes = {}
+setmetatable(Pm10ConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(Pm10ConcentrationMeasurement, {__index = cluster_base})
+
+return Pm10ConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm10ConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("Pm10ConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local Pm10ConcentrationMeasurementServerAttributes = {}
+
+function Pm10ConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(Pm10ConcentrationMeasurementServerAttributes, attr_mt)
+
+return Pm10ConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local Pm1ConcentrationMeasurementServerAttributes = require "Pm1ConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local Pm1ConcentrationMeasurement = {}
+
+Pm1ConcentrationMeasurement.ID = 0x042C
+Pm1ConcentrationMeasurement.NAME = "Pm1ConcentrationMeasurement"
+Pm1ConcentrationMeasurement.server = {}
+Pm1ConcentrationMeasurement.client = {}
+Pm1ConcentrationMeasurement.server.attributes = Pm1ConcentrationMeasurementServerAttributes:set_parent_cluster(Pm1ConcentrationMeasurement)
+Pm1ConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function Pm1ConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function Pm1ConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+Pm1ConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+Pm1ConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function Pm1ConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = Pm1ConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, Pm1ConcentrationMeasurement.NAME))
+  end
+  return Pm1ConcentrationMeasurement[direction].attributes[key]
+end
+Pm1ConcentrationMeasurement.attributes = {}
+setmetatable(Pm1ConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(Pm1ConcentrationMeasurement, {__index = cluster_base})
+
+return Pm1ConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm1ConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("Pm1ConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local Pm1ConcentrationMeasurementServerAttributes = {}
+
+function Pm1ConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(Pm1ConcentrationMeasurementServerAttributes, attr_mt)
+
+return Pm1ConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local Pm25ConcentrationMeasurementServerAttributes = require "Pm25ConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local Pm25ConcentrationMeasurement = {}
+
+Pm25ConcentrationMeasurement.ID = 0x042A
+Pm25ConcentrationMeasurement.NAME = "Pm25ConcentrationMeasurement"
+Pm25ConcentrationMeasurement.server = {}
+Pm25ConcentrationMeasurement.client = {}
+Pm25ConcentrationMeasurement.server.attributes = Pm25ConcentrationMeasurementServerAttributes:set_parent_cluster(Pm25ConcentrationMeasurement)
+Pm25ConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function Pm25ConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function Pm25ConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+Pm25ConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+Pm25ConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function Pm25ConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = Pm25ConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, Pm25ConcentrationMeasurement.NAME))
+  end
+  return Pm25ConcentrationMeasurement[direction].attributes[key]
+end
+Pm25ConcentrationMeasurement.attributes = {}
+setmetatable(Pm25ConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(Pm25ConcentrationMeasurement, {__index = cluster_base})
+
+return Pm25ConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/Pm25ConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("Pm25ConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local Pm25ConcentrationMeasurementServerAttributes = {}
+
+function Pm25ConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(Pm25ConcentrationMeasurementServerAttributes, attr_mt)
+
+return Pm25ConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local RadonConcentrationMeasurementServerAttributes = require "RadonConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local RadonConcentrationMeasurement = {}
+
+RadonConcentrationMeasurement.ID = 0x042F
+RadonConcentrationMeasurement.NAME = "RadonConcentrationMeasurement"
+RadonConcentrationMeasurement.server = {}
+RadonConcentrationMeasurement.client = {}
+RadonConcentrationMeasurement.server.attributes = RadonConcentrationMeasurementServerAttributes:set_parent_cluster(RadonConcentrationMeasurement)
+RadonConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function RadonConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function RadonConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+RadonConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+RadonConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function RadonConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = RadonConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, RadonConcentrationMeasurement.NAME))
+  end
+  return RadonConcentrationMeasurement[direction].attributes[key]
+end
+RadonConcentrationMeasurement.attributes = {}
+setmetatable(RadonConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(RadonConcentrationMeasurement, {__index = cluster_base})
+
+return RadonConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/RadonConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("RadonConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local RadonConcentrationMeasurementServerAttributes = {}
+
+function RadonConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(RadonConcentrationMeasurementServerAttributes, attr_mt)
+
+return RadonConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/init.lua
@@ -1,0 +1,44 @@
+local cluster_base = require "st.matter.cluster_base"
+local TotalVolatileOrganicCompoundsConcentrationMeasurementServerAttributes = require "TotalVolatileOrganicCompoundsConcentrationMeasurement.server.attributes"
+local ConcentrationMeasurement = require "ConcentrationMeasurement"
+
+local TotalVolatileOrganicCompoundsConcentrationMeasurement = {}
+
+TotalVolatileOrganicCompoundsConcentrationMeasurement.ID = 0x042E
+TotalVolatileOrganicCompoundsConcentrationMeasurement.NAME = "TotalVolatileOrganicCompoundsConcentrationMeasurement"
+TotalVolatileOrganicCompoundsConcentrationMeasurement.server = {}
+TotalVolatileOrganicCompoundsConcentrationMeasurement.client = {}
+TotalVolatileOrganicCompoundsConcentrationMeasurement.server.attributes = TotalVolatileOrganicCompoundsConcentrationMeasurementServerAttributes:set_parent_cluster(TotalVolatileOrganicCompoundsConcentrationMeasurement)
+TotalVolatileOrganicCompoundsConcentrationMeasurement.types = ConcentrationMeasurement.types
+
+function TotalVolatileOrganicCompoundsConcentrationMeasurement:get_attribute_by_id(attr_id)
+  return ConcentrationMeasurement:get_attribute_by_id(attr_id)
+end
+
+function TotalVolatileOrganicCompoundsConcentrationMeasurement:get_server_command_by_id(command_id)
+  return ConcentrationMeasurement:get_server_command_by_id(command_id)
+end
+
+TotalVolatileOrganicCompoundsConcentrationMeasurement.attribute_direction_map = ConcentrationMeasurement.attribute_direction_map
+
+TotalVolatileOrganicCompoundsConcentrationMeasurement.FeatureMap = ConcentrationMeasurement.types.Feature
+
+function TotalVolatileOrganicCompoundsConcentrationMeasurement.are_features_supported(feature, feature_map)
+  return ConcentrationMeasurement.are_features_supported(feature, feature_map)
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = TotalVolatileOrganicCompoundsConcentrationMeasurement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, TotalVolatileOrganicCompoundsConcentrationMeasurement.NAME))
+  end
+  return TotalVolatileOrganicCompoundsConcentrationMeasurement[direction].attributes[key]
+end
+TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes = {}
+setmetatable(TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes, attribute_helper_mt)
+
+setmetatable(TotalVolatileOrganicCompoundsConcentrationMeasurement, {__index = cluster_base})
+
+return TotalVolatileOrganicCompoundsConcentrationMeasurement
+

--- a/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/LevelValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/LevelValue.lua
@@ -1,0 +1,41 @@
+local ConcentrationMeasurementServerAttributesLevelValue = require "ConcentrationMeasurement.server.attributes.LevelValue"
+
+local LevelValue = {
+  ID = 0x000A,
+  NAME = "LevelValue",
+  base_type = require "ConcentrationMeasurement.types.LevelValueEnum",
+}
+
+function LevelValue:new_value(...)
+  ConcentrationMeasurementServerAttributesLevelValue:new_value(...)
+end
+
+function LevelValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesLevelValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function LevelValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function LevelValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesLevelValue:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function LevelValue:deserialize(tlv_buf)
+  return ConcentrationMeasurementServerAttributesLevelValue:deserialize(tlv_buf)
+end
+
+setmetatable(LevelValue, {__call = LevelValue.new_value, __index = LevelValue.base_type})
+return LevelValue
+

--- a/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/MeasuredValue.lua
+++ b/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/MeasuredValue.lua
@@ -1,0 +1,56 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasuredValue = require "ConcentrationMeasurement.server.attributes.MeasuredValue"
+
+
+local MeasuredValue = {
+  ID = 0x0000,
+  NAME = "MeasuredValue",
+  base_type = require "st.matter.data_types.SinglePrecisionFloat",
+}
+
+function MeasuredValue:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:new_value(...)
+end
+
+function MeasuredValue:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasuredValue:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasuredValue:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasuredValue:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function MeasuredValue:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(MeasuredValue, {__call = MeasuredValue.new_value, __index = MeasuredValue.base_type})
+return MeasuredValue
+

--- a/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/MeasurementUnit.lua
+++ b/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/MeasurementUnit.lua
@@ -1,0 +1,45 @@
+local TLVParser = require "st.matter.TLV.TLVParser"
+local ConcentrationMeasurementServerAttributesMeasurementUnit = require "ConcentrationMeasurement.server.attributes.MeasurementUnit"
+
+
+local MeasurementUnit = {
+  ID = 0x0008,
+  NAME = "MeasurementUnit",
+  base_type = require "ConcentrationMeasurement.types.MeasurementUnitEnum",
+}
+
+function MeasurementUnit:new_value(...)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:new_value(...)
+end
+
+function MeasurementUnit:read(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:read(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:subscribe(device, endpoint_id)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:subscribe(device, endpoint_id, self._cluster.ID)
+end
+
+function MeasurementUnit:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function MeasurementUnit:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  return ConcentrationMeasurementServerAttributesMeasurementUnit:build_test_report_data(device, endpoint_id, value, status, self._cluster.ID)
+end
+
+function MeasurementUnit:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+  self:augment_type(data)
+  return data
+end
+
+setmetatable(MeasurementUnit, {__call = MeasurementUnit.new_value, __index = MeasurementUnit.base_type})
+return MeasurementUnit
+

--- a/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/TotalVolatileOrganicCompoundsConcentrationMeasurement/server/attributes/init.lua
@@ -1,0 +1,24 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("TotalVolatileOrganicCompoundsConcentrationMeasurement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local TotalVolatileOrganicCompoundsConcentrationMeasurementServerAttributes = {}
+
+function TotalVolatileOrganicCompoundsConcentrationMeasurementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(TotalVolatileOrganicCompoundsConcentrationMeasurementServerAttributes, attr_mt)
+
+return TotalVolatileOrganicCompoundsConcentrationMeasurementServerAttributes
+

--- a/drivers/SmartThings/matter-thermostat/src/embedded-cluster-utils.lua
+++ b/drivers/SmartThings/matter-thermostat/src/embedded-cluster-utils.lua
@@ -6,13 +6,35 @@ local version = require "version"
 if version.api < 10 then
   clusters.HepaFilterMonitoring = require "HepaFilterMonitoring"
   clusters.ActivatedCarbonFilterMonitoring = require "ActivatedCarbonFilterMonitoring"
+  clusters.AirQuality = require "AirQuality"
+  clusters.CarbonMonoxideConcentrationMeasurement = require "CarbonMonoxideConcentrationMeasurement"
+  clusters.CarbonDioxideConcentrationMeasurement = require "CarbonDioxideConcentrationMeasurement"
+  clusters.FormaldehydeConcentrationMeasurement = require "FormaldehydeConcentrationMeasurement"
+  clusters.NitrogenDioxideConcentrationMeasurement = require "NitrogenDioxideConcentrationMeasurement"
+  clusters.OzoneConcentrationMeasurement = require "OzoneConcentrationMeasurement"
+  clusters.Pm1ConcentrationMeasurement = require "Pm1ConcentrationMeasurement"
+  clusters.Pm10ConcentrationMeasurement = require "Pm10ConcentrationMeasurement"
+  clusters.Pm25ConcentrationMeasurement = require "Pm25ConcentrationMeasurement"
+  clusters.RadonConcentrationMeasurement = require "RadonConcentrationMeasurement"
+  clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement = require "TotalVolatileOrganicCompoundsConcentrationMeasurement"
 end
 
 local embedded_cluster_utils = {}
 
 local embedded_clusters = {
   [clusters.HepaFilterMonitoring.ID] = clusters.HepaFilterMonitoring,
-  [clusters.ActivatedCarbonFilterMonitoring.ID] = clusters.ActivatedCarbonFilterMonitoring
+  [clusters.ActivatedCarbonFilterMonitoring.ID] = clusters.ActivatedCarbonFilterMonitoring,
+  [clusters.AirQuality.ID] = clusters.AirQuality,
+  [clusters.CarbonMonoxideConcentrationMeasurement.ID] = clusters.CarbonMonoxideConcentrationMeasurement,
+  [clusters.CarbonDioxideConcentrationMeasurement.ID] = clusters.CarbonDioxideConcentrationMeasurement,
+  [clusters.FormaldehydeConcentrationMeasurement.ID] = clusters.FormaldehydeConcentrationMeasurement,
+  [clusters.NitrogenDioxideConcentrationMeasurement.ID] = clusters.NitrogenDioxideConcentrationMeasurement,
+  [clusters.OzoneConcentrationMeasurement.ID] = clusters.OzoneConcentrationMeasurement,
+  [clusters.Pm1ConcentrationMeasurement.ID] = clusters.Pm1ConcentrationMeasurement,
+  [clusters.Pm10ConcentrationMeasurement.ID] = clusters.Pm10ConcentrationMeasurement,
+  [clusters.Pm25ConcentrationMeasurement.ID] = clusters.Pm25ConcentrationMeasurement,
+  [clusters.RadonConcentrationMeasurement.ID] = clusters.RadonConcentrationMeasurement,
+  [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID] = clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement,
 }
 
 function embedded_cluster_utils.get_endpoints(device, cluster_id, opts)

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -26,6 +26,17 @@ local version = require "version"
 if version.api < 10 then
   clusters.HepaFilterMonitoring = require "HepaFilterMonitoring"
   clusters.ActivatedCarbonFilterMonitoring = require "ActivatedCarbonFilterMonitoring"
+  clusters.AirQuality = require "AirQuality"
+  clusters.CarbonMonoxideConcentrationMeasurement = require "CarbonMonoxideConcentrationMeasurement"
+  clusters.CarbonDioxideConcentrationMeasurement = require "CarbonDioxideConcentrationMeasurement"
+  clusters.FormaldehydeConcentrationMeasurement = require "FormaldehydeConcentrationMeasurement"
+  clusters.NitrogenDioxideConcentrationMeasurement = require "NitrogenDioxideConcentrationMeasurement"
+  clusters.OzoneConcentrationMeasurement = require "OzoneConcentrationMeasurement"
+  clusters.Pm1ConcentrationMeasurement = require "Pm1ConcentrationMeasurement"
+  clusters.Pm10ConcentrationMeasurement = require "Pm10ConcentrationMeasurement"
+  clusters.Pm25ConcentrationMeasurement = require "Pm25ConcentrationMeasurement"
+  clusters.RadonConcentrationMeasurement = require "RadonConcentrationMeasurement"
+  clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement = require "TotalVolatileOrganicCompoundsConcentrationMeasurement"
   -- new modes add in Matter 1.2
   clusters.Thermostat.types.ThermostatSystemMode.DRY = 0x8
   clusters.Thermostat.types.ThermostatSystemMode.SLEEP = 0x9
@@ -61,6 +72,8 @@ local WIND_MODE_MAP = {
 local RAC_DEVICE_TYPE_ID = 0x0072
 local AP_DEVICE_TYPE_ID = 0x002D
 local FAN_DEVICE_TYPE_ID = 0x002B
+
+local MGM3_PPM_CONVERSION_FACTOR = 24.45
 
 local setpoint_limit_device_field = {
   MIN_SETPOINT_DEADBAND_CHECKED = "MIN_SETPOINT_DEADBAND_CHECKED",
@@ -131,6 +144,77 @@ local subscribed_attributes = {
   [capabilities.filterStatus.ID] = {
     clusters.HepaFilterMonitoring.attributes.ChangeIndication,
     clusters.ActivatedCarbonFilterMonitoring.attributes.ChangeIndication
+  },
+  [capabilities.airQualityHealthConcern.ID] = {
+    clusters.AirQuality.attributes.AirQuality
+  },
+  [capabilities.carbonMonoxideMeasurement.ID] = {
+    clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.carbonMonoxideHealthConcern.ID] = {
+    clusters.CarbonMonoxideConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.carbonDioxideMeasurement.ID] = {
+    clusters.CarbonDioxideConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.CarbonDioxideConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.carbonDioxideHealthConcern.ID] = {
+    clusters.CarbonDioxideConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.nitrogenDioxideMeasurement.ID] = {
+    clusters.NitrogenDioxideConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.NitrogenDioxideConcentrationMeasurement.attributes.MeasurementUnit
+  },
+  [capabilities.nitrogenDioxideHealthConcern.ID] = {
+    clusters.NitrogenDioxideConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.ozoneMeasurement.ID] = {
+    clusters.OzoneConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.OzoneConcentrationMeasurement.attributes.MeasurementUnit
+  },
+  [capabilities.ozoneHealthConcern.ID] = {
+    clusters.OzoneConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.formaldehydeMeasurement.ID] = {
+    clusters.FormaldehydeConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.FormaldehydeConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.formaldehydeHealthConcern.ID] = {
+    clusters.FormaldehydeConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.veryFineDustSensor.ID] = {
+    clusters.Pm1ConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.Pm1ConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.veryFineDustHealthConcern.ID] = {
+    clusters.Pm1ConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.fineDustHealthConcern.ID] = {
+    clusters.Pm25ConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.dustSensor.ID] = {
+    clusters.Pm25ConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.Pm25ConcentrationMeasurement.attributes.MeasurementUnit,
+    clusters.Pm10ConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.Pm10ConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.dustHealthConcern.ID] = {
+    clusters.Pm10ConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.radonMeasurement.ID] = {
+    clusters.RadonConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.RadonConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.radonHealthConcern.ID] = {
+    clusters.RadonConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.tvocMeasurement.ID] = {
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.tvocHealthConcern.ID] = {
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.LevelValue
   }
 }
 
@@ -212,6 +296,50 @@ local function get_device_type(driver, device)
   return false
 end
 
+local AIR_QUALITY_MAP = {
+  {capabilities.carbonDioxideMeasurement.ID,     "-co2",   clusters.CarbonDioxideConcentrationMeasurement},
+  {capabilities.carbonDioxideHealthConcern.ID,   "-co2",   clusters.CarbonDioxideConcentrationMeasurement},
+  {capabilities.carbonMonoxideMeasurement.ID,    "-co",    clusters.CarbonMonoxideConcentrationMeasurement},
+  {capabilities.carbonMonoxideHealthConcern.ID,  "-co",    clusters.CarbonMonoxideConcentrationMeasurement},
+  {capabilities.dustSensor.ID,                   "-pm10",  clusters.Pm10ConcentrationMeasurement},
+  {capabilities.dustHealthConcern.ID,            "-pm10",  clusters.Pm10ConcentrationMeasurement},
+  {capabilities.fineDustSensor.ID,               "-pm25",  clusters.Pm25ConcentrationMeasurement},
+  {capabilities.fineDustHealthConcern.ID,        "-pm25",  clusters.Pm25ConcentrationMeasurement},
+  {capabilities.formaldehydeMeasurement.ID,      "-ch2o",  clusters.FormaldehydeConcentrationMeasurement},
+  {capabilities.formaldehydeHealthConcern.ID,    "-ch2o",  clusters.FormaldehydeConcentrationMeasurement},
+  {capabilities.nitrogenDioxideHealthConcern.ID, "-no2",   clusters.NitrogenDioxideConcentrationMeasurement},
+  {capabilities.nitrogenDioxideMeasurement.ID,   "-no2",   clusters.NitrogenDioxideConcentrationMeasurement},
+  {capabilities.ozoneHealthConcern.ID,           "-ozone", clusters.OzoneConcentrationMeasurement},
+  {capabilities.ozoneMeasurement.ID,             "-ozone", clusters.OzoneConcentrationMeasurement},
+  {capabilities.radonHealthConcern.ID,           "-radon", clusters.RadonConcentrationMeasurement},
+  {capabilities.radonMeasurement.ID,             "-radon", clusters.RadonConcentrationMeasurement},
+  {capabilities.tvocHealthConcern.ID,            "-tvoc",  clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement},
+  {capabilities.tvocMeasurement.ID,              "-tvoc",  clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement},
+  {capabilities.veryFineDustHealthConcern.ID,    "-pm1",   clusters.Pm1ConcentrationMeasurement},
+  {capabilities.veryFineDustSensor.ID,           "-pm1",   clusters.Pm1ConcentrationMeasurement},
+}
+
+local function create_level_measurement_profile(device)
+  local meas_name, level_name = "", ""
+  for _, details in ipairs(AIR_QUALITY_MAP) do
+    local cap_id  = details[1]
+    local cluster = details[3]
+    -- capability describes either a HealthConcern or Measurement/Sensor
+    if (cap_id:match("HealthConcern$")) then
+      local attr_eps = embedded_cluster_utils.get_endpoints(device, cluster.ID, { feature_bitmap = cluster.types.Feature.LEVEL_INDICATION })
+      if #attr_eps > 0 then
+        level_name = level_name .. details[2]
+      end
+    elseif (cap_id:match("Measurement$") or cap_id:match("Sensor$")) then
+      local attr_eps = embedded_cluster_utils.get_endpoints(device, cluster.ID, { feature_bitmap = cluster.types.Feature.NUMERIC_MEASUREMENT })
+      if #attr_eps > 0 then
+        meas_name = meas_name .. details[2]
+      end
+    end
+  end
+  return meas_name, level_name
+end
+
 local function do_configure(driver, device)
   local heat_eps = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.HEATING})
   local cool_eps = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.COOLING})
@@ -223,15 +351,14 @@ local function do_configure(driver, device)
   -- use get_endpoints for embedded clusters
   local hepa_filter_eps = embedded_cluster_utils.get_endpoints(device, clusters.HepaFilterMonitoring.ID)
   local ac_filter_eps = embedded_cluster_utils.get_endpoints(device, clusters.ActivatedCarbonFilterMonitoring.ID)
+  local aqs_eps = embedded_cluster_utils.get_endpoints(device, clusters.AirQuality.ID)
   local device_type = get_device_type(driver, device)
   local profile_name = "thermostat"
-  --Note: we have not encountered thermostats with multiple endpoints that support the Thermostat cluster
   if device_type == RAC_DEVICE_TYPE_ID then
     device.log.warn_with({hub_logs=true}, "Room Air Conditioner supports only one profile")
   elseif device_type == FAN_DEVICE_TYPE_ID then
     device.log.warn_with({hub_logs=true}, "Fan supports only one profile")
   elseif device_type == AP_DEVICE_TYPE_ID then
-    -- currently no profile switching for Air Purifier
     profile_name = "air-purifier"
     if #hepa_filter_eps > 0 and #ac_filter_eps > 0 then
       profile_name = profile_name .. "-hepa" .. "-ac"
@@ -243,6 +370,50 @@ local function do_configure(driver, device)
     if #wind_eps > 0 then
       profile_name = profile_name .. "-wind"
     end
+
+    if #thermo_eps > 0 then
+      profile_name = profile_name .. "-thermostat"
+      if #humidity_eps > 0 and #fan_eps > 0 then
+        profile_name = profile_name .. "-humidity" .. "-fan"
+      elseif #humidity_eps > 0 then
+        profile_name = profile_name .. "-humidity"
+      elseif #fan_eps > 0 then
+        profile_name = profile_name .. "-fan"
+      end
+
+      if #heat_eps == 0 and #cool_eps == 0 then
+        device.log.warn_with({hub_logs=true}, "Thermostat does not support heating or cooling. No matching profile")
+        return
+      elseif #heat_eps > 0 and #cool_eps == 0 then
+        profile_name = profile_name .. "-heating-only"
+      elseif #cool_eps > 0 and #heat_eps == 0 then
+        profile_name = profile_name .. "-cooling-only"
+      end
+
+      -- TODO remove this in favor of reading Thermostat clusters AttributeList attribute
+      -- to determine support for ThermostatRunningState
+      -- Add nobattery profiles if updated
+      profile_name = profile_name .. "-nostate"
+
+      if #battery_eps == 0 then
+        profile_name = profile_name .. "-nobattery"
+      end
+    end
+
+    if #aqs_eps > 0 then
+      profile_name = profile_name .. "-aqs"
+    end
+
+    local meas_name, level_name = create_level_measurement_profile(device)
+
+    if meas_name ~= "" then
+      profile_name = profile_name .. meas_name .. "-meas"
+    end
+
+    if level_name ~= "" then
+      profile_name = profile_name .. level_name .. "-level"
+    end
+
     device.log.info_with({hub_logs=true}, string.format("Updating device profile to %s.", profile_name))
     device:try_update_metadata({profile = profile_name})
   elseif #thermo_eps == 1 then
@@ -283,11 +454,169 @@ local function do_configure(driver, device)
   end
 end
 
-
 local function device_added(driver, device)
   device:send(clusters.Thermostat.attributes.ControlSequenceOfOperation:read(device))
   device:send(clusters.FanControl.attributes.FanModeSequence:read(device))
   device:send(clusters.FanControl.attributes.WindSupport:read(device))
+end
+
+local function store_unit_factory(capability_name)
+  return function(driver, device, ib, response)
+    device:set_field(capability_name.."_unit", ib.data.value, {persist = true})
+  end
+end
+
+local units = {
+  PPM = 0,
+  PPB = 1,
+  PPT = 2,
+  MGM3 = 3,
+  UGM3 = 4,
+  NGM3 = 5,
+  PM3 = 6,
+  BQM3 = 7,
+  PCIL = 0xFF -- not in matter spec
+}
+
+local unit_strings = {
+  [units.PPM] = "ppm",
+  [units.PPB] = "ppb",
+  [units.PPT] = "ppt",
+  [units.MGM3] = "mg/m^3",
+  [units.NGM3] = "ng/m^3",
+  [units.UGM3] = "μg/m^3",
+  [units.BQM3] = "Bq/m^3",
+  [units.PCIL] = "pCi/L"
+}
+
+local unit_default = {
+  [capabilities.carbonMonoxideMeasurement.NAME] = units.PPM,
+  [capabilities.carbonDioxideMeasurement.NAME] = units.PPM,
+  [capabilities.nitrogenDioxideMeasurement.NAME] = units.PPM,
+  [capabilities.ozoneMeasurement.NAME] = units.PPM,
+  [capabilities.formaldehydeMeasurement.NAME] = units.PPM,
+  [capabilities.veryFineDustSensor.NAME] = units.UGM3,
+  [capabilities.fineDustSensor.NAME] = units.UGM3,
+  [capabilities.dustSensor.NAME] = units.UGM3,
+  [capabilities.radonMeasurement.NAME] = units.BQM3,
+  [capabilities.tvocMeasurement.NAME] = units.PPM
+}
+
+-- All ConcentrationMesurement clusters inherit from the same base cluster definitions,
+-- so CarbonMonoxideConcentratinMeasurement is used below but the same enum types exist
+-- in all ConcentrationMeasurement clusters
+local level_strings = {
+  [clusters.CarbonMonoxideConcentrationMeasurement.types.LevelValueEnum.UNKNOWN] = "unknown",
+  [clusters.CarbonMonoxideConcentrationMeasurement.types.LevelValueEnum.LOW] = "good",
+  [clusters.CarbonMonoxideConcentrationMeasurement.types.LevelValueEnum.MEDIUM] = "moderate",
+  [clusters.CarbonMonoxideConcentrationMeasurement.types.LevelValueEnum.HIGH] = "unhealthy",
+  [clusters.CarbonMonoxideConcentrationMeasurement.types.LevelValueEnum.CRITICAL] = "hazardous",
+}
+
+-- measured in g/mol
+local molecular_weights = {
+  [capabilities.carbonDioxideMeasurement.NAME] = 44.010,
+  [capabilities.nitrogenDioxideMeasurement.NAME] = 28.014,
+  [capabilities.ozoneMeasurement.NAME] = 48.0,
+  [capabilities.formaldehydeMeasurement.NAME] = 30.031,
+  [capabilities.veryFineDustSensor.NAME] = "N/A",
+  [capabilities.fineDustSensor.NAME] = "N/A",
+  [capabilities.dustSensor.NAME] = "N/A",
+  [capabilities.radonMeasurement.NAME] = 222.018,
+  [capabilities.tvocMeasurement.NAME] = "N/A",
+}
+
+local conversion_tables = {
+  [units.PPM] = {
+    [units.PPM] = function(value) return utils.round(value) end,
+    [units.UGM3] = function(value, molecular_weight) return utils.round((value * molecular_weight * 10^3) / MGM3_PPM_CONVERSION_FACTOR) end,
+    [units.MGM3] = function(value, molecular_weight) return utils.round((value * molecular_weight) / MGM3_PPM_CONVERSION_FACTOR) end,
+  },
+  [units.PPB] = {
+    [units.PPM] = function(value) return utils.round(value/(10^3)) end
+  },
+  [units.PPT] = {
+    [units.PPM] = function(value) return utils.round(value/(10^6)) end
+  },
+  [units.MGM3] = {
+    [units.UGM3] = function(value) return utils.round(value * (10^3)) end,
+    [units.PPM] = function(value, molecular_weight) return utils.round((value * MGM3_PPM_CONVERSION_FACTOR) / molecular_weight) end,
+  },
+  [units.UGM3] = {
+    [units.UGM3] = function(value) return utils.round(value) end,
+    [units.PPM] = function(value, molecular_weight) return utils.round((value * MGM3_PPM_CONVERSION_FACTOR) / (molecular_weight * 10^3)) end,
+  },
+  [units.NGM3] = {
+    [units.UGM3] = function(value) return utils.round(value/(10^3)) end
+  },
+  [units.BQM3] = {
+    [units.PCIL] = function(value) return utils.round(value/37) end
+  },
+}
+
+local function unit_conversion(value, from_unit, to_unit, capability_name)
+  local conversion_function = conversion_tables[from_unit][to_unit]
+  if not conversion_function then
+    log.info_with( {hub_logs = true} , string.format("Unsupported unit conversion from %s to %s", unit_strings[from_unit], unit_strings[to_unit]))
+    return
+  end
+
+  if not value then
+    log.info_with( {hub_logs = true} , "unit conversion value is nil")
+    return
+  end
+
+  return conversion_function(value, molecular_weights[capability_name])
+end
+
+local function measurementHandlerFactory(capability_name, attribute, target_unit)
+  return function(driver, device, ib, response)
+    local reporting_unit = device:get_field(capability_name.."_unit")
+
+    if not reporting_unit then
+      reporting_unit = unit_default[capability_name]
+      device:set_field(capability_name.."_unit", reporting_unit, {persist = true})
+    end
+
+    local value = nil
+    if reporting_unit then
+      value = unit_conversion(ib.data.value, reporting_unit, target_unit, capability_name)
+    end
+
+    if value then
+      device:emit_event_for_endpoint(ib.endpoint_id, attribute({value = value, unit = unit_strings[target_unit]}))
+      -- handle case where device profile supports both fineDustLevel and dustLevel
+      if capability_name == capabilities.fineDustSensor.NAME and device:supports_capability(capabilities.dustSensor) then
+        device:emit_event_for_endpoint(ib.endpoint_id, capabilities.dustSensor.fineDustLevel({value = value, unit = unit_strings[target_unit]}))
+      end
+    end
+  end
+end
+
+local function levelHandlerFactory(attribute)
+  return function(driver, device, ib, response)
+    device:emit_event_for_endpoint(ib.endpoint_id, attribute(level_strings[ib.data.value]))
+  end
+end
+
+-- handlers
+local function air_quality_attr_handler(driver, device, ib, response)
+  local state = ib.data.value
+  if state == 0 then -- Unknown
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.unknown())
+  elseif state == 1 then -- Good
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.good())
+  elseif state == 2 then -- Fair
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.moderate())
+  elseif state == 3 then -- Moderate
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.slightlyUnhealthy())
+  elseif state == 4 then -- Poor
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.unhealthy())
+  elseif state == 5 then -- VeryPoor
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.veryUnhealthy())
+  elseif state == 6 then -- ExtremelyPoor
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.airQualityHealthConcern.airQualityHealthConcern.hazardous())
+  end
 end
 
 local function on_off_attr_handler(driver, device, ib, response)
@@ -897,6 +1226,59 @@ local matter_driver_template = {
       [clusters.ActivatedCarbonFilterMonitoring.ID] = {
         [clusters.ActivatedCarbonFilterMonitoring.attributes.Condition.ID] = activated_carbon_filter_condition_handler,
         [clusters.ActivatedCarbonFilterMonitoring.attributes.ChangeIndication.ID] = activated_carbon_filter_change_indication_handler
+      },
+      [clusters.AirQuality.ID] = {
+        [clusters.AirQuality.attributes.AirQuality.ID] = air_quality_attr_handler,
+      },
+      [clusters.CarbonMonoxideConcentrationMeasurement.ID] = {
+        [clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.carbonMonoxideMeasurement.NAME, capabilities.carbonMonoxideMeasurement.carbonMonoxideLevel, units.PPM),
+        [clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.carbonMonoxideMeasurement.NAME),
+        [clusters.CarbonMonoxideConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.carbonMonoxideHealthConcern.carbonMonoxideHealthConcern),
+      },
+      [clusters.CarbonDioxideConcentrationMeasurement.ID] = {
+        [clusters.CarbonDioxideConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.carbonDioxideMeasurement.NAME, capabilities.carbonDioxideMeasurement.carbonDioxide, units.PPM),
+        [clusters.CarbonDioxideConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.carbonDioxideMeasurement.NAME),
+        [clusters.CarbonDioxideConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.carbonDioxideHealthConcern.carbonDioxideHealthConcern),
+      },
+      [clusters.NitrogenDioxideConcentrationMeasurement.ID] = {
+        [clusters.NitrogenDioxideConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.nitrogenDioxideMeasurement.NAME, capabilities.nitrogenDioxideMeasurement.nitrogenDioxide, units.PPM),
+        [clusters.NitrogenDioxideConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.nitrogenDioxideMeasurement.NAME),
+        [clusters.NitrogenDioxideConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.nitrogenDioxideHealthConcern.nitrogenDioxideHealthConcern)
+      },
+      [clusters.OzoneConcentrationMeasurement.ID] = {
+        [clusters.OzoneConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.ozoneMeasurement.NAME, capabilities.ozoneMeasurement.ozone, units.PPM),
+        [clusters.OzoneConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.ozoneMeasurement.NAME),
+        [clusters.OzoneConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.ozoneHealthConcern.ozoneHealthConcern)
+      },
+      [clusters.FormaldehydeConcentrationMeasurement.ID] = {
+        [clusters.FormaldehydeConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.formaldehydeMeasurement.NAME, capabilities.formaldehydeMeasurement.formaldehydeLevel, units.PPM),
+        [clusters.FormaldehydeConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.formaldehydeMeasurement.NAME),
+        [clusters.FormaldehydeConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.formaldehydeHealthConcern.formaldehydeHealthConcern),
+      },
+      [clusters.Pm1ConcentrationMeasurement.ID] = {
+        [clusters.Pm1ConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.veryFineDustSensor.NAME, capabilities.veryFineDustSensor.veryFineDustLevel, units.UGM3),
+        [clusters.Pm1ConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.veryFineDustSensor.NAME),
+        [clusters.Pm1ConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.veryFineDustHealthConcern.veryFineDustHealthConcern),
+      },
+      [clusters.Pm25ConcentrationMeasurement.ID] = {
+        [clusters.Pm25ConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.fineDustSensor.NAME, capabilities.fineDustSensor.fineDustLevel, units.UGM3),
+        [clusters.Pm25ConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.fineDustSensor.NAME),
+        [clusters.Pm25ConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.fineDustHealthConcern.fineDustHealthConcern),
+      },
+      [clusters.Pm10ConcentrationMeasurement.ID] = {
+        [clusters.Pm10ConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.dustSensor.NAME, capabilities.dustSensor.dustLevel, units.UGM3),
+        [clusters.Pm10ConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.dustSensor.NAME),
+        [clusters.Pm10ConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.dustHealthConcern.dustHealthConcern),
+      },
+      [clusters.RadonConcentrationMeasurement.ID] = {
+        [clusters.RadonConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.radonMeasurement.NAME, capabilities.radonMeasurement.radonLevel, units.PCIL),
+        [clusters.RadonConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.radonMeasurement.NAME),
+        [clusters.RadonConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.radonHealthConcern.radonHealthConcern)
+      },
+      [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID] = {
+        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.tvocMeasurement.NAME, capabilities.tvocMeasurement.tvocLevel, units.PPM),
+        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.tvocMeasurement.NAME),
+        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.tvocHealthConcern.tvocHealthConcern)
       }
     }
   },
@@ -950,7 +1332,28 @@ local matter_driver_template = {
     capabilities.windMode,
     capabilities.battery,
     capabilities.filterState,
-    capabilities.filterStatus
+    capabilities.filterStatus,
+    capabilities.airQualityHealthConcern,
+    capabilities.carbonDioxideHealthConcern,
+    capabilities.carbonDioxideMeasurement,
+    capabilities.carbonMonoxideHealthConcern,
+    capabilities.carbonMonoxideMeasurement,
+    capabilities.nitrogenDioxideHealthConcern,
+    capabilities.nitrogenDioxideMeasurement,
+    capabilities.ozoneHealthConcern,
+    capabilities.ozoneMeasurement,
+    capabilities.formaldehydeHealthConcern,
+    capabilities.formaldehydeMeasurement,
+    capabilities.veryFineDustHealthConcern,
+    capabilities.veryFineDustSensor,
+    capabilities.fineDustHealthConcern,
+    capabilities.fineDustSensor,
+    capabilities.dustSensor,
+    capabilities.dustHealthConcern,
+    capabilities.radonHealthConcern,
+    capabilities.radonMeasurement,
+    capabilities.tvocHealthConcern,
+    capabilities.tvocMeasurement
   },
 }
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
@@ -14,11 +14,23 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
+local SinglePrecisionFloat = require "st.matter.data_types.SinglePrecisionFloat"
 
 local clusters = require "st.matter.clusters"
 
 clusters.HepaFilterMonitoring = require "HepaFilterMonitoring"
 clusters.ActivatedCarbonFilterMonitoring = require "ActivatedCarbonFilterMonitoring"
+clusters.AirQuality = require "AirQuality"
+clusters.CarbonMonoxideConcentrationMeasurement = require "CarbonMonoxideConcentrationMeasurement"
+clusters.CarbonDioxideConcentrationMeasurement = require "CarbonDioxideConcentrationMeasurement"
+clusters.FormaldehydeConcentrationMeasurement = require "FormaldehydeConcentrationMeasurement"
+clusters.NitrogenDioxideConcentrationMeasurement = require "NitrogenDioxideConcentrationMeasurement"
+clusters.OzoneConcentrationMeasurement = require "OzoneConcentrationMeasurement"
+clusters.Pm1ConcentrationMeasurement = require "Pm1ConcentrationMeasurement"
+clusters.Pm10ConcentrationMeasurement = require "Pm10ConcentrationMeasurement"
+clusters.Pm25ConcentrationMeasurement = require "Pm25ConcentrationMeasurement"
+clusters.RadonConcentrationMeasurement = require "RadonConcentrationMeasurement"
+clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement = require "TotalVolatileOrganicCompoundsConcentrationMeasurement"
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("air-purifier-hepa-ac-wind.yml"),
@@ -47,6 +59,190 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
+local mock_device_ap_aqs = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("air-purifier-hepa-ac-wind.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.HepaFilterMonitoring.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.ActivatedCarbonFilterMonitoring.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x002D, device_type_revision = 1} -- AP
+      }
+    },
+    {
+      endpoint_id = 3,
+      clusters = {
+        {cluster_id = clusters.AirQuality.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.CarbonDioxideConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 3},
+        {cluster_id = clusters.RadonConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 2},
+        {cluster_id = clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 1},
+      },
+      device_types = {
+        {device_type_id = 0x002C, device_type_revision = 1} -- AQS
+      }
+    }
+  }
+})
+
+local mock_device_ap_thermo_aqs = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("air-purifier-hepa-ac-wind.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.HepaFilterMonitoring.ID, cluster_type = "SERVER", feature_map = 7},
+        {cluster_id = clusters.ActivatedCarbonFilterMonitoring.ID, cluster_type = "SERVER", feature_map = 7},
+      },
+      device_types = {
+        {device_type_id = 0x002D, device_type_revision = 1} -- AP
+      }
+    },
+    {
+      endpoint_id = 3,
+      clusters = {
+        {cluster_id = clusters.AirQuality.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.NitrogenDioxideConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 14},
+        {cluster_id = clusters.Pm25ConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 15},
+        {cluster_id = clusters.FormaldehydeConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 15},
+        {cluster_id = clusters.Pm10ConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 15},
+        {cluster_id = clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 14},
+      },
+      device_types = {
+        {device_type_id = 0x002C, device_type_revision = 1} -- AQS
+      }
+    },
+    {
+      endpoint_id = 4,
+      clusters = {
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0302, device_type_revision = 1} -- Temperature Sensor
+      }
+    },
+    {
+      endpoint_id = 6,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0307, device_type_revision = 1} -- Humidity Sensor
+      }
+    },
+    {
+      endpoint_id = 7,
+      clusters = {
+        {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 1},
+      },
+      device_types = {
+        {device_type_id = 0x0301, device_type_revision = 1} -- Thermostat
+      }
+    },
+  }
+})
+
+local mock_device_ap_thermo_aqs_preconfigured = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("air-purifier-hepa-ac-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.HepaFilterMonitoring.ID, cluster_type = "SERVER", feature_map = 7},
+        {cluster_id = clusters.ActivatedCarbonFilterMonitoring.ID, cluster_type = "SERVER", feature_map = 7},
+      },
+      device_types = {
+        {device_type_id = 0x002D, device_type_revision = 1} -- AP
+      }
+    },
+    {
+      endpoint_id = 3,
+      clusters = {
+        {cluster_id = clusters.AirQuality.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.NitrogenDioxideConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 14},
+        {cluster_id = clusters.Pm25ConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 15},
+        {cluster_id = clusters.FormaldehydeConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 15},
+        {cluster_id = clusters.Pm10ConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 15},
+        {cluster_id = clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = 14},
+      },
+      device_types = {
+        {device_type_id = 0x002C, device_type_revision = 1} -- AQS
+      }
+    },
+    {
+      endpoint_id = 4,
+      clusters = {
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0302, device_type_revision = 1} -- Temperature Sensor
+      }
+    },
+    {
+      endpoint_id = 6,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0307, device_type_revision = 1} -- Humidity Sensor
+      }
+    },
+    {
+      endpoint_id = 7,
+      clusters = {
+        {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 1},
+      },
+      device_types = {
+        {device_type_id = 0x0301, device_type_revision = 1} -- Thermostat
+      }
+    },
+  }
+})
+
 local cluster_subscribe_list = {
   clusters.FanControl.attributes.FanModeSequence,
   clusters.FanControl.attributes.FanMode,
@@ -56,8 +252,82 @@ local cluster_subscribe_list = {
   clusters.HepaFilterMonitoring.attributes.ChangeIndication,
   clusters.HepaFilterMonitoring.attributes.Condition,
   clusters.ActivatedCarbonFilterMonitoring.attributes.ChangeIndication,
-  clusters.ActivatedCarbonFilterMonitoring.attributes.Condition
+  clusters.ActivatedCarbonFilterMonitoring.attributes.Condition,
+}
 
+local cluster_subscribe_list_configured = {
+  [capabilities.temperatureMeasurement.ID] = {
+    clusters.Thermostat.attributes.LocalTemperature,
+    clusters.TemperatureMeasurement.attributes.MeasuredValue,
+    clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
+    clusters.TemperatureMeasurement.attributes.MaxMeasuredValue
+  },
+  [capabilities.relativeHumidityMeasurement.ID] = {
+    clusters.RelativeHumidityMeasurement.attributes.MeasuredValue
+  },
+  [capabilities.thermostatMode.ID] = {
+    clusters.Thermostat.attributes.SystemMode,
+    clusters.Thermostat.attributes.ControlSequenceOfOperation
+  },
+  [capabilities.thermostatOperatingState.ID] = {
+    clusters.Thermostat.attributes.ThermostatRunningState
+  },
+  [capabilities.thermostatFanMode.ID] = {
+    clusters.FanControl.attributes.FanModeSequence,
+    clusters.FanControl.attributes.FanMode
+  },
+  [capabilities.thermostatHeatingSetpoint.ID] = {
+    clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+    clusters.Thermostat.attributes.AbsMinHeatSetpointLimit,
+    clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit
+  },
+  [capabilities.airPurifierFanMode.ID] = {
+    clusters.FanControl.attributes.FanModeSequence,
+    clusters.FanControl.attributes.FanMode
+  },
+  [capabilities.fanSpeedPercent.ID] = {
+    clusters.FanControl.attributes.PercentCurrent
+  },
+  [capabilities.windMode.ID] = {
+    clusters.FanControl.attributes.WindSupport,
+    clusters.FanControl.attributes.WindSetting
+  },
+  [capabilities.filterState.ID] = {
+    clusters.HepaFilterMonitoring.attributes.Condition,
+    clusters.ActivatedCarbonFilterMonitoring.attributes.Condition
+  },
+  [capabilities.filterStatus.ID] = {
+    clusters.HepaFilterMonitoring.attributes.ChangeIndication,
+    clusters.ActivatedCarbonFilterMonitoring.attributes.ChangeIndication
+  },
+  [capabilities.airQualityHealthConcern.ID] = {
+    clusters.AirQuality.attributes.AirQuality
+  },
+  [capabilities.nitrogenDioxideHealthConcern.ID] = {
+    clusters.NitrogenDioxideConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.formaldehydeMeasurement.ID] = {
+    clusters.FormaldehydeConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.FormaldehydeConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.formaldehydeHealthConcern.ID] = {
+    clusters.FormaldehydeConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.fineDustHealthConcern.ID] = {
+    clusters.Pm25ConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.dustSensor.ID] = {
+    clusters.Pm25ConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.Pm25ConcentrationMeasurement.attributes.MeasurementUnit,
+    clusters.Pm10ConcentrationMeasurement.attributes.MeasuredValue,
+    clusters.Pm10ConcentrationMeasurement.attributes.MeasurementUnit,
+  },
+  [capabilities.dustHealthConcern.ID] = {
+    clusters.Pm10ConcentrationMeasurement.attributes.LevelValue,
+  },
+  [capabilities.tvocHealthConcern.ID] = {
+    clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.LevelValue
+  }
 }
 
 local function test_init()
@@ -71,6 +341,86 @@ local function test_init()
   test.mock_device.add_test_device(mock_device)
 end
 test.set_test_init_function(test_init)
+
+local function test_init_ap_aqs()
+  local subscribe_request_ap_aqs = cluster_subscribe_list[1]:subscribe(mock_device_ap_aqs)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request_ap_aqs:merge(cluster:subscribe(mock_device_ap_aqs))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_ap_aqs.id, subscribe_request_ap_aqs})
+  test.mock_device.add_test_device(mock_device_ap_aqs)
+end
+
+local function test_init_ap_thermo_aqs_preconfigured()
+  local subscribe_request = nil
+  for _, attributes in pairs(cluster_subscribe_list_configured) do
+    for _, attribute in ipairs(attributes) do
+      if subscribe_request == nil then
+        subscribe_request = attribute:subscribe(mock_device)
+      else
+        subscribe_request:merge(attribute:subscribe(mock_device))
+      end
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_ap_thermo_aqs_preconfigured.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device_ap_thermo_aqs_preconfigured)
+end
+
+local function test_init_ap_thermo_aqs()
+  local subscribe_request_ap_aqs = cluster_subscribe_list[1]:subscribe(mock_device_ap_thermo_aqs)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request_ap_aqs:merge(cluster:subscribe(mock_device_ap_thermo_aqs))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_ap_thermo_aqs.id, subscribe_request_ap_aqs})
+  test.mock_device.add_test_device(mock_device_ap_thermo_aqs)
+end
+
+test.register_coroutine_test(
+  "Test profile change on init for AP and AQS combined device type",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_ap_aqs.id, "doConfigure" })
+    mock_device_ap_aqs:expect_metadata_update({ profile = "air-purifier-hepa-ac-aqs-co2-tvoc-meas-co2-radon-level" })
+    mock_device_ap_aqs:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  { test_init = test_init_ap_aqs }
+)
+
+test.register_coroutine_test(
+  "Test profile change on init for AP and Thermo and AQS combined device type",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_ap_thermo_aqs.id, "doConfigure" })
+    mock_device_ap_thermo_aqs:expect_metadata_update({ profile = "air-purifier-hepa-ac-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level" })
+    mock_device_ap_thermo_aqs:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    print(mock_device_ap_thermo_aqs.profile)
+  end,
+  { test_init = test_init_ap_thermo_aqs }
+)
+
+test.register_coroutine_test(
+  "Molecular weight conversion should be handled appropriately in unit_conversion",
+  function ()
+    test.socket.matter:__queue_receive({
+      mock_device_ap_thermo_aqs_preconfigured.id,
+      clusters.FormaldehydeConcentrationMeasurement.attributes.MeasurementUnit:build_test_report_data(
+        mock_device_ap_thermo_aqs_preconfigured, 1, clusters.FormaldehydeConcentrationMeasurement.types.MeasurementUnitEnum.MGM3
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device_ap_thermo_aqs_preconfigured.id,
+      clusters.FormaldehydeConcentrationMeasurement.attributes.MeasuredValue:build_test_report_data(
+        mock_device_ap_thermo_aqs_preconfigured, 1, SinglePrecisionFloat(0, 4, .11187500)
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_device_ap_thermo_aqs_preconfigured:generate_test_message("main", capabilities.formaldehydeMeasurement.formaldehydeLevel({value = 14, unit = "ppm"}))
+    )
+  end,
+  { test_init = test_init_ap_thermo_aqs_preconfigured }
+)
 
 test.register_message_test(
   "setAirPurifierFanMode command should send the appropriate commands",


### PR DESCRIPTION
This is cherry-pick to beta of #1479 . This will only be expedited to beta, not production. It should go to production next week with the regular driver deploy.


Testing of this change has been documented here: https://smartthings.atlassian.net/wiki/spaces/~62de3b63b6b0b70770d7905d/pages/3317399870/Matter+Thermostat+AQS+Support+Testing. This includes testing of two Air Purifier Devices on 52 lua libs (without Matter 1.2 clusters in lua libs) and 53 lua libs (with Matter 1.2 cluster in lua libs), as well as regression testing with the VDA with a thermostat and air purifier device.

Allows for profiles to be created that use any combination of AQS, thermostat, and fan device types. Also adds a new profile that includes much of this extended functionality.

* new cluster definitions imported to thermostat
* greater unit conversion inclusion
* do_configure logic updated to include aqs and ap + thermostat profiles
* added air purifier test cases for unit conversion and device configuration