### PR TITLE
Add RPC check before sending tempSetpoint range

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/init.lua
@@ -249,7 +249,11 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
     minimum = min,
     maximum = max,
   }
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureSetpoint.temperatureSetpointRange({value = range, unit = unit}))
+  -- Only emit the capability for RPC version >= 5, since unit conversion for
+  -- range capabilities is only supported in that case.
+  if version.rpc >= 5 then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureSetpoint.temperatureSetpointRange({value = range, unit = unit}))
+  end
 
   local temp = ib.data.value / 100.0
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureSetpoint.temperatureSetpoint({value = temp, unit = unit}))

--- a/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
@@ -142,7 +142,11 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
     minimum = min,
     maximum = max,
   }
-  device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureSetpoint.temperatureSetpointRange({value = range, unit = unit}), { visibility = { displayed = false } })
+  -- Only emit the capability for RPC version >= 5, since unit conversion for
+  -- range capabilities is only supported in that case.
+  if version.rpc >= 5 then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureSetpoint.temperatureSetpointRange({value = range, unit = unit}), { visibility = { displayed = false } })
+  end
 
   local temp = ib.data.value / 100.0
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureSetpoint.temperatureSetpoint({value = temp, unit = unit}))


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
[CHAD-14137](https://smartthings.atlassian.net/browse/CHAD-14137)
These fixes were made to the Matter 1.3 drivers, just extending it to the Matter 1.2 device types as well.

# Summary of Completed Tests




[CHAD-14137]: https://smartthings.atlassian.net/browse/CHAD-14137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ