### PR TITLE
Sort endpoints before initializing switch

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -458,6 +458,8 @@ end
 local function initialize_switch(driver, device)
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
   local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH})
+  table.sort(switch_eps)
+  table.sort(button_eps)
 
   local profile_name = nil
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -302,72 +302,6 @@ local mock_device_parent_child_unsupported_device_type = test.mock_device.build_
   }
 })
 
-local parent_ep = 10
-local child1_ep = 20
-local child2_ep = 40
-local child3_ep = 30
-
-local mock_device_parent_child_endpoints_out_of_order = test.mock_device.build_test_matter_device({
-  label = "Matter Switch",
-  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
-  manufacturer_info = {
-    vendor_id = 0x0000,
-    product_id = 0x0000,
-  },
-  endpoints = {
-    {
-      endpoint_id = 0,
-      clusters = {
-        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
-      },
-      device_types = {
-        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
-      }
-    },
-    {
-      endpoint_id = parent_ep,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-      },
-      device_types = {
-        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
-      }
-    },
-    {
-      endpoint_id = child1_ep,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
-      },
-      device_types = {
-        {device_type_id = 0x0100, device_type_revision = 2}, -- On/Off Light
-        {device_type_id = 0x0101, device_type_revision = 2} -- Dimmable Light
-      }
-    },
-    {
-      endpoint_id = child2_ep,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
-        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
-      },
-      device_types = {
-        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
-      }
-    },
-    {
-      endpoint_id = child3_ep,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
-        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
-      },
-      device_types = {
-        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
-      }
-    },
-  }
-})
 local function test_init_parent_child_switch_types()
   local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_child_switch_types)
   test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
@@ -460,75 +394,6 @@ local function test_init_parent_child_unsupported_device_type()
   })
 end
 
-local function test_init_parent_child_endpoints_out_of_order()
-  local child_profiles = {
-    [child1_ep] = t_utils.get_profile_definition("light-level.yml"),
-    [child2_ep] = t_utils.get_profile_definition("light-color-level.yml"),
-    [child3_ep] = t_utils.get_profile_definition("light-color-level.yml")
-  }
-  local mock_children = {}
-  for i, endpoint in ipairs(mock_device_parent_child_endpoints_out_of_order.endpoints) do
-    if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
-      local child_data = {
-        profile = child_profiles[endpoint.endpoint_id],
-        device_network_id = string.format("%s:%d", mock_device_parent_child_endpoints_out_of_order.id, endpoint.endpoint_id),
-        parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
-        parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
-      }
-      mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
-    end
-  end
-  local cluster_subscribe_list = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel,
-    clusters.ColorControl.attributes.ColorTemperatureMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
-    clusters.ColorControl.attributes.CurrentHue,
-    clusters.ColorControl.attributes.CurrentSaturation,
-    clusters.ColorControl.attributes.CurrentX,
-    clusters.ColorControl.attributes.CurrentY
-  }
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_parent_child_endpoints_out_of_order)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_parent_child_endpoints_out_of_order))
-    end
-  end
-  test.socket.matter:__expect_send({mock_device_parent_child_endpoints_out_of_order.id, subscribe_request})
-
-  test.mock_device.add_test_device(mock_device_parent_child_endpoints_out_of_order)
-  for _, child in pairs(mock_children) do
-    test.mock_device.add_test_device(child)
-  end
-
-  mock_device_parent_child_endpoints_out_of_order:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Switch 2",
-    profile = "light-level",
-    parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
-    parent_assigned_child_key = string.format("%d", child1_ep)
-  })
-
-  mock_device_parent_child_endpoints_out_of_order:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Switch 3",
-    profile = "light-color-level",
-    parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
-    parent_assigned_child_key = string.format("%d", child3_ep)
-  })
-
-  mock_device_parent_child_endpoints_out_of_order:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Switch 4",
-    profile = "light-color-level",
-    parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
-    parent_assigned_child_key = string.format("%d", child2_ep)
-  })
-end
-
 test.register_coroutine_test(
   "Test profile change on init for onoff parent cluster as server",
   function()
@@ -590,13 +455,6 @@ test.register_coroutine_test(
   function()
   end,
   { test_init = test_init_parent_child_unsupported_device_type }
-)
-
-test.register_coroutine_test(
-  "Test child devices are created in order of their endpoints",
-  function()
-  end,
-  { test_init = test_init_parent_child_endpoints_out_of_order }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -460,26 +460,24 @@ local function test_init_parent_child_unsupported_device_type()
   })
 end
 
-local child_profiles = {
-  [child1_ep] = t_utils.get_profile_definition("light-level.yml"),
-  [child2_ep] = t_utils.get_profile_definition("light-color-level.yml"),
-  [child3_ep] = t_utils.get_profile_definition("light-color-level.yml")
-}
-
-local mock_children = {}
-for i, endpoint in ipairs(mock_device_parent_child_endpoints_out_of_order.endpoints) do
-  if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
-    local child_data = {
-      profile = child_profiles[endpoint.endpoint_id],
-      device_network_id = string.format("%s:%d", mock_device_parent_child_endpoints_out_of_order.id, endpoint.endpoint_id),
-      parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
-      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
-    }
-    mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
-  end
-end
-
 local function test_init_parent_child_endpoints_out_of_order()
+  local child_profiles = {
+    [child1_ep] = t_utils.get_profile_definition("light-level.yml"),
+    [child2_ep] = t_utils.get_profile_definition("light-color-level.yml"),
+    [child3_ep] = t_utils.get_profile_definition("light-color-level.yml")
+  }
+  local mock_children = {}
+  for i, endpoint in ipairs(mock_device_parent_child_endpoints_out_of_order.endpoints) do
+    if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
+      local child_data = {
+        profile = child_profiles[endpoint.endpoint_id],
+        device_network_id = string.format("%s:%d", mock_device_parent_child_endpoints_out_of_order.id, endpoint.endpoint_id),
+        parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
+        parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+      }
+      mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+    end
+  end
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LevelControl.attributes.CurrentLevel,

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -302,6 +302,72 @@ local mock_device_parent_child_unsupported_device_type = test.mock_device.build_
   }
 })
 
+local parent_ep = 10
+local child1_ep = 20
+local child2_ep = 40
+local child3_ep = 30
+
+local mock_device_parent_child_endpoints_out_of_order = test.mock_device.build_test_matter_device({
+  label = "Matter Switch",
+  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = parent_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
+      }
+    },
+    {
+      endpoint_id = child1_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 2}, -- On/Off Light
+        {device_type_id = 0x0101, device_type_revision = 2} -- Dimmable Light
+      }
+    },
+    {
+      endpoint_id = child2_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+      },
+      device_types = {
+        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
+      }
+    },
+    {
+      endpoint_id = child3_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+      },
+      device_types = {
+        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
+      }
+    },
+  }
+})
 local function test_init_parent_child_switch_types()
   local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_child_switch_types)
   test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
@@ -394,6 +460,77 @@ local function test_init_parent_child_unsupported_device_type()
   })
 end
 
+local child_profiles = {
+  [child1_ep] = t_utils.get_profile_definition("light-level.yml"),
+  [child2_ep] = t_utils.get_profile_definition("light-color-level.yml"),
+  [child3_ep] = t_utils.get_profile_definition("light-color-level.yml")
+}
+
+local mock_children = {}
+for i, endpoint in ipairs(mock_device_parent_child_endpoints_out_of_order.endpoints) do
+  if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
+    local child_data = {
+      profile = child_profiles[endpoint.endpoint_id],
+      device_network_id = string.format("%s:%d", mock_device_parent_child_endpoints_out_of_order.id, endpoint.endpoint_id),
+      parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
+      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+    }
+    mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
+
+local function test_init_parent_child_endpoints_out_of_order()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+    clusters.LevelControl.attributes.CurrentLevel,
+    clusters.LevelControl.attributes.MaxLevel,
+    clusters.LevelControl.attributes.MinLevel,
+    clusters.ColorControl.attributes.ColorTemperatureMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+    clusters.ColorControl.attributes.CurrentHue,
+    clusters.ColorControl.attributes.CurrentSaturation,
+    clusters.ColorControl.attributes.CurrentX,
+    clusters.ColorControl.attributes.CurrentY
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_parent_child_endpoints_out_of_order)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device_parent_child_endpoints_out_of_order))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_parent_child_endpoints_out_of_order.id, subscribe_request})
+
+  test.mock_device.add_test_device(mock_device_parent_child_endpoints_out_of_order)
+  for _, child in pairs(mock_children) do
+    test.mock_device.add_test_device(child)
+  end
+
+  mock_device_parent_child_endpoints_out_of_order:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 2",
+    profile = "light-level",
+    parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
+    parent_assigned_child_key = string.format("%d", child1_ep)
+  })
+
+  mock_device_parent_child_endpoints_out_of_order:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 3",
+    profile = "light-color-level",
+    parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
+    parent_assigned_child_key = string.format("%d", child3_ep)
+  })
+
+  mock_device_parent_child_endpoints_out_of_order:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 4",
+    profile = "light-color-level",
+    parent_device_id = mock_device_parent_child_endpoints_out_of_order.id,
+    parent_assigned_child_key = string.format("%d", child2_ep)
+  })
+end
+
 test.register_coroutine_test(
   "Test profile change on init for onoff parent cluster as server",
   function()
@@ -455,6 +592,13 @@ test.register_coroutine_test(
   function()
   end,
   { test_init = test_init_parent_child_unsupported_device_type }
+)
+
+test.register_coroutine_test(
+  "Test child devices are created in order of their endpoints",
+  function()
+  end,
+  { test_init = test_init_parent_child_endpoints_out_of_order }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -76,9 +76,75 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
+local child1_ep_non_sequential = 50
+local child2_ep_non_sequential = 30
+local child3_ep_non_sequential = 40
+
+local mock_device_parent_child_endpoints_non_sequential = test.mock_device.build_test_matter_device({
+  label = "Matter Switch",
+  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = parent_ep,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 2} -- On/Off Light
+      }
+    },
+    {
+      endpoint_id = child1_ep_non_sequential,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 2}, -- On/Off Light
+        {device_type_id = 0x0101, device_type_revision = 2} -- Dimmable Light
+      }
+    },
+    {
+      endpoint_id = child2_ep_non_sequential,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+      },
+      device_types = {
+        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
+      }
+    },
+    {
+      endpoint_id = child3_ep_non_sequential,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+      },
+      device_types = {
+        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
+      }
+    },
+  }
+})
+
 local child_profiles = {
   [child1_ep] = t_utils.get_profile_definition("light-level.yml"),
-  [child2_ep] = t_utils.get_profile_definition("light-color-level.yml")
+  [child2_ep] = t_utils.get_profile_definition("light-color-level.yml"),
 }
 
 local mock_children = {}
@@ -135,6 +201,77 @@ local function test_init()
     profile = "light-color-level",
     parent_device_id = mock_device.id,
     parent_assigned_child_key = string.format("%d", child2_ep)
+  })
+end
+
+local child_profiles_non_sequential = {
+  [child1_ep_non_sequential] = t_utils.get_profile_definition("light-level.yml"),
+  [child2_ep_non_sequential] = t_utils.get_profile_definition("light-color-level.yml"),
+  [child3_ep_non_sequential] = t_utils.get_profile_definition("light-color-level.yml"),
+}
+
+local mock_children_non_sequential = {}
+for i, endpoint in ipairs(mock_device_parent_child_endpoints_non_sequential.endpoints) do
+  if endpoint.endpoint_id ~= parent_ep and endpoint.endpoint_id ~= 0 then
+    local child_data = {
+      profile = child_profiles_non_sequential[endpoint.endpoint_id],
+      device_network_id = string.format("%s:%d", mock_device_parent_child_endpoints_non_sequential.id, endpoint.endpoint_id),
+      parent_device_id = mock_device_parent_child_endpoints_non_sequential.id,
+      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+    }
+    mock_children_non_sequential[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
+
+local function test_init_parent_child_endpoints_non_sequential()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+    clusters.LevelControl.attributes.CurrentLevel,
+    clusters.LevelControl.attributes.MaxLevel,
+    clusters.LevelControl.attributes.MinLevel,
+    clusters.ColorControl.attributes.ColorTemperatureMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+    clusters.ColorControl.attributes.CurrentHue,
+    clusters.ColorControl.attributes.CurrentSaturation,
+    clusters.ColorControl.attributes.CurrentX,
+    clusters.ColorControl.attributes.CurrentY
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_parent_child_endpoints_non_sequential)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device_parent_child_endpoints_non_sequential))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_parent_child_endpoints_non_sequential.id, subscribe_request})
+
+  test.mock_device.add_test_device(mock_device_parent_child_endpoints_non_sequential)
+  for _, child in pairs(mock_children_non_sequential) do
+    test.mock_device.add_test_device(child)
+  end
+
+  mock_device_parent_child_endpoints_non_sequential:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 2",
+    profile = "light-color-level",
+    parent_device_id = mock_device_parent_child_endpoints_non_sequential.id,
+    parent_assigned_child_key = string.format("%d", child2_ep_non_sequential)
+  })
+
+  mock_device_parent_child_endpoints_non_sequential:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 3",
+    profile = "light-color-level",
+    parent_device_id = mock_device_parent_child_endpoints_non_sequential.id,
+    parent_assigned_child_key = string.format("%d", child3_ep_non_sequential)
+  })
+
+  mock_device_parent_child_endpoints_non_sequential:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "Matter Switch 4",
+    profile = "light-level",
+    parent_device_id = mock_device_parent_child_endpoints_non_sequential.id,
+    parent_assigned_child_key = string.format("%d", child1_ep_non_sequential)
   })
 end
 
@@ -492,6 +629,13 @@ test.register_message_test(
       message = mock_children[child2_ep]:generate_test_message("main", capabilities.colorTemperature.colorTemperatureRange({minimum = 1800, maximum = 6500}))
     }
   }
+)
+
+test.register_coroutine_test(
+  "Test child devices are created in order of their endpoints",
+  function()
+  end,
+  { test_init = test_init_parent_child_endpoints_non_sequential }
 )
 
 test.run_registered_tests()


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[PR 1547](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1547) introduced a minor regression where the device endpoints are not being sorted before creating child devices. This is causing labels for child devices to be incorrect in some cases, as in [MTR-828](https://smartthings.atlassian.net/browse/MTR-828).

# Summary of Completed Tests

A new test case was added to verify that child devices are created in order of their endpoints. The child devices listed in the mock device are in a different order than their endpoints sequentially, but they are created in the correct order. This test case fails without this change.



[MTR-828]: https://smartthings.atlassian.net/browse/MTR-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ