### PR TITLE
New Device (Matter Thermostat) Eve Thermostat

### DIFF
--- a/drivers/SmartThings/matter-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/matter-thermostat/fingerprints.yml
@@ -10,6 +10,13 @@ matterManufacturer:
     vendorId: 0x1396
     productId: 0x0043A
     deviceProfileName: air-purifier-hepa
+#Eve
+  - id: "4874/79"
+    deviceLabel: Eve Thermo
+    vendorId: 0x130A
+    productId: 0x004F
+    deviceProfileName: thermostat-heating-only-nostate
+
 
 matterGeneric:
   - id: "matter/hvac/heatcool"


### PR DESCRIPTION
This is a new Matter WWST request for a Eve Thermostat. The product ID for this device is "79 (0x4f)" and has a matter device type id of "769 (0x301)". 