### PR TITLE
[FP2] Offline event after reconnection attempt to prevent fake offline

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/init.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/init.lua
@@ -105,12 +105,16 @@ end
 local function check_and_update_connection(driver, device)
   local conn_info = device:get_field(fields.CONN_INFO)
   if not driver.device_manager.is_valid_connection(driver, device, conn_info) then
-    device:offline()
     find_new_connection(driver, device)
     conn_info = device:get_field(fields.CONN_INFO)
-  end
 
-  if driver.device_manager.is_valid_connection(driver, device, conn_info) then
+    -- Check if the new connection works well
+    if driver.device_manager.is_valid_connection(driver, device, conn_info) then
+      device:online()
+    else
+      device:offline()
+    end
+  else
     device:online()
   end
 end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
If the socket connection is lost due to the router settings, etc., an offline event has been raised.
This causes confusion by posting a fake offline event in a situation where reconnection is possible.
Therefore, after checking if reconnection is possible, it modifies offline to be raised only when reconnection is not possible.

# Summary of Completed Tests
Registering devices in SmartThings Station, leaving them for more than the monitoring time, and checking for reconnection



