### PR TITLE
CHAD-14284: Test zigbee health monitoring opt out with zigbee-motion and zigbee-contact drivers

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/init.lua
@@ -106,6 +106,7 @@ local zigbee_contact_driver_template = {
     require("smartsense-multi"),
     require("sengled")
   },
+  health_check = false,
   ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE
 }
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
@@ -31,7 +31,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
   test.mock_device.add_test_device(mock_device)
-  zigbee_test_utils.init_noop_health_check_timer()
+  --zigbee_test_utils.init_noop_health_check_timer() removal due to change to stop health checks going forward
 end
 
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/zigbee-motion-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/init.lua
@@ -130,6 +130,7 @@ local zigbee_motion_driver = {
   additional_zcl_profiles = {
     [0xFC01] = true
   },
+  health_check = false,
   ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE
 }
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartthings_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartthings_motion.lua
@@ -37,7 +37,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
   test.mock_device.add_test_device(mock_device)
-  zigbee_test_utils.init_noop_health_check_timer()
+  --zigbee_test_utils.init_noop_health_check_timer() removal due to change to stop health checks going forward
 end
 test.set_test_init_function(test_init)
 


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [x] I have reviewed the README.md file
          - [x] I have reviewed the CODE_OF_CONDUCT.md file
          - [x] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Changed health check action for 2 drivers and their associated tests:  zigbee-motion and zigbee-contact
# Summary of Completed Tests

This is not needed to keep device online, and so its being removed to gain the small memory/latency savings of having it disabled. Overnight tests were done for both zigbee-motion and zigbee-contact drivers.
