### PR TITLE
Matter Thermostat: add temp/humidity offset preferences to profiles

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
@@ -43,6 +43,11 @@ components:
     version: 1
   categories:
   - name: AirPurifier
+  preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true
 - id: hepaFilter
   label: Hepa Filter
   capabilities:

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling.yml
@@ -24,3 +24,6 @@ components:
     version: 1
   categories:
   - name: AirConditioner
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-wind-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-wind-heating-cooling.yml
@@ -26,3 +26,6 @@ components:
     version: 1
   categories:
   - name: AirConditioner
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-heating-cooling.yml
@@ -20,3 +20,6 @@ components:
     version: 1
   categories:
   - name: AirConditioner
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-fan-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-fan-heating-cooling.yml
@@ -26,3 +26,8 @@ components:
     version: 1
   categories:
   - name: AirConditioner
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-heating-cooling.yml
@@ -24,3 +24,8 @@ components:
     version: 1
   categories:
   - name: AirConditioner
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner.yml
@@ -28,3 +28,8 @@ components:
     version: 1
   categories:
   - name: AirConditioner
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-nobattery.yml
@@ -14,3 +14,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate.yml
@@ -16,3 +16,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only.yml
@@ -18,3 +18,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-nobattery.yml
@@ -16,3 +16,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate.yml
@@ -18,3 +18,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only.yml
@@ -20,3 +20,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-nobattery.yml
@@ -16,3 +16,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate.yml
@@ -18,3 +18,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only.yml
@@ -20,3 +20,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-nobattery.yml
@@ -18,3 +18,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate.yml
@@ -20,3 +20,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan.yml
@@ -22,3 +22,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-nobattery.yml
@@ -14,3 +14,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate.yml
@@ -16,3 +16,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only.yml
@@ -18,3 +18,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-nobattery.yml
@@ -16,3 +16,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate.yml
@@ -18,3 +18,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate-nobattery.yml
@@ -18,3 +18,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only.yml
@@ -22,3 +22,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-nobattery.yml
@@ -18,3 +18,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only.yml
@@ -22,3 +22,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-nobattery.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate.yml
@@ -22,3 +22,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan.yml
@@ -24,3 +24,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-nobattery.yml
@@ -16,3 +16,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate.yml
@@ -18,3 +18,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-nobattery.yml
@@ -18,3 +18,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate.yml
@@ -20,3 +20,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity.yml
@@ -22,3 +22,8 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-nobattery.yml
@@ -16,3 +16,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate.yml
@@ -18,3 +18,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat.yml
@@ -20,3 +20,6 @@ components:
     version: 1
   categories:
   - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true


### PR DESCRIPTION
[CHAD-14584](https://smartthings.atlassian.net/browse/CHAD-14584)
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adds temperatureOffset and relativeHumidityOffset preferences to profiles that support the temperatureMeasurement and relativeHumidityMeasurement capabilities.

profile change only

# Summary of Completed Tests
Onboarded a thermostat device using one of the updated profiles (`thermostat-humidity-fan-nostate`) without the changes. Preferences were not visible in the "Settings" menu of the device card. Then, the driver was updated to include the new profile with the preferences added from this PR. Upon driver update, confirmed that the preferences are now visible in the "Settings" menu of the device after the driver is updated. No reonboarding is needed. Offsets working as expected and can be updated by the user in the "Settings" menu.



[CHAD-14584]: https://smartthings.atlassian.net/browse/CHAD-14584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ