### PR TITLE
Fix for virtual switch regression

### DIFF
--- a/drivers/SmartThings/virtual-switch/src/init.lua
+++ b/drivers/SmartThings/virtual-switch/src/init.lua
@@ -2,10 +2,12 @@ local capabilities = require "st.capabilities"
 local Driver = require "st.driver"
 
 local function force_state_change(device)
-  if device.preferences["certifiedpreferences.forceStateChange"] then
+  if device.preferences == nil or device.preferences["certifiedpreferences.forceStateChange"] == nil then
     return {state_change = true}
-  else
+  elseif not device.preferences["certifiedpreferences.forceStateChange"] then
     return nil
+  else
+    return {state_change = true}
   end
 end
 

--- a/drivers/SmartThings/virtual-switch/src/test/test_virtual_switch.lua
+++ b/drivers/SmartThings/virtual-switch/src/test/test_virtual_switch.lua
@@ -10,8 +10,15 @@ local mock_simple_device = test.mock_device.build_test_generic_device(
     }
 )
 
+local mock_device_no_prefs = test.mock_device.build_test_generic_device(
+    {
+      profile = t_utils.get_profile_definition("virtual-dimmer-switch.yml"),
+    }
+)
+
 local function test_init()
   test.mock_device.add_test_device(mock_simple_device)
+  test.mock_device.add_test_device(mock_device_no_prefs)
 end
 
 test.set_test_init_function(test_init)
@@ -49,6 +56,22 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_simple_device:generate_test_message("main", capabilities.switch.switch.on({state_change=true}))
+      }
+    }
+)
+
+test.register_message_test(
+    "Reported on off status should be handled: on",
+    {
+      {
+        channel = "capability",
+        direction = "receive",
+        message = { mock_device_no_prefs.id, { capability = "switch", component = "main", command = "on", args = {}}}
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device_no_prefs:generate_test_message("main", capabilities.switch.switch.on({state_change=true}))
       }
     }
 )


### PR DESCRIPTION
There have been some issues getting this fully deployed, so this changes the behavior to default to the old behavior in case the preference is missing.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


