### PR TITLE
Matter Sensor: add temp/humidity offset preferences to profiles

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/aqs-level.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-level.yml
@@ -44,3 +44,8 @@ components:
         version: 1
     categories:
     - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-all-level-all-meas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-all-level-all-meas.yml
@@ -52,3 +52,8 @@ components:
         version: 1
     categories:
     - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-all-level.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-all-level.yml
@@ -34,3 +34,8 @@ components:
         version: 1
     categories:
     - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-all-meas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-all-meas.yml
@@ -32,3 +32,8 @@ components:
         version: 1
     categories:
     - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-co2-pm25-tvoc-meas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-co2-pm25-tvoc-meas.yml
@@ -20,3 +20,8 @@ components:
         version: 1
     categories:
     - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-pressure-tvoc-meas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-pressure-tvoc-meas.yml
@@ -18,3 +18,8 @@ components:
         version: 1
     categories:
     - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-tvoc-level-pm25-meas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-tvoc-level-pm25-meas.yml
@@ -18,3 +18,8 @@ components:
         version: 1
     categories:
       - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature-battery.yml
@@ -16,3 +16,6 @@ components:
     version: 1
   categories:
   - name: MotionSensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature.yml
@@ -14,3 +14,6 @@ components:
     version: 1
   categories:
   - name: MotionSensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/sensor.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/sensor.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: GenericSensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-temp-humidity-comeas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-temp-humidity-comeas.yml
@@ -25,3 +25,7 @@ components:
 preferences:
   - preferenceId: certifiedpreferences.smokeSensorSensitivity
     explicit: true
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true


### PR DESCRIPTION
[CHAD-14584](https://smartthings.atlassian.net/browse/CHAD-14584)
Note: This is a profile-only change!

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adds temperatureOffset and relativeHumidityOffset preferences to profiles that support the temperatureMeasurement and relativeHumidityMeasurement capabilities.

This is a profile change only to add preferences.

# Summary of Completed Tests

Onboarded a device using one of the updated profiles (`aqs-temp-humidity-all-meas`) without the changes. Preferences were not visible in the "Settings" menu of the device card. Then, the driver was updated to the new profile with the preferences added from this PR. Confirmed that the preferences are now visible in the "Settings" menu of the device after the driver is updated. No reonboarding is needed.

[CHAD-14584]: https://smartthings.atlassian.net/browse/CHAD-14584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ