### PR TITLE
[HCS-5080] Add hub drivers for TV, Fridge, Soundbar, and all other types

### DIFF
--- a/drivers/SmartThings/hub/config.yml
+++ b/drivers/SmartThings/hub/config.yml
@@ -1,0 +1,4 @@
+name: 'hub'
+packageKey: 'hub'
+description: "SmartThings driver for Hub devices"
+vendorSupportInformation: "https://support.smartthings.com"

--- a/drivers/SmartThings/hub/fingerprints.yml
+++ b/drivers/SmartThings/hub/fingerprints.yml
@@ -1,0 +1,17 @@
+hub:
+  - id: "tv-hub"
+    deviceLabel: SmartThings Hub
+    hardwareType: SAMSUNG-TV-TIZEN-OPEN
+    deviceProfileName: tv-hub
+  - id: "soundbar-hub"
+    deviceLabel: Harman Kardon Virtuo
+    hardwareType: HARMAN_SPEAKER_LINUX_OPEN_HUB
+    deviceProfileName: soundbar-hub
+  - id: "refrigerator-hub"
+    deviceLabel: SmartThings Hub
+    hardwareType: SAMSUNG_DA_REFRIGERATOR_HUB
+    deviceProfileName: refrigerator-hub
+hubThing:
+  - id: "hub-thing"
+    deviceLabel: SmartThings Hub
+    deviceProfileName: hub-thing

--- a/drivers/SmartThings/hub/profiles/hub-thing.yml
+++ b/drivers/SmartThings/hub/profiles/hub-thing.yml
@@ -1,0 +1,13 @@
+name: hub-thing
+components:
+  - id: main
+    label: main
+    capabilities:
+      - id: bridge
+        version: 1
+        ephemeral: false
+    categories:
+      - name: Hub
+        categoryType: manufacturer
+metadata:
+  ocfDeviceType: x.com.st.d.hub

--- a/drivers/SmartThings/hub/profiles/refrigerator-hub.yml
+++ b/drivers/SmartThings/hub/profiles/refrigerator-hub.yml
@@ -1,0 +1,17 @@
+name: refrigerator-hub
+components:
+  - id: main
+    label: main
+    capabilities:
+    - id: bridge
+      version: 1
+      ephemeral: false
+    categories:
+      - name: Hub
+        categoryType: manufacturer
+config:
+  icons:
+    - badge:
+      - iconUrl: badge://refrigerator
+metadata:
+  ocfDeviceType: x.com.st.d.hub

--- a/drivers/SmartThings/hub/profiles/soundbar-hub.yml
+++ b/drivers/SmartThings/hub/profiles/soundbar-hub.yml
@@ -1,0 +1,17 @@
+name: soundbar-hub
+components:
+  - id: main
+    label: main
+    capabilities:
+    - id: bridge
+      version: 1
+      ephemeral: false
+    categories:
+      - name: Hub
+        categoryType: manufacturer
+config:
+  icons:
+    - badge:
+      - iconUrl: badge://soundbar
+metadata:
+  ocfDeviceType: x.com.st.d.hub

--- a/drivers/SmartThings/hub/profiles/tv-hub.yml
+++ b/drivers/SmartThings/hub/profiles/tv-hub.yml
@@ -1,0 +1,17 @@
+name: tv-hub
+components:
+  - id: main
+    label: main
+    capabilities:
+    - id: bridge
+      version: 1
+      ephemeral: false
+    categories:
+      - name: Hub
+        categoryType: manufacturer
+config:
+  icons:
+    - badge:
+      - iconUrl: badge://tv
+metadata:
+  ocfDeviceType: x.com.st.d.hub


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [X] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adding some basic profiles for 4 types of hubs:
1. Refrigerator
2. TV Hub
3. Soundbar
4. Everything else

# Summary of Completed Tests


