### PR TITLE
Yale Zigbee Locks: Use MASTER_CODE user type

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/yale/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/init.lua
@@ -51,10 +51,11 @@ local set_code = function(driver, device, command)
       args = {command.args.codeSlot, command.args.codeName}
     })
   else
+    local user_type = command.args.codeSlot == 0 and UserTypeEnum.MASTER_USER or UserTypeEnum.UNRESTRICTED
     device:send(LockCluster.server.commands.SetPINCode(device,
             command.args.codeSlot,
             UserStatusEnum.OCCUPIED_ENABLED,
-            UserTypeEnum.UNRESTRICTED,
+            user_type,
             command.args.codePIN)
     )
     if (command.args.codeName ~= nil) then


### PR DESCRIPTION
When setting the code at index 0 for yale locks, the MASTER_CODE user type should be sent.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


