### PR TITLE
Matter Bridge Aqara Cube Support with Custom Capability

### DIFF
--- a/drivers/SmartThings/matter-button/capabilities/cubeAction.yaml
+++ b/drivers/SmartThings/matter-button/capabilities/cubeAction.yaml
@@ -1,0 +1,29 @@
+id: stse.cubeAction
+version: 1
+status: proposed
+name: Cube Action
+ephemeral: false
+attributes:
+  cubeAction:
+    schema:
+      type: object
+      properties:
+        value:
+          title: ActionType
+          type: string
+          enum:
+            - noAction
+            - shake
+            - rotate
+            - pickUpAndHold
+            - flipToSide1
+            - flipToSide2
+            - flipToSide3
+            - flipToSide4
+            - flipToSide5
+            - flipToSide6
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-button/capabilities/cubeFace.yaml
+++ b/drivers/SmartThings/matter-button/capabilities/cubeFace.yaml
@@ -1,0 +1,25 @@
+id: stse.cubeFace
+version: 1
+status: proposed
+name: Cube Face
+ephemeral: false
+attributes:
+  cubeFace:
+    schema:
+      type: object
+      properties:
+        value:
+          title: CubeFace
+          type: string
+          enum:
+            - face1Up
+            - face2Up
+            - face3Up
+            - face4Up
+            - face5Up
+            - face6Up
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-button/profiles/cube-t1-pro.yml
+++ b/drivers/SmartThings/matter-button/profiles/cube-t1-pro.yml
@@ -1,0 +1,19 @@
+name: cube-t1-pro
+components:
+  - id: main
+    capabilities:
+      - id: stse.cubeAction
+        version: 1
+      - id: stse.cubeFace
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: RemoteController
+metadata:
+  mnmn: SolutionsEngineering
+  vid: SmartThings-smartthings-Aqara_CubeT1Pro

--- a/drivers/SmartThings/matter-button/src/aqara-cube/init.lua
+++ b/drivers/SmartThings/matter-button/src/aqara-cube/init.lua
@@ -1,0 +1,230 @@
+local capabilities = require "st.capabilities"
+local log = require "log"
+local clusters = require "st.matter.generated.zap_clusters"
+local MatterDriver = require "st.matter.driver"
+local device_lib = require "st.device"
+
+local cubeAction = capabilities["stse.cubeAction"]
+local cubeFace = capabilities["stse.cubeFace"]
+
+local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
+local DEFERRED_CONFIGURE = "__DEFERRED_CONFIGURE"
+local INITIAL_PRESS_ONLY = "__initial_press_only" -- for devices that support MS (MomentarySwitch), but not MSR (MomentarySwitchRelease)
+
+local CUBEACTION_TIMER = "cubeAction_timer"
+local CUBEACTION_TIME = 3
+
+local function is_aqara_cube(opts, driver, device)
+  local name = string.format("%s", device.label)
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
+    string.find(name, "Aqara Cube T1 Pro") then
+      return true
+  end
+  return false
+end
+
+local callback_timer = function(device)
+  return function()
+    device:emit_event(cubeAction.cubeAction("noAction"))
+  end
+end
+
+local function reset_thread(device)
+  local timer = device:get_field(CUBEACTION_TIMER)
+  if timer then
+    device.thread:cancel_timer(timer)
+    device:set_field(CUBEACTION_TIMER, nil)
+  end
+  device:set_field(CUBEACTION_TIMER, device.thread:call_with_delay(CUBEACTION_TIME, callback_timer(device)))
+end
+
+local function do_refresh(driver, device)
+  -- refresh
+  device:send(clusters.PowerSource.attributes.BatPercentRemaining:read(device))
+end
+
+local function get_field_for_endpoint(device, field, endpoint)
+  return device:get_field(string.format("%s_%d", field, endpoint))
+end
+
+local function set_field_for_endpoint(device, field, endpoint, value, persist)
+  device:set_field(string.format("%s_%d", field, endpoint), value, {persist = persist})
+end
+
+-- The endpoints of each face may increase sequentially, but may increase as in [250, 251, 2, 3, 4, 5] 
+-- and the current device:get_endpoints function is valid only for the former so, adds this function.
+local function get_reordered_endpoints(driver, device)
+  if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
+    -- find the default/main endpoint, the device with the lowest EP that supports MS
+    table.sort(MS)
+    if MS[6] < (MS[1] + 150) then
+      -- When the endpoints of each face increase sequentially
+      -- The lowest EP is the main endpoint
+      -- as a workaround, it is assumed that the first endpoint number and the last endpoint number are not larger than 150.
+      return MS
+    else
+      -- When the endpoints of each face do not increase sequentially... [250, 251, 2, 3, 4, 5] 250 is the main endpoint.
+      -- For the situation where a node following these mechanisms has exhausted all available 65535 endpoint addresses for exposed entities,
+      -- it MAY wrap around to the lowest unused endpoint address (refter to Matter Core Spec 9.2.4. Dynamic Endpoint Allocation)
+      local ept1 = {}   -- First consecutive end points
+      local ept2 = {}   -- Second consecutive end points
+      local idx1 = 1
+      local idx2 = 1
+      local flag = 0
+      local previous = 0
+      for _, ep in ipairs(MS) do
+        if idx1 == 1 then
+          ept1[idx1] = ep
+        else
+          if flag == 0
+            and ep <= (previous + 15) then
+            -- the endpoint number does not always increase by 1
+            -- as a workaround, assume that the next endpoint number is not greater than 15
+            ept1[idx1] = ep
+          else
+            ept2[idx2] = ep
+            idx2 = idx2 + 1
+            if flag ~= 1 then
+              flag = 1
+            end
+          end
+        end
+        idx1 = idx1 + 1
+        previous = ep
+      end
+
+      local start = #ept2 + 1
+      idx1 = 1
+      idx2 = start
+      for i=start, 6 do
+        ept2[idx2] = ept1[idx1]
+        idx1 = idx1 + 1
+        idx2 = idx2 + 1
+      end
+      return ept2
+    end
+  end
+end
+
+local function endpoint_to_component(device, endpoint)
+  return "main"
+end
+
+local function device_init(driver, device)
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
+    device:subscribe()
+    device:set_endpoint_to_component_fn(endpoint_to_component)
+  end
+end
+
+-- This is called either on add for parent/child devices, or after the device profile changes for components
+local function configure_buttons(device)
+  if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
+    device.log.debug(#MS.." momentary switch endpoints")
+    for _, ep in ipairs(MS) do
+      -- device only supports momentary switch, no release events
+      device.log.debug("configuring for press event only")
+      set_field_for_endpoint(device, INITIAL_PRESS_ONLY, ep, true, true)
+    end
+  end
+end
+
+local function device_added(driver, device)
+  if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    local MS = {}
+    MS = get_reordered_endpoints(driver, device)
+    local main_endpoint = device.MATTER_DEFAULT_ENDPOINT
+    if #MS > 0 then
+      main_endpoint = MS[1] -- the endpoint matching to the non-child device
+      if MS[1] == 0 then main_endpoint = MS[2] end -- we shouldn't hit this, but just in case
+    end
+    device.log.debug("main button endpoint is "..main_endpoint)
+
+    -- At the moment, we're taking it for granted that all momentary switches only have 2 positions
+    local current_component_number = 1
+    local component_map = {}
+    local component_map_used = false
+    for _, ep in ipairs(MS) do -- for each momentary switch endpoint (including main)
+      device.log.debug("Configuring endpoint "..ep)
+      -- build the mapping of endpoints to components
+      component_map[string.format("%d", current_component_number)] = ep
+      current_component_number = current_component_number + 1
+    end
+
+    device:set_field(COMPONENT_TO_ENDPOINT_MAP, component_map, {persist = true})
+    device:try_update_metadata({profile = "cube-t1-pro"})
+    device:set_field(DEFERRED_CONFIGURE, true)
+  end
+end
+
+local function info_changed(driver, device, event, args)
+  if device.profile.id ~= args.old_st_store.profile.id
+    and device:get_field(DEFERRED_CONFIGURE)
+    and device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+
+    -- At the time of device_added, there is an error that the corresponding capability cannot be found
+    -- because the profile has not been changed from the generic profile of fingerprint to the Aqara Cube.
+    reset_thread(device)
+    device:emit_event(cubeFace.cubeFace("face1Up"))
+
+    -- profile has changed, and we deferred setting up our buttons, so do that now
+    configure_buttons(device)
+    device:set_field(DEFERRED_CONFIGURE, nil)
+  end
+end
+
+-- initial press
+local function initial_press_event_handler(driver, device, ib, response)
+  if get_field_for_endpoint(device, INITIAL_PRESS_ONLY, ib.endpoint_id) then
+    local map = device:get_field(COMPONENT_TO_ENDPOINT_MAP) or {}
+    local face = 1
+    for component, ep in pairs(map) do
+      if map[component] == ib.endpoint_id then
+        face = component
+        break
+      end
+    end
+
+    reset_thread(device)
+    device:emit_event(cubeAction.cubeAction(string.format("flipToSide%d", face)))
+    device:emit_event(cubeFace.cubeFace(string.format("face%dUp", face)))
+  end
+end
+
+local function battery_percent_remaining_attr_handler(driver, device, ib, response)
+  if ib.data.value then
+    device:emit_event(capabilities.battery.battery(math.floor(ib.data.value / 2.0 + 0.5)))
+  end
+end
+
+-- [[ register ]]
+local aqara_cube_t1_pro_handler = {
+  NAME = "Aqara Cube T1 Pro",
+  lifecycle_handlers = {
+    init = device_init,
+    added = device_added,
+    infoChanged = info_changed
+  },
+  capability_handlers = {
+    [capabilities.refresh.ID] = {
+      [capabilities.refresh.commands.refresh.NAME] = do_refresh
+    },
+  },
+  matter_handlers = {
+    attr = {
+      [clusters.PowerSource.ID] = {
+        [clusters.PowerSource.attributes.BatPercentRemaining.ID] = battery_percent_remaining_attr_handler
+      }
+    },
+    event = {
+      [clusters.Switch.ID] = {
+        [clusters.Switch.events.InitialPress.ID] = initial_press_event_handler
+      }
+    },
+  },
+  can_handle = is_aqara_cube
+}
+
+return aqara_cube_t1_pro_handler

--- a/drivers/SmartThings/matter-button/src/init.lua
+++ b/drivers/SmartThings/matter-button/src/init.lua
@@ -397,6 +397,9 @@ local matter_driver_template = {
       clusters.Switch.events.MultiPressComplete
     }
   },
+  sub_drivers = {
+    require("aqara-cube")
+  }
 }
 
 local matter_driver = MatterDriver("matter-button", matter_driver_template)

--- a/drivers/SmartThings/matter-button/src/test/test_aqara_cube.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_aqara_cube.lua
@@ -1,0 +1,130 @@
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+test.add_package_capability("cubeAction.yaml")
+test.add_package_capability("cubeFace.yaml")
+local t_utils = require "integration_test.utils"
+
+local clusters = require "st.matter.generated.zap_clusters"
+
+local cubeAction = capabilities["stse.cubeAction"]
+local cubeFace = capabilities["stse.cubeFace"]
+
+--mock the actual device
+local mock_device = test.mock_device.build_test_matter_device(
+  {
+    profile = t_utils.get_profile_definition("cube-t1-pro.yml"),
+    manufacturer_info = {vendor_id = 0x115f, product_id = 0x0000},
+    endpoints = 
+    {
+      {
+        endpoint_id = 1,
+        clusters =
+        {
+          {
+            cluster_id = clusters.Switch.ID,
+            feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH,
+            cluster_type = "SERVER"
+          },
+          {
+            cluster_id = clusters.PowerSource.ID,
+            cluster_type = "SERVER",
+            feature_map = clusters.PowerSource.types.PowerSourceFeature.BATTERY
+          }
+        },
+      },
+    },
+  }
+)
+
+-- add device for each mock device
+local CLUSTER_SUBSCRIBE_LIST ={
+  clusters.PowerSource.server.attributes.BatPercentRemaining,
+  -- In order to add InitialPress, button capability must be added. 
+  -- In this case, the rest of the button events must also be added.
+--  clusters.Switch.server.events.InitialPress,
+--  clusters.Switch.server.events.LongPress,
+--  clusters.Switch.server.events.ShortRelease,
+--  clusters.Switch.server.events.MultiPressComplete,
+}
+
+local function test_init()
+  local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
+  for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
+    if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+end
+
+test.set_test_init_function(test_init)
+
+--[[
+-- custom capability cannot be supported by the test framework.
+-- Error Message :
+--   capability was not sent expected message:
+--   {"00000000-1111-2222-3333-000000000001", {attribute_id="cubeAction", capability_id="stse.cubeAction", component_id="main", state={value="noAction"}}}
+test.register_message_test(
+  "Handle single press sequence for cubeAction", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Switch.events.InitialPress:build_test_event_report(
+          mock_device, 1, {new_position = 1}  --move to position 1?
+        ),
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", cubeAction.cubeAction({value = "noAction"}, {state_change = true})) --should send initial press
+    }
+  }
+)
+
+test.register_message_test(
+  "Handle single press sequence for cubeFace", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Switch.events.InitialPress:build_test_event_report(
+          mock_device, 1, {new_position = 1}  --move to position 1?
+        ),
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", cubeFace.cubeFace({value = "face1Up"}, {state_change = true})) --should send initial press
+    }
+  }
+)
+--]]
+
+test.register_message_test(
+  "Handle received BatPercentRemaining from device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
+          mock_device, 1, 150
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message(
+        "main", capabilities.battery.battery(math.floor(150 / 2.0 + 0.5))
+      ),
+    },
+  }
+)
+-- run the tests
+test.run_registered_tests()


### PR DESCRIPTION
Currently, the Generic EdgeDriver applied to the Matter Bridge Aqara Cube is implemented by mapping six faces into individual components, making it difficult to check the event occurrence of individual faces on one screen.

 - REQ-15926, REQ-16285, IOTE-4217, IOTE-4266


Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [V] Refactor

# Checklist

- [V] I have performed a self-review of my code
- [V] I have commented my code in hard-to-understand areas
- [V] I have verified my changes by testing with a device or have communicated a plan for testing
- [V] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This commit wants to improve the problem by mapping the event from Matter Bridge with Aqara Cube Custom Capability developed by Zigbee driver. This means that there is a limitation that the Action Event of the Cube that the Matter Bridge does not give can not be processed.

# Summary of Completed Tests
- Successful test for Plugin UI update and Dash Board's Device Card status update according to the selection of each face
- Successful Automation Routine Test for Cube Face
- Even though the Cube Face is changed, the status is sometimes not updated because the Aqara Matter Bride does not send the event.