### PR TITLE
New Device (Matter Switch) Huepress MH003-001

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -165,6 +165,12 @@ matterManufacturer:
     vendorId: 0x1021
     productId: 0x0007
     deviceProfileName: plug-binary
+#Huepress
+  - id: "8707/1"
+    deviceLabel: RGBW LED CONTROLLER
+    vendorId: 0x2203
+    productId: 0x0001
+    deviceProfileName: light-color-level-2200K-6500K
 #Lifx
   - id: "5155/169"
     deviceLabel: LIFX Color (A21)

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -149,6 +149,12 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x0065
     deviceProfileName: light-color-level-2000K-7000K
+#Huepress
+  - id: "8707/1"
+    deviceLabel: RGBW LED CONTROLLER
+    vendorId: 0x2203
+    productId: 0x0001
+    deviceProfileName: light-color-level-2200K-6500K
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug
@@ -165,12 +171,6 @@ matterManufacturer:
     vendorId: 0x1021
     productId: 0x0007
     deviceProfileName: plug-binary
-#Huepress
-  - id: "8707/1"
-    deviceLabel: RGBW LED CONTROLLER
-    vendorId: 0x2203
-    productId: 0x0001
-    deviceProfileName: light-color-level-2200K-6500K
 #Lifx
   - id: "5155/169"
     deviceLabel: LIFX Color (A21)


### PR DESCRIPTION
This PR is for an open WWSTCERT Request for a device with the Brand of "Huepress" Model "MH003-001". I could not verify this device in the CSA website as nothing came up for that vendor. Additionally I reviewed the WWSTCERT ticket and did not find a working link for the product page.

This PR will not be merged with out passing test results and Matter Certification from the CSA. 