### PR TITLE
Add profile for NEO SmartPlug/Button device

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/plug-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/plug-button.yml
@@ -1,0 +1,18 @@
+name: plug-button
+components:
+  - id: main
+    capabilities:
+      - id: switch
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: SmartPlug
+  - id: button
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-14507](https://smartthings.atlassian.net/browse/CHAD-14507)

Add a new profile in the matter-switch driver for NEO plug + button device (see WWSTCERT-4757). Note that this profile was originally going to be added by [PR 1799](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1799), but that PR was split into two, so that the profile could be expediated into production to support the WWST certification.

# Summary of Completed Tests




[CHAD-14507]: https://smartthings.atlassian.net/browse/CHAD-14507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ