### PR TITLE
Add datastore:commit() calls around API key operations

### DIFF
--- a/drivers/SmartThings/philips-hue/src/hue_driver_template.lua
+++ b/drivers/SmartThings/philips-hue/src/hue_driver_template.lua
@@ -32,6 +32,9 @@ local function _remove(driver, device)
       device:set_field(Fields.EVENT_SOURCE, nil)
     end
 
+
+    -- This operation will be committed to the datastore
+    -- immediately, see the note in init.lua#L57
     Discovery.api_keys[device.device_network_id] = nil
   end
 end
@@ -59,6 +62,7 @@ local set_color_temp_handler = utils.safe_wrap_handler(command_handlers.set_colo
 --- @field public bridge_netinfo table<string,HueBridgeInfo>
 --- @field public dni_to_device_id table<string,string>
 --- @field public api_keys table<string,string>
+--- @field public commit fun(self: HueDriverDatastore)
 --- @field public save fun(self: HueDriverDatastore)
 
 --- @class HueDriver:Driver

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -54,6 +54,12 @@ Discovery.api_keys = setmetatable({}, {
     )
     hue.datastore.api_keys[k] = v
     hue.datastore:save()
+    -- Because we never actually store keys on the metatable target itself,
+    -- __newindex is invoked for ever mutation; values for a new key, updating
+    -- the value for an existing key, and setting an existing key to `nil` will
+    -- all hit this path.
+    local commit_result = table.pack(hue.datastore:commit())
+    log.trace(st_utils.stringify_table(commit_result, "[DataStoreCommit] commit result", true))
   end,
   __index = function(self, k)
     return hue.datastore.api_keys[k]


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change calls `datastore:commit()` every time a Hue Bridge API key is captured/modified/removed. This is an API that's gated behind a SmartThings controlled allowlist, so it will not currently work until the Hue driver has been added to the allowlist. But I have tested that it does not cause a crash or issues with the driver's operation in any way, so the change is safe.


# Summary of Completed Tests

Real device developer testing has been performed.

