### PR TITLE
fp2: Label change for easy distinction

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/fp2/discovery_helper.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/fp2/discovery_helper.lua
@@ -33,10 +33,17 @@ function discovery_helper.get_device_create_msg(driver, device_dni, device_ip)
     return nil
   end
 
+  local device_label = device_info.label or "Aqara-FP2"
+  if device_dni then
+    -- To make it easier to distinguish devices, add the last four letters of dni to the label
+    -- for example, if device_info.label is "Aqara-FP2" and device_dni is "00:11:22:33:44:55", then device_label will be "Aqara-FP2 (4455)"
+    device_label = string.format("%s (%s)", device_label, string.sub(string.gsub(tostring(device_dni), ":", ""), -4))
+  end
+
   local create_device_msg = {
     type = "LAN",
     device_network_id = device_dni,
-    label = device_info.label,
+    label = device_label,
     profile = "aqara-fp2-zoneDetection",
     manufacturer = device_info.manufacturerName,
     model = device_info.modelName,


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

if a user with two or more FP2 registers the device, it is registered only under the name 'Aqara FP2', making it difficult to distinguish devices.

I would like to make it easier to distinguish by adding the last four letters of mac to the device name when adding fp2 in the Aqara app.


# Summary of Completed Tests

complete fp2 registration test on V3
