### PR TITLE
New Device (Matter Switch) Cync Reveal Full Color A21

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -165,6 +165,11 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x007B
     deviceProfileName: light-color-level-2000K-7000K
+  - id: "4921/107"
+    deviceLabel: Cync Reveal Full Color A19
+    vendorId: 0x1339
+    productId: 0x006D
+    deviceProfileName: light-color-level-2000K-7000K
   - id: "4921/111"
     deviceLabel: Cync Outdoor Plug
     vendorId: 0x1339

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -165,7 +165,7 @@ matterManufacturer:
     vendorId: 0x1339
     productId: 0x007B
     deviceProfileName: light-color-level-2000K-7000K
-  - id: "4921/107"
+  - id: "4921/109"
     deviceLabel: Cync Reveal Full Color A21
     vendorId: 0x1339
     productId: 0x006D

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -166,7 +166,7 @@ matterManufacturer:
     productId: 0x007B
     deviceProfileName: light-color-level-2000K-7000K
   - id: "4921/107"
-    deviceLabel: Cync Reveal Full Color A19
+    deviceLabel: Cync Reveal Full Color A21
     vendorId: 0x1339
     productId: 0x006D
     deviceProfileName: light-color-level-2000K-7000K


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adding a new fingerprint for the  Cync Reveal Full Color A21 device. This device will be CxS. According to the Matter DCL this device is certified as a Matter device type = (0x10D)

# Summary of Completed Tests


