### PR TITLE
feat: Hue dynamic constraints

### DIFF
--- a/drivers/SmartThings/philips-hue/src/consts.lua
+++ b/drivers/SmartThings/philips-hue/src/consts.lua
@@ -1,9 +1,11 @@
 local Consts = {}
 
---- minimum colortemp value from Hue
-Consts.DEFAULT_MIREK = 153
+--- minimum possible colortemp value for Hue bulbs.
+Consts.DEFAULT_MIN_MIREK = 153
+Consts.DEFAULT_MAX_MIREK = 500
 Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE = 2000
 Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE = 2200
 Consts.MAX_TEMP_KELVIN = 6500
+Consts.DEFAULT_MIN_DIMMING = 2
 
 return Consts

--- a/drivers/SmartThings/philips-hue/src/fields.lua
+++ b/drivers/SmartThings/philips-hue/src/fields.lua
@@ -26,6 +26,7 @@ local Fields = {
   IS_MULTI_SERVICE = "is_multi_service",
   MIN_DIMMING = "mindim",
   MIN_KELVIN = "mintemp",
+  MAX_KELVIN = "maxtemp",
   MODEL_ID = "modelid",
   PARENT_DEVICE_ID = "parent_device_id_local",
   RESOURCE_ID = "rid",

--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -42,7 +42,15 @@ local function _emit_light_events_inner(light_device, light_repr)
     end
 
     if light_repr.dimming then
-      local adjusted_level = st_utils.round(st_utils.clamp_value(light_repr.dimming.brightness, 1, 100))
+      local min_dim = light_device:get_field(Fields.MIN_DIMMING)
+      local api_min_dim = st_utils.round(st_utils.clamp_value(light_repr.dimming.min_dim_level or Consts.DEFAULT_MIN_DIMMING, 1, 100))
+      if min_dim ~= api_min_dim then
+        min_dim = api_min_dim
+        light_device:set_field(Fields.MIN_DIMMING, min_dim, { persist = true })
+        log.info("EMITTING DIMMING CAP RANGE")
+        light_device:emit_event(capabilities.switchLevel.levelRange({ minimum = min_dim, maximum = 100 }))
+      end
+      local adjusted_level = st_utils.round(st_utils.clamp_value(light_repr.dimming.brightness, min_dim, 100))
       if utils.is_nan(adjusted_level) then
         light_device.log.warn(
           string.format(
@@ -56,13 +64,42 @@ local function _emit_light_events_inner(light_device, light_repr)
     end
 
     if light_repr.color_temperature then
-      local mirek = Consts.DEFAULT_MIREK
+      local mirek = Consts.DEFAULT_MIN_MIREK
       if light_repr.color_temperature.mirek_valid then
         mirek = light_repr.color_temperature.mirek
       end
-      local min = light_device:get_field(Fields.MIN_KELVIN) or Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE
+      local mirek_schema = light_repr.color_temperature.mirek_schema or {
+        mirek_minimum = Consts.DEFAULT_MIN_MIREK,
+        mirek_maximum = Consts.DEFAULT_MAX_MIREK
+      }
+
+      -- See note in `src/handlers/lifecycle_handlers/light.lua` about min/max relationship
+      -- if the below is not intuitive.
+      local min_kelvin = light_device:get_field(Fields.MIN_KELVIN)
+      local api_min_kelvin = math.floor(utils.mirek_to_kelvin(mirek_schema.mirek_maximum) or Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE)
+      local max_kelvin = light_device:get_field(Fields.MAX_KELVIN)
+      local api_max_kelvin = math.floor(utils.mirek_to_kelvin(mirek_schema.mirek_minimum) or Consts.MAX_TEMP_KELVIN)
+
+      local update_range = false
+      if min_kelvin ~= api_min_kelvin then
+        update_range = true
+        min_kelvin = api_min_kelvin
+        light_device:set_field(Fields.MIN_KELVIN, min_kelvin, { persist = true })
+      end
+
+      if max_kelvin ~= api_max_kelvin then
+        update_range = true
+        max_kelvin = api_max_kelvin
+        light_device:set_field(Fields.MAX_KELVIN, max_kelvin, { persist = true })
+      end
+
+      if update_range then
+        light_device:emit_event(capabilities.colorTemperature.colorTemperatureRange({ minimum = min_kelvin, maximum = max_kelvin }))
+      end
+
+      -- local min =  or Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE
       local kelvin = math.floor(
-        st_utils.clamp_value(utils.mirek_to_kelvin(mirek), min, Consts.MAX_TEMP_KELVIN)
+        st_utils.clamp_value(utils.mirek_to_kelvin(mirek), min_kelvin, max_kelvin)
       )
       if utils.is_nan(kelvin) then
         light_device.log.warn(

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
@@ -139,7 +139,48 @@ function LightLifecycleHandlers.added(driver, device, parent_device_id, resource
   local light_info = Discovery.device_state_disco_cache[device_light_resource_id]
   local minimum_dimming = 2
 
-  if light_info.dimming and light_info.dimming.min_dim_level then minimum_dimming = light_info.dimming.min_dim_level end
+  if light_info.dimming and light_info.dimming.min_dim_level then
+    minimum_dimming = st_utils.round(st_utils.clamp_value(light_info.dimming.min_dim_level, 1, 100))
+  end
+
+  device:set_field(Fields.MIN_DIMMING, minimum_dimming, { persist = true })
+
+  -- Remembering that mirek are reciprocal to kelvin, note the following:
+  --  ** Minimum Mirek -> _Maximum_ Kelvin
+  --  ** Maximum Mirek -> _Minimum_ Kelvin
+  --
+  -- Not necessarily obvious/intuitive, but easy enough to validate with the math:
+  --
+  -- Given that `kelvin = 1000000 / mirek`, and `mirek = 1000000 / kelvin`, pick
+  -- one of our minimum consts: `Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE = 2000`
+  --
+  -- `floor(1000000 / 2000) = 500` and 500 is the max mirek we see on almost all Hue lights.
+  -- Similarly:
+  -- `floor(1000000 / 6500) = 153`, which is the minimum we see from the API for color control lights.
+  if light_info.color_temperature and light_info.color_temperature.mirek_schema then
+    local caps = device.profile.components.main.capabilities
+    if caps.colorTemperature then
+      local min_ct_kelvin, max_ct_kelvin = nil, nil
+      if type(light_info.color_temperature.mirek_schema.mirek_maximum) == "number" then
+        min_ct_kelvin = math.floor(utils.mirek_to_kelvin(light_info.color_temperature.mirek_schema.mirek_maximum))
+      end
+      if type(light_info.color_temperature.mirek_schema.mirek_minimum) == "number" then
+        max_ct_kelvin = math.floor(utils.mirek_to_kelvin(light_info.color_temperature.mirek_schema.mirek_minimum))
+      end
+      if not min_ct_kelvin then
+        if caps.colorControl then
+          min_ct_kelvin = Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE
+        else
+          min_ct_kelvin = Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE
+        end
+      end
+      if not max_ct_kelvin then
+        max_ct_kelvin = Consts.MAX_TEMP_KELVIN
+      end
+      device:set_field(Fields.MIN_KELVIN, min_ct_kelvin, { persist = true })
+      device:set_field(Fields.MAX_KELVIN, max_ct_kelvin, { persist = true })
+    end
+  end
 
   -- persistent fields
   device:set_field(Fields.DEVICE_TYPE, "light", { persist = true })
@@ -147,7 +188,6 @@ function LightLifecycleHandlers.added(driver, device, parent_device_id, resource
     device:set_field(Fields.GAMUT, light_info.color.gamut, { persist = true })
   end
   device:set_field(Fields.HUE_DEVICE_ID, light_info.hue_device_id, { persist = true })
-  device:set_field(Fields.MIN_DIMMING, minimum_dimming, { persist = true })
   device:set_field(Fields.PARENT_DEVICE_ID, light_info.parent_device_id, { persist = true })
   device:set_field(Fields.RESOURCE_ID, device_light_resource_id, { persist = true })
   device:set_field(Fields._ADDED, true, { persist = true })
@@ -164,14 +204,7 @@ end
 function LightLifecycleHandlers.init(driver, device)
   log.info(
     string.format("Init Light for device %s", (device.label or device.id or "unknown device")))
-  local caps = device.profile.components.main.capabilities
-  if caps.colorTemperature then
-    if caps.colorControl then
-      device:set_field(Fields.MIN_KELVIN, Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE, { persist = true })
-    else
-      device:set_field(Fields.MIN_KELVIN, Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE, { persist = true })
-    end
-  end
+
   local device_light_resource_id =
       utils.get_hue_rid(device) or
       device.device_network_id

--- a/drivers/SmartThings/philips-hue/src/types.lua
+++ b/drivers/SmartThings/philips-hue/src/types.lua
@@ -41,7 +41,7 @@
 ---@field public on { on: boolean }
 ---@field public color { xy: HueColorCoords, gamut: HueGamut, gamut_type: string }
 ---@field public dimming { brightness: number, min_dim_level: number }
----@field public color_temperature { mirek: number?, mirek_valid: boolean}
+---@field public color_temperature { mirek: number?, mirek_valid: boolean, mirek_schema: { mirek_minimum: number, mirek_maximum: number }?}
 ---@field public mode string
 
 ---@class HueMotionInfo: HueResourceInfo


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Adds dynamic constraint ranges to the `switchLevel` and the
`colorTemperatureLevel` capabilities, now that they're fully rolled out.

Existing light devices will update these ranges the next time they emit a
capability attribute event for the given capability. New devices will
emit these during onboarding.

