### PR TITLE
Add fingerprint for SONOFF/SNZB-02D

### DIFF
--- a/drivers/SmartThings/zigbee-humidity-sensor/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/fingerprints.yml
@@ -73,6 +73,11 @@ zigbeeManufacturer:
     manufacturer: eWeLink
     model: SNZB-02P
     deviceProfileName: humidity-temp-battery
+  - id: SONOFF/SNZB-02D
+    deviceLabel: SONOFF Multipurpose Sensor
+    manufacturer: SONOFF
+    model: SNZB-02D
+    deviceProfileName: humidity-temp-battery
 zigbeeGeneric:
   - id: "HumidityTempGeneric"
     deviceLabel: Multipurpose Sensor


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This adds the fingerprint for the Sonoff Zigbee multipurpose sensor with LED display (SONOFF/SNZB-02D) so that it uses the humidity-temp-battery profile instead of just the humidity-temperature profile.

# Summary of Completed Tests

I used the Edge Device Builder to switch all my sensors to the humidity-temp-battery profile. After a manual power reset on the sensors (or possibly it would just happen if I waited longer), they report their battery level in the SmartThings mobile app and advanced web app.