### PR TITLE
Matter Bridge Aqara Cube Support with Custom Capability

### DIFF
--- a/drivers/SmartThings/matter-button/capabilities/cubeAction.yaml
+++ b/drivers/SmartThings/matter-button/capabilities/cubeAction.yaml
@@ -1,0 +1,29 @@
+id: stse.cubeAction
+version: 1
+status: proposed
+name: Cube Action
+ephemeral: false
+attributes:
+  cubeAction:
+    schema:
+      type: object
+      properties:
+        value:
+          title: ActionType
+          type: string
+          enum:
+            - noAction
+            - shake
+            - rotate
+            - pickUpAndHold
+            - flipToSide1
+            - flipToSide2
+            - flipToSide3
+            - flipToSide4
+            - flipToSide5
+            - flipToSide6
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-button/capabilities/cubeFace.yaml
+++ b/drivers/SmartThings/matter-button/capabilities/cubeFace.yaml
@@ -1,0 +1,25 @@
+id: stse.cubeFace
+version: 1
+status: proposed
+name: Cube Face
+ephemeral: false
+attributes:
+  cubeFace:
+    schema:
+      type: object
+      properties:
+        value:
+          title: CubeFace
+          type: string
+          enum:
+            - face1Up
+            - face2Up
+            - face3Up
+            - face4Up
+            - face5Up
+            - face6Up
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-button/profiles/cube-t1-pro.yml
+++ b/drivers/SmartThings/matter-button/profiles/cube-t1-pro.yml
@@ -1,0 +1,19 @@
+name: cube-t1-pro
+components:
+  - id: main
+    capabilities:
+      - id: stse.cubeAction
+        version: 1
+      - id: stse.cubeFace
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: RemoteController
+metadata:
+  mnmn: SolutionsEngineering
+  vid: SmartThings-smartthings-Aqara_CubeT1Pro


### PR DESCRIPTION
Currently, the Generic EdgeDriver applied to the Matter Bridge Aqara Cube is implemented by mapping six faces into individual components, making it difficult to check the event occurrence of individual faces on one screen.

 - REQ-15926, REQ-16285, IOTE-4217, IOTE-4266

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [V] Refactor

# Checklist

- [V] I have performed a self-review of my code
- [V] I have commented my code in hard-to-understand areas
- [V] I have verified my changes by testing with a device or have communicated a plan for testing
- [V] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This commit wants to improve the problem by mapping the event from Matter Bridge with Aqara Cube Custom Capability developed by Zigbee driver. This means that there is a limitation that the Action Event of the Cube that the Matter Bridge does not give can not be processed.

# Summary of Completed Tests
- Successful test for Plugin UI update and Dash Board's Device Card status update according to the selection of each face
- Successful Automation Routine Test for Cube Face
- Even though the Cube Face is changed, the status is sometimes not updated because the Aqara Matter Bride does not send the event.