### PR TITLE
Fp2:Stabilization of connection and addition of convenience functions

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/discovery.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/discovery.lua
@@ -40,7 +40,7 @@ local function try_add_device(driver, device_dni, device_ip)
     if driver.datastore.discovery_cache[device_dni] and driver.datastore.discovery_cache[device_dni].credential then
       log.info(string.format("use stored credential. This may have expired. dni= %s, ip= %s", device_dni, device_ip))
     else
-      log.error(string.format("Failed to get credential. dni= %s, ip= %s", device_dni, device_ip))
+      log.error(string.format("Failed to get credential. The device appears to have already generated a credential. In that case, a device reset is needed to generate a new credential. dni= %s, ip= %s", device_dni, device_ip))
       return "credential not found"
     end
   else

--- a/drivers/Aqara/aqara-presence-sensor/src/fp2/api.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/fp2/api.lua
@@ -39,14 +39,6 @@ local function process_rest_response(response, err, partial)
   end
 end
 
-local function retry_fn(retry_attempts)
-  local count = 0
-  return function()
-    count = count + 1
-    return count < retry_attempts
-  end
-end
-
 local function do_get(api_instance, path)
   return process_rest_response(RestClient.one_shot_get(api_instance.base_url .. path, api_instance.headers, api_instance.socket_builder))
 end

--- a/drivers/Aqara/aqara-presence-sensor/src/fp2/api.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/fp2/api.lua
@@ -48,7 +48,7 @@ local function retry_fn(retry_attempts)
 end
 
 local function do_get(api_instance, path)
-  return process_rest_response(api_instance.client:get(path, api_instance.headers, retry_fn(5)))
+  return process_rest_response(RestClient.one_shot_get(api_instance.base_url .. path, api_instance.headers, api_instance.socket_builder))
 end
 
 function fp2_api.new_device_manager(device_ip, bridge_info, socket_builder)
@@ -57,7 +57,7 @@ function fp2_api.new_device_manager(device_ip, bridge_info, socket_builder)
   return setmetatable(
     {
       headers = ADDITIONAL_HEADERS,
-      client = RestClient.new(base_url, socket_builder),
+      socket_builder = socket_builder,
       base_url = base_url,
     }, fp2_api
   )

--- a/drivers/Aqara/aqara-presence-sensor/src/fp2/device_manager.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/fp2/device_manager.lua
@@ -256,6 +256,7 @@ function device_manager.is_valid_connection(driver, device, conn_info)
       device.device_network_id))
     return false
   end
+
   local _, err, status = conn_info:get_attr()
   if err or status ~= 200 then
     log.warn(string.format(

--- a/drivers/Aqara/aqara-presence-sensor/src/fp2/discovery_helper.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/fp2/discovery_helper.lua
@@ -33,10 +33,17 @@ function discovery_helper.get_device_create_msg(driver, device_dni, device_ip)
     return nil
   end
 
+  local device_label = device_info.label or "Aqara-FP2"
+  if device_dni then
+    -- To make it easier to distinguish devices, add the last four letters of dni to the label
+    -- for example, if device_info.label is "Aqara-FP2" and device_dni is "00:11:22:33:44:55", then device_label will be "Aqara-FP2 (4455)"
+    device_label = string.format("%s (%s)", device_label, string.sub(string.gsub(tostring(device_dni), ":", ""), -4))
+  end
+
   local create_device_msg = {
     type = "LAN",
     device_network_id = device_dni,
-    label = device_info.label,
+    label = device_label,
     profile = "aqara-fp2-zoneDetection",
     manufacturer = device_info.manufacturerName,
     model = device_info.modelName,

--- a/drivers/Aqara/aqara-presence-sensor/src/init.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/init.lua
@@ -105,12 +105,16 @@ end
 local function check_and_update_connection(driver, device)
   local conn_info = device:get_field(fields.CONN_INFO)
   if not driver.device_manager.is_valid_connection(driver, device, conn_info) then
-    device:offline()
     find_new_connection(driver, device)
     conn_info = device:get_field(fields.CONN_INFO)
-  end
 
-  if driver.device_manager.is_valid_connection(driver, device, conn_info) then
+    -- Check if the new connection works well
+    if driver.device_manager.is_valid_connection(driver, device, conn_info) then
+      device:online()
+    else
+      device:offline()
+    end
+  else
     device:online()
   end
 end

--- a/drivers/Aqara/aqara-presence-sensor/src/init.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/init.lua
@@ -26,9 +26,6 @@ local function status_update(driver, device)
     if err or status ~= 200 then
       log.error(string.format("refresh : failed to get attr, dni= %s, err= %s, status= %s", device.device_network_id, err,
         status))
-      if status == 404 then
-        device:offline()
-      end
     else
       driver.device_manager.handle_status(driver, device, resp)
     end
@@ -64,7 +61,9 @@ local function create_sse(driver, device, credential)
     end
 
     eventsource.onopen = function()
+      log.info(string.format("Eventsource open: dni= %s", device.device_network_id))
       device:online()
+      status_update(driver, device)
     end
 
     local old_eventsource = device:get_field(fields.EVENT_SOURCE)

--- a/drivers/Aqara/aqara-presence-sensor/src/init.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/init.lua
@@ -108,7 +108,10 @@ end
 
 local function check_and_update_connection(driver, device)
   local conn_info = device:get_field(fields.CONN_INFO)
-  if not driver.device_manager.is_valid_connection(driver, device, conn_info) then
+  local eventsource = device:get_field(fields.EVENT_SOURCE)
+  if eventsource and eventsource.ready_state == eventsource.ReadyStates.OPEN then
+    log.info(string.format("SSE connection is being maintained well, dni = %s", device.device_network_id))
+  elseif not driver.device_manager.is_valid_connection(driver, device, conn_info) then
     find_new_connection(driver, device)
   end
 end

--- a/drivers/Aqara/aqara-presence-sensor/src/init.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/init.lua
@@ -105,16 +105,6 @@ local function check_and_update_connection(driver, device)
   local conn_info = device:get_field(fields.CONN_INFO)
   if not driver.device_manager.is_valid_connection(driver, device, conn_info) then
     find_new_connection(driver, device)
-    conn_info = device:get_field(fields.CONN_INFO)
-
-    -- Check if the new connection works well
-    if driver.device_manager.is_valid_connection(driver, device, conn_info) then
-      device:online()
-    else
-      device:offline()
-    end
-  else
-    device:online()
   end
 end
 

--- a/drivers/Aqara/aqara-presence-sensor/src/lunchbox/rest.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/lunchbox/rest.lua
@@ -182,6 +182,7 @@ local function handle_response(sock)
   if api_version >= 9 then
     local response, err = Response.tcp_source(sock)
     if err or (not response) then return response, (err or "unknown error") end
+    if response.status == 403 then return response, "403 Forbidden" end
     return response, response:fill_body()
   end
   -- called select right before passing in so we receive immediately

--- a/drivers/Aqara/aqara-presence-sensor/src/lunchbox/sse/eventsource.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/lunchbox/sse/eventsource.lua
@@ -343,8 +343,10 @@ local function open_action(source)
       return
     else
       --- real error, close the connection.
-      source._sock:close()
-      source._sock = nil
+      if source._sock ~= nil then
+        source._sock:close()
+        source._sock = nil
+      end
       source.ready_state = EventSource.ReadyStates.CLOSED
       return nil, err, partial
     end
@@ -360,8 +362,10 @@ local function open_action(source)
         return
       else
         --- real error, close the connection.
-        source._sock:close()
-        source._sock = nil
+        if source._sock ~= nil then
+          source._sock:close()
+          source._sock = nil
+        end
         source.ready_state = EventSource.ReadyStates.CLOSED
         return nil, err, partial
       end
@@ -373,8 +377,10 @@ local function open_action(source)
         return
       else
         --- real error, close the connection.
-        source._sock:close()
-        source._sock = nil
+        if source._sock ~= nil then
+          source._sock:close()
+          source._sock = nil
+        end
         source.ready_state = EventSource.ReadyStates.CLOSED
         return nil, err, partial
       end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
**fp2: add get_credential failure handling** 
When 403 error occurs after get_credential during device registration, the driver is waiting for socket timeout to occur while calling fill_body().
In the event of a 403 error, there is no need to fill the body, so in this case, the fill_body() is not called and treated as an error so that a quick return can be made.
This will help users with multiple devices quickly register their devices.
In addition, the log was changed more clearly when get_creditial failed.

**fp2: add nil check in eventsource**
add nil check for sock.
As shown below, there was a driver restart due to sock nil, so there was a request for modification.
2024-11-14_05:01:00.094 | E | edi | <Aqara Presence Sensor (01976eca)> runtime error: [string "cosock.lua"]:313: [string "lunchbox/sse/eventsource.lua"]:346: attempt to index a nil value (field '_sock')


**fp2: Label change for easy distinction** 
if a user with two or more FP2 registers the device, it is registered only under the name 'Aqara FP2', making it difficult to distinguish devices.
I would like to make it easier to distinguish by adding the last four letters of mac to the device name when adding fp2 in the Aqara app.

**Offline event after reconnection attempt to prevent fake offline**
If the socket connection is lost due to the router settings, etc., an offline event has been raised.
This causes confusion by posting a fake offline event in a situation where reconnection is possible.
Therefore, after checking if reconnection is possible, it modifies offline to be raised only when reconnection is not possible.

**fp2: remove socket connection for fp2 resource** 
the socket connection for the rest call was maintained, but it was removed to reduce the resource of fp2

**fp2: update status when sse reconnect** 
modified to update to the current value because status mismatch may occur after sse reconnect and before sse event occurs.

# Summary of Completed Tests

complete fp2 registration test on V3
