### PR TITLE
fp2: add nil check in eventsource

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/lunchbox/sse/eventsource.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/lunchbox/sse/eventsource.lua
@@ -343,8 +343,10 @@ local function open_action(source)
       return
     else
       --- real error, close the connection.
-      source._sock:close()
-      source._sock = nil
+      if source._sock ~= nil then
+        source._sock:close()
+        source._sock = nil
+      end
       source.ready_state = EventSource.ReadyStates.CLOSED
       return nil, err, partial
     end
@@ -360,8 +362,10 @@ local function open_action(source)
         return
       else
         --- real error, close the connection.
-        source._sock:close()
-        source._sock = nil
+        if source._sock ~= nil then
+          source._sock:close()
+          source._sock = nil
+        end
         source.ready_state = EventSource.ReadyStates.CLOSED
         return nil, err, partial
       end
@@ -373,8 +377,10 @@ local function open_action(source)
         return
       else
         --- real error, close the connection.
-        source._sock:close()
-        source._sock = nil
+        if source._sock ~= nil then
+          source._sock:close()
+          source._sock = nil
+        end
         source.ready_state = EventSource.ReadyStates.CLOSED
         return nil, err, partial
       end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
add nil check for sock.
As shown below, there was a driver restart due to sock nil, so there was a request for modification.

2024-11-14_05:01:00.094 | E | edi        | <Aqara Presence Sensor (01976eca)> runtime error: [string "cosock.lua"]:313: [string "lunchbox/sse/eventsource.lua"]:346: attempt to index a nil value (field '_sock')

# Summary of Completed Tests


complete fp2 registration test on V3