### PR TITLE
New Devices (Matter Switch) AiDot Orein St58CCT Bulbs 

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -393,12 +393,12 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x044E
     deviceProfileName: plug-binary
-  - id: 4456/1019
+  - id: "4456/1019"
     deviceLabel: Matter Smart Filament  Bulb ST58 CCT
     vendorId: 0x1168
     productId: 0x03FB
     deviceProfileName: light-level-colorTemperature-2700K-6500K
-  - id: 4456/1020
+  - id: "4456/1020"
     deviceLabel: AiDot OREiN Matter Smart Filament Bulb ST58 CCT
     vendorId: 0x1168
     productId: 0x03FC

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -393,6 +393,17 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x044E
     deviceProfileName: plug-binary
+  - id: 4456/1019
+    deviceLabel: Matter Smart Filament  Bulb ST58 CCT
+    vendorId: 0x1168
+    productId: 0x03FB
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+  - id: 4456/1020
+    deviceLabel: AiDot OREiN Matter Smart Filament Bulb ST58 CCT
+    vendorId: 0x1168
+    productId: 0x03FC
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+  
 #WiZ
   - id: "WiZ A19"
     deviceLabel: WiZ A19

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -403,7 +403,6 @@ matterManufacturer:
     vendorId: 0x1168
     productId: 0x03FC
     deviceProfileName: light-level-colorTemperature-2700K-6500K
-  
 #WiZ
   - id: "WiZ A19"
     deviceLabel: WiZ A19


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adding two unique fingerprints for CSA Certified Matter devices, with the Matter device type id of 268 (0x10c). 
Device 1:
  vendorId: 0x1168
  productId: 0x03FB
  
Device 2:
  vendorId: 0x1168
  productId: 0x03FC


# Summary of Completed Tests
Provided by partner using the ATS, no further testing will occur

