### PR TITLE
fp2: add lowercase search parameter

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/search-parameters.yml
+++ b/drivers/Aqara/aqara-presence-sensor/search-parameters.yml
@@ -1,2 +1,3 @@
 mdns:
     - service: "_Aqara-FP2._tcp"
+    - service: "_aqara-fp2._tcp"


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

The mDNS service name of the actual Aqara FP2 is “_Aqara-FP2. _tcp".

if the search parameter is "_Aqara-FP2. _tcp", the driver is executed in V3 and SmartThings Station, but not in the hub on the monitor.
if the search parameter is "_aqara-fp2. _tcp", the driver is executed in the hub on the monitor, but not in V3 and SmartThings Station.
if the search parameter contains both “_Aqara-FP2. _tcp” and “_Aqara-fp2. _tcp”, the driver runs well in both v3, station, and hub on the monitor.

# Summary of Completed Tests

complete fp2 registration test on hub on monitor M5, v3, smartthings station