### PR TITLE
Add deviceConfig in hub profiles for plugin unification

### DIFF
--- a/drivers/SmartThings/hub/profiles/hub-thing.yml
+++ b/drivers/SmartThings/hub/profiles/hub-thing.yml
@@ -9,5 +9,21 @@ components:
     categories:
       - name: Hub
         categoryType: manufacturer
+deviceConfig:
+  dashboard:
+    states:
+    - component: main
+      capability: bridge
+      version: 1
+  dpInfo:
+  - os: ios
+    dpUri: 'plugin://com.samsung.ios.plugin.stplugin/assets/files/index.html'
+  - os: android
+    dpUri: 'plugin://com.samsung.android.plugin.stplugin'
+  - os: web
+    dpUri: 'wwst://com.samsung.one.plugin.stplugin'
+    arguments:
+    - key: int_hub
+      value: 'wwst://com.samsung.one.plugin.chargerplugin'
 metadata:
   ocfDeviceType: x.com.st.d.hub

--- a/drivers/SmartThings/hub/profiles/refrigerator-hub.yml
+++ b/drivers/SmartThings/hub/profiles/refrigerator-hub.yml
@@ -9,9 +9,25 @@ components:
     categories:
       - name: Hub
         categoryType: manufacturer
-config:
+deviceConfig:
   icons:
-    - badge:
-      - iconUrl: badge://refrigerator
+  - group: main
+    badge:
+    - iconUrl: 'badge://refrigerator'
+  dashboard:
+    states:
+    - component: main
+      capability: bridge
+      version: 1
+  dpInfo:
+  - os: ios
+    dpUri: 'plugin://com.samsung.ios.plugin.stplugin/assets/files/index.html'
+  - os: android
+    dpUri: 'plugin://com.samsung.android.plugin.stplugin'
+  - os: web
+    dpUri: 'wwst://com.samsung.one.plugin.stplugin'
+    arguments:
+    - key: int_hub
+      value: 'wwst://com.samsung.one.plugin.chargerplugin'
 metadata:
   ocfDeviceType: x.com.st.d.hub

--- a/drivers/SmartThings/hub/profiles/soundbar-hub.yml
+++ b/drivers/SmartThings/hub/profiles/soundbar-hub.yml
@@ -9,9 +9,25 @@ components:
     categories:
       - name: Hub
         categoryType: manufacturer
-config:
+deviceConfig:
   icons:
-    - badge:
-      - iconUrl: badge://soundbar
+  - group: main
+    badge:
+    - iconUrl: 'badge://soundbar'
+  dashboard:
+    states:
+    - component: main
+      capability: bridge
+      version: 1
+  dpInfo:
+  - os: ios
+    dpUri: 'plugin://com.samsung.ios.plugin.stplugin/assets/files/index.html'
+  - os: android
+    dpUri: 'plugin://com.samsung.android.plugin.stplugin'
+  - os: web
+    dpUri: 'wwst://com.samsung.one.plugin.stplugin'
+    arguments:
+    - key: int_hub
+      value: 'wwst://com.samsung.one.plugin.chargerplugin'
 metadata:
   ocfDeviceType: x.com.st.d.hub

--- a/drivers/SmartThings/hub/profiles/tv-hub.yml
+++ b/drivers/SmartThings/hub/profiles/tv-hub.yml
@@ -9,9 +9,25 @@ components:
     categories:
       - name: Hub
         categoryType: manufacturer
-config:
+deviceConfig:
   icons:
-    - badge:
-      - iconUrl: badge://tv
+  - group: main
+    badge:
+    - iconUrl: 'badge://tv'
+  dashboard:
+    states:
+    - component: main
+      capability: bridge
+      version: 1
+  dpInfo:
+  - os: ios
+    dpUri: 'plugin://com.samsung.ios.plugin.stplugin/assets/files/index.html'
+  - os: android
+    dpUri: 'plugin://com.samsung.android.plugin.stplugin'
+  - os: web
+    dpUri: 'wwst://com.samsung.one.plugin.stplugin'
+    arguments:
+    - key: int_hub
+      value: 'wwst://com.samsung.one.plugin.chargerplugin'
 metadata:
   ocfDeviceType: x.com.st.d.hub


### PR DESCRIPTION
Plugin team want to apply an unified plugin for all hubs in R4.
For that, deviceConfig(new key&value and mandatory things) should be added in all hub's presentation.
※deviceConfig(icons / dashboard / dpInfo)