### PR TITLE
Update doConfigure for RVC

### DIFF
--- a/drivers/SmartThings/matter-rvc/fingerprints.yml
+++ b/drivers/SmartThings/matter-rvc/fingerprints.yml
@@ -3,11 +3,11 @@ matterManufacturer:
     deviceLabel: Matter RVC
     vendorId: 0x10e1
     productId: 0x1025
-    deviceProfileName: rvc
+    deviceProfileName: rvc-clean-mode
 
 matterGeneric:
   - id: "matter/rvc"
     deviceLabel: Matter RVC
     deviceTypes:
       - id: 0x0074
-    deviceProfileName: rvc
+    deviceProfileName: rvc-clean-mode

--- a/drivers/SmartThings/matter-rvc/profiles/rvc-clean-mode.yml
+++ b/drivers/SmartThings/matter-rvc/profiles/rvc-clean-mode.yml
@@ -1,4 +1,4 @@
-name: rvc
+name: rvc-clean-mode
 components:
   - id: main
     label: Main
@@ -13,6 +13,13 @@ components:
     - name: RobotCleaner
   - id: runMode
     label: Run mode
+    capabilities:
+      - id: mode
+        version: 1
+    categories:
+    - name: RobotCleaner
+  - id: cleanMode
+    label: Clean mode
     capabilities:
       - id: mode
         version: 1

--- a/drivers/SmartThings/matter-rvc/src/init.lua
+++ b/drivers/SmartThings/matter-rvc/src/init.lua
@@ -289,8 +289,6 @@ local function rvc_operational_state_attr_handler(driver, device, ib, response)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.robotCleanerOperatingState.operatingState.running())
   elseif ib.data.value == clusters.OperationalState.types.OperationalStateEnum.PAUSED then
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.robotCleanerOperatingState.operatingState.paused())
-  elseif ib.data.value == clusters.OperationalState.types.OperationalStateEnum.ERROR then
-    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.robotCleanerOperatingState.operatingState.error())
   elseif ib.data.value == clusters.RvcOperationalState.types.OperationalStateEnum.SEEKING_CHARGER then
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.robotCleanerOperatingState.operatingState.seekingCharger())
   elseif ib.data.value == clusters.RvcOperationalState.types.OperationalStateEnum.CHARGING then


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
There's an issue that Dreame RVC is not working.
In detail, Dreame RVC has mandatory clusters RVC RunMode, RVC Operational state cluster but doesn't have RunCleanMode cluster. so we need to map the appropriate profile accoding to the cluster list supported by each device.

https://smartthings.atlassian.net/browse/IOTE-4435

# Summary of Completed Tests


