### PR TITLE
New Device (Matter Switch) Orein OS0100411267

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -342,6 +342,11 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x03ED
     deviceProfileName: light-color-level-1800K-6500K
+  - id: 4456/1006
+    deviceLabel: Matter Smart Light Bulb A19 RGBTW 1100lm
+    vendorId: 0x1168
+    productId: 0x03EE
+    deviceProfileName: light-color-level-1800K-6500K
 #WiZ
   - id: "WiZ A19"
     deviceLabel: WiZ A19

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -337,6 +337,11 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x03EF
     deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1005"
+    deviceLabel: Matter Smart Light Bulb A19 RGBTW 1100lm
+    vendorId: 0x1168
+    productId: 0x03ED
+    deviceProfileName: light-color-level-1800K-6500K
 #WiZ
   - id: "WiZ A19"
     deviceLabel: WiZ A19

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -332,6 +332,11 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x03F5
     deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1007"
+    deviceLabel: Matter Smart Light Bulb A21 RGBTW 1600lm
+    vendorId: 0x1168
+    productId: 0x03EF
+    deviceProfileName: light-color-level-1800K-6500K
 #WiZ
   - id: "WiZ A19"
     deviceLabel: WiZ A19


### PR DESCRIPTION
This PR is for a WWST CERT submission for a multiple Matter Switch Devices their brands are related:  

1. Orien OS0100411267 
-- According to the DCL the PID = 1007 (0x3ef) and the Matter Device Type ID = 269 (0x10d)

2. Linkind LS01009110
-- According to the DCL the PID = 1005 (0x3ed) and the Matter Device Type ID = 269 (0x10d)

3. Orien OS01006110
-- According to the DCL the PID = 1006 (0x3ee) Matter Device Type ID = 269 (0x10d)

<br class="Apple-interchange-newline">

This will be CxS and merged / deployed after PR approval. 