### PR TITLE
CHAD-13655 Add emulated reset implementation

### DIFF
--- a/drivers/SmartThings/zigbee-power-meter/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/ezex/init.lua
@@ -16,6 +16,7 @@ local capabilities = require "st.capabilities"
 local constants = require "st.zigbee.constants"
 local clusters = require "st.zigbee.zcl.clusters"
 local SimpleMetering = clusters.SimpleMetering
+local energy_meter_defaults = require "st.zigbee.defaults.energyMeter_defaults"
 
 local ZIGBEE_POWER_METER_FINGERPRINTS = {
   { model = "E240-KR080Z0-HA" }
@@ -63,10 +64,7 @@ local function energy_meter_handler(driver, device, value, zb_rx)
   end
   device:emit_event(capabilities.powerConsumptionReport.powerConsumption({energy = raw_value_watts, deltaEnergy = delta_energy })) -- the unit of these values should be 'Wh'
 
-  local multiplier = device:get_field(constants.SIMPLE_METERING_MULTIPLIER_KEY) or 1
-  local divisor = device:get_field(constants.SIMPLE_METERING_DIVISOR_KEY) or 1000000
-  local converted_value = raw_value_miliwatts * multiplier/divisor -- unit: kWh
-  device:emit_event(capabilities.energyMeter.energy({value = converted_value, unit = "kWh"}))
+  energy_meter_defaults.energy_meter_handler(driver, device, value, zb_rx)
 end
 
 local ezex_power_meter_handler = {

--- a/drivers/SmartThings/zigbee-switch/src/aqara/version/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/version/init.lua
@@ -1,5 +1,6 @@
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
+local constants = require "st.zigbee.constants"
 
 local OnOff = clusters.OnOff
 local AnalogInput = clusters.AnalogInput
@@ -22,7 +23,13 @@ end
 
 local function energy_meter_power_consumption_report(device, raw_value)
   -- energy meter
-  device:emit_event(capabilities.energyMeter.energy({ value = raw_value, unit = "Wh" }))
+  local offset = device:get_field(constants.ENERGY_METER_OFFSET) or 0
+  if raw_value < offset then
+    --- somehow our value has gone below the offset, so we'll reset the offset, since the device seems to have
+    offset = 0
+    device:set_field(constants.ENERGY_METER_OFFSET, offset, {persist = true})
+  end
+  device:emit_event(capabilities.energyMeter.energy({ value = raw_value - offset, unit = "Wh" }))
 
   -- report interval
   local current_time = os.time()

--- a/drivers/SmartThings/zigbee-switch/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ezex/init.lua
@@ -12,11 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-local zcl_clusters = require "st.zigbee.zcl.clusters"
-local capabilities = require "st.capabilities"
-
-local SimpleMetering = zcl_clusters.SimpleMetering
-local ElectricalMeasurement = zcl_clusters.ElectricalMeasurement
+local zigbee_constants = require "st.zigbee.constants"
 
 local ZIGBEE_METERING_SWITCH_FINGERPRINTS = {
   { model = "E240-KR116Z-HA" }
@@ -33,30 +29,15 @@ local is_zigbee_ezex_switch = function(opts, driver, device)
   return false
 end
 
-local function energy_meter_handler(driver, device, value, zb_rx)
-  local raw_value = value.value
-  raw_value = raw_value / 1000000
-  device:emit_event(capabilities.energyMeter.energy({value = raw_value, unit = "kWh" }))
-end
-
-local function power_meter_handler(driver, device, value, zb_rx)
-  local raw_value = value.value
-  raw_value = raw_value / 1000
-  device:emit_event(capabilities.powerMeter.power({value = raw_value, unit = "W" }))
+local do_init = function(self, device)
+  device:set_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY, 1000000, {persist = true})
+  device:set_field(zigbee_constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 1000, {persist = true})
 end
 
 local ezex_switch_handler = {
   NAME = "ezex switch handler",
-  zigbee_handlers = {
-    attr = {
-      [SimpleMetering.ID] = {
-        [SimpleMetering.attributes.InstantaneousDemand.ID] = power_meter_handler,
-        [SimpleMetering.attributes.CurrentSummationDelivered.ID] = energy_meter_handler
-      },
-      [ElectricalMeasurement.ID] = {
-        [ElectricalMeasurement.attributes.ActivePower.ID] = power_meter_handler
-      }
-    }
+  lifecycle_handlers = {
+    init = do_init
   },
   can_handle = is_zigbee_ezex_switch
 }

--- a/drivers/SmartThings/zigbee-switch/src/robb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/robb/init.lua
@@ -12,13 +12,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+local constants = require "st.zigbee.constants"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
-
-local constants = require "st.zigbee.constants"
-
 local SimpleMetering = zcl_clusters.SimpleMetering
-local ElectricalMeasurement = zcl_clusters.ElectricalMeasurement
 
 local ROBB_DIMMER_FINGERPRINTS = {
   { mfr = "ROBB smarrt", model = "ROB_200-011-0" },
@@ -35,19 +32,16 @@ local function is_robb_dimmer(opts, driver, device)
   return false
 end
 
-local function energy_meter_handler(driver, device, value, zb_rx)
-  local raw_value = value.value
-  local multiplier = device:get_field(constants.SIMPLE_METERING_MULTIPLIER_KEY) or 1
-  local divisor = device:get_field(constants.SIMPLE_METERING_DIVISOR_KEY) or 1000000
-
-  raw_value = raw_value * multiplier / divisor
-  device:emit_event(capabilities.energyMeter.energy({ value = raw_value, unit = "kWh" }))
+local do_init = function(driver, device)
+  device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1000000, {persist = true})
+  device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 10, {persist = true})
 end
+
 
 local function power_meter_handler(driver, device, value, zb_rx)
   local raw_value = value.value
   local multiplier = device:get_field(constants.ELECTRICAL_MEASUREMENT_MULTIPLIER_KEY) or 1
-  local divisor = device:get_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY) or 10
+  local divisor = 10
 
   raw_value = raw_value * multiplier / divisor
   device:emit_event(capabilities.powerMeter.power({ value = raw_value, unit = "W" }))
@@ -58,13 +52,12 @@ local robb_dimmer_handler = {
   zigbee_handlers = {
     attr = {
       [SimpleMetering.ID] = {
-        [SimpleMetering.attributes.InstantaneousDemand.ID] = power_meter_handler,
-        [SimpleMetering.attributes.CurrentSummationDelivered.ID] = energy_meter_handler
-      },
-      [ElectricalMeasurement.ID] = {
-        [ElectricalMeasurement.attributes.ActivePower.ID] = power_meter_handler
+        [SimpleMetering.attributes.InstantaneousDemand.ID] = power_meter_handler
       }
     }
+  },
+  lifecycle_handlers = {
+    init = do_init
   },
   can_handle = is_robb_dimmer
 }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
@@ -95,6 +95,23 @@ test.register_message_test(
 )
 
 test.register_message_test(
+  "Handle Power meter",
+  {
+    {
+      channel = "zigbee",
+      direction = "receive",
+      message = { mock_device.id,
+        SimpleMetering.attributes.InstantaneousDemand:build_test_attr_report(mock_device, 90) }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 9.0, unit = "W" }))
+    }
+  }
+)
+
+test.register_message_test(
   "Handle Energy meter",
   {
     {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
@@ -14,16 +14,13 @@
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
-local constants = require "st.zigbee.constants"
 local zigbee_constants = require "st.zigbee.constants"
+local energy_meter_defaults = require "st.zigbee.defaults.energyMeter_defaults"
 
 local SimpleMetering = clusters.SimpleMetering
 
 local function energy_meter_handler(driver, device, value, zb_rx)
   local raw_value = value.value
-  local multiplier = device:get_field(constants.SIMPLE_METERING_MULTIPLIER_KEY) or 1
-  local divisor = device:get_field(constants.SIMPLE_METERING_DIVISOR_KEY) or 1000
-  local converted_value = raw_value * multiplier/divisor
 
   local delta_energy = 0.0
   local current_power_consumption = device:get_latest_state("main", capabilities.powerConsumptionReport.ID, capabilities.powerConsumptionReport.powerConsumption.NAME)
@@ -32,7 +29,7 @@ local function energy_meter_handler(driver, device, value, zb_rx)
   end
   device:emit_event(capabilities.powerConsumptionReport.powerConsumption({energy = raw_value, deltaEnergy = delta_energy })) -- the unit of these values should be 'Wh'
 
-  device:emit_event(capabilities.energyMeter.energy({value = converted_value, unit = "kWh"}))
+  energy_meter_defaults.energy_meter_handler(driver, device, value, zb_rx)
 end
 
 local do_configure = function(self, device)


### PR DESCRIPTION
This emulated reset behavior is defined in the defaults, but some sub-drivers overwrote the defaults without including it.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [x] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Adds default emulated reset behavior to sub-drivers that chose to overwrite it.

# Summary of Completed Tests

Existing unit tests were not affected by this change

