### PR TITLE
New Devices (Matter Switch) Cync Bulbs and Winees Plug

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -149,6 +149,16 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x0065
     deviceProfileName: light-color-level-2000K-7000K
+  - id: "4921/105"
+    deviceLabel: Cync Full Color A21
+    vendorId: 0x1339
+    productId: 0x0069
+    deviceProfileName: light-color-level-2000K-7000K
+  - id: "4921/173"
+    deviceLabel: Cync Full Color BR30
+    vendorId: 0x1339
+    productId: 0x00AD
+    deviceProfileName: light-color-level-2000K-7000K
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug
@@ -347,6 +357,11 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x03EE
     deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1102"
+    deviceLabel: Matter Smart Plug
+    vendorId: 0x1168
+    productId: 0x044E
+    deviceProfileName: plug-binary
 #WiZ
   - id: "WiZ A19"
     deviceLabel: WiZ A19

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -159,7 +159,7 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x00AD
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/107
+  - id: "4921/107"
     deviceLabel: Cync Reveal Full Color A19
     vendorId: 0x1339
     productId: 0x006B

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -159,6 +159,11 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x00AD
     deviceProfileName: light-color-level-2000K-7000K
+  - id: 4921/21
+    deviceLabel: Cync Full Color A19
+    vendorId: 0x1339
+    productId: 0x0015
+    deviceProfileName: light-color-level-2000K-7000K  
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -159,11 +159,11 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x00AD
     deviceProfileName: light-color-level-2000K-7000K
-  - id: 4921/21
-    deviceLabel: Cync Full Color A19
+  - id: 4921/107
+    deviceLabel: Cync Reveal Full Color A19
     vendorId: 0x1339
-    productId: 0x0015
-    deviceProfileName: light-color-level-2000K-7000K  
+    productId: 0x006B
+    deviceProfileName: light-color-level-2000K-7000K
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug


### PR DESCRIPTION
# Type of Change

- [ **X** ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [  **X** ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This PR is adding 4 new devices to the Matter Switch Driver the devices are:
1. Cync Full Color A21 Model Number: CLEDA2116CDMS. According to the DCL:
PID: 0x0069
VID: 0x1339
Matter Device Type ID: 10D


2. Cync Full Color BR30 Model Number: CLEDR309CD1MS. According to the DCL:
PID: 0x00AD
VID: 0x1339
Matter Device Type ID: 10D 

3. Matter Smart Plug from Winees (owned by AiDot) Model Number WC0900184. According to the DCL: 
PID: 0x044E
VID: 0x1168
Matter Device Type: 10A 

4. Additional commit due to a recently opened WWSTCERT request for a Cync Reveal Full Color A19
- id: "4921/107"
    deviceLabel: Cync Reveal Full Color A19
    vendorId: 0x1339
    productId: 0x006B
    deviceProfileName: light-color-level-2000K-7000K

I could not confirm the Matter Device Type ID


# Summary of Completed Tests
- These devices will not be tested in SPROL or elsewhere as they are Certified by Similarity. The parters have submitted their own results with the Automated Test Suite. No additional testing changes are planned. 


