### PR TITLE
fp2: add get_credential failure handling

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/discovery.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/discovery.lua
@@ -40,7 +40,7 @@ local function try_add_device(driver, device_dni, device_ip)
     if driver.datastore.discovery_cache[device_dni] and driver.datastore.discovery_cache[device_dni].credential then
       log.info(string.format("use stored credential. This may have expired. dni= %s, ip= %s", device_dni, device_ip))
     else
-      log.error(string.format("Failed to get credential. dni= %s, ip= %s", device_dni, device_ip))
+      log.error(string.format("Failed to get credential. The device appears to have already generated a credential. In that case, a device reset is needed to generate a new credential. dni= %s, ip= %s", device_dni, device_ip))
       return "credential not found"
     end
   else

--- a/drivers/Aqara/aqara-presence-sensor/src/lunchbox/rest.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/lunchbox/rest.lua
@@ -182,6 +182,7 @@ local function handle_response(sock)
   if api_version >= 9 then
     local response, err = Response.tcp_source(sock)
     if err or (not response) then return response, (err or "unknown error") end
+    if response.status == 403 then return response, "403 Forbidden" end
     return response, response:fill_body()
   end
   -- called select right before passing in so we receive immediately


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

When 403 error occurs after get_credential during device registration, the driver is waiting for socket timeout to occur while calling fill_body().

In the event of a 403 error, there is no need to fill the body, so in this case, the fill_body() is not called and treated as an error so that a quick return can be made.

This will help users with multiple devices quickly register their devices.

In addition, the log was changed more clearly when get_creditial failed.

# Summary of Completed Tests

complete fp2 registration test on V3
