### PR TITLE
Add not support battery percent remaining devices

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -91,7 +91,7 @@ end
 
 local function battery_device_not_support_bat_percent_remaining(device)
   for i = 1, #NOT_SUPPORT_BAT_PERCENT_REMAINING_VID do
-    if device.manufacturer_info.vendor_id == NOT_SUPPORT_BAT_PERCENT_REMAINING_VID[I] then
+    if device.manufacturer_info.vendor_id == NOT_SUPPORT_BAT_PERCENT_REMAINING_VID[i] then
       return false
     end
   end

--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -52,7 +52,7 @@ local TEMP_MIN = "__temp_min"
 local TEMP_MAX = "__temp_max"
 
 -- HUE-0x100B, MultiIR-0x1477
-local NOT_SUPPORT_BAT_PERCENT_REMAINING_VID = {0x100B, 0x1477}
+local NOT_SUPPORT_BATTERY_PERCENT_REMAINING_VID = {0x100B, 0x1477}
 
 local function get_field_for_endpoint(device, field, endpoint)
   return device:get_field(string.format("%s_%d", field, endpoint))
@@ -89,9 +89,9 @@ local function set_boolean_device_type_per_endpoint(driver, device)
   end
 end
 
-local function battery_device_not_support_bat_percent_remaining(device)
-  for i = 1, #NOT_SUPPORT_BAT_PERCENT_REMAINING_VID do
-    if device.manufacturer_info.vendor_id == NOT_SUPPORT_BAT_PERCENT_REMAINING_VID[i] then
+local function battery_device_not_support_battery_percent_remaining(device)
+  for i = 1, #NOT_SUPPORT_BATTERY_PERCENT_REMAINING_VID do
+    if device.manufacturer_info.vendor_id == NOT_SUPPORT_BATTERY_PERCENT_REMAINING_VID[i] then
       return false
     end
   end
@@ -102,7 +102,7 @@ local function supports_battery_percentage_remaining(device)
   local battery_eps = device:get_endpoints(clusters.PowerSource.ID,
           {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
   -- Hue devices support the PowerSource cluster but don't support reporting battery percentage remaining
-  if #battery_eps > 0 and battery_device_not_support_bat_percent_remaining(device) then
+  if #battery_eps > 0 and battery_device_not_support_battery_percent_remaining(device) then
     return true
   end
   return false

--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -51,7 +51,8 @@ local TEMP_BOUND_RECEIVED = "__temp_bound_received"
 local TEMP_MIN = "__temp_min"
 local TEMP_MAX = "__temp_max"
 
-local HUE_MANUFACTURER_ID = 0x100B
+-- HUE-0x100B, MultiIR-0x1477
+local NOT_SUPPORT_BAT_PERCENT_REMAINING_VID = {0x100B, 0x1477}
 
 local function get_field_for_endpoint(device, field, endpoint)
   return device:get_field(string.format("%s_%d", field, endpoint))
@@ -88,11 +89,20 @@ local function set_boolean_device_type_per_endpoint(driver, device)
   end
 end
 
+local function battery_device_not_support_bat_percent_remaining(device)
+  for i = 1, #NOT_SUPPORT_BAT_PERCENT_REMAINING_VID do
+    if device.manufacturer_info.vendor_id == NOT_SUPPORT_BAT_PERCENT_REMAINING_VID[I] then
+      return false
+    end
+  end
+  return true
+end
+
 local function supports_battery_percentage_remaining(device)
   local battery_eps = device:get_endpoints(clusters.PowerSource.ID,
           {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
   -- Hue devices support the PowerSource cluster but don't support reporting battery percentage remaining
-  if #battery_eps > 0 and device.manufacturer_info.vendor_id ~= HUE_MANUFACTURER_ID then
+  if #battery_eps > 0 and battery_device_not_support_bat_percent_remaining(device) then
     return true
   end
   return false


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Add battery device vid witch does not support battery percent remaining attribute.

# Summary of Completed Tests
Tested with hue device witch also does not support battery percent remaining attribute.

