### PR TITLE
Add Sonoff M5-2C to child profile override list

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -151,6 +151,7 @@ local device_type_attribute_map = {
 }
 
 local child_device_profile_overrides = {
+  { vendor_id = 0x1321, product_id = 0x000C,  child_profile = "switch-binary" },
   { vendor_id = 0x1321, product_id = 0x000D,  child_profile = "switch-binary" },
 }
 


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-14335](https://smartthings.atlassian.net/browse/CHAD-14335)

The Sonoff M5-2C contains two endpoints with the On/Off Plug-in Unit device type. This results in a parent and child device being created for each of these endpoints. There is a fingerprint for this device for the switch-binary profile, and the child device should also join to this profile, however, the child device is joining the `plug-binary` profile instead because of its device type (0x10A). Therefore the device should be added to the `child_device_profile_overrides` list to map it to this profile.

# Summary of Completed Tests

See [CHAD-14335](https://smartthings.atlassian.net/browse/CHAD-14335) for screenshots from testing this change.
