### PR TITLE
Prevent multiple reads of MinSetpointDeadBand

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -280,7 +280,7 @@ local function device_init(driver, device)
       deadband_read:merge(clusters.Thermostat.attributes.MinSetpointDeadBand:read())
       device:send(deadband_read)
     end
-    device:set_field(setpoint_limit_device_field.MIN_SETPOINT_DEADBAND_CHECKED, true)
+    device:set_field(setpoint_limit_device_field.MIN_SETPOINT_DEADBAND_CHECKED, true, {persist = true})
   end
 end
 

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -271,7 +271,6 @@ end
 local function device_init(driver, device)
   device:subscribe()
   device:set_component_to_endpoint_fn(component_to_endpoint)
-
   if not device:get_field(setpoint_limit_device_field.MIN_SETPOINT_DEADBAND_CHECKED) then
     local auto_eps = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE})
     --Query min setpoint deadband if needed
@@ -280,7 +279,6 @@ local function device_init(driver, device)
       deadband_read:merge(clusters.Thermostat.attributes.MinSetpointDeadBand:read())
       device:send(deadband_read)
     end
-    device:set_field(setpoint_limit_device_field.MIN_SETPOINT_DEADBAND_CHECKED, true, {persist = true})
   end
 end
 
@@ -808,6 +806,7 @@ local function min_deadband_limit_handler(driver, device, ib, response)
   local val = ib.data.value / 10.0
   log.info("Setting " .. setpoint_limit_device_field.MIN_DEADBAND .. " to " .. string.format("%s", val))
   device:set_field(setpoint_limit_device_field.MIN_DEADBAND, val, { persist = true })
+  device:set_field(setpoint_limit_device_field.MIN_SETPOINT_DEADBAND_CHECKED, true, {persist = true})
 end
 
 local function fan_mode_handler(driver, device, ib, response)

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -250,6 +250,19 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Set MIN_SETPOINT_DEADBAND_CHECKED flag on MinSetpointDeadBand attribute handler",
+  function()
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.Thermostat.attributes.MinSetpointDeadBand:build_test_report_data(mock_device, 1, 16) --1.6 celcius
+    })
+    test.wait_for_events()
+    local min_setpoint_deadband_checked = mock_device:get_field("MIN_SETPOINT_DEADBAND_CHECKED")
+    assert(min_setpoint_deadband_checked == true, "min_setpoint_deadband_checked is True")
+  end
+)
+
 test.register_message_test(
   "Min and max heating setpoint attributes set capability constraint",
   {


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-14135](https://smartthings.atlassian.net/browse/CHAD-14135)

The driver currently attempts to only read `MinSetpointDeadBand` once during the first time `device_init` is called, but the `MIN_SETPOINT_DEADBAND_CHECKED` field is not persisted, so the read request is sent during each device init. This is contributing to a spike in `InteractionQueueFull` exceptions. This change ensures that the field is persisted so that the read request is only sent once.

# Summary of Completed Tests

Added unit test to verify that the `MIN_SETPOINT_DEADBAND_CHECKED` flag is set after the `MinSetpointDeadBand` attribute is received to ensure that this value is only read one time.

Tested with a VDA bridge consisting of 20 thermostats and 20 color temperature lights to ensure that no regressions were introduced. Note that the issue is still present when dealing with a large number of bridged devices because the queue can still reach capacity even with this change. This is meant to help alleviate the issue rather than provide a full solution, which would require optimizations to the read request logic in the firmware.

[CHAD-14135]: https://smartthings.atlassian.net/browse/CHAD-14135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ