### PR TITLE
fix an issue of fan proposed capabilities

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/fan-without-windmode.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/fan-without-windmode.yml
@@ -1,0 +1,17 @@
+name: fan-without-windmode
+components:
+- id: main
+  capabilities:
+  - id: airConditionerFanMode
+    version: 1
+  - id: fanSpeedPercent
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Fan
+metadata:
+  mnmn: SmartThingsEdge
+  vid: generic-fan-wind

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -240,6 +240,12 @@ end
 
 local function device_init(driver, device)
   device:subscribe()
+  -- To check if the device support WindSupportMask
+  local eps = device:get_endpoints(clusters.FanControl.ID, {feature_bitmap = clusters.FanControl.types.WindSupportMask.SLEEP_WIND})
+  local new_profile = "fan-without-windmode"
+  if #eps == 0 then
+    device:try_update_metadata({profile = new_profile})
+  end
   device:set_component_to_endpoint_fn(component_to_endpoint)
 end
 


### PR DESCRIPTION
Description: During the WWST for the Yeelight fan (a bridged device), we discovered that after onboarding the devices by sharing through yeelight App, it displays an unsupported capability called "windMode."

The reason is that the "fan.yml" profile is chosen for the bridged device (fan device type) when it is shared via Matter, and the windMode capability is included by default in this profile. However, certain fan device types do not support windMode because the WindSetting (0x000A) is not a mandatory attribute, which means that the command to write the WindSetting cannot be sent.

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


