### PR TITLE
Matter Child Device Test Driver

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -473,6 +473,18 @@ local function initialize_switch(driver, device)
     return
   end
 
+  -- create dummy child device
+  driver:try_create_device(
+    {
+      type = "EDGE_CHILD",
+      label = "Child Device",
+      profile = "matter-thing",
+      parent_device_id = device.id,
+      parent_assigned_child_key = string.format("%d", 99),
+      vendor_provided_label = "Child Device"
+    }
+  )
+
   -- Since we do not support bindings at the moment, we only want to count clusters
   -- that have been implemented as server. This can be removed when we have
   -- support for bindings.


### PR DESCRIPTION
Creates a dummy non-functional child device to test EDGE_CHILD device creation. Works when onboarding any matter-switch device.

For test purposes only - DO NOT MERGE.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


