### PR TITLE
Cherry-pick WWST SiHAS buttons to beta before production release

### DIFF
--- a/drivers/SmartThings/zigbee-switch/fingerprints.yml
+++ b/drivers/SmartThings/zigbee-switch/fingerprints.yml
@@ -1090,6 +1090,21 @@ zigbeeManufacturer:
     manufacturer: ShinaSystem
     model: SBM300Z6
     deviceProfileName: basic-switch
+  - id: ShinaSystem/SQM300Z1
+    deviceLabel: SiHAS Switch
+    manufacturer: ShinaSystem
+    model: SQM300Z1
+    deviceProfileName: basic-switch
+  - id: ShinaSystem/SQM300Z2
+    deviceLabel: SiHAS Switch 1
+    manufacturer: ShinaSystem
+    model: SQM300Z2
+    deviceProfileName: basic-switch
+  - id: ShinaSystem/SQM300Z3
+    deviceLabel: SiHAS Switch 1
+    manufacturer: ShinaSystem
+    model: SQM300Z3
+    deviceProfileName: basic-switch
   - id: Samsung/SAMSUNG-ITM-Z-002
     deviceLabel: Samsung Light
     manufacturer: Samsung Electronics

--- a/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
@@ -46,6 +46,8 @@ local MULTI_SWITCH_NO_MASTER_FINGERPRINTS = {
   { mfr = "ShinaSystem", model = "SBM300Z4", children = 3 },
   { mfr = "ShinaSystem", model = "SBM300Z5", children = 4 },
   { mfr = "ShinaSystem", model = "SBM300Z6", children = 5 },
+  { mfr = "ShinaSystem", model = "SQM300Z2", children = 1 },
+  { mfr = "ShinaSystem", model = "SQM300Z3", children = 2 },
   { model = "E220-KR2N0Z0-HA", children = 1 },
   { model = "E220-KR3N0Z0-HA", children = 2 },
   { model = "E220-KR4N0Z0-HA", children = 3 },


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Release

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This cherry-picks the following PR to Beta ahead of the production release:
* https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1604

# Summary of Completed Tests


