### PR TITLE
CHAD-13777 Allow virtual device events to not always be a state change

### DIFF
--- a/drivers/SmartThings/virtual-switch/profiles/virtual-dimmer-switch.yml
+++ b/drivers/SmartThings/virtual-switch/profiles/virtual-dimmer-switch.yml
@@ -8,3 +8,6 @@ components:
         version: 1
     categories:
       - name: Switch
+preferences:
+  - preferenceId: certifiedpreferences.forceStateChange
+    explicit: true

--- a/drivers/SmartThings/virtual-switch/profiles/virtual-dimmer.yml
+++ b/drivers/SmartThings/virtual-switch/profiles/virtual-dimmer.yml
@@ -6,3 +6,6 @@ components:
         version: 1
     categories:
       - name: Switch
+preferences:
+  - preferenceId: certifiedpreferences.forceStateChange
+    explicit: true

--- a/drivers/SmartThings/virtual-switch/profiles/virtual-switch.yml
+++ b/drivers/SmartThings/virtual-switch/profiles/virtual-switch.yml
@@ -6,3 +6,6 @@ components:
         version: 1
     categories:
       - name: Switch
+preferences:
+  - preferenceId: certifiedpreferences.forceStateChange
+    explicit: true

--- a/drivers/SmartThings/virtual-switch/src/init.lua
+++ b/drivers/SmartThings/virtual-switch/src/init.lua
@@ -1,26 +1,30 @@
 local capabilities = require "st.capabilities"
 local Driver = require "st.driver"
-local additional_fields = {
-  state_change = true
-}
 
+local function force_state_change(device)
+  if device.preferences["certifiedpreferences.forceStateChange"] then
+    return {state_change = true}
+  else
+    return nil
+  end
+end
 
 local function handle_set_level(driver, device, command)
   if (command.args.level == 0) then
-    device:emit_event(capabilities.switch.switch.off(additional_fields))
+    device:emit_event(capabilities.switch.switch.off(force_state_change(device)))
   else
-    device:emit_event(capabilities.switchLevel.level(command.args.level, additional_fields))
+    device:emit_event(capabilities.switchLevel.level(command.args.level, force_state_change(device)))
     device:emit_event(capabilities.switch.switch.on())
   end
 
 end
 
 local function handle_on(driver, device, command)
-  device:emit_event(capabilities.switch.switch.on(additional_fields))
+  device:emit_event(capabilities.switch.switch.on(force_state_change(device)))
 end
 
 local function handle_off(driver, device, command)
-  device:emit_event(capabilities.switch.switch.off(additional_fields))
+  device:emit_event(capabilities.switch.switch.off(force_state_change(device)))
 end
 
 local virtual_driver = Driver("virtual-switch", {


### PR DESCRIPTION
Adds a new certified preference 'forceStateChange' that allows users to select whether they want their virtual device events to always be a state change or not.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [X] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


