### PR TITLE
Update tests to account for default native handler registration

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -92,6 +92,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -111,6 +119,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         { capability = "switch", component = "main", command = "off", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -114,6 +114,14 @@ test.register_message_test(
 				{ capability = "switch", component = "main", command = "on", args = { } }
 			}
 		},
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
 		{
 			channel = "matter",
 			direction = "send",
@@ -134,6 +142,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         { capability = "switch", component = "main", command = "off", args = { } }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {
@@ -158,6 +174,14 @@ test.register_message_test(
 				{ capability = "switchLevel", component = "main", command = "setLevel", args = {20,20} }
 			}
 		},
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
+      }
+    },
 		{
 			channel = "matter",
 			direction = "send",

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -125,6 +125,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -147,6 +155,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -166,6 +182,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         { capability = "switchLevel", component = "main", command = "setLevel", args = {20,20} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -148,6 +148,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -183,6 +191,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_children[child1_ep].id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -215,6 +231,14 @@ test.register_message_test(
       message = {
         mock_children[child2_ep].id,
         { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_children[child2_ep].id, capability_id = "switch", capability_cmd_id = "on" }
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -215,6 +215,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -250,6 +258,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_children[child1_ep].id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -282,6 +298,14 @@ test.register_message_test(
       message = {
         mock_children[child2_ep].id,
         { capability = "switch", component = "main", command = "on", args = { } }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_children[child2_ep].id, capability_id = "switch", capability_cmd_id = "on" }
       }
     },
     {

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -112,6 +112,14 @@ test.register_message_test(
         message = { mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57, 0 } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_device.id, Level.server.commands.MoveToLevelWithOnOff(mock_device,

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
@@ -178,6 +178,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -188,6 +189,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
@@ -179,6 +179,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -189,6 +190,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module.lua
@@ -103,6 +103,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -113,6 +114,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module_no_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module_no_power.lua
@@ -96,6 +96,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -106,6 +107,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_no_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_no_power.lua
@@ -153,6 +153,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -163,6 +164,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_child.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_child:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end
@@ -173,6 +175,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end
@@ -183,6 +186,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_child.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_child:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_power.lua
@@ -188,6 +188,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -198,6 +199,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_child.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_child:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end
@@ -208,6 +210,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end
@@ -218,6 +221,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_child.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_child:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
@@ -103,6 +103,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device) })
   end
@@ -113,6 +114,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_child.id,
       { capability = "switch", component = "main", command = "on", args = {} } })
+    mock_child:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end
@@ -123,6 +125,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device) })
   end
@@ -133,6 +136,7 @@ test.register_coroutine_test(
   function()
     test.socket.capability:__queue_receive({ mock_child.id,
       { capability = "switch", component = "main", command = "off", args = {} } })
+    mock_child:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zigbee:__expect_send({ mock_device.id,
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
@@ -60,6 +60,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOff.commands.On(mock_device) }
@@ -74,6 +82,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
@@ -48,6 +48,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOffCluster.server.commands.On(mock_device) }
@@ -64,6 +72,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOffCluster.server.commands.Off(mock_device) }
@@ -78,6 +94,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57, 0 } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
@@ -390,6 +390,14 @@ test.register_message_test(
         message = { mock_parent_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x01) }
@@ -404,6 +412,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_first_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
       },
       {
         channel = "zigbee",
@@ -422,6 +438,14 @@ test.register_message_test(
         message = { mock_second_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x03) }
@@ -436,6 +460,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_third_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
       },
       {
         channel = "zigbee",
@@ -454,6 +486,14 @@ test.register_message_test(
         message = { mock_fourth_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_fourth_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x05) }
@@ -468,6 +508,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_fifth_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_fifth_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
       },
       {
         channel = "zigbee",
@@ -486,6 +534,14 @@ test.register_message_test(
         message = { mock_parent_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x01) }
@@ -500,6 +556,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_first_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",
@@ -518,6 +582,14 @@ test.register_message_test(
         message = { mock_second_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x03) }
@@ -532,6 +604,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_third_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",
@@ -550,6 +630,14 @@ test.register_message_test(
         message = { mock_fourth_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_fourth_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x05) }
@@ -564,6 +652,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_fifth_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_fifth_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
@@ -47,6 +47,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOffCluster.server.commands.On(mock_device) }
@@ -61,6 +69,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
@@ -230,6 +230,14 @@ test.register_message_test(
       message = { mock_parent_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device) }
@@ -244,6 +252,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_first_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_first_child.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
     },
     {
       channel = "zigbee",
@@ -262,6 +278,14 @@ test.register_message_test(
       message = { mock_second_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_second_child.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x03) }
@@ -276,6 +300,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_parent_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
     },
     {
       channel = "zigbee",
@@ -294,6 +326,14 @@ test.register_message_test(
       message = { mock_first_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_first_child.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x02) }
@@ -308,6 +348,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_second_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_second_child.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
@@ -247,6 +247,14 @@ test.register_message_test(
         message = { mock_child_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_child_device.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x02) }
@@ -261,6 +269,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_parent_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
       },
       {
         channel = "zigbee",
@@ -279,6 +295,14 @@ test.register_message_test(
         message = { mock_child_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_child_device.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x02) }
@@ -293,6 +317,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_parent_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
@@ -96,6 +96,14 @@ test.register_message_test(
         message = { mock_simple_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57, 0 } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_simple_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_simple_device.id, Level.server.commands.MoveToLevelWithOnOff(mock_simple_device,

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
@@ -54,6 +54,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOff.server.commands.On(mock_device) }
@@ -68,6 +76,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
@@ -54,6 +54,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOff.server.commands.On(mock_device) }
@@ -68,6 +76,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
@@ -361,6 +361,14 @@ test.register_message_test(
         message = { mock_parent_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x01) }
@@ -375,6 +383,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_first_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
       },
       {
         channel = "zigbee",
@@ -393,6 +409,14 @@ test.register_message_test(
         message = { mock_second_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.On(mock_parent_device):to_endpoint(0x03) }
@@ -407,6 +431,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_third_child.id, { capability = "switch", component = "main", command = "on", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
       },
       {
         channel = "zigbee",
@@ -426,6 +458,14 @@ test.register_message_test(
         message = { mock_parent_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x01) }
@@ -440,6 +480,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_first_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",
@@ -458,6 +506,14 @@ test.register_message_test(
         message = { mock_second_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_parent_device.id, OnOff.server.commands.Off(mock_parent_device):to_endpoint(0x03) }
@@ -472,6 +528,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_third_child.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_dimmer_power_energy.lua
@@ -46,6 +46,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOffCluster.server.commands.On(mock_device) }
@@ -62,6 +70,14 @@ test.register_message_test(
       message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
+    },
+    {
       channel = "zigbee",
       direction = "send",
       message = { mock_device.id, OnOffCluster.server.commands.Off(mock_device) }
@@ -76,6 +92,14 @@ test.register_message_test(
       channel = "capability",
       direction = "receive",
       message = { mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57, 0 } } }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
+      }
     },
     {
       channel = "zigbee",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
@@ -53,6 +53,14 @@ test.register_message_test(
         message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
+        }
+      },
+      {
         channel = "zigbee",
         direction = "send",
         message = { mock_device.id, OnOff.server.commands.On(mock_device) }
@@ -67,6 +75,14 @@ test.register_message_test(
         channel = "capability",
         direction = "receive",
         message = { mock_device.id, { capability = "switch", component = "main", command = "off", args = { } } }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_cmd_handler",
+          { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
+        }
       },
       {
         channel = "zigbee",

--- a/drivers/SmartThings/zwave-bulb/src/test/test_aeon_multiwhite_bulb.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_aeon_multiwhite_bulb.lua
@@ -384,6 +384,7 @@ test.register_coroutine_test(
   function ()
     test.timer.__create_and_queue_test_time_advance_timer(5, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "switch", component = "main", command = "on", args = { } }})
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
@@ -407,6 +408,7 @@ test.register_coroutine_test(
   function ()
     test.timer.__create_and_queue_test_time_advance_timer(4, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "switch", component = "main", command = "off", args = { } }})
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
@@ -431,6 +433,7 @@ test.register_coroutine_test(
     local level = math.random(1,100)
     test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { level, 10 } }})
+    mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-bulb/src/test/test_zwave_bulb.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_zwave_bulb.lua
@@ -121,6 +121,8 @@ test.register_coroutine_test(
       mock_zwave_bulb.id,
       { capability = "switch", command = "off", args = {} }
     })
+    mock_zwave_bulb:expect_native_cmd_handler_registration("switch", "off")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_zwave_bulb,
@@ -177,6 +179,8 @@ test.register_coroutine_test(
       mock_zwave_bulb.id,
       { capability = "switchLevel", command = "setLevel", args = { level } }
     })
+    mock_zwave_bulb:expect_native_cmd_handler_registration("switchLevel", "setLevel")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_zwave_bulb,
@@ -207,6 +211,8 @@ test.register_coroutine_test(
       mock_zwave_bulb.id,
       { capability = "switch", command = "on", args = {} }
     })
+    mock_zwave_bulb:expect_native_cmd_handler_registration("switch", "on")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_zwave_bulb,

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
@@ -297,6 +297,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -362,6 +363,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -426,6 +428,8 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switchLevel", command = "setLevel", args = { 50 } }
     })
+    mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_heavy_duty_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_heavy_duty_switch.lua
@@ -179,6 +179,8 @@ test.register_coroutine_test(
         { capability = "switch", command = "off", args = {} }
       }
     )
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,
@@ -200,6 +202,8 @@ test.register_coroutine_test(
         { capability = "switch", command = "on", args = {} }
       }
     )
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
@@ -321,6 +321,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -386,6 +387,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -450,6 +452,8 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switchLevel", command = "setLevel", args = { 50 } }
     })
+    mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
@@ -437,6 +437,7 @@ test.register_coroutine_test(
       mock_parent.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_parent:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -504,6 +505,7 @@ test.register_coroutine_test(
       mock_parent.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_parent:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -570,6 +572,7 @@ test.register_coroutine_test(
       mock_child.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_child:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -634,6 +637,7 @@ test.register_coroutine_test(
       mock_child.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_child:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_generic_zwave_device1.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_generic_zwave_device1.lua
@@ -168,6 +168,7 @@ test.register_coroutine_test(
       mock_zwave_device1.id,
       { capability = "switch", command = "off", args = {} }
     })
+    mock_zwave_device1:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_zwave_device1,
@@ -193,6 +194,7 @@ test.register_coroutine_test(
       mock_zwave_device1.id,
       { capability = "switch", command = "on", args = {} }
     })
+    mock_zwave_device1:expect_native_cmd_handler_registration("switch", "on")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_zwave_device1,
@@ -219,6 +221,7 @@ test.register_coroutine_test(
       mock_zwave_device1.id,
       { capability = "switchLevel", command = "setLevel", args = { level } }
     })
+    mock_zwave_device1:expect_native_cmd_handler_registration("switchLevel", "setLevel")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_zwave_device1,

--- a/drivers/SmartThings/zwave-switch/src/test/test_multi_metering_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_multi_metering_switch.lua
@@ -238,6 +238,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -260,6 +268,14 @@ test.register_message_test(
       message = {
         mock_child_device.id,
         { capability = "switch", command = "on", component = "main", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_child_device.id, capability_id = "switch", capability_cmd_id = "on" }
       }
     },
     {
@@ -288,6 +304,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -310,6 +334,14 @@ test.register_message_test(
       message = {
         mock_child_device.id,
         { capability = "switch", command = "off", component = "main", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_child_device.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {
@@ -574,6 +606,7 @@ test.register_coroutine_test(
       mock_parent_device.id,
       { capability = "switch", command = "off", component = "main", args = {} }
     })
+    mock_parent_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_parent_device,
@@ -604,6 +637,7 @@ test.register_coroutine_test(
       mock_child_device.id,
       { capability = "switch", command = "off", component = "main", args = {} }
     })
+    mock_child_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_parent_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
@@ -337,6 +337,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -402,6 +403,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -466,6 +468,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switchLevel", command = "setLevel", args = { 50 } }
     })
+    mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
@@ -326,6 +326,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -391,6 +392,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -455,6 +457,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switchLevel", command = "setLevel", args = { 50 } }
     })
+    mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
@@ -207,6 +207,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -272,6 +273,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_without_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_without_power.lua
@@ -120,6 +120,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -169,6 +170,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch.lua
@@ -95,6 +95,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -117,6 +125,14 @@ test.register_message_test(
       message = {
         mock_child_device.id,
         { capability = "switch", command = "on", component = "main", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_child_device.id, capability_id = "switch", capability_cmd_id = "on" }
       }
     },
     {
@@ -145,6 +161,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_cmd_id = "off" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -167,6 +191,14 @@ test.register_message_test(
       message = {
         mock_child_device.id,
         { capability = "switch", command = "off", component = "main", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_child_device.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {
@@ -251,6 +283,8 @@ test.register_coroutine_test(
       mock_parent_device.id,
       { capability = "switch", command = "off", component = "main", args = {} }
     })
+    mock_parent_device:expect_native_cmd_handler_registration("switch", "off")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_parent_device,
@@ -281,6 +315,7 @@ test.register_coroutine_test(
       mock_child_device.id,
       { capability = "switch", command = "off", component = "main", args = {} }
     })
+    mock_child_device:expect_native_cmd_handler_registration("switch", "off")
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_parent_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
@@ -192,6 +192,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -213,6 +221,14 @@ test.register_message_test(
       message = {
         mock_parent.id,
         { capability = "switch", command = "off", component = "main", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_parent.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {
@@ -241,6 +257,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_child.id, capability_id = "switch", capability_cmd_id = "on" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -262,6 +286,14 @@ test.register_message_test(
       message = {
         mock_child.id,
         { capability = "switch", command = "off", component = "main", args = {} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_child.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay.lua
@@ -433,6 +433,7 @@ test.register_coroutine_test(
         mock_parent.id,
         { capability = "switchLevel", component = "main", command = "setLevel", args = { 50 } }
       })
+      mock_parent:expect_native_cmd_handler_registration("switchLevel", "setLevel")
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
@@ -229,6 +229,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -293,6 +294,7 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
+    mock_device:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -355,6 +357,8 @@ test.register_coroutine_test(
       mock_device.id,
       { capability = "switchLevel", command = "setLevel", args = { 50 } }
     })
+    mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel")
+
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_device,

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dual_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dual_switch.lua
@@ -467,6 +467,8 @@ test.register_coroutine_test(
         mock_parent.id,
         { capability = "switch", component = "main", command = "on", args = {} }
       })
+      mock_parent:expect_native_cmd_handler_registration("switch", "on")
+
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
@@ -503,6 +505,8 @@ test.register_coroutine_test(
         mock_child.id,
         { capability = "switch", component = "main", command = "on", args = {} }
       })
+      mock_child:expect_native_cmd_handler_registration("switch", "on")
+
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
@@ -539,6 +543,8 @@ test.register_coroutine_test(
         mock_parent.id,
         { capability = "switch", component = "main", command = "off", args = {} }
       })
+      mock_parent:expect_native_cmd_handler_registration("switch", "off")
+
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,
@@ -575,6 +581,8 @@ test.register_coroutine_test(
         mock_child.id,
         { capability = "switch", component = "main", command = "off", args = {} }
       })
+      mock_child:expect_native_cmd_handler_registration("switch", "off")
+
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_parent,

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch.lua
@@ -203,6 +203,7 @@ test.register_coroutine_test(
             { capability = "switch", command = "on", args = {} }
           }
       )
+      mock_switch_basic:expect_native_cmd_handler_registration("switch", "on")
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_switch_basic,
@@ -233,6 +234,7 @@ test.register_coroutine_test(
             { capability = "switch", command = "off", args = {} }
           }
       )
+      mock_switch_basic:expect_native_cmd_handler_registration("switch", "off")
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_switch_basic,
@@ -263,6 +265,7 @@ test.register_coroutine_test(
             { capability = "switch", command = "on", args = {} }
           }
       )
+      mock_switch_binary:expect_native_cmd_handler_registration("switch", "on")
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_switch_binary,
@@ -293,6 +296,7 @@ test.register_coroutine_test(
             { capability = "switch", command = "off", args = {} }
           }
       )
+      mock_switch_binary:expect_native_cmd_handler_registration("switch", "off")
       test.socket.zwave:__expect_send(
           zw_test_utils.zwave_test_build_send_command(
               mock_switch_binary,


### PR DESCRIPTION
This is only valid for the 54.x lua libs which is where support for native handlers was first added

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


