### PR TITLE
Add Dynamic Battery Support for Base-Lock Profiled Door Lock Devices 

### DIFF
--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -32,11 +32,6 @@ matterManufacturer:
     vendorId: 0x135d
     productId: 0xb0
     deviceProfileName: lock-nocodes-notamper
-#Bridged Devices
-  - id: "matter/bridged/door-lock"
-    deviceLabel: Matter Bridged Door Lock
-    vendorId: 0x0
-    deviceProfileName: base-lock-nobattery
 matterGeneric:
   - id: "matter/door-lock"
     deviceLabel: Matter Door Lock

--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -32,6 +32,11 @@ matterManufacturer:
     vendorId: 0x135d
     productId: 0xb0
     deviceProfileName: lock-nocodes-notamper
+#Bridged Devices
+  - id: "matter/bridged/door-lock"
+    deviceLabel: Matter Bridged Door Lock
+    vendorId: 0x0
+    deviceProfileName: base-lock-nobattery
 matterGeneric:
   - id: "matter/door-lock"
     deviceLabel: Matter Door Lock

--- a/drivers/SmartThings/matter-lock/profiles/base-lock-nobattery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock-nobattery.yml
@@ -1,0 +1,23 @@
+name: base-lock-nobattery
+components:
+- id: main
+  capabilities:
+  - id: lock
+    version: 1
+    config:
+      values:
+      - key: "lock.value"
+        enabledValues:
+        - locked
+        - unlocked
+        - not fully locked
+  - id: lockCodes
+    version: 1
+  - id: tamperAlert
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock

--- a/drivers/SmartThings/matter-lock/profiles/lock-without-codes-nobattery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-without-codes-nobattery.yml
@@ -1,0 +1,21 @@
+name: lock-without-codes-nobattery
+components:
+- id: main
+  capabilities:
+  - id: lock
+    version: 1
+    config:
+      values:
+      - key: "lock.value"
+        enabledValues:
+        - locked
+        - unlocked
+        - not fully locked
+  - id: tamperAlert
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -527,6 +527,12 @@ local function component_to_endpoint(device, component_name)
   return find_default_endpoint(device, clusters.DoorLock.ID)
 end
 
+local function info_changed(driver, device, event, args)
+  if device.profile.id ~= args.old_st_store.profile.id then
+    device:subscribe()
+  end
+end
+
 local function do_configure(driver, device)
   -- check if the device is NOT currently profiled as base-lock
   -- by ANDing a query for every capability in the base-lock profiles.
@@ -681,7 +687,12 @@ local matter_lock_driver = {
   sub_drivers = {
     require("new-matter-lock"),
   },
-  lifecycle_handlers = {init = device_init, added = device_added, doConfigure = do_configure },
+  lifecycle_handlers = {
+    init = device_init,
+    added = device_added,
+    doConfigure = do_configure,
+    infoChanged = info_changed,
+  },
 }
 
 -----------------------------------------------------------------------------------------------------------------------------

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -520,23 +520,14 @@ local function component_to_endpoint(device, component_name)
 end
 
 local function do_configure(driver, device)
-  local fingerprinted_devices = {
-    { vendor_id = 0x115F, product_id = 0x2802 }, -- Aqara Smart Lock U200
-    { vendor_id = 0x115F, product_id = 0x2801 }, -- Aqara Smart Lock U300
-    { vendor_id = 0x129F, product_id = 0x0001 }, -- Level Lock Plus (Matter)
-    { vendor_id = 0x129F, product_id = 0x0003 }, -- Level Bolt (Matter)
-    { vendor_id = 0x135d, product_id = 0xb1 }, -- Nuki Smart Lock Pro
-    { vendor_id = 0x135d, product_id = 0xb0 }, -- Nuki Smart Lock
-  }
-
-  -- check if device has a wwst fingerprint
-  if device.manufacturer_info ~= nil then
-    for _, fingerprint in ipairs(fingerprinted_devices) do
-      if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
-        device.manufacturer_info.product_id == fingerprint.product_id then
-        return
-      end
-    end
+  -- check if the device is NOT currently profiled as base-lock
+  -- by ANDing a query for every capability in the base-lock profiles.
+  -- If it does not use base-lock, it is WWST and does not need re-profiling.
+  if not (device:supports_capability(capabilities.lock) and
+    device:supports_capability(capabilities.lockCodes) and
+    device:supports_capability(capabilities.tamperAlert) and
+    device:supports_capability(capabilities.battery)) then
+    return
   end
 
   -- if not  fingerprinted, dynamically configure base-lock profile based on Power Source cluster checks

--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -524,6 +524,7 @@ local function do_configure(driver, device)
     { vendor_id = 0x115F, product_id = 0x2802 }, -- Aqara Smart Lock U200
     { vendor_id = 0x115F, product_id = 0x2801 }, -- Aqara Smart Lock U300
     { vendor_id = 0x129F, product_id = 0x0001 }, -- Level Lock Plus (Matter)
+    { vendor_id = 0x129F, product_id = 0x0003 }, -- Level Bolt (Matter)
     { vendor_id = 0x135d, product_id = 0xb1 }, -- Nuki Smart Lock Pro
     { vendor_id = 0x135d, product_id = 0xb0 }, -- Nuki Smart Lock
   }

--- a/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
@@ -1,0 +1,102 @@
+-- Copyright 2024 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+test.add_package_capability("lockAlarm.yml")
+local t_utils = require "integration_test.utils"
+local clusters = require "st.matter.clusters"
+
+local mock_device_record = {
+  profile = t_utils.get_profile_definition("base-lock-nobattery.yml"),
+  manufacturer_info = {vendor_id = 0, product_id = 0},
+  endpoints = {
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 10,
+      clusters = {
+        {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
+      },
+    },
+  },
+}
+local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
+
+local mock_device_record_aqara = {
+    profile = t_utils.get_profile_definition("base-lock-nobattery.yml"),
+    manufacturer_info = {vendor_id = 0x115F, product_id = 0x2801}, -- Aqara Smart Lock U300
+    endpoints = {
+      {
+        endpoint_id = 2,
+        clusters = {
+          {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+        },
+        device_types = {
+          device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+        }
+      },
+      {
+        endpoint_id = 10,
+        clusters = {
+          {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
+        },
+      },
+    },
+}
+
+local mock_device_aqara = test.mock_device.build_test_matter_device(mock_device_record_aqara)
+
+local function test_init()
+    local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
+    subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
+    subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device))
+    subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device))
+    test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+    test.mock_device.add_test_device(mock_device)
+
+    local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device_aqara)
+    subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device_aqara))
+    subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device_aqara))
+    subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device_aqara))
+    test.socket["matter"]:__expect_send({mock_device_aqara.id, subscribe_request})
+    test.mock_device.add_test_device(mock_device_aqara)
+end
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+    "doConfigure lifecycle event for base-lock-nobattery",
+    function()
+        test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+        mock_device:expect_metadata_update({ profile = "base-lock-nobattery" })
+        mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    end
+)
+
+test.register_coroutine_test(
+    "doConfigure lifecycle event for aqara lock",
+    function()
+        test.socket.device_lifecycle:__queue_receive({ mock_device_aqara.id, "doConfigure" })
+        mock_device_aqara:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 local test = require "integration_test"
-local capabilities = require "st.capabilities"
 test.add_package_capability("lockAlarm.yml")
 local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"

--- a/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
@@ -40,9 +40,9 @@ local mock_device_record = {
 }
 local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
 
-local mock_device_record_aqara = {
-    profile = t_utils.get_profile_definition("lock-lockalarm-nobattery.yml"),
-    manufacturer_info = {vendor_id = 0x115F, product_id = 0x2801}, -- Aqara Smart Lock U300
+local mock_device_record_level = {
+    profile = t_utils.get_profile_definition("lock-nocodes-notamper-batteryLevel.yml"),
+    manufacturer_info = {vendor_id = 0x129F, product_id = 0x0001}, -- Level Lock Plus
     endpoints = {
       {
         endpoint_id = 2,
@@ -62,7 +62,7 @@ local mock_device_record_aqara = {
     },
 }
 
-local mock_device_aqara = test.mock_device.build_test_matter_device(mock_device_record_aqara)
+local mock_device_level = test.mock_device.build_test_matter_device(mock_device_record_level)
 
 local function test_init()
     local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
@@ -72,10 +72,9 @@ local function test_init()
     test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
     test.mock_device.add_test_device(mock_device)
 
-    local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device_aqara)
-    subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device_aqara))
-    test.socket["matter"]:__expect_send({mock_device_aqara.id, subscribe_request})
-    test.mock_device.add_test_device(mock_device_aqara)
+    local subscribe_request_level = clusters.DoorLock.attributes.LockState:subscribe(mock_device_level)
+    test.socket["matter"]:__expect_send({mock_device_level.id, subscribe_request_level})
+    test.mock_device.add_test_device(mock_device_level)
 end
 test.set_test_init_function(test_init)
 
@@ -89,10 +88,10 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-    "doConfigure lifecycle event for aqara lock",
+    "doConfigure lifecycle event for Level Lock Plus profile",
     function()
-        test.socket.device_lifecycle:__queue_receive({ mock_device_aqara.id, "doConfigure" })
-        mock_device_aqara:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+        test.socket.device_lifecycle:__queue_receive({ mock_device_level.id, "doConfigure" })
+        mock_device_level:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
@@ -18,7 +18,7 @@ local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"
 
 local mock_device_record = {
-  profile = t_utils.get_profile_definition("base-lock-nobattery.yml"),
+  profile = t_utils.get_profile_definition("base-lock.yml"),
   manufacturer_info = {vendor_id = 0, product_id = 0},
   endpoints = {
     {
@@ -33,7 +33,7 @@ local mock_device_record = {
     {
       endpoint_id = 10,
       clusters = {
-        {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
+        {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0101},
       },
     },
   },
@@ -41,7 +41,7 @@ local mock_device_record = {
 local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
 
 local mock_device_record_aqara = {
-    profile = t_utils.get_profile_definition("base-lock-nobattery.yml"),
+    profile = t_utils.get_profile_definition("lock-lockalarm-nobattery.yml"),
     manufacturer_info = {vendor_id = 0x115F, product_id = 0x2801}, -- Aqara Smart Lock U300
     endpoints = {
       {
@@ -74,8 +74,6 @@ local function test_init()
 
     local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device_aqara)
     subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device_aqara))
-    subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device_aqara))
-    subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device_aqara))
     test.socket["matter"]:__expect_send({mock_device_aqara.id, subscribe_request})
     test.mock_device.add_test_device(mock_device_aqara)
 end

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
@@ -35,7 +35,7 @@ local mock_device_record = {
       endpoint_id = 10,
       clusters = {
         {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 10},
       },
     },
   },

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -56,7 +56,7 @@ local mock_device_record = {
           cluster_type = "SERVER",
           feature_map = 0x0181, -- PIN & USR & COTA
         },
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 10},
       },
     },
   },


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Jira ticket showing mis-profiling of a bridged door lock: https://smartthings.atlassian.net/browse/MTR-821
Further, there is a general ticket on adding dynamic profiling to this driver: https://smartthings.atlassian.net/browse/CHAD-13948

This logic will permit dynamic profiling on the base-lock profile depending on the Power Source cluster, and will ignore devices that do not auto-profile as base-lock.

# Summary of Completed Tests
Unit tests
Bridged Switchbot device - Passed
VDA Door Lock - Passed
VDA Door Lock (Lock Codes) - Passed
Yale Assure Matter Lock - Passed