### PR TITLE
Matter Switch: add child profile overrides

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -66,6 +66,11 @@ local device_type_profile_map = {
   [ON_OFF_DIMMER_SWITCH_ID] = "switch-level",
   [ON_OFF_COLOR_DIMMER_SWITCH_ID] = "switch-color-level",
 }
+
+local child_device_profile_overrides = {
+  { vendor_id = 0x1321, product_id = 0x000D,  child_profile = "switch-binary" },
+}
+
 local detect_matter_thing
 
 local function get_field_for_endpoint(device, field, endpoint)
@@ -109,6 +114,16 @@ end
 
 local function assign_child_profile(device, child_ep)
   local profile
+
+  -- check if device has an overriden child profile that differs from the profile
+  -- that would match the child's device type
+  for _, fingerprint in ipairs(child_device_profile_overrides) do
+    if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
+       device.manufacturer_info.product_id == fingerprint.product_id then
+      return fingerprint.child_profile
+    end
+  end
+
   for _, ep in ipairs(device.endpoints) do
     if ep.endpoint_id == child_ep then
       -- Some devices report multiple device types which are a subset of

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -19,6 +19,7 @@ local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 
 local child_profile = t_utils.get_profile_definition("plug-binary.yml")
+local child_profile_override = t_utils.get_profile_definition("switch-binary.yml")
 local parent_ep = 10
 local child1_ep = 20
 local child2_ep = 30
@@ -29,6 +30,53 @@ local mock_device = test.mock_device.build_test_matter_device({
   manufacturer_info = {
     vendor_id = 0x0000,
     product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = parent_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
+      }
+    },
+    {
+      endpoint_id = child1_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
+      }
+    },
+    {
+      endpoint_id = child2_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
+      }
+    },
+  }
+})
+
+local mock_device_child_profile_override = test.mock_device.build_test_matter_device({
+  label = "Matter Switch",
+  profile = t_utils.get_profile_definition("switch-binary.yml"),
+  manufacturer_info = {
+    vendor_id = 0x1321,
+    product_id = 0x000D,
   },
   endpoints = {
     {
@@ -108,6 +156,47 @@ local function test_init()
     label = "Matter Switch 3",
     profile = "plug-binary",
     parent_device_id = mock_device.id,
+    parent_assigned_child_key = string.format("%d", child2_ep)
+  })
+end
+
+local mock_children_child_profile_override = {}
+for i, endpoint in ipairs(mock_device_child_profile_override.endpoints) do
+  if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
+    local child_data = {
+      profile = child_profile_override,
+      device_network_id = string.format("%s:%d", mock_device_child_profile_override.id, endpoint.endpoint_id),
+      parent_device_id = mock_device_child_profile_override.id,
+      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+    }
+    mock_children_child_profile_override[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
+local function test_init_child_profile_override()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_child_profile_override)
+  test.socket.matter:__expect_send({mock_device_child_profile_override.id, subscribe_request})
+
+  test.mock_device.add_test_device(mock_device_child_profile_override)
+  for _, child in pairs(mock_children_child_profile_override) do
+    test.mock_device.add_test_device(child)
+  end
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 2",
+    profile = "switch-binary",
+    parent_device_id = mock_device_child_profile_override.id,
+    parent_assigned_child_key = string.format("%d", child1_ep)
+  })
+
+  mock_device:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 3",
+    profile = "switch-binary",
+    parent_device_id = mock_device_child_profile_override.id,
     parent_assigned_child_key = string.format("%d", child2_ep)
   })
 end
@@ -226,6 +315,12 @@ test.register_coroutine_test(
     local req = clusters.OnOff.attributes.OnOff:read(mock_children[child1_ep])
     test.socket.matter:__expect_send({mock_device.id, req})
   end
+)
+
+test.register_coroutine_test(
+  "Child device profiles should be overriden for specific devices", function()
+    end,
+    { test_init = test_init_child_profile_override }
 )
 
 test.run_registered_tests()


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
[CHAD-13811](https://smartthings.atlassian.net/browse/CHAD-13811)
Add the ability to override the child profile that would be assigned based on the child's device type. This is done because some devices have the "On/Off Plug" device type, but it would make more sense for them to appear with the switch icon as indicated in their WWST fingerprint.

# Summary of Completed Tests

- [x] Unit test added
A unit test has been added to test this behavior.

- [x] Tested on device (Sonoff 3-Key Switch)
Additionally, testing was done with the Sonoff 3-key switch, which is a device that would need a child profile override to show up correctly. This is because the child devices have the "On Off Plug" device type (which is correct in this case), but it would make more sense for this device to appear with our `switch` icon rather than our `plug` icon. The parent device will already show as a `switch` because that is the profile that is used in the fingerprint for the parent device. Therefore, we needed this override so that the child and parent devices show up with the same icon (switch instead of plug). This change was tested with this device and now parent and child devices show up correctly.

- [x] Test on VDA
Tested with composed light device on VDA to confirm there was no regression in existing functionality. The mutli-light device type still appears correctly with the child devices being assigned to the expected profiles.



[CHAD-13811]: https://smartthings.atlassian.net/browse/CHAD-13811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ