### PR TITLE
Matter Button: Add profile for 5-button devices

### DIFF
--- a/drivers/SmartThings/matter-button/profiles/5-button-battery.yml
+++ b/drivers/SmartThings/matter-button/profiles/5-button-battery.yml
@@ -1,0 +1,38 @@
+name: 5-button-battery
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: battery
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button5
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/profiles/5-button.yml
+++ b/drivers/SmartThings/matter-button/profiles/5-button.yml
@@ -1,0 +1,36 @@
+name: 5-button
+components:
+  - id: main
+    capabilities:
+      - id: button
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController
+  - id: button5
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+    - name: RemoteController

--- a/drivers/SmartThings/matter-button/src/init.lua
+++ b/drivers/SmartThings/matter-button/src/init.lua
@@ -9,7 +9,7 @@ local START_BUTTON_PRESS = "__start_button_press"
 local TIMEOUT_THRESHOLD = 10 --arbitrary timeout
 local HELD_THRESHOLD = 1
 -- this is the number of buttons for which we have a static profile already made
-local STATIC_PROFILE_SUPPORTED = {2, 4, 6, 8}
+local STATIC_PROFILE_SUPPORTED = {2, 4, 5, 6, 8}
 
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
 local DEFERRED_CONFIGURE = "__DEFERRED_CONFIGURE"

--- a/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
@@ -40,27 +40,9 @@ local mock_device = test.mock_device.build_test_matter_device(
       clusters = {
         {
           cluster_id = clusters.Switch.ID,
-          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS,
-          cluster_type = "SERVER"
-        },
-      },
-    },
-    {
-      endpoint_id = 5,
-      clusters = {
-        {
-          cluster_id = clusters.Switch.ID,
-          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS,
-          cluster_type = "SERVER"
-        },
-      },
-    },
-    {
-      endpoint_id = 6,
-      clusters = {
-        {
-          cluster_id = clusters.Switch.ID,
-          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS,
+          feature_map = clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH
+            | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS
+            | clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS,
           cluster_type = "SERVER"
         },
       },
@@ -124,28 +106,8 @@ local function test_init()
     parent_device_id = mock_device.id,
     parent_assigned_child_key = "04"
   })
-  test.socket.capability:__expect_send(mock_children[4]:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
+  test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 4)})
   test.socket.capability:__expect_send(mock_children[4]:generate_test_message("main", button_attr.pushed({state_change = false})))
-
-  mock_device:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Button 4",
-    profile = "button",
-    parent_device_id = mock_device.id,
-    parent_assigned_child_key = "05"
-  })
-  test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 5)})
-  test.socket.capability:__expect_send(mock_children[5]:generate_test_message("main", button_attr.pushed({state_change = false})))
-
-  mock_device:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Button 5",
-    profile = "button",
-    parent_device_id = mock_device.id,
-    parent_assigned_child_key = "06"
-  })
-  test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 6)})
-  test.socket.capability:__expect_send(mock_children[6]:generate_test_message("main", button_attr.pushed({state_change = false})))
 
 end
 
@@ -243,27 +205,6 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Receiving a max press attribute of 2 should emit correct event", {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.Switch.attributes.MultiPressMax:build_test_report_data(
-          mock_device, 6, 2
-        )
-      },
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_children[6]:generate_test_message("main",
-        capabilities.button.supportedButtonValues({"pushed", "double"}, {visibility = {displayed = false}}))
-    },
-  }
-)
-
-test.register_message_test(
   "Receiving a max press attribute of 3 should emit correct event", {
     {
       channel = "matter",
@@ -271,15 +212,15 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.Switch.attributes.MultiPressMax:build_test_report_data(
-          mock_device, 5, 3
+          mock_device, 4, 3
         )
       },
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_children[5]:generate_test_message("main",
-        capabilities.button.supportedButtonValues({"pushed", "double", "pushed_3x"}, {visibility = {displayed = false}}))
+      message = mock_children[4]:generate_test_message("main",
+        capabilities.button.supportedButtonValues({"pushed", "double", "held", "pushed_3x"}, {visibility = {displayed = false}}))
     },
   }
 )
@@ -313,7 +254,7 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 5, {new_position = 1}
+        mock_device, 4, {new_position = 1}
       )
     }
   },
@@ -323,14 +264,14 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.MultiPressComplete:build_test_event_report(
-        mock_device, 5, {new_position = 1, total_number_of_presses_counted = 2, previous_position = 0}
+        mock_device, 4, {new_position = 1, total_number_of_presses_counted = 2, previous_position = 0}
       )
     }
   },
   {
     channel = "capability",
     direction = "send",
-    message = mock_children[5]:generate_test_message("main", button_attr.double({state_change = true}))
+    message = mock_children[4]:generate_test_message("main", button_attr.double({state_change = true}))
   },
 
 }
@@ -344,7 +285,7 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.InitialPress:build_test_event_report(
-        mock_device, 6, {new_position = 1}
+        mock_device, 4, {new_position = 1}
       )
     }
   },
@@ -354,14 +295,14 @@ test.register_message_test(
     message = {
       mock_device.id,
       clusters.Switch.events.MultiPressComplete:build_test_event_report(
-        mock_device, 6, {new_position = 1, total_number_of_presses_counted = 4, previous_position = 0}
+        mock_device, 4, {new_position = 1, total_number_of_presses_counted = 4, previous_position = 0}
       )
     }
   },
   {
     channel = "capability",
     direction = "send",
-    message = mock_children[6]:generate_test_message("main", button_attr.pushed_4x({state_change = true}))
+    message = mock_children[4]:generate_test_message("main", button_attr.pushed_4x({state_change = true}))
   },
 
 }


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

There are some 5-button Matter devices out there so the addition of the 5-button profiles will allow those devices to join as a single multi-component device instead of a parent/child device.

https://smartthings.atlassian.net/browse/CHAD-13761

# Summary of Completed Tests

- [x] Testing with physical device
