### PR TITLE
Chore/fixup unit tests for 0.55 api v12 release

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -257,14 +257,6 @@ test.register_message_test(
       }
     },
     {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
-      }
-    },
-    {
       channel = "matter",
       direction = "send",
       message = {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -345,7 +345,9 @@ end
 
 local function test_init_water_valve()
   test.mock_device.add_test_device(mock_device_water_valve)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_water_valve.id, "doConfigure" })
   mock_device_water_valve:expect_metadata_update({ profile = "water-valve-level" })
+  mock_device_water_valve:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_parent_child_different_types()
@@ -393,6 +395,7 @@ local function test_init_parent_child_unsupported_device_type()
     parent_assigned_child_key = string.format("%d", 10)
   })
 end
+
 
 test.register_coroutine_test(
   "Test profile change on init for onoff parent cluster as server",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -348,6 +348,7 @@ test.register_coroutine_test(
     function()
       test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
       test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } } })
+      mock_device:expect_native_cmd_handler_registration("colorControl", "setColor")
       test.socket.zigbee:__expect_send(
           {
             mock_device.id,
@@ -382,6 +383,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {1800}}})
+    mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature")
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.server.commands.MoveToColorTemperature(mock_device, 556, 0x0000)})
     test.socket.zigbee:__expect_send({mock_device.id, OnOff.server.commands.On(mock_device)})
     test.wait_for_events()

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
@@ -123,6 +123,7 @@ test.register_coroutine_test(
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = { 200 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature")
     local temp_in_mired = math.floor(1000000 / 200)
     test.socket.zigbee:__expect_send(
       {

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
@@ -128,6 +128,7 @@ test.register_coroutine_test(
     test.socket.capability:__queue_receive({ mock_device.id,
       { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = { 200 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature")
     local temp_in_mired = math.floor(1000000 / 200)
     test.socket.zigbee:__expect_send(
       {

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgb_bulb.lua
@@ -131,6 +131,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setHue", args = { 50 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setHue")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
     local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -154,6 +155,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setSaturation", args = { 50 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setSaturation")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
     local saturation = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -176,6 +178,7 @@ test.register_coroutine_test(
   function()
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } } })
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setColor")
     test.socket.zigbee:__expect_send(
       {
         mock_device.id,

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
@@ -162,6 +162,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setHue", args = { 50 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setHue")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
     local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -185,6 +186,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setSaturation", args = { 50 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setSaturation")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
     local saturation = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -208,6 +210,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setColor")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.server.commands.On(mock_device) })
 
     local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -228,7 +231,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Set Saturation command test",
+  "Set ColorTemperature command test",
   function()
     test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = { 200 } } })

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
@@ -197,6 +197,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setHue", args = { 50 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setHue")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
     local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -221,6 +222,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setSaturation", args = { 50 } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setSaturation")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
     local saturation = math.floor((50 * 0xFE) / 100.0 + 0.5)
@@ -245,6 +247,7 @@ test.register_coroutine_test(
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({mock_device.id, { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } } })
 
+    mock_device:expect_native_cmd_handler_registration("colorControl", "setColor")
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.server.commands.On(mock_device) })
 
     local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
@@ -437,7 +437,6 @@ test.register_coroutine_test(
       mock_parent.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
-    mock_parent:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -505,7 +504,6 @@ test.register_coroutine_test(
       mock_parent.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
-    mock_parent:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -572,7 +570,6 @@ test.register_coroutine_test(
       mock_child.id,
       { capability = "switch", component = "main", command = "on", args = {} }
     })
-    mock_child:expect_native_cmd_handler_registration("switch", "on")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -637,7 +634,6 @@ test.register_coroutine_test(
       mock_child.id,
       { capability = "switch", component = "main", command = "off", args = {} }
     })
-    mock_child:expect_native_cmd_handler_registration("switch", "off")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
@@ -192,14 +192,6 @@ test.register_message_test(
       }
     },
     {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_parent.id, capability_id = "switch", capability_cmd_id = "on" }
-      }
-    },
-    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -221,14 +213,6 @@ test.register_message_test(
       message = {
         mock_parent.id,
         { capability = "switch", command = "off", component = "main", args = {} }
-      }
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_parent.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {
@@ -257,14 +241,6 @@ test.register_message_test(
       }
     },
     {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_child.id, capability_id = "switch", capability_cmd_id = "on" }
-      }
-    },
-    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -286,14 +262,6 @@ test.register_message_test(
       message = {
         mock_child.id,
         { capability = "switch", command = "off", component = "main", args = {} }
-      }
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_child.id, capability_id = "switch", capability_cmd_id = "off" }
       }
     },
     {


### PR DESCRIPTION
This fixes unit tests to reflect new native handlers released in 0.55 FW/api v12 lua libs (Note we still need to enable colorTemperature and colorControl cmd registration in the matter-switch driver).

There was also an integration test framework bug that was fixed in api v12, that caused some tests to fail that should have never been passing (related to native handler registration for parent child/ mcd device)

One other test started failing with the integration test framework bugfix that needs analysis by someone more familiar with the matter profile switching 


