### PR TITLE
BUG2-2243 Add composite display to zigbee humidity sensors

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-battery.yml
@@ -19,3 +19,45 @@ preferences:
     explicit: true
   - preferenceId: humidityOffset
     explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: battery
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: battery
+        version: 1
+    actions: []

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-battery.yml
@@ -21,3 +21,51 @@ preferences:
     explicit: true
   - preferenceId: humidityOffset
     explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: atmosphericPressureMeasurement
+      version: 1
+    - component: main
+      capability: battery
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: atmosphericPressureMeasurement
+        version: 1
+      - component: main
+        capability: battery
+        version: 1
+    actions: []

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure.yml
@@ -19,3 +19,45 @@ preferences:
     explicit: true
   - preferenceId: humidityOffset
     explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: atmosphericPressureMeasurement
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: atmosphericPressureMeasurement
+        version: 1
+    actions: []

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity.yml
@@ -17,3 +17,39 @@ preferences:
     explicit: true
   - preferenceId: humidityOffset
     explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+    actions: []

--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temp-battery.yml
@@ -19,3 +19,45 @@ preferences:
     explicit: true
   - preferenceId: humidityOffset
     explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: battery
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: battery
+        version: 1
+    actions: []

--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/humidity-temperature.yml
@@ -17,3 +17,39 @@ preferences:
     explicit: true
   - preferenceId: humidityOffset
     explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+    actions: []

--- a/drivers/SmartThings/zwave-sensor/profiles/humidity-temperature-battery.yml
+++ b/drivers/SmartThings/zwave-sensor/profiles/humidity-temperature-battery.yml
@@ -4,10 +4,6 @@ components:
   capabilities:
   - id: temperatureMeasurement
     version: 1
-    config:
-      values:
-        - key: "temperature.value"
-          range: [-20, 100]
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery
@@ -16,3 +12,54 @@ components:
     version: 1
   categories:
   - name: TempHumiditySensor
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        values:
+          - key: "temperature.value"
+            range: [-20, 100]
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: [ ]
+    basicPlus: [ ]
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+      values:
+        - key: "temperature.value"
+          range: [-20, 100]
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: battery
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        values:
+          - key: "temperature.value"
+            range: [-20, 100]
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: battery
+        version: 1
+    actions: []


### PR DESCRIPTION
Updates profile to show both temperature and humidity on the device card for zigbee humidity/temperature sensors.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [X] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


