### PR TITLE
CI: Increase timeout for getting all channels

### DIFF
--- a/.github/workflows/create-channel.yml
+++ b/.github/workflows/create-channel.yml
@@ -48,6 +48,7 @@ jobs:
           url: 'https://api.smartthings.com/distchannels/'
           method: GET
           bearerToken: ${{ secrets.TOKEN }}
+          timeout: 10000
       - name: Store channel name
         uses: actions/github-script@v5
         with:

--- a/.github/workflows/delete-channel.yml
+++ b/.github/workflows/delete-channel.yml
@@ -17,6 +17,7 @@ jobs:
           url: 'https://api.smartthings.com/distchannels/'
           method: GET
           bearerToken: ${{ secrets.TOKEN }}
+          timeout: 10000
       - name: Store channel name
         uses: actions/github-script@v5
         with:


### PR DESCRIPTION
As the number of channels has grown, it sometimes takes the API longer than 5s to return all the channels. This should be a little bandage on that issue.