### PR TITLE
Matter Sensor: add BooleanStateConfiguration in embedded cluster utils

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/embedded-cluster-utils.lua
+++ b/drivers/SmartThings/matter-sensor/src/embedded-cluster-utils.lua
@@ -24,7 +24,7 @@ end
 
 local embedded_cluster_utils = {}
 
-local embedded_clusters = {
+local embedded_clusters_api_10 = {
   [clusters.AirQuality.ID] = clusters.AirQuality,
   [clusters.CarbonMonoxideConcentrationMeasurement.ID] = clusters.CarbonMonoxideConcentrationMeasurement,
   [clusters.CarbonDioxideConcentrationMeasurement.ID] = clusters.CarbonDioxideConcentrationMeasurement,
@@ -39,11 +39,16 @@ local embedded_clusters = {
   [clusters.SmokeCoAlarm.ID] = clusters.SmokeCoAlarm,
 }
 
+local embedded_clusters_api_11 = {
+  [clusters.BooleanStateConfiguration.ID] = clusters.BooleanStateConfiguration
+}
+
 function embedded_cluster_utils.get_endpoints(device, cluster_id, opts)
     -- If using older lua libs and need to check for an embedded cluster feature,
     -- we must use the embedded cluster definitions here
-    if version.api < 10 and embedded_clusters[cluster_id] ~= nil then
-      local embedded_cluster = embedded_clusters[cluster_id]
+    if version.api < 10 and embedded_clusters_api_10[cluster_id] ~= nil or
+       version.api < 11 and embedded_clusters_api_11[cluster_id] ~= nil then
+      local embedded_cluster = embedded_clusters_api_10[cluster_id] or embedded_clusters_api_11[cluster_id]
       local opts = opts or {}
       if utils.table_size(opts) > 1 then
         device.log.warn_with({hub_logs = true}, "Invalid options for get_endpoints")


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adds the BooleanStateConfiguration to the cluster list in the embedded cluster utils so that get_endpoints() calls will work correctly on hub running older lua libs.

Resolves [CHAD-14121](https://smartthings.atlassian.net/browse/CHAD-14121)

# Summary of Completed Tests
Each of the boolean sensors were testing on a hub running 53 lua libs to confirm that the embedded clusters are working as expected and the device joins to the correct profile:

- Water Freeze Detector
- [x] onboards to correct profile
- [x] preferences are useable
- Water Leak Detector
- [x] onboards to correct profile
- [x] preferences are useable
- Rain Sensor
- [x] onboards to correct profile
- [x] preferences are useable



[CHAD-14121]: https://smartthings.atlassian.net/browse/CHAD-14121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ