### PR TITLE
New Device (Matter Switch) Cync Full Color Deco 

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -144,6 +144,11 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x006F
     deviceProfileName: plug-binary
+  - id: "4921/101"
+    deviceLabel: Cync Full Color Deco Candle Base
+    vendorId: 0x1339
+    productId: 0x0065
+    deviceProfileName: light-color-level-2000K-7000K
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug


### PR DESCRIPTION
This PR is to add a fingerprint for a Matter Switch device:  Cync Full Color Deco Candle Base. In the DCL the Product ID for this device is 101 (0x65) and the Matter Device ID is  269 (0x10d). 

