### PR TITLE
Add support for Inovelli VTM31-SN Dimmer Switch

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -261,6 +261,12 @@ matterManufacturer:
     vendorId: 0x1372
     productId: 0x0002
     deviceProfileName: switch-4
+# Inovelli
+  - id: "4961/1"
+    deviceLabel: Inovelli Dimmer Switch
+    vendorId: 0x1361
+    productId: 0x0001
+    deviceProfileName: inovelli-vtm31-sn
 #Legrand
   - id: "4129/3"
     deviceLabel: Smart Lights Smart Plug

--- a/drivers/SmartThings/matter-switch/profiles/inovelli-vtm31-sn.yml
+++ b/drivers/SmartThings/matter-switch/profiles/inovelli-vtm31-sn.yml
@@ -1,0 +1,127 @@
+name: inovelli-vtm31-sn
+components:
+  - id: main
+    capabilities:
+      - id: switch
+        version: 1
+      - id: switchLevel
+        version: 1
+      - id: refresh
+        version: 1
+      - id: configuration
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+    categories:
+      - name: Switch
+  - id: button1
+    label: Up Button
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button2
+    label: Down Button
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button3
+    label: Config Button
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+preferences:
+  - name: "switchMode"
+    title: "1. Switch Mode"
+    description: "Use as a Dimmer or an On/Off switch"
+    required: false
+    preferenceType: enumeration
+    definition:
+      options:
+        "0": "On/Off + Single (default)"
+        "1": "On/OFf + Dumb"
+        "2": "On/Off + Aux"
+        "3": "On/OFf + Full Wave"
+        "4": "Dimmer + Single"
+        "5": "Dimmer + Dumb"
+        "6": "Dimmer + Aux"
+      default: 0
+  - name: "smartBulbMode"
+    title: "2. Smart Bulb Mode"
+    description: "For use with Smart Bulbs that need constant power and are controlled via commands rather than power. Smart Bulb Mode does not work in Sumb 3-Way Switch mode"
+    required: false
+    preferenceType: enumeration
+    definition:
+      options:
+        "0": "Disabled (default)"
+        "1": "Smart Bulb Mode"
+      default: 0
+  - name: "dimmingEdge"
+    title: "3. Dimming Edge"
+    description: "Change dimming type to leading edge (default) or trailing edge for better bulb compatibility"
+    required: false
+    preferenceType: enumeration
+    definition:
+      options:
+        "0": "Leading (default)"
+        "1": "Trailing"
+      default: 0
+  - name: "dimmingSpeed"
+    title: "4. Dimming Speed"
+    description: "This changes the speed that the light dims. A setting of '0' turns the light immediately on. Increasing the value slows down the transition speed. Default=25 (2500ms or 2.5s)"
+    required: false
+    preferenceType: enumeration
+    definition:
+      options:
+        "0": "Instant"
+        "1": "500ms"
+        "2": "800ms"
+        "3": "1s"
+        "4": "1.5s"
+        "5": "2s"
+        "6": "2.5s (default)"
+        "7": "3s"
+        "8": "3.5s"
+        "9": "4s"
+        "10": "5s"
+        "11": "6s"
+        "12": "7s"
+        "13": "8s"
+        "14": "10s"
+      default: 6
+  - name: "relayClick"
+    title: "5. Relay Click"
+    description: "Audible Click in On/Off mode"
+    required: false
+    preferenceType: enumeration
+    definition:
+      options:
+        "0": "Enabled (default)"
+        "1": "Disabled"
+      default: 0
+  - name: "ledIndicatorColor"
+    title: "6. LED Indicator Color (w/On)"
+    description: "Set the color of the Full LED Indicator when the load is on"
+    required: false
+    preferenceType: enumeration
+    definition:
+      options:
+        "0": "Red"
+        "1": "Orange"
+        "2": "Lemon"
+        "3": "Lime"
+        "4": "Green"
+        "5": "Teal"
+        "6": "Cyan"
+        "7": "Aqua"
+        "8": "Blue (default)"
+        "9": "Violet"
+        "10": "Magenta"
+        "11": "Pink"
+        "12": "White"
+      default: 8

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -19,6 +19,7 @@ local MatterDriver = require "st.matter.driver"
 local lua_socket = require "socket"
 local utils = require "st.utils"
 local device_lib = require "st.device"
+local data_types = require "st.matter.data_types"
 
 local MOST_RECENT_TEMP = "mostRecentTemp"
 local RECEIVED_X = "receivedX"
@@ -154,6 +155,21 @@ local child_device_profile_overrides = {
   { vendor_id = 0x1321, product_id = 0x000D,  child_profile = "switch-binary" },
 }
 
+local fingerprint_profile_overrides = {
+  { vendor_id = 0x1361, product_id = 0x0001 }, -- Inovelli VTM31-SN
+}
+
+local LATEST_CLOCK_SET_TIMESTAMP = "latest_clock_set_timestamp"
+
+local preference_map_inovelli_vtm31sn = {
+  switchMode = {parameter_number = 1, size = data_types.Uint8},
+  smartBulbMode = {parameter_number = 2, size = data_types.Uint8},
+  dimmingEdge = {parameter_number = 3, size = data_types.Uint8},
+  dimmingSpeed = {parameter_number = 4, size = data_types.Uint8},
+  relayClick = {parameter_number = 5, size = data_types.Uint8},
+  ledIndicatorColor = {parameter_number = 6, size = data_types.Uint8},
+}
+
 local detect_matter_thing
 
 local CUMULATIVE_REPORTS_NOT_SUPPORTED = "__cumulative_reports_not_supported"
@@ -246,6 +262,14 @@ local function set_poll_report_timer_and_schedule(device, is_cumulative_report)
     end
     device:set_field(EXPORT_POLL_TIMER_SETTING_ATTEMPTED, true)
   end
+end
+
+local preferences_to_numeric_value = function(new_value)
+  local numeric = tonumber(new_value)
+  if numeric == nil then -- in case the value is Boolean
+    numeric = new_value and 1 or 0
+  end
+  return numeric
 end
 
 local START_BUTTON_PRESS = "__start_button_press"
@@ -499,6 +523,16 @@ local function find_child(parent, ep_id)
   return parent:get_child_by_parent_assigned_key(string.format("%d", ep_id))
 end
 
+local function check_fingerprint_profile_overrides(device)
+  for _, fingerprint in ipairs(fingerprint_profile_overrides) do
+    if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
+      device.manufacturer_info.product_id == fingerprint.product_id then
+      return true
+    end
+  end
+  return false
+end
+
 local function initialize_switch(driver, device)
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
   local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
@@ -568,6 +602,15 @@ local function initialize_switch(driver, device)
 
   if component_map_used then
     device:set_field(COMPONENT_TO_ENDPOINT_MAP_BUTTON, component_map, {persist = true})
+  end
+
+  -- If there is a custom static profile for the device, configure buttons if needed and
+  -- then return to prevent profile from being updated.
+  if check_fingerprint_profile_overrides(device) then
+    if #button_eps > 0 then
+      configure_buttons(device)
+    end
+    return
   end
 
   if #button_eps > 0 and is_supported_combination_button_switch_device_type(device, main_endpoint) then
@@ -1112,6 +1155,28 @@ local function info_changed(driver, device, event, args)
       -- profile has changed, and we deferred setting up our buttons, so do that now
       configure_buttons(device)
       device:set_field(DEFERRED_CONFIGURE, nil)
+    end
+  end
+
+  if device.network_type ~= device_lib.NETWORK_TYPE_CHILD then
+    if device.manufacturer_info.vendor_id == fingerprint_profile_overrides[1].vendor_id and
+      device.manufacturer_info.product_id == fingerprint_profile_overrides[1].product_id then
+      local time_diff = 3
+      local last_clock_set_time = device:get_field(LATEST_CLOCK_SET_TIMESTAMP)
+      if last_clock_set_time ~= nil then
+        time_diff = os.difftime(os.time(), last_clock_set_time)
+      end
+      device:set_field(LATEST_CLOCK_SET_TIMESTAMP, os.time(), {persist = true})
+      if time_diff > 2 then
+        local preferences = preference_map_inovelli_vtm31sn
+        for id, value in pairs(device.preferences) do
+          if args.old_st_store.preferences[id] ~= value and preferences and preferences[id] then
+            local new_parameter_value = preferences_to_numeric_value(device.preferences[id])
+            local req = clusters.ModeSelect.server.commands.ChangeToMode(device, preferences[id].parameter_number, new_parameter_value)
+            device:send(req)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change adds support for the Inovelli VTM31-SN Dimmer Switch. Initial support for this device was added by [PR 1663](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1663). This PR includes a profile for this device with embedded preferences as well as handling for these preferences.

# Summary of Completed Tests

See here for screenshots from testing with the device.
Also see [test_matter_multi_button_switch_mcd.lua](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/main/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua) which tests a mock device with a similar endpoint structure as the Inovelli device.