### PR TITLE
matter-lock: Expose 'not fully locked' when reported by the lock

### DIFF
--- a/drivers/SmartThings/matter-lock/src/aqara-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/aqara-lock/init.lua
@@ -57,7 +57,7 @@ local function lock_state_handler(driver, device, ib, response)
   local LockState = DoorLock.attributes.LockState
   local attr = capabilities.lock.lock
   local LOCK_STATE = {
-    [LockState.NOT_FULLY_LOCKED] = attr.unknown(),
+    [LockState.NOT_FULLY_LOCKED] = attr.not_fully_locked(),
     [LockState.LOCKED] = attr.locked(),
     [LockState.UNLOCKED] = attr.unlocked(),
   }
@@ -143,3 +143,4 @@ local aqara_lock_handler = {
 }
 
 return aqara_lock_handler
+

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -78,7 +78,7 @@ local function lock_state_handler(driver, device, ib, response)
   local LockState = DoorLock.attributes.LockState
   local attr = capabilities.lock.lock
   local LOCK_STATE = {
-    [LockState.NOT_FULLY_LOCKED] = attr.unknown(),
+    [LockState.NOT_FULLY_LOCKED] = attr.not_fully_locked(),
     [LockState.LOCKED] = attr.locked(),
     [LockState.UNLOCKED] = attr.unlocked(),
     [UNLATCHED_STATE] = attr.unlocked(), -- Fully unlocked with latch pulled

--- a/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
@@ -100,7 +100,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Handle received Lock State from Matter device.", {
+  "Handle received LockState.LOCKED from Matter device.", {
     {
       channel = "matter",
       direction = "receive",
@@ -115,6 +115,46 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.lock.lock.locked()),
+    },
+  }
+)
+
+test.register_message_test(
+  "Handle received LockState.UNLOCKED from Matter device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.DoorLock.attributes.LockState:build_test_report_data(
+          mock_device, 1, clusters.DoorLock.attributes.LockState.UNLOCKED
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.lock.lock.unlocked()),
+    },
+  }
+)
+
+test.register_message_test(
+  "Handle received LockState.NOT_FULLY_LOCKED from Matter device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.DoorLock.attributes.LockState:build_test_report_data(
+          mock_device, 1, clusters.DoorLock.attributes.LockState.NOT_FULLY_LOCKED
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.lock.lock.not_fully_locked()),
     },
   }
 )

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
@@ -96,7 +96,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Handle received Lock State from Matter device.", {
+  "Handle received LockState.LOCKED from Matter device.", {
     {
       channel = "matter",
       direction = "receive",
@@ -111,6 +111,66 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.lock.lock.locked()),
+    },
+  }
+)
+
+test.register_message_test(
+  "Handle received LockState.UNLOCKED from Matter device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.DoorLock.attributes.LockState:build_test_report_data(
+          mock_device, 10, clusters.DoorLock.attributes.LockState.UNLOCKED
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.lock.lock.unlocked()),
+    },
+  }
+)
+
+test.register_message_test(
+  "Handle received LockState.NOT_FULLY_LOCKED from Matter device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.DoorLock.attributes.LockState:build_test_report_data(
+          mock_device, 10, clusters.DoorLock.attributes.LockState.NOT_FULLY_LOCKED
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.lock.lock.not_fully_locked()),
+    },
+  }
+)
+
+test.register_message_test(
+  "Handle received LockState.UNLATCHED from Matter device.", {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.DoorLock.attributes.LockState:build_test_report_data(
+          mock_device, 10, clusters.DoorLock.attributes.LockState.UNLATCHED
+        ),
+      },
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.lock.lock.unlocked()),
     },
   }
 )


### PR DESCRIPTION
Previously we were mapping the 'not fully locked' to 'unknown' but now that the lock attribute has the 'not fully locked' variant we can expose that directly.

https://smartthings.atlassian.net/browse/CHAD-11259

# Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing

# Summary of Completed Tests

Tested with a Yale Matter lock 


