### PR TITLE
Device Label (Z-Wave Switch) for two devices

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -387,7 +387,7 @@ zwaveManufacturer:
     productId: 0xA002
     deviceProfileName: switch-binary
   - id: 0063/4952
-    deviceLabel: Jasco Pro In-Wall Switch
+    deviceLabel: JascoPro In-Wall Switch
     manufacturerId: 0x0063
     productType: 0x4952
     deviceProfileName: switch-binary-indicator

--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -23,7 +23,7 @@ zwaveManufacturer:
     productType: 0x4457
     deviceProfileName: switch-level-indicator
   - id: 0063/4944
-    deviceLabel: GE Dimmer Switch
+    deviceLabel: JascoPro In-Wall Dimmer
     manufacturerId: 0x0063
     productType: 0x4944
     deviceProfileName: switch-level-indicator
@@ -387,7 +387,7 @@ zwaveManufacturer:
     productId: 0xA002
     deviceProfileName: switch-binary
   - id: 0063/4952
-    deviceLabel: GE Switch
+    deviceLabel: Jasco Pro In-Wall Switch
     manufacturerId: 0x0063
     productType: 0x4952
     deviceProfileName: switch-binary-indicator


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [  X] Refactor

# Checklist

- [X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This PR is a request of @Brianj94 on behalf of Jasco. There are two existing fingerprints that need a device label name change only.
id: 0063/4944, current device label   `GE Dimmer Switch`, to JascoPro In-Wall Dimmer
id: 0063/4952, current device label `deviceLabel: GE Switch`, to Jasco Pro In-Wall Switch

# Summary of Completed Tests
No tests completed beyond unit tests

