### PR TITLE
[HCS-5080] Change hardwareType used for hub fingerprints

### DIFF
--- a/drivers/SmartThings/hub/fingerprints.yml
+++ b/drivers/SmartThings/hub/fingerprints.yml
@@ -1,11 +1,11 @@
 hub:
   - id: "tv-hub"
     deviceLabel: SmartThings Hub
-    hardwareType: SAMSUNG-TV-TIZEN-OPEN
+    hardwareType: SAMSUNG_VD_TV_HUB
     deviceProfileName: tv-hub
   - id: "soundbar-hub"
-    deviceLabel: Harman Kardon Virtuo
-    hardwareType: HARMAN_SPEAKER_LINUX_OPEN_HUB
+    deviceLabel: SmartThings Hub
+    hardwareType: SAMSUNG_SOUNDBAR_TIZEN_OPEN_HUB
     deviceProfileName: soundbar-hub
   - id: "refrigerator-hub"
     deviceLabel: SmartThings Hub


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Changed hub driver fingerprints - specifically the hardwareType used by the tv-hub and soundbar-hub.

# Summary of Completed Tests


