### PR TITLE
Matter Switch: Use previous cluster feature path name

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -341,7 +341,7 @@ end
 --- BRIDGED_NODE_DEVICE_TYPE on bridged devices.
 local function find_default_endpoint(device, component)
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
-  local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH})
+  local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
   local all_eps = {}
 
   for _,ep in ipairs(switch_eps) do
@@ -417,12 +417,12 @@ end
 
 local function configure_buttons(device)
   if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
-    local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH})
-    local MSR = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH_RELEASE})
+    local MS = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
+    local MSR = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_RELEASE})
     device.log.debug(#MSR.." momentary switch release endpoints")
-    local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH_LONG_PRESS})
+    local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS})
     device.log.debug(#MSL.." momentary switch long press endpoints")
-    local MSM = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH_MULTI_PRESS})
+    local MSM = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_MULTI_PRESS})
     device.log.debug(#MSM.." momentary switch multi press endpoints")
     for _, ep in ipairs(MS) do
       local supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})
@@ -458,7 +458,7 @@ end
 
 local function initialize_switch(driver, device)
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
-  local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH})
+  local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
   table.sort(switch_eps)
   table.sort(button_eps)
 
@@ -557,7 +557,7 @@ local function initialize_switch(driver, device)
   elseif #button_eps > 0 then
     local battery_support = false
     if device.manufacturer_info.vendor_id ~= HUE_MANUFACTURER_ID and
-      #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.Feature.BATTERY}) > 0 then
+      #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY}) > 0 then
       battery_support = true
     end
     if tbl_contains(STATIC_BUTTON_PROFILE_SUPPORTED, #button_eps) then
@@ -1044,7 +1044,7 @@ local function max_press_handler(driver, device, ib, response)
     log.info("Device supports more than 6 presses")
     max = 6
   end
-  local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.Feature.MOMENTARY_SWITCH_LONG_PRESS})
+  local MSL = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH_LONG_PRESS})
   local supportsHeld = tbl_contains(MSL, ib.endpoint_id)
   local values = create_multi_press_values_list(max, supportsHeld)
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.supportedButtonValues(values, {visibility = {displayed = false}}))


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-14220](https://smartthings.atlassian.net/browse/CHAD-14220)

When the button driver was merged into the switch driver, the old paths for cluster type definitions for the Switch cluster were updated to use the new paths defined in the lua libs. For example, `clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH` was changed to `clusters.Switch.types.Feature.MOMENTARY_SWITCH`. However, hubs running firmware 52 or below still use the old path which results in the driver not being able to find the type definition.

Using the new paths for existing cluster definitions is common in other drivers, however in all of these cases, embedded cluster definitions were included so this issue was not noticed before.

# Summary of Completed Tests

A Color Temperature Light was tested on lua libs 52 both with and without this change. In the attached hub logs, it can be seen that this issue occurred in without this change in `hubcore_20241024_pre_driver_change2.log` on line 177. The device does not onboard correctly and says that it hasn't updated all its information yet in the ST app. This does not happen with this change in `hubcore_20241024_post_driver_change.log`, where the device onboards correctly and is fully functional.

This was also tested with the latest lua libs, which also did not have any issues after this change was applied. See `hubcore_20241024_lua_libs_54.log`.

[hubcore_20241024_pre_driver_change2.log](https://github.com/user-attachments/files/17510321/hubcore_20241024_pre_driver_change2.log)
[hubcore_20241024_post_driver_change.log](https://github.com/user-attachments/files/17510130/hubcore_20241024_post_driver_change.log)
[hubcore_20241024_lua_libs_54.log](https://github.com/user-attachments/files/17511005/hubcore_20241024_lua_libs_54.log)

[CHAD-14220]: https://smartthings.atlassian.net/browse/CHAD-14220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ