### PR TITLE
New Device (Matter Switch) Lifx T10PL4AE26 

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -350,6 +350,11 @@ matterManufacturer:
     vendorId: 0x1423
     productId: 0x00B0
     deviceProfileName: light-level-colorTemperature-1500k-9000k
+  - id: "5155/217"
+    deviceLabel: LIFX Tube
+    vendorId: 0x1423
+    productId: 0x00D9
+    deviceProfileName: light-level-colorTemperature-1500k-9000k
 #Nanoleaf
   - id: "Nanoleaf NL53"
     deviceLabel: Essentials BR30


### PR DESCRIPTION
Adds a new fingerprint for the WWST certification for the Lifx Tube light Model Number T10PL4AE26

Check all that apply

# Type of Change

- [  X] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adds a new fingerprint for the WWST certification for the Lifx Tube light Model Number T10PL4AE26. In the Matter DCL this device is listed to have a Matter Device type as (0x10D).

# Summary of Completed Tests
This is CxS

