### PR TITLE
fix-an-issue-of-thermostat-does-not-support-fan-speed

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-cooling-only-nostate-nobattery.yml
@@ -1,0 +1,20 @@
+name: thermostat-fan-speed-cooling-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-cooling-only-nostate.yml
@@ -1,0 +1,22 @@
+name: thermostat-fan-speed-cooling-only-nostate
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-cooling-only.yml
@@ -1,0 +1,24 @@
+name: thermostat-fan-speed-cooling-only
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-heating-only-nostate-nobattery.yml
@@ -1,0 +1,20 @@
+name: thermostat-fan-speed-heating-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-heating-only-nostate.yml
@@ -1,0 +1,22 @@
+name: thermostat-fan-speed-heating-only-nostate
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-heating-only.yml
@@ -1,0 +1,24 @@
+name: thermostat-fan-speed-heating-only
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-nostate-nobattery.yml
@@ -1,0 +1,22 @@
+name: thermostat-fan-speed-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed-nostate.yml
@@ -1,0 +1,24 @@
+name: thermostat-fan-speed-nostate
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-speed.yml
@@ -1,0 +1,26 @@
+name: thermostat-fan-speed
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-cooling-only-nostate-nobattery.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-fan-speed-cooling-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-cooling-only-nostate.yml
@@ -1,0 +1,24 @@
+name: thermostat-humidity-fan-speed-cooling-only-nostate
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-cooling-only.yml
@@ -1,0 +1,26 @@
+name: thermostat-humidity-fan-speed-cooling-only
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-heating-only-nostate-nobattery.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-fan-speed-heating-only-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-heating-only-nostate.yml
@@ -1,0 +1,24 @@
+name: thermostat-humidity-fan-speed-heating-only-nostate
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-heating-only.yml
@@ -1,0 +1,26 @@
+name: thermostat-humidity-fan-speed-heating-only
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-nostate-nobattery.yml
@@ -1,0 +1,24 @@
+name: thermostat-humidity-fan-speed-nostate-nobattery
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed-nostate.yml
@@ -1,0 +1,26 @@
+name: thermostat-humidity-fan-speed-nostate
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-speed.yml
@@ -1,0 +1,28 @@
+name: thermostat-humidity-fan-speed
+components:
+- id: main
+  capabilities:
+  - id: fanSpeedPercent
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -1271,8 +1271,9 @@ local function set_thermostat_fan_mode(driver, device, cmd)
   elseif cmd.args.mode == capabilities.thermostatFanMode.thermostatFanMode.on.NAME then
     fan_mode_id = clusters.FanControl.attributes.FanMode.ON
   end
+  local fan_ep = find_default_endpoint(device, clusters.FanControl.ID)
   if fan_mode_id then
-    device:send(clusters.FanControl.attributes.FanMode:write(device, device:component_to_endpoint(cmd.component), fan_mode_id))
+    device:send(clusters.FanControl.attributes.FanMode:write(device, fan_ep, fan_mode_id))
   end
 end
 
@@ -1297,9 +1298,9 @@ local function set_fan_mode(driver, device, cmd)
   else
     fan_mode_id = clusters.FanControl.attributes.FanMode.OFF
   end
-  local ep = find_default_endpoint(device, clusters.FanControl.ID)
+  local fan_ep = find_default_endpoint(device, clusters.FanControl.ID)
   if fan_mode_id then
-    device:send(clusters.FanControl.attributes.FanMode:write(device, ep, fan_mode_id))
+    device:send(clusters.FanControl.attributes.FanMode:write(device, fan_ep, fan_mode_id))
   end
 end
 
@@ -1322,16 +1323,16 @@ local function set_air_purifier_fan_mode(driver, device, cmd)
   else
     fan_mode_id = clusters.FanControl.attributes.FanMode.OFF
   end
-  local ep = find_default_endpoint(device, clusters.FanControl.ID)
+  local fan_ep = find_default_endpoint(device, clusters.FanControl.ID)
   if fan_mode_id then
-    device:send(clusters.FanControl.attributes.FanMode:write(device, ep, fan_mode_id))
+    device:send(clusters.FanControl.attributes.FanMode:write(device, fan_ep, fan_mode_id))
   end
 end
 
 local function set_fan_speed_percent(driver, device, cmd)
-  local ep = find_default_endpoint(device, clusters.FanControl.ID)
+  local fan_ep = find_default_endpoint(device, clusters.FanControl.ID)
   local speed = math.floor(cmd.args.percent)
-  device:send(clusters.FanControl.attributes.PercentSetting:write(device, ep, speed))
+  device:send(clusters.FanControl.attributes.PercentSetting:write(device, fan_ep, speed))
 end
 
 local function set_wind_mode(driver, device, cmd)
@@ -1345,6 +1346,7 @@ local function set_wind_mode(driver, device, cmd)
 end
 
 local function set_rock_mode(driver, device, cmd)
+  local fan_ep = find_default_endpoint(device, clusters.FanControl.ID)
   local rock_mode = 0
   if cmd.args.fanOscillationMode == capabilities.fanOscillationMode.fanOscillationMode.horizontal.NAME then
     rock_mode = clusters.FanControl.types.RockSupportMask.ROCK_LEFT_RIGHT
@@ -1353,7 +1355,7 @@ local function set_rock_mode(driver, device, cmd)
   elseif cmd.args.fanOscillationMode == capabilities.fanOscillationMode.fanOscillationMode.swing.NAME then
     rock_mode = clusters.FanControl.types.RockSupportMask.ROCK_ROUND
   end
-  device:send(clusters.FanControl.attributes.RockSetting:write(device, device:component_to_endpoint(cmd.component), rock_mode))
+  device:send(clusters.FanControl.attributes.RockSetting:write(device, fan_ep, rock_mode))
 end
 
 local function battery_percent_remaining_attr_handler(driver, device, ib, response)

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -853,7 +853,7 @@ local function sequence_of_operation_handler(driver, device, ib, response)
 
   local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.auto})
   if #auto > 0 then
-    -- table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.auto.NAME)
+    table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.auto.NAME)
   end
 
   if ib.data.value <= clusters.Thermostat.attributes.ControlSequenceOfOperation.COOLING_WITH_REHEAT then

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -851,9 +851,7 @@ local function sequence_of_operation_handler(driver, device, ib, response)
   -- or not the device supports emergency heat or fan only
   local supported_modes = {capabilities.thermostatMode.thermostatMode.off.NAME}
 
-  local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE})
-
-  local autos = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.auto})
+  local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.auto})
   if #auto > 0 then
     -- table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.auto.NAME)
   end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Problem:
The LengCeoi HAVC Remote were recently tested in ST App, which include Thermostat and Fan device type. However the capabilities in plugin shows incorrectly

Expectation Result:
The capabilities of thermostat, humidity, fan speed, thermostat mode, thermostat fan mode and set temperature show in the ST plugin.

Current Issue:
The plugin show fan mode and fan speed.

Analysis:
Is it found that the edge driver(matter-thermostat) will re-assign a new profile while driver initialize, and go to the Fan logic, the fan logic does not check if the device support thermostat, or humidity, which means it will re-assign the “fan-generic” for driver.

The profile name re-assign logic is changed to check if the fan speed is supported.

Related tickets: https://smartthings.atlassian.net/browse/MTR-866

# Summary of Completed Tests


