### PR TITLE
Convert Power and Energy reads from mW(h) to W(h). 

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -158,7 +158,7 @@ local LAST_EXPORTED_REPORT_TIMESTAMP = "__last_exported_report_timestamp"
 local RECURRING_EXPORT_REPORT_POLL_TIMER = "__recurring_export_report_poll_timer"
 local MINIMUM_ST_ENERGY_REPORT_INTERVAL = (15 * 60) -- 15 minutes, reported in seconds
 local SUBSCRIPTION_REPORT_OCCURRED = "__subscription_report_occurred"
-local CONVERSION_MILLIWATTS_TO_WATTS = 0.001 -- A milliwatt is 1/1000th of a watt
+local CONVERSION_CONST_MILLIWATT_TO_WATT = 1000 -- A milliwatt is 1/1000th of a watt
 
 local embedded_cluster_utils = require "embedded-cluster-utils"
 
@@ -925,7 +925,7 @@ end
 
 local function cumul_energy_exported_handler(driver, device, ib, response)
   if ib.data.elements.energy then
-    local watt_hour_value = ib.data.elements.energy.value * CONVERSION_MILLIWATTS_TO_WATTS
+    local watt_hour_value = ib.data.elements.energy.value / CONVERSION_CONST_MILLIWATT_TO_WATT
     device:set_field(TOTAL_EXPORTED_ENERGY, watt_hour_value)
     device:emit_event(capabilities.energyMeter.energy({ value = watt_hour_value, unit = "Wh" }))
   end
@@ -933,7 +933,7 @@ end
 
 local function per_energy_exported_handler(driver, device, ib, response)
   if ib.data.elements.energy then
-    local watt_hour_value = ib.data.elements.energy.value * CONVERSION_MILLIWATTS_TO_WATTS
+    local watt_hour_value = ib.data.elements.energy.value / CONVERSION_CONST_MILLIWATT_TO_WATT
     local latest_energy_report = device:get_field(TOTAL_EXPORTED_ENERGY) or 0
     local summed_energy_report = latest_energy_report + watt_hour_value
     device:set_field(TOTAL_EXPORTED_ENERGY, summed_energy_report)
@@ -989,7 +989,7 @@ end
 
 local function active_power_handler(driver, device, ib, response)
   if ib.data.value then
-    local watt_value = ib.data.value * CONVERSION_MILLIWATTS_TO_WATTS
+    local watt_value = ib.data.value / CONVERSION_CONST_MILLIWATT_TO_WATT
     device:emit_event(capabilities.powerMeter.power({ value = watt_value, unit = "W"}))
   end
 end

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -158,6 +158,7 @@ local LAST_EXPORTED_REPORT_TIMESTAMP = "__last_exported_report_timestamp"
 local RECURRING_EXPORT_REPORT_POLL_TIMER = "__recurring_export_report_poll_timer"
 local MINIMUM_ST_ENERGY_REPORT_INTERVAL = (15 * 60) -- 15 minutes, reported in seconds
 local SUBSCRIPTION_REPORT_OCCURRED = "__subscription_report_occurred"
+local CONVERSION_MILLIWATTS_TO_WATTS = 0.001 -- A milliwatt is 1/1000th of a watt
 
 local embedded_cluster_utils = require "embedded-cluster-utils"
 
@@ -923,15 +924,21 @@ local function occupancy_attr_handler(driver, device, ib, response)
 end
 
 local function cumul_energy_exported_handler(driver, device, ib, response)
-  device:set_field(TOTAL_EXPORTED_ENERGY, ib.data.elements.energy.value)
-  device:emit_event(capabilities.energyMeter.energy({ value = ib.data.elements.energy.value, unit = "Wh" }))
+  if ib.data.elements.energy then
+    local watt_hour_value = ib.data.elements.energy.value * CONVERSION_MILLIWATTS_TO_WATTS
+    device:set_field(TOTAL_EXPORTED_ENERGY, watt_hour_value)
+    device:emit_event(capabilities.energyMeter.energy({ value = watt_hour_value, unit = "Wh" }))
+  end
 end
 
 local function per_energy_exported_handler(driver, device, ib, response)
-  local latest_energy_report = device:get_field(TOTAL_EXPORTED_ENERGY) or 0
-  local summed_energy_report = latest_energy_report + ib.data.elements.energy.value
-  device:set_field(TOTAL_EXPORTED_ENERGY, summed_energy_report)
-  device:emit_event(capabilities.energyMeter.energy({ value = summed_energy_report, unit = "Wh" }))
+  if ib.data.elements.energy then
+    local watt_hour_value = ib.data.elements.energy.value * CONVERSION_MILLIWATTS_TO_WATTS
+    local latest_energy_report = device:get_field(TOTAL_EXPORTED_ENERGY) or 0
+    local summed_energy_report = latest_energy_report + watt_hour_value
+    device:set_field(TOTAL_EXPORTED_ENERGY, summed_energy_report)
+    device:emit_event(capabilities.energyMeter.energy({ value = summed_energy_report, unit = "Wh" }))
+  end
 end
 
 local function energy_report_handler_factory(is_cumulative_report)
@@ -982,7 +989,8 @@ end
 
 local function active_power_handler(driver, device, ib, response)
   if ib.data.value then
-    device:emit_event(capabilities.powerMeter.power({ value = ib.data.value, unit = "W"}))
+    local watt_value = ib.data.value * CONVERSION_MILLIWATTS_TO_WATTS
+    device:emit_event(capabilities.powerMeter.power({ value = watt_value, unit = "W"}))
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -100,7 +100,7 @@ local subscribed_attributes = {
 }
 
 local cumulative_report_val_19 = {
-  energy = 19,
+  energy = 19000,
   start_timestamp = 0,
   end_timestamp = 0,
   start_systime = 0,
@@ -108,7 +108,7 @@ local cumulative_report_val_19 = {
 }
 
 local cumulative_report_val_29 = {
-  energy = 29,
+  energy = 29000,
   start_timestamp = 0,
   end_timestamp = 0,
   start_systime = 0,
@@ -116,7 +116,7 @@ local cumulative_report_val_29 = {
 }
 
 local cumulative_report_val_39 = {
-  energy = 39,
+  energy = 39000,
   start_timestamp = 0,
   end_timestamp = 0,
   start_systime = 0,
@@ -124,7 +124,7 @@ local cumulative_report_val_39 = {
 }
 
 local periodic_report_val_23 = {
-  energy = 23,
+  energy = 23000,
   start_timestamp = 0,
   end_timestamp = 0,
   start_systime = 0,
@@ -245,13 +245,13 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        clusters.ElectricalPowerMeasurement.server.attributes.ActivePower:build_test_report_data(mock_device, 1, 17)
+        clusters.ElectricalPowerMeasurement.server.attributes.ActivePower:build_test_report_data(mock_device, 1, 17000)
       }
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.powerMeter.power({value = 17, unit="W"}))
+      message = mock_device:generate_test_message("main", capabilities.powerMeter.power({value = 17.0, unit="W"}))
     },
   }
 )
@@ -270,7 +270,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 19, unit="Wh"}))
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 19.0, unit="Wh"}))
     },
     {
       channel = "matter",
@@ -283,7 +283,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 19, unit="Wh"}))
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 19.0, unit="Wh"}))
     },
     {
       channel = "matter",
@@ -300,13 +300,13 @@ test.register_message_test(
         start = "1970-01-01T00:00:00Z",
         ["end"] = "1969-12-31T23:59:59Z",
         deltaEnergy = 0.0,
-        energy = 19
+        energy = 19.0
       }))
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 29, unit="Wh"}))
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 29.0, unit="Wh"}))
     },
     {
       channel = "matter",
@@ -319,7 +319,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 39, unit="Wh"}))
+      message = mock_device:generate_test_message("main", capabilities.energyMeter.energy({value = 39.0, unit="Wh"}))
     },
   }
 )
@@ -360,7 +360,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({value = 23, unit="Wh"}))
+      message = mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({value = 23.0, unit="Wh"}))
     },
     {
       channel = "matter",
@@ -373,7 +373,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({value = 46, unit="Wh"}))
+      message = mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({value = 46.0, unit="Wh"}))
     },
     {
       channel = "matter",
@@ -390,13 +390,13 @@ test.register_message_test(
         start = "1970-01-01T00:00:00Z",
         ["end"] = "1969-12-31T23:59:59Z",
         deltaEnergy = 0.0,
-        energy = 46
+        energy = 46.0
       }))
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({value = 69, unit="Wh"}))
+      message = mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({value = 69.0, unit="Wh"}))
     },
   },
   { test_init = test_init_periodic }
@@ -416,7 +416,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
     test.socket["matter"]:__queue_receive(
       {
@@ -427,7 +427,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
     test.wait_for_events()
     test.mock_time.advance_time(899)
@@ -444,11 +444,11 @@ test.register_coroutine_test(
             start = "1970-01-01T00:00:00Z",
             ["end"] = "1970-01-01T00:14:58Z",
             deltaEnergy = 0.0,
-            energy = 19
+            energy = 19.0
         }))
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 29, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 29.0, unit = "Wh" }))
     )
     test.wait_for_events()
     local report_export_poll_timer = mock_device:get_field("__recurring_export_report_poll_timer")
@@ -471,7 +471,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
     test.socket["matter"]:__queue_receive(
       {
@@ -482,7 +482,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
     test.wait_for_events()
     test.mock_time.advance_time(2000)
@@ -499,11 +499,11 @@ test.register_coroutine_test(
             start = "1970-01-01T00:00:00Z",
             ["end"] = "1970-01-01T00:33:19Z",
             deltaEnergy = 0.0,
-            energy = 19
+            energy = 19.0
         }))
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 29, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 29.0, unit = "Wh" }))
     )
     test.wait_for_events()
     local report_export_poll_timer = mock_device:get_field("__recurring_export_report_poll_timer")
@@ -526,7 +526,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
     test.socket["matter"]:__queue_receive(
       {
@@ -537,7 +537,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
     test.wait_for_events()
     test.mock_time.advance_time(2000)
@@ -554,11 +554,11 @@ test.register_coroutine_test(
             start = "1970-01-01T00:00:00Z",
             ["end"] = "1970-01-01T00:33:19Z",
             deltaEnergy = 0.0,
-            energy = 19
+            energy = 19.0
         }))
     )
     test.socket["capability"]:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 29, unit = "Wh" }))
+      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 29.0, unit = "Wh" }))
     )
     test.wait_for_events()
     local report_export_poll_timer = mock_device:get_field("__recurring_export_report_poll_timer")
@@ -588,7 +588,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 23, unit = "Wh" }))
+      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 23.0, unit = "Wh" }))
     )
     test.socket["matter"]:__queue_receive(
       {
@@ -599,7 +599,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 46, unit = "Wh" }))
+      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 46.0, unit = "Wh" }))
     )
     test.wait_for_events()
     test.mock_time.advance_time(899)
@@ -615,12 +615,12 @@ test.register_coroutine_test(
       mock_device_periodic:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
         deltaEnergy=0.0,
         ["end"]="1970-01-01T00:14:58Z",
-        energy=46,
+        energy=46.0,
         start="1970-01-01T00:00:00Z"
       }))
     )
     test.socket["capability"]:__expect_send(
-      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 69, unit = "Wh" }))
+      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 69.0, unit = "Wh" }))
     )
     test.wait_for_events()
     local report_export_poll_timer = mock_device_periodic:get_field("__recurring_export_report_poll_timer")
@@ -644,7 +644,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 23, unit = "Wh" }))
+      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 23.0, unit = "Wh" }))
     )
     test.socket["matter"]:__queue_receive(
       {
@@ -655,7 +655,7 @@ test.register_coroutine_test(
       }
     )
     test.socket["capability"]:__expect_send(
-      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 46, unit = "Wh" }))
+      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 46.0, unit = "Wh" }))
     )
     test.wait_for_events()
     test.mock_time.advance_time(2000)
@@ -671,12 +671,12 @@ test.register_coroutine_test(
       mock_device_periodic:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
         deltaEnergy=0.0,
         ["end"] = "1970-01-01T00:33:19Z",
-        energy=46,
+        energy=46.0,
         start="1970-01-01T00:00:00Z"
       }))
     )
     test.socket["capability"]:__expect_send(
-      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 69, unit = "Wh" }))
+      mock_device_periodic:generate_test_message("main", capabilities.energyMeter.energy({ value = 69.0, unit = "Wh" }))
     )
     test.wait_for_events()
     local report_export_poll_timer = mock_device_periodic:get_field("__recurring_export_report_poll_timer")


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
The Electrical Energy Measurement cluster and Electrical Power Measurement cluster report readings in mWh and mW respectively, but SmartThings uses W and Wh for our capabilities. This change converts the read values into those of the correct unit. 

# Summary of Completed Tests
Unit tests were converted to match the new system.
See user testing reports in [this Slack page](https://smartthings.slack.com/archives/CDNPD1P8Q/p1728941844831519): 