### PR TITLE
CHAD-12279 Some zigbee locks reporting invalid lockStates

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/init.lua
@@ -322,11 +322,11 @@ local lock_state_handler = function(driver, device, value, zb_rx)
   local delay = device:get_field(DELAY_LOCK_EVENT) or 100
   if (delay < MAX_DELAY) then
     device.thread:call_with_delay(delay+.5, function ()
-      device:emit_event_for_endpoint(zb_rx.address_header.src_endpoint.value, LOCK_STATE[value.value])
+      device:emit_event_for_endpoint(zb_rx.address_header.src_endpoint.value, LOCK_STATE[value.value] or attr.unknown())
     end)
   else
     device:set_field(DELAY_LOCK_EVENT, socket.gettime())
-    device:emit_event_for_endpoint(zb_rx.address_header.src_endpoint.value, LOCK_STATE[value.value])
+    device:emit_event_for_endpoint(zb_rx.address_header.src_endpoint.value, LOCK_STATE[value.value] or attr.unknown())
   end
 end
 


### PR DESCRIPTION
Fixes a crash seen when some locks report an invalid value for the LockState

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


