### PR TITLE
Set setpointRange when setpoint is set

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/init.lua
@@ -248,6 +248,7 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
   local range = {
     minimum = min,
     maximum = max,
+    step = 0.1
   }
   -- Only emit the capability for RPC version >= 5, since unit conversion for
   -- range capabilities is only supported in that case.

--- a/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-dishwasher/init.lua
@@ -144,6 +144,7 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
   local range = {
     minimum = min,
     maximum = max,
+    step = 0.1
   }
 
   -- Only emit the capability for RPC version >= 5, since unit conversion for

--- a/drivers/SmartThings/matter-appliance/src/matter-laundry/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-laundry/init.lua
@@ -171,6 +171,7 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
   local range = {
     minimum = min,
     maximum = max,
+    step = 0.1
   }
 
   -- Only emit the capability for RPC version >= 5, since unit conversion for

--- a/drivers/SmartThings/matter-appliance/src/matter-oven/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-oven/init.lua
@@ -159,6 +159,7 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
   local range = {
     minimum = min,
     maximum = max,
+    step = 0.1
   }
 
   -- Only emit the capability for RPC version >= 5, since unit conversion for

--- a/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
+++ b/drivers/SmartThings/matter-appliance/src/matter-refrigerator/init.lua
@@ -166,6 +166,7 @@ local function temperature_setpoint_attr_handler(driver, device, ib, response)
   local range = {
     minimum = min,
     maximum = max,
+    step = 0.1
   }
 
   -- Only emit the capability for RPC version >= 5, since unit conversion for

--- a/drivers/SmartThings/matter-appliance/src/test/test_dishwasher.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_dishwasher.lua
@@ -505,7 +505,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=33.0,maximum=90.0}, unit = "C"}, {visibility = {displayed = false}}))
+      message = mock_device:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=33.0,maximum=90.0, step = 0.1}, unit = "C"}, {visibility = {displayed = false}}))
     },
     {
       channel = "capability",

--- a/drivers/SmartThings/matter-appliance/src/test/test_laundry_dryer.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_laundry_dryer.lua
@@ -548,7 +548,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=30.0,maximum=70.0}, unit = "C"}, {visibility = {displayed = false}}))
+      message = mock_device:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=30.0,maximum=70.0, step = 0.1}, unit = "C"}, {visibility = {displayed = false}}))
     },
     {
       channel = "capability",
@@ -604,7 +604,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=27.0,maximum=80.0}, unit = "C"}, {visibility = {displayed = false}}))
+      message = mock_device:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=27.0,maximum=80.0, step = 0.1}, unit = "C"}, {visibility = {displayed = false}}))
     },
     {
       channel = "capability",
@@ -660,7 +660,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_washer:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=15.0,maximum=50.0}, unit = "C"}, {visibility = {displayed = false}}))
+      message = mock_device_washer:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=15.0,maximum=50.0, step = 0.1}, unit = "C"}, {visibility = {displayed = false}}))
     },
     {
       channel = "capability",
@@ -716,7 +716,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_washer:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=13.0,maximum=55.0}, unit = "C"}, {visibility = {displayed = false}}))
+      message = mock_device_washer:generate_test_message("main", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=13.0,maximum=55.0, step = 0.1}, unit = "C"}, {visibility = {displayed = false}}))
     },
     {
       channel = "capability",

--- a/drivers/SmartThings/matter-appliance/src/test/test_oven.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_oven.lua
@@ -253,7 +253,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("tccOne", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=128.0,maximum=200.0}, unit = "C"}, {visibility = {displayed = false}}))
+      message = mock_device:generate_test_message("tccOne", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=128.0,maximum=200.0, step = 0.1}, unit = "C"}, {visibility = {displayed = false}}))
     },
     {
       channel = "capability",

--- a/drivers/SmartThings/matter-appliance/src/test/test_refrigerator.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_refrigerator.lua
@@ -180,7 +180,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("refrigerator", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=0.0,maximum=15.0}, unit = "C"}))
+      message = mock_device:generate_test_message("refrigerator", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=0.0,maximum=15.0, step = 0.1}, unit = "C"}))
     },
     {
       channel = "capability",
@@ -236,7 +236,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("refrigerator", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=-6.0,maximum=20.0}, unit = "C"}))
+      message = mock_device:generate_test_message("refrigerator", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=-6.0,maximum=20.0, step = 0.1}, unit = "C"}))
     },
     {
       channel = "capability",
@@ -292,7 +292,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("freezer", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=-22.0,maximum=-14.0}, unit = "C"}))
+      message = mock_device:generate_test_message("freezer", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=-22.0,maximum=-14.0, step = 0.1}, unit = "C"}))
     },
     {
       channel = "capability",
@@ -348,7 +348,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("freezer", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=-24.0,maximum=-12.0}, unit = "C"}))
+      message = mock_device:generate_test_message("freezer", capabilities.temperatureSetpoint.temperatureSetpointRange({value = {minimum=-24.0,maximum=-12.0, step = 0.1}, unit = "C"}))
     },
     {
       channel = "capability",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -106,17 +106,23 @@ local function configure(device)
     clusters.Thermostat.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, 1, 2667) --26.67 celcius
   })
   test.socket.capability:__expect_send(
+    device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 5.00, maximum = 40.00, step = 0.1 }, unit = "C" }))
+  )
+  test.socket.capability:__expect_send(
     device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 24.44, unit = "C" }))
+  )
+  test.socket.capability:__expect_send(
+    device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 5.00, maximum = 40.00, step = 0.1 }, unit = "C" }))
   )
   test.socket.capability:__expect_send(
     device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 26.67, unit = "C" }))
   )
-  test.wait_for_events()
 end
 
 test.register_coroutine_test(
   "Heat setpoint lower than min",
   function()
+    configure(mock_device)
     test.socket.matter:__queue_receive({
       mock_device.id,
       clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:build_test_report_data(mock_device, 1, 1000)
@@ -126,9 +132,9 @@ test.register_coroutine_test(
       clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:build_test_report_data(mock_device, 1, 3222)
     })
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 10.00, maximum = 32.22 }, unit = "C" }))
+      mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 10.00, maximum = 32.22, step = 0.1 }, unit = "C" }))
     )
-    configure(mock_device)
+    test.wait_for_events()
     test.socket.capability:__queue_receive({
       mock_device.id,
       { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 9 } }
@@ -142,6 +148,7 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Cool setpoint lower than min",
   function()
+    configure(mock_device)
     test.socket.matter:__queue_receive({
       mock_device.id,
       clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:build_test_report_data(mock_device, 1, 1000)
@@ -151,9 +158,9 @@ test.register_coroutine_test(
       clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:build_test_report_data(mock_device, 1, 3222)
     })
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 10.00, maximum = 32.22 }, unit = "C" }))
+      mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 10.00, maximum = 32.22, step = 0.1 }, unit = "C" }))
     )
-    configure(mock_device)
+    test.wait_for_events()
     test.socket.capability:__queue_receive({
       mock_device.id,
       { capability = "thermostatCoolingSetpoint", component = "main", command = "setCoolingSetpoint", args = { 9 } }
@@ -167,6 +174,7 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Heat setpoint higher than max",
   function()
+    configure(mock_device)
     test.socket.matter:__queue_receive({
       mock_device.id,
       clusters.Thermostat.attributes.AbsMinHeatSetpointLimit:build_test_report_data(mock_device, 1, 1000)
@@ -176,9 +184,9 @@ test.register_coroutine_test(
       clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit:build_test_report_data(mock_device, 1, 3222)
     })
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 10.00, maximum = 32.22 }, unit = "C" }))
+      mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 10.00, maximum = 32.22, step = 0.1 }, unit = "C" }))
     )
-    configure(mock_device)
+    test.wait_for_events()
     test.socket.capability:__queue_receive({
       mock_device.id,
       { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 33 } }
@@ -192,6 +200,7 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Cool setpoint higher than max",
   function()
+    configure(mock_device)
     test.socket.matter:__queue_receive({
       mock_device.id,
       clusters.Thermostat.attributes.AbsMinCoolSetpointLimit:build_test_report_data(mock_device, 1, 1000)
@@ -201,9 +210,9 @@ test.register_coroutine_test(
       clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit:build_test_report_data(mock_device, 1, 3222)
     })
     test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 10.00, maximum = 32.22 }, unit = "C" }))
+      mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 10.00, maximum = 32.22, step = 0.1 }, unit = "C" }))
     )
-    configure(mock_device)
+    test.wait_for_events()
     test.socket.capability:__queue_receive({
       mock_device.id,
       { capability = "thermostatCoolingSetpoint", component = "main", command = "setCoolingSetpoint", args = { 33 } }
@@ -217,11 +226,12 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Heat setpoint inside deadband",
   function()
+    configure(mock_device)
     test.socket.matter:__queue_receive({
       mock_device.id,
       clusters.Thermostat.attributes.MinSetpointDeadBand:build_test_report_data(mock_device, 1, 16) --1.6 celcius
     })
-    configure(mock_device)
+    test.wait_for_events()
     test.socket.capability:__queue_receive({
       mock_device.id,
       { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 26 } }
@@ -235,11 +245,12 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Cool setpoint inside deadband",
   function()
+    configure(mock_device)
     test.socket.matter:__queue_receive({
       mock_device.id,
       clusters.Thermostat.attributes.MinSetpointDeadBand:build_test_report_data(mock_device, 1, 16) --1.6 celcius
     })
-    configure(mock_device)
+    test.wait_for_events()
     test.socket.capability:__queue_receive({
       mock_device.id,
       { capability = "thermostatCoolingSetpoint", component = "main", command = "setCoolingSetpoint", args = { 25 } }
@@ -285,7 +296,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 10.00, maximum = 32.22 }, unit = "C" }))
+      message = mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 10.00, maximum = 32.22, step = 0.1 }, unit = "C" }))
     }
   }
 )
@@ -312,7 +323,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 10.00, maximum = 32.22 }, unit = "C" }))
+      message = mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 10.00, maximum = 32.22, step = 0.1 }, unit = "C" }))
     }
   }
 )


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
If the unit value is changed in the cloud and then the setpoint value is changed, there is an issue of out of range. For the information, you can refer to the link below.
https://smartthings.atlassian.net/browse/IOTE-4629

# Summary of Completed Tests


