### PR TITLE
New Devices (Z-Wave Switch) Shelly Multiple Switch Binary

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -923,6 +923,30 @@ zwaveManufacturer:
     productId: 0x0088
     productType: 0x0002
     deviceProfileName: smartplug-switch-power-energy
+  - id: 1120/2/131
+    deviceLabel: Wave 1
+    manufacturerId: 0x0460
+    productId: 0x0083
+    productType: 0x0002
+    deviceProfileName: switch-binary
+  - id: 1120/2/142
+    deviceLabel: Wave 1 Mini
+    manufacturerId: 0x0460
+    productId: 0x008E
+    productType: 0x0002
+    deviceProfileName: switch-binary
+  - id: 1120/2/138
+    deviceLabel: Wave Pro 1
+    manufacturerId: 0x0460
+    productId: 0x008A
+    productType: 0x0002
+    deviceProfileName: switch-binary
+  - id: 1120/2/140
+    deviceLabel: Wave Pro 2
+    manufacturerId: 0x0460
+    productId: 0x008C
+    productType: 0x0002
+    deviceProfileName: switch-binary
 zwaveGeneric:
   - id: "GenericSwitch/1"
     deviceLabel: Switch


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
There are four devices being added for this change. They are all devices under the brand name, Shelly. They all use the same profile. 

Model Numbers of the devices are:
1. ModelNumber: QNSW-001X16AU
2. ModelNumber: QMSW-0A1X8US
3. ModelNumber: QPSW-0A1X16EU
4. ModelNumber: QPSW-0A2X16US


# Summary of Completed Tests
These devices will be tested according to the WWST Certification process. 


