### PR TITLE
Matter Thermostat: check for nil in temp attribute handler

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -720,6 +720,9 @@ end
 
 local function temp_event_handler(attribute)
   return function(driver, device, ib, response)
+    if ib.data.value == nil then
+      return
+    end
     local unit = "C"
 
     -- Only emit the capability for RPC version >= 5, since unit conversion for


### PR DESCRIPTION
[CHAD-14525](https://smartthings.atlassian.net/browse/CHAD-14525)
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Add a check that a non-nil value was recieved before using the value to avoid an error with trying to divide a nil value.


# Summary of Completed Tests
Tested with VDA bridged thermostat devices.



[CHAD-14525]: https://smartthings.atlassian.net/browse/CHAD-14525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ