### PR TITLE
Enable native handlers for drivers that can use them

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -250,6 +250,9 @@ local function device_removed(driver, device)
 end
 
 local function handle_switch_on(driver, device, cmd)
+  if type(device.register_native_capability_cmd_handler) == "function" then
+    device:register_native_capability_cmd_handler(cmd.capability, cmd.command)
+  end
   local endpoint_id = device:component_to_endpoint(cmd.component)
   --TODO use OnWithRecallGlobalScene for devices with the LT feature
   local req = clusters.OnOff.server.commands.On(device, endpoint_id)
@@ -257,12 +260,18 @@ local function handle_switch_on(driver, device, cmd)
 end
 
 local function handle_switch_off(driver, device, cmd)
+  if type(device.register_native_capability_cmd_handler) == "function" then
+    device:register_native_capability_cmd_handler(cmd.capability, cmd.command)
+  end
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local req = clusters.OnOff.server.commands.Off(device, endpoint_id)
   device:send(req)
 end
 
 local function handle_set_level(driver, device, cmd)
+  if type(device.register_native_capability_cmd_handler) == "function" then
+    device:register_native_capability_cmd_handler(cmd.capability, cmd.command)
+  end
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local level = math.floor(cmd.args.level/100.0 * 254)
   local req = clusters.LevelControl.server.commands.MoveToLevelWithOnOff(device, endpoint_id, level, cmd.args.rate or 0, 0 ,0)

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -127,6 +127,6 @@ local zigbee_switch_driver_template = {
 }
 
 defaults.register_for_default_handlers(zigbee_switch_driver_template,
-  zigbee_switch_driver_template.supported_capabilities)
+  zigbee_switch_driver_template.supported_capabilities,  {native_capability_cmds_enabled = true})
 local zigbee_switch = ZigbeeDriver("zigbee_switch", zigbee_switch_driver_template)
 zigbee_switch:run()

--- a/drivers/SmartThings/zwave-bulb/src/init.lua
+++ b/drivers/SmartThings/zwave-bulb/src/init.lua
@@ -37,7 +37,7 @@ local driver_template = {
   },
 }
 
-defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)
+defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities, {native_capability_cmds_enabled = true})
 --- @type st.zwave.Driver
 local bulb = ZwaveDriver("zwave_bulb", driver_template)
 bulb:run()

--- a/drivers/SmartThings/zwave-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/init.lua
@@ -172,7 +172,7 @@ local driver_template = {
   }
 }
 
-defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)
+defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities,  {native_capability_cmds_enabled = true})
 --- @type st.zwave.Driver
 local switch = ZwaveDriver("zwave_switch", driver_template)
 switch:run()


### PR DESCRIPTION
Only switch and switchLevel capabilities will be supported for Matter, Zigbee, and Z-Wave devices in the 0.54.x firmware. Using this functionality give a huge latency improvement for handling these capability commands which is important when a driver is handling several commands all at once (i.e. a routine is triggered that toggles a bunch of switches). 

These changes are backwards compatible with old FW so we can get them released prior to the hub FW being released (and should to ensure we get runtime during customer beta for 0.54)

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests

* Tested on 0.53 FW

