### PR TITLE
New Devices (Z-Wave Switch) Shelly Metering Switch(s)

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -923,6 +923,36 @@ zwaveManufacturer:
     productId: 0x0088
     productType: 0x0002
     deviceProfileName: smartplug-switch-power-energy
+  - id: 1120/2/132
+    deviceLabel: Wave 1PM
+    manufacturerId: 0x0460
+    productId: 0x0084
+    productType: 0x0002
+    deviceProfileName: metering-switch
+  - id: 1120/2/129
+    deviceLabel: Wave 2PM
+    manufacturerId: 0x0460
+    productId: 0x0081
+    productType: 0x0002
+    deviceProfileName: metering-switch
+  - id: 1120/2/143
+    deviceLabel: Wave 1PM Mini
+    manufacturerId: 0x0460
+    productId: 0x008F
+    productType: 0x0002
+    deviceProfileName: metering-switch
+  - id: 1120/2/139
+    deviceLabel: Wave Pro 1PM
+    manufacturerId: 0x0460
+    productId: 0x008B
+    productType: 0x0002
+    deviceProfileName: metering-switch
+  - id: 1120/2/141
+    deviceLabel: Wave Pro 2PM
+    manufacturerId: 0x0460
+    productId: 0x008D
+    productType: 0x0002
+    deviceProfileName: metering-switch
 zwaveGeneric:
   - id: "GenericSwitch/1"
     deviceLabel: Switch


### PR DESCRIPTION
Check all that apply

# Type of Change

- [X] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This change is for a WWST submission for Shelly devices that use the same profile. The devices are:
1. ModelNumber: QNSW-001P16US
2. ModelNumber: QNSW-002P16AU
3. ModelNumber: QMSW-0A1P8AU
4. ModelNumber: QPSW-0A1P16AU
5. ModelNumber: QPSW-0A2P16US


# Summary of Completed Tests
This will be tested as part of the WWST Process


