### PR TITLE
matter-lock: Add 'not fully locked' to the embedded device config

### DIFF
--- a/drivers/SmartThings/matter-lock/profiles/base-lock.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock.yml
@@ -10,7 +10,7 @@ components:
         enabledValues:
         - locked
         - unlocked
-        - unknown
+        - not fully locked
   - id: lockCodes
     version: 1
   - id: tamperAlert

--- a/drivers/SmartThings/matter-lock/profiles/lock-lockalarm-nobattery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-lockalarm-nobattery.yml
@@ -10,7 +10,7 @@ components:
         enabledValues:
         - locked
         - unlocked
-        - unknown
+        - not fully locked
   - id: lockAlarm
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-lock/profiles/lock-lockalarm.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-lockalarm.yml
@@ -10,7 +10,7 @@ components:
         enabledValues:
         - locked
         - unlocked
-        - unknown
+        - not fully locked
   - id: lockAlarm
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-lock/profiles/lock-nocodes-notamper.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-nocodes-notamper.yml
@@ -10,7 +10,7 @@ components:
         enabledValues:
         - locked
         - unlocked
-        - unknown
+        - not fully locked
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-lock/profiles/lock-without-codes.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-without-codes.yml
@@ -10,7 +10,7 @@ components:
         enabledValues:
         - locked
         - unlocked
-        - unknown
+        - not fully locked
   - id: battery
     version: 1
   - id: tamperAlert


### PR DESCRIPTION
Without this change the 'not fully locked' was being displayed but without the correct translations.

https://smartthings.atlassian.net/browse/CHAD-11259

# Type of Change

- [ ] WWST Certification Request
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Summary of Completed Tests

Tested with a Yale lock

