### PR TITLE
Revert (Zigbee Window Treatment) Aqara/Roller Shade PR 1494

### DIFF
--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/aqara_utils.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/aqara_utils.lua
@@ -15,28 +15,21 @@ local SHADE_STATE_STOP = 0
 local SHADE_STATE_OPEN = 1
 local SHADE_STATE_CLOSE = 2
 
-local UPDATE_SHADE_LEVEL = "update_shade_level"
 local PREF_REVERSE_DEFAULT = "\x00\x02\x00\x00\x00\x00\x00"
 local PREF_REVERSE_OFF = "\x00\x02\x00\x00\x00\x00\x00"
 local PREF_REVERSE_ON = "\x00\x02\x00\x01\x00\x00\x00"
 
 local aqara_utils = {}
 
-local function enable_update_shade_level(device)
-  device:set_field(UPDATE_SHADE_LEVEL, true)
-end
-
-local function disable_update_shade_level(device)
-  device:set_field(UPDATE_SHADE_LEVEL, false)
-end
-
 local function shade_level_cmd(driver, device, command)
-  disable_update_shade_level(device)
   local level = command.args.shadeLevel
   if level > 100 then
     level = 100
   end
   level = utils.round(level)
+
+  -- update ui to the new level
+  device:emit_event(capabilities.windowShadeLevel.shadeLevel(level))
 
   -- send
   device:send_to_component(command.component, WindowCovering.server.commands.GoToLiftPercentage(device, level))
@@ -48,7 +41,6 @@ local function emit_shade_event_by_state(device, value)
   -- update state ui
   if state == SHADE_STATE_STOP or state == 0x04 then
     -- read shade position to update the UI
-    enable_update_shade_level(device)
     device:send(AnalogOutput.attributes.PresentValue:read(device))
   elseif state == SHADE_STATE_OPEN then
     device:emit_event(capabilities.windowShade.windowShade.opening())
@@ -58,29 +50,25 @@ local function emit_shade_event_by_state(device, value)
 end
 
 local function emit_shade_event(device, value)
-  if device:get_field(UPDATE_SHADE_LEVEL) then
-    local level = value.value
-    if level >= 100 then
-      device:emit_event(capabilities.windowShade.windowShade.open())
-    elseif level == 0 then
-      device:emit_event(capabilities.windowShade.windowShade.closed())
-    else
-      device:emit_event(capabilities.windowShade.windowShade.partially_open())
-    end
+  local level = value.value
+  if level >= 100 then
+    device:emit_event(capabilities.windowShade.windowShade.open())
+  elseif level == 0 then
+    device:emit_event(capabilities.windowShade.windowShade.closed())
+  else
+    device:emit_event(capabilities.windowShade.windowShade.partially_open())
   end
 end
 
 local function emit_shade_level_event(device, value)
-  if device:get_field(UPDATE_SHADE_LEVEL) then
-    local level = value.value
-    if level > 100 then
-      level = 100
-    end
-    level = utils.round(level)
-
-    -- update level ui
-    device:emit_event(capabilities.windowShadeLevel.shadeLevel(level))
+  local level = value.value
+  if level > 100 then
+    level = 100
   end
+  level = utils.round(level)
+
+  -- update level ui
+  device:emit_event(capabilities.windowShadeLevel.shadeLevel(level))
 end
 
 aqara_utils.PRIVATE_CLUSTER_ID = PRIVATE_CLUSTER_ID
@@ -93,8 +81,6 @@ aqara_utils.PREF_REVERSE_DEFAULT = PREF_REVERSE_DEFAULT
 aqara_utils.PREF_REVERSE_OFF = PREF_REVERSE_OFF
 aqara_utils.PREF_REVERSE_ON = PREF_REVERSE_ON
 
-aqara_utils.enable_update_shade_level = enable_update_shade_level
-aqara_utils.disable_update_shade_level = disable_update_shade_level
 aqara_utils.emit_shade_event = emit_shade_event
 aqara_utils.emit_shade_event_by_state = emit_shade_event_by_state
 aqara_utils.emit_shade_level_event = emit_shade_level_event

--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/init.lua
@@ -124,7 +124,6 @@ local function application_version_handler(driver, device, value, zb_rx)
 end
 
 local function do_refresh(self, device)
-  aqara_utils.enable_update_shade_level(device)
   device:send(AnalogOutput.attributes.PresentValue:read(device))
   device:send(cluster_base.read_manufacturer_specific_attribute(device, Basic.ID, aqara_utils.PREF_ATTRIBUTE_ID,
     aqara_utils.MFG_CODE))
@@ -167,10 +166,8 @@ local function do_configure(self, device)
 end
 
 local function device_added(driver, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },
-    { visibility = { displayed = false } }))
-  device:emit_event(deviceInitialization.supportedInitializedState({ "notInitialized", "initializing", "initialized" },
-    { visibility = { displayed = false } }))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
+  device:emit_event(deviceInitialization.supportedInitializedState({ "notInitialized", "initializing", "initialized" }, {visibility = {displayed = false}}))
   device:emit_event(capabilities.windowShadeLevel.shadeLevel(0))
   device:emit_event(capabilities.windowShade.windowShade.closed())
   device:emit_event(deviceInitialization.initializedState.notInitialized())
@@ -179,7 +176,6 @@ local function device_added(driver, device)
     aqara_utils.PRIVATE_ATTRIBUTE_ID, aqara_utils.MFG_CODE, data_types.Uint8, 1))
 
   -- Initial default settings
-  aqara_utils.enable_update_shade_level(device)
   device:send(cluster_base.write_manufacturer_specific_attribute(device, Basic.ID, aqara_utils.PREF_ATTRIBUTE_ID,
     aqara_utils.MFG_CODE, data_types.CharString, aqara_utils.PREF_REVERSE_OFF))
   device:send(cluster_base.write_manufacturer_specific_attribute(device, Basic.ID, aqara_utils.PREF_ATTRIBUTE_ID,

--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/roller-shade/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/roller-shade/init.lua
@@ -33,7 +33,6 @@ local function window_shade_open_cmd(driver, device, command)
   local initialized = device:get_latest_state("main", initializedStateWithGuide.ID,
     initializedStateWithGuide.initializedStateWithGuide.NAME) or 0
   if initialized == initializedStateWithGuide.initializedStateWithGuide.initialized.NAME then
-    aqara_utils.enable_update_shade_level(device)
     device:send_to_component(command.component, WindowCovering.server.commands.GoToLiftPercentage(device, 100))
   end
 end
@@ -43,13 +42,12 @@ local function window_shade_close_cmd(driver, device, command)
   local initialized = device:get_latest_state("main", initializedStateWithGuide.ID,
     initializedStateWithGuide.initializedStateWithGuide.NAME) or 0
   if initialized == initializedStateWithGuide.initializedStateWithGuide.initialized.NAME then
-    aqara_utils.enable_update_shade_level(device)
     device:send_to_component(command.component, WindowCovering.server.commands.GoToLiftPercentage(device, 0))
   end
 end
 
 local function set_rotate_command_handler(driver, device, command)
-  device:emit_event(shadeRotateState.rotateState.idle({ state_change = true })) -- update UI
+  device:emit_event(shadeRotateState.rotateState.idle({state_change = true})) -- update UI
 
   -- Cannot be controlled if not initialized
   local initialized = device:get_latest_state("main", initializedStateWithGuide.ID,
@@ -94,8 +92,7 @@ local function device_info_changed(driver, device, event, args)
 end
 
 local function device_added(driver, device)
-  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },
-    { visibility = { displayed = false } }))
+  device:emit_event(capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
   device:emit_event(capabilities.windowShadeLevel.shadeLevel(0))
   device:emit_event(capabilities.windowShade.windowShade.closed())
   device:emit_event(initializedStateWithGuide.initializedStateWithGuide.notInitialized())

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
@@ -40,7 +40,6 @@ local PREF_SOFT_TOUCH_OFF = "\x00\x08\x00\x00\x00\x01\x00"
 local PREF_SOFT_TOUCH_ON = "\x00\x08\x00\x00\x00\x00\x00"
 
 local APPLICATION_VERSION = "application_version"
-local UPDATE_SHADE_LEVEL = "update_shade_level"
 
 local mock_device = test.mock_device.build_test_zigbee_device(
   {
@@ -159,7 +158,6 @@ test.register_coroutine_test(
   "Window shade state closed",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    mock_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.zigbee:__queue_receive(
       {
         mock_device.id,
@@ -179,7 +177,6 @@ test.register_coroutine_test(
   "Window shade state open",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    mock_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.zigbee:__queue_receive(
       {
         mock_device.id,
@@ -199,7 +196,6 @@ test.register_coroutine_test(
   "Window shade state partially open",
   function()
     test.socket.capability:__set_channel_ordering("relaxed")
-    mock_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.zigbee:__queue_receive(
       {
         mock_device.id,
@@ -377,7 +373,6 @@ test.register_coroutine_test(
         WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_version_device, 0)
       }
     )
-    mock_version_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.capability:__expect_send(
       mock_version_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0))
     )
@@ -405,7 +400,6 @@ test.register_coroutine_test(
         WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_version_device, 100)
       }
     )
-    mock_version_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.capability:__expect_send(
       mock_version_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(100))
     )
@@ -433,7 +427,6 @@ test.register_coroutine_test(
         WindowCovering.attributes.CurrentPositionLiftPercentage:build_test_attr_report(mock_version_device, 50)
       }
     )
-    mock_version_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.capability:__expect_send(
       mock_version_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(50))
     )

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
@@ -34,16 +34,11 @@ local AnalogOutput = clusters.AnalogOutput
 local Groups = clusters.Groups
 
 local SHADE_LEVEL = "shadeLevel"
-local UPDATE_SHADE_LEVEL = "update_shade_level"
 
 local PRIVATE_CLUSTER_ID = 0xFCC0
 local PRIVATE_ATTRIBUTE_ID = 0x0009
 local MFG_CODE = 0x115F
 local PREF_ATTRIBUTE_ID = 0x0401
-local SHADE_STATE_ATTRIBUTE_ID = 0x0404
-
-local SHADE_STATE_STOP = 0
-local SHADE_STATE_CLOSE = 2
 
 local PREF_REVERSE_OFF = "\x00\x02\x00\x00\x00\x00\x00"
 local PREF_REVERSE_ON = "\x00\x02\x00\x01\x00\x00\x00"
@@ -77,8 +72,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
-        capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" },
-          { visibility = { displayed = false } }))
+        capabilities.windowShade.supportedWindowShadeCommands({ "open", "close", "pause" }, {visibility = {displayed = false}}))
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0))
@@ -147,7 +141,6 @@ test.register_coroutine_test(
         AnalogOutput.attributes.PresentValue:build_test_attr_report(mock_device, SinglePrecisionFloat(0, -127, 0))
       }
     )
-    mock_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0))
     )
@@ -167,7 +160,6 @@ test.register_coroutine_test(
         AnalogOutput.attributes.PresentValue:build_test_attr_report(mock_device, SinglePrecisionFloat(0, 6, 0.5625))
       }
     )
-    mock_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(100))
     )
@@ -187,7 +179,6 @@ test.register_coroutine_test(
         AnalogOutput.attributes.PresentValue:build_test_attr_report(mock_device, SinglePrecisionFloat(0, 5, 0.5625))
       }
     )
-    mock_device:set_field(UPDATE_SHADE_LEVEL, true)
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(50))
     )
@@ -248,7 +239,7 @@ test.register_coroutine_test(
       }
     )
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", shadeRotateState.rotateState.idle({ state_change = true }))
+      mock_device:generate_test_message("main", shadeRotateState.rotateState.idle({state_change = true}))
     )
   end
 )
@@ -260,16 +251,12 @@ test.register_coroutine_test(
     test.socket.capability:__queue_receive(
       {
         mock_device.id,
-        {
-          capability = shadeRotateStateId,
-          component = "main",
-          command = "setRotateState",
-          args = { state = "rotateDown" }
-        }
+        { capability = shadeRotateStateId, component = "main", command = "setRotateState",
+          args = { state = "rotateDown" } }
       }
     )
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", shadeRotateState.rotateState.idle({ state_change = true }))
+      mock_device:generate_test_message("main", shadeRotateState.rotateState.idle({state_change = true}))
     )
   end
 )
@@ -325,53 +312,6 @@ test.register_coroutine_test(
       mock_device.id,
       AnalogOutput.attributes.PresentValue:read(mock_device)
     })
-  end
-)
-
-test.register_coroutine_test(
-  "Window shade level update flag test",
-  function()
-    test.socket.capability:__set_channel_ordering("relaxed")
-    test.socket.capability:__queue_receive({ mock_device.id, { capability = "windowShadeLevel", component = "main", command = "setShadeLevel", args = { 20 } } })
-    local attr_report_closing_data = {
-      { SHADE_STATE_ATTRIBUTE_ID, data_types.Uint8.ID, SHADE_STATE_CLOSE }
-    }
-    test.socket.zigbee:__queue_receive({
-      mock_device.id,
-      zigbee_test_utils.build_attribute_report(mock_device, Basic.ID, attr_report_closing_data, MFG_CODE)
-    })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closing())
-    )
-    test.socket.zigbee:__queue_receive(
-      {
-        mock_device.id,
-        AnalogOutput.attributes.PresentValue:build_test_attr_report(mock_device, SinglePrecisionFloat(0, 5, 0.5625)) -- ignoring
-      }
-    )
-    local attr_report_stop_data = {
-      { SHADE_STATE_ATTRIBUTE_ID, data_types.Uint8.ID, SHADE_STATE_STOP }
-    }
-    test.socket.zigbee:__queue_receive({
-      mock_device.id,
-      zigbee_test_utils.build_attribute_report(mock_device, Basic.ID, attr_report_stop_data, MFG_CODE)
-    })
-    test.socket.zigbee:__expect_send({
-      mock_device.id,
-      AnalogOutput.attributes.PresentValue:read(mock_device)
-    })
-    test.socket.zigbee:__queue_receive(
-      {
-        mock_device.id,
-        AnalogOutput.attributes.PresentValue:build_test_attr_report(mock_device, SinglePrecisionFloat(0, 4, 0.25)) -- 20%
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(20))
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
-    )
   end
 )
 


### PR DESCRIPTION

# Type of Change

- [ ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ X ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
To prepare for the production release on Monday July 29, we need to revert changes merged to beta specific to PR [1494](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1494). There are open discussions on slack regarding a device failure. 


# Summary of Completed Tests
- This PR will not be tested specifically


