### PR TITLE
Set setpoint to original value

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -1122,7 +1122,7 @@ local function set_setpoint(setpoint)
           "Invalid setpoint (%s) outside the min (%s) and the max (%s)",
           value, min, max
         ))
-        device:emit_event(capabilities.thermostatHeatingSetpoint.heatingSetpoint(heating_setpoint))
+        device:emit_event(capabilities.thermostatHeatingSetpoint.heatingSetpoint(heating_setpoint, {state_change = true}))
         return
       end
       if is_auto_capable and value > (cached_cooling_val - deadband) then
@@ -1130,7 +1130,7 @@ local function set_setpoint(setpoint)
           "Invalid setpoint (%s) is greater than the cooling setpoint (%s) with the deadband (%s)",
           value, cooling_setpoint, deadband
         ))
-        device:emit_event(capabilities.thermostatHeatingSetpoint.heatingSetpoint(heating_setpoint))
+        device:emit_event(capabilities.thermostatHeatingSetpoint.heatingSetpoint(heating_setpoint, {state_change = true}))
         return
       end
     else
@@ -1141,7 +1141,7 @@ local function set_setpoint(setpoint)
           "Invalid setpoint (%s) outside the min (%s) and the max (%s)",
           value, min, max
         ))
-        device:emit_event(capabilities.thermostatCoolingSetpoint.coolingSetpoint(cooling_setpoint))
+        device:emit_event(capabilities.thermostatCoolingSetpoint.coolingSetpoint(cooling_setpoint, {state_change = true}))
         return
       end
       if is_auto_capable and value < (cached_heating_val + deadband) then
@@ -1149,7 +1149,7 @@ local function set_setpoint(setpoint)
           "Invalid setpoint (%s) is less than the heating setpoint (%s) with the deadband (%s)",
           value, heating_setpoint, deadband
         ))
-        device:emit_event(capabilities.thermostatCoolingSetpoint.coolingSetpoint(cooling_setpoint))
+        device:emit_event(capabilities.thermostatCoolingSetpoint.coolingSetpoint(cooling_setpoint, {state_change = true}))
         return
       end
     end

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -87,8 +87,8 @@ local function test_init()
 end
 test.set_test_init_function(test_init)
 
-local cached_heating_setpoint = capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 24.44, unit = "C" })
-local cached_cooling_setpoint = capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 26.67, unit = "C" })
+local cached_heating_setpoint = capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 24.44, unit = "C" }, {state_change = true})
+local cached_cooling_setpoint = capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 26.67, unit = "C" }, {state_change = true})
 
 local function configure(device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
@@ -106,10 +106,10 @@ local function configure(device)
     clusters.Thermostat.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, 1, 2667) --26.67 celcius
   })
   test.socket.capability:__expect_send(
-    device:generate_test_message("main", cached_heating_setpoint)
+    device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 24.44, unit = "C" }))
   )
   test.socket.capability:__expect_send(
-    device:generate_test_message("main", cached_cooling_setpoint)
+    device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 26.67, unit = "C" }))
   )
   test.wait_for_events()
 end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
There's a issue that if the setpoint is set to a value which is in the deadband range, the setpoint of device isn't set to the value and the setpoint of SmartThings plugin keeps the value.
You can refer to below link for detail.
https://smartthings.atlassian.net/browse/IOTE-4626
# Summary of Completed Tests


