### PR TITLE
Replace int index with string literals for endpoint based maps

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/matter-cook-top/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-cook-top/init.lua
@@ -139,10 +139,11 @@ local function selected_temperature_level_attr_handler(driver, device, ib, respo
 
   local temperatureLevel = ib.data.value
   local supportedTemperatureLevelsMap = device:get_field(SUPPORTED_TEMPERATURE_LEVELS_MAP) or {}
-  local supportedTemperatureLevels = supportedTemperatureLevelsMap[ib.endpoint_id] or {}
+  local supportedTemperatureLevels = supportedTemperatureLevelsMap[tostring(ib.endpoint_id)] or {}
   if supportedTemperatureLevels[temperatureLevel+1] then
     local tempLevel = supportedTemperatureLevels[temperatureLevel+1]
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureLevel.temperatureLevel(tempLevel))
+    return
   end
   log.warn("Received unsupported temperature level for endpoint "..(ib.endpoint_id))
 end
@@ -161,7 +162,7 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
     log.info(string.format("supported_temperature_levels_attr_handler: %s", tempLevel.value))
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
-  supportedTemperatureLevelsMap[ib.endpoint_id] = supportedTemperatureLevels
+  supportedTemperatureLevelsMap[tostring(ib.endpoint_id)] = supportedTemperatureLevels
   device:set_field(SUPPORTED_TEMPERATURE_LEVELS_MAP, supportedTemperatureLevelsMap, { persist = true })
   local event = capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels,
     { visibility = { displayed = false } })
@@ -187,7 +188,7 @@ local function handle_temperature_level(driver, device, cmd)
 
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local supportedTemperatureLevelsMap = device:get_field(SUPPORTED_TEMPERATURE_LEVELS_MAP) or {}
-  local supportedTemperatureLevels = supportedTemperatureLevelsMap[endpoint_id] or {}
+  local supportedTemperatureLevels = supportedTemperatureLevelsMap[tostring(endpoint_id)] or {}
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
       device:send(clusters.TemperatureControl.commands.SetTemperature(device, endpoint_id, nil, i - 1))

--- a/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
@@ -214,7 +214,7 @@ local function selected_temperature_level_attr_handler(driver, device, ib, respo
   if not supportedTemperatureLevelsMap then
     return
   end
-  local supportedTemperatureLevels = supportedTemperatureLevelsMap[ib.endpoint_id]
+  local supportedTemperatureLevels = supportedTemperatureLevelsMap[tostring(ib.endpoint_id)]
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     device.log.info(string.format("selected_temperature_level_attr_handler: %d, %s", i, tempLevel))
     if i - 1 == temperatureLevel then
@@ -234,13 +234,8 @@ local function supported_temperature_levels_attr_handler(driver, device, ib, res
     device.log.info(string.format("supported_temperature_levels_attr_handler: %s", tempLevel.value))
     table.insert(supportedTemperatureLevels, tempLevel.value)
   end
-  for ep = 1, ib.endpoint_id - 1 do
-    if not supportedTemperatureLevelsMap[ep] then
-      device.log.info(string.format("supportedTemperatureLevelsMap[%d] is nil", ep))
-      supportedTemperatureLevelsMap[ep] = {"Nothing"}
-    end
-  end
-  supportedTemperatureLevelsMap[ib.endpoint_id] = supportedTemperatureLevels
+
+  supportedTemperatureLevelsMap[tostring(ib.endpoint_id)] = supportedTemperatureLevels
   device:set_field(SUPPORTED_TEMPERATURE_LEVELS_MAP, supportedTemperatureLevelsMap, { persist = true })
   local event = capabilities.temperatureLevel.supportedTemperatureLevels(supportedTemperatureLevels, {visibility = {displayed = false}})
   device:emit_event_for_endpoint(ib.endpoint_id, event)
@@ -255,7 +250,7 @@ local function refrigerator_tcc_supported_modes_attr_handler(driver, device, ib,
     end
     table.insert(supportedRefrigeratorTccModes, mode.elements.label.value)
   end
-  supportedRefrigeratorTccModesMap[ib.endpoint_id] = supportedRefrigeratorTccModes
+  supportedRefrigeratorTccModesMap[tostring(ib.endpoint_id)] = supportedRefrigeratorTccModes
   device:set_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP, supportedRefrigeratorTccModesMap, {persist = true})
   local event = capabilities.mode.supportedModes(supportedRefrigeratorTccModes, {visibility = {displayed = false}})
   device:emit_event_for_endpoint(ib.endpoint_id, event)
@@ -268,7 +263,7 @@ local function refrigerator_tcc_mode_attr_handler(driver, device, ib, response)
     string.format("refrigerator_tcc_mode_attr_handler currentMode: %s", ib.data.value))
 
   local supportedRefrigeratorTccModesMap = device:get_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP)
-  local supportedRefrigeratorTccModes = supportedRefrigeratorTccModesMap[ib.endpoint_id] or {}
+  local supportedRefrigeratorTccModes = supportedRefrigeratorTccModesMap[tostring(ib.endpoint_id)] or {}
   local currentMode = ib.data.value
   for i, mode in ipairs(supportedRefrigeratorTccModes) do
     if i - 1 == currentMode then
@@ -305,7 +300,7 @@ local function handle_refrigerator_tcc_mode(driver, device, cmd)
   device.log.info(string.format("handle_refrigerator_tcc_mode mode: %s", cmd.args.mode))
   local ep = component_to_endpoint(device, cmd.component)
   local supportedRefrigeratorTccModesMap = device:get_field(SUPPORTED_REFRIGERATOR_TCC_MODES_MAP)
-  local supportedRefrigeratorTccModes = supportedRefrigeratorTccModesMap[ep] or {}
+  local supportedRefrigeratorTccModes = supportedRefrigeratorTccModesMap[tostring(ep)] or {}
   for i, mode in ipairs(supportedRefrigeratorTccModes) do
     if cmd.args.mode == mode then
       device:send(clusters.RefrigeratorAndTemperatureControlledCabinetMode.commands.ChangeToMode(device, ep, i - 1))
@@ -371,7 +366,7 @@ local function handle_temperature_level(driver, device, cmd)
   if not supportedTemperatureLevelsMap then
     return
   end
-  local supportedTemperatureLevels = supportedTemperatureLevelsMap[ep]
+  local supportedTemperatureLevels = supportedTemperatureLevelsMap[tostring(ep)]
   for i, tempLevel in ipairs(supportedTemperatureLevels) do
     if cmd.args.temperatureLevel == tempLevel then
       device:send(clusters.TemperatureControl.commands.SetTemperature(device, ep, nil, i - 1))

--- a/drivers/SmartThings/matter-evse/profiles/evse-energy-meas-power-meas.yml
+++ b/drivers/SmartThings/matter-evse/profiles/evse-energy-meas-power-meas.yml
@@ -1,0 +1,27 @@
+#EVSE with Electrical Power Measurement & Electrical Energy Measurement Cluster in Electrical Sensor DT
+name: evse-energy-meas-power-meas
+components:
+- id: main
+  capabilities:
+  - id: evseState
+    version: 1
+  - id: evseChargingSession
+    version: 1
+  - id: mode
+    version: 1
+  - id: powerConsumptionReport
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: ElectricVehicleCharger
+- id: electricalSensor
+  label: Electrical Sensor
+  capabilities:
+  - id: powerSource
+    version: 1
+metadata:
+  mnmn: SmartThingsEdge
+  vid: generic-evse


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Some maps in matter-appliace and matter-evse driver to store supported values use integer value as index.
This can cause serialization issues when storing data store. More details regarding this is captured here: [IOTE-4570](https://smartthings.atlassian.net/browse/IOTE-4570)
This change replaces integer to use string-based literal.

# Summary of Completed Tests




[IOTE-4570]: https://smartthings.atlassian.net/browse/IOTE-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ