### PR TITLE
Remove health check from zigbee thermostat

### DIFF
--- a/drivers/SmartThings/zigbee-thermostat/src/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/init.lua
@@ -376,6 +376,7 @@ local zigbee_thermostat_driver = {
     require("resideo_korea"),
     require("aqara")
   },
+  health_check = false,
 }
 
 defaults.register_for_default_handlers(zigbee_thermostat_driver, zigbee_thermostat_driver.supported_capabilities)


### PR DESCRIPTION
This is not needed to keep device online, and so its being removed to gain the small memory/latency savings of having it disabled. Tested with a Sinope thermostat.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


