### PR TITLE
Matter-Switch: Improve color temp conversion rounding

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -105,7 +105,7 @@ local function mired_to_kelvin(value, minOrMax)
   elseif minOrMax == COLOR_TEMP_MAX then
     return utils.round(MIRED_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value - 1)) - rounding_value) * kelvin_step_size
   else
-    log.warn("Attempted to convert temperature unit for an undefined value")
+    log.warn_with({hub_logs = true}, "Attempted to convert temperature unit for an undefined value")
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -96,11 +96,16 @@ local function mired_to_kelvin(value, minOrMax)
   -- bounds to be multiples of 100. For the maximum mired value (minimum K value),
   -- add 1 before converting and round up to nearest hundreds. For the minimum mired
   -- (maximum K value) value, subtract 1 before converting and round down to nearest
-  -- hundreds.
+  -- hundreds. Note that 1 is added/subtracted from the mired value in order to avoid
+  -- rounding errors from the conversion of Kelvin to mireds.
+  local kelvin_step_size = 100
+  local rounding_value = 0.5
   if minOrMax == COLOR_TEMP_MIN then
-    return utils.round(((MIRED_KELVIN_CONVERSION_CONSTANT / (value + 1)) / 100) + 0.5) * 100
+    return utils.round(MIRED_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value + 1)) + rounding_value) * kelvin_step_size
+  elseif minOrMax == COLOR_TEMP_MAX then
+    return utils.round(MIRED_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value - 1)) - rounding_value) * kelvin_step_size
   else
-    return utils.round(((MIRED_KELVIN_CONVERSION_CONSTANT / (value - 1)) / 100) - 0.5) * 100
+    log.warn("Attempted to convert temperature unit for an undefined value")
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -649,6 +649,33 @@ test.register_message_test(
 )
 
 test.register_message_test(
+  "Min and max color temperature attributes set capability constraint using improved temperature conversion rounding",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorTempPhysicalMinMireds:build_test_report_data(mock_device, 1, 165)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds:build_test_report_data(mock_device, 1, 365)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorTemperature.colorTemperatureRange({minimum = 2800, maximum = 6000}))
+    }
+  }
+)
+
+test.register_message_test(
   "Min color temperature outside of range, capability not sent",
   {
     {


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-13828](https://smartthings.atlassian.net/browse/CHAD-13828)

This change adjusts the way that the color temperature bounds are rounded while converting them from mireds into Kelvin. Previously, they were rounded to the nearest hundreds value and this sometimes resulted in the range displayed in the ST app being larger than the range supported by the device. This change will prevent this from occurring by shortening the range, if needed, to always be within the range supported by the device.

See [here](https://smartthings.atlassian.net/wiki/spaces/CHIP/pages/3386376304/Color+Temperature+Range+Selection+Proposal) for a comparison of the current rounding method to the method proposed by this PR.

Note that the `mired_to_kelvin` function is not used anywhere else in the matter-switch driver, so making these changes in this function won't affect any other functionality.

# Summary of Completed Tests

The unit test added by this PR tests a case where the minimum and maximum mired values get converted to Kelvin and are send out in the colorTemperatureRange capability. In the main branch, this test will fail because 165 mireds, which is equal to 6060.6K, would be rounded to 6100K, and 365 mireds, equal to 2739.7K would be rounded to 2700K. With the changes in this PR, 165 mireds is converted to 6000K and 365 mireds is converted to 2800K, a range that lies within the supported range in this scenario.

[CHAD-13828]: https://smartthings.atlassian.net/browse/CHAD-13828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ