### PR TITLE
fix: luacov-cobertura dependency acquisition

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -108,9 +108,11 @@ jobs:
       - name: Install lua rocks
         run: |
           wget https://luarocks.org/manifests/hisham/luacov-0.15.0-1.rockspec
-          wget https://luarocks.org/manifests/ssharma/luacov-cobertura-0.2-1.rockspec
+          wget https://raw.githubusercontent.com/britzl/luacov-cobertura/refs/tags/1.1.0/rockspec -O luacov-cobertura-1.1.0-0.rockspec
+          sed -i 's/master/1\.1\.0/g' luacov-cobertura-1.1.0-0.rockspec
+          sed -i 's/1\.0-0/1\.1\.0-0/g' luacov-cobertura-1.1.0-0.rockspec
           sudo luarocks install luacov-0.15.0-1.rockspec
-          sudo luarocks install luacov-cobertura-0.2-1.rockspec
+          sudo luarocks install luacov-cobertura-1.1.0-0.rockspec
       - name: Set LUA_PATH
         id: lua_path
         env:


### PR DESCRIPTION
The version of `luacov-cobertura` on Luarocks is no longer available on `github`, and the rockspec we're downloading uses the GitHub source URL in its source definition, so we're failing to acquire it.

There's an alternative rockspec for this package, that's even recommended by the README of `luacov`, but it's not on Luarocks. So we acquire it from its release tag on GitHub.

The `sed` one-liners are because the rockspec from the tag reference the artifact from `master` instead of the artifact from the tag itself, and the version number wasn't properly incremented.

**This will need to be hotfixed to Beta and Prod once we're happy with it**