### PR TITLE
fix: Avoid a nil index crash when data loss occurs

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -270,7 +270,7 @@ end
 
 local function noop_event_emitter(device, ...)
   local label = (device and device.label) or "Unknown Device Name"
-  local device_type = (device and device:get_field(Fields.DEVICE_TYPE)) or "Unknown Device Type"
+  local device_type = (device and utils.determine_device_type(device)) or "Unknown Device Type"
   log.warn(string.format("Tried to find attribute event emitter for device [%s] of unsupported type [%s], ignoring", label, device_type))
 end
 

--- a/drivers/SmartThings/philips-hue/src/handlers/commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/commands.lua
@@ -306,7 +306,7 @@ local refresh_handlers = require "handlers.refresh_handlers"
 ---@param cmd table?
 ---@return table? refreshed_device_info
 function CommandHandlers.refresh_handler(driver, device, cmd)
-  return refresh_handlers.handler_for_device_type(device:get_field(Fields.DEVICE_TYPE))(driver, device, cmd)
+  return refresh_handlers.handler_for_device_type(utils.determine_device_type(device))(driver, device, cmd)
 end
 
 return CommandHandlers

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
@@ -47,7 +47,7 @@ local LifecycleHandlers = {}
 ---@param device HueDevice
 ---@param ... any arguments for device specific handler
 function LifecycleHandlers.device_init(driver, device, ...)
-  local device_type = device:get_field(Fields.DEVICE_TYPE)
+  local device_type = utils.determine_device_type(device)
   log.info(
     string.format
     ("device_init for device %s, device_type: %s", (device.label or device.id or "unknown device"),

--- a/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
@@ -118,7 +118,7 @@ function RefreshHandlers.do_refresh_all_for_bridge(driver, bridge_device)
 
       local statuses_by_device_type = {}
       for _, device in ipairs(child_devices) do
-        local device_type = device:get_field(Fields.DEVICE_TYPE)
+        local device_type = utils.determine_device_type(device)
         -- Query for the states of all devices for a device type for a given child device,
         -- but only the first time we encounter a device type. We cache them since we're refreshing
         -- everything.
@@ -359,7 +359,7 @@ end
 
 local function noop_refresh_handler(driver, device, ...)
   local label = (device and device.label) or "Unknown Device Name"
-  local device_type = (device and device:get_field(Fields.DEVICE_TYPE)) or "Unknown Device Type"
+  local device_type = (device and utils.determine_device_type(device)) or "Unknown Device Type"
   log.warn(string.format("Received Refresh capability for unknown device [%s] type [%s], ignoring", label, device_type))
 end
 

--- a/drivers/SmartThings/philips-hue/src/hue_driver_template.lua
+++ b/drivers/SmartThings/philips-hue/src/hue_driver_template.lua
@@ -19,7 +19,7 @@ local utils = require "utils"
 ---@param device HueDevice
 local function _remove(driver, device)
   driver.datastore.dni_to_device_id[device.device_network_id] = nil
-  if device:get_field(Fields.DEVICE_TYPE) == "bridge" then
+  if utils.determine_device_type(device) == "bridge" then
     local api_instance = device:get_field(Fields.BRIDGE_API) --[[@as PhilipsHueApi]]
     if api_instance then
       api_instance:shutdown()

--- a/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
+++ b/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
@@ -249,7 +249,7 @@ function StrayDeviceHelper.spawn()
                 maybe_bridge:get_field(Fields.BRIDGE_API) --[[@as PhilipsHueApi]]
                 or Discovery.disco_api_instances[maybe_bridge.device_network_id]
 
-            if not api_instance then
+            if not api_instance and bridge_ip then
               api_instance = HueApi.new_bridge_manager(
                 "https://" .. bridge_ip,
                 maybe_bridge:get_field(HueApi.APPLICATION_KEY_HEADER),
@@ -258,7 +258,9 @@ function StrayDeviceHelper.spawn()
               Discovery.disco_api_instances[maybe_bridge.device_network_id] = api_instance
             end
 
-            StrayDeviceHelper.process_strays(thread_local_driver, stray_devices, maybe_bridge.id)
+            if api_instance then
+              StrayDeviceHelper.process_strays(thread_local_driver, stray_devices, maybe_bridge.id)
+            end
           end
         end
       end

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -17,6 +17,7 @@ function utils.lazy_handler_loader(parent_module)
     {},
     {
       __index = function(tbl, key)
+        if key == nil then return nil end
         if nils[key] then return nil end
         if rawget(tbl, key) == nil then
           local success, mod = pcall(require, string.format("%s.%s", parent_module, key))


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This fixes an edge case where we were assuming that a persistent field on a device was always present; while this should more or less hold true, there are times when it won't. In those cases, the driver would crash.

Drivers in this state would already be nonfunctional, but we want to avoid chewing up resources with a hot crash loop.

# Summary of Completed Tests

I tested this locally by onboarding my Hue setup and then deliberaly taking actions that would lead to the persisted fields getting blown away; the driver is nonfunctional, but no longer hits a hot crash loop.
