### PR TITLE
Hue: Fix multi-component device initialization race condition

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco/button.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/button.lua
@@ -1,6 +1,9 @@
 local log = require "log"
 local socket = require "cosock".socket
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local HueDeviceTypes = require "hue_device_types"
 

--- a/drivers/SmartThings/philips-hue/src/disco/contact.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/contact.lua
@@ -1,6 +1,9 @@
 local log = require "log"
 local socket = require "cosock".socket
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local HueDeviceTypes = require "hue_device_types"
 

--- a/drivers/SmartThings/philips-hue/src/disco/init.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/init.lua
@@ -4,6 +4,9 @@ local socket = require "cosock.socket"
 local mdns = require "st.mdns"
 local net_utils = require "st.net_utils"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Fields = require "fields"
 local HueApi = require "hue.api"

--- a/drivers/SmartThings/philips-hue/src/disco/light.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/light.lua
@@ -1,6 +1,9 @@
 local log = require "log"
 local socket = require "cosock".socket
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local HueDeviceTypes = require "hue_device_types"
 

--- a/drivers/SmartThings/philips-hue/src/disco/motion.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/motion.lua
@@ -1,6 +1,9 @@
 local log = require "log"
 local socket = require "cosock".socket
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local HueDeviceTypes = require "hue_device_types"
 

--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -2,7 +2,7 @@ local capabilities = require "st.capabilities"
 local log = require "log"
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
----@type fun(val: table, name: string?, multi_line: boolean?): string
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
 
 local Consts = require "consts"

--- a/drivers/SmartThings/philips-hue/src/handlers/commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/commands.lua
@@ -1,5 +1,8 @@
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Consts = require "consts"
 local Fields = require "fields"
@@ -8,7 +11,7 @@ local HueColorUtils = require "utils.cie_utils"
 local utils = require "utils"
 
 -- trick to fix the VS Code Lua Language Server typechecking
----@type fun(val: table, name: string?, multi_line: boolean?): string
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
 
 ---@class CommandHandlers

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/button.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/button.lua
@@ -1,6 +1,9 @@
 local capabilities = require "st.capabilities"
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local refresh_handler = require("handlers.commands").refresh_handler
 

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
@@ -1,5 +1,8 @@
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local refresh_handler = require("handlers.commands").refresh_handler
 

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
@@ -1,5 +1,9 @@
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
+
 local capabilities = require "st.capabilities"
 
 local Discovery = require "disco"

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
@@ -1,6 +1,9 @@
 local log = require "log"
 local refresh_handler = require("handlers.commands").refresh_handler
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Consts = require "consts"
 local Discovery = require "disco"

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
@@ -1,5 +1,8 @@
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local refresh_handler = require("handlers.commands").refresh_handler
 

--- a/drivers/SmartThings/philips-hue/src/handlers/migration_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/migration_handlers/light.lua
@@ -1,6 +1,9 @@
 local capabilities = require "st.capabilities"
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Discovery = require "disco"
 local Fields = require "fields"

--- a/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
@@ -1,6 +1,9 @@
 local cosock = require "cosock"
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Fields = require "fields"
 local HueDeviceTypes = require "hue_device_types"
@@ -123,6 +126,7 @@ function RefreshHandlers.do_refresh_all_for_bridge(driver, bridge_device)
         -- but only the first time we encounter a device type. We cache them since we're refreshing
         -- everything.
         if
+            device_type and
             type(device_type_refresh_handlers_map[device_type]) == "function" and
             statuses_by_device_type[device_type] == nil
         then

--- a/drivers/SmartThings/philips-hue/src/hue/api.lua
+++ b/drivers/SmartThings/philips-hue/src/hue/api.lua
@@ -5,11 +5,14 @@ local json = require "st.json"
 local log = require "log"
 local RestClient = require "lunchbox.rest"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local HueDeviceTypes = require "hue_device_types"
 
 -- trick to fix the VS Code Lua Language Server typechecking
----@type fun(val: table, name: string?, multi_line: boolean?): string
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
 
 local APPLICATION_KEY_HEADER = "hue-application-key"
@@ -82,6 +85,7 @@ end
 ---@return table? tbl the table representation of the JSON response, nil on error
 ---@return string? err the error message, nil on success
 ---@return string? partial the partial response if the response was not complete
+---@return ...
 local function process_rest_response(response, err, partial, err_callback)
   if err == nil and response == nil then
     log.error_with({ hub_logs = true },
@@ -208,6 +212,7 @@ end
 ---@param path string
 ---@return table|nil response REST response, nil if error
 ---@return nil|string error nil on success
+---@return ...
 local function do_get(instance, path)
   local reply_tx, reply_rx = channel.new()
   reply_rx:settimeout(10)
@@ -226,6 +231,7 @@ end
 ---@param payload string
 ---@return table|nil response REST response, nil if error
 ---@return nil|string error nil on success
+---@return ...
 local function do_put(instance, path, payload)
   local reply_tx, reply_rx = channel.new()
   reply_rx:settimeout(10)
@@ -244,6 +250,7 @@ end
 ---@return HueBridgeInfo|nil bridge_info nil on err
 ---@return nil|string error nil on success
 ---@return nil|string partial partial response if available, nil otherwise
+---@return ...
 function PhilipsHueApi.get_bridge_info(bridge_ip, socket_builder)
   local tx, rx = channel.new()
   rx:settimeout(10)
@@ -266,6 +273,7 @@ end
 ---@return HueApiKeyResponse[]? api_key_response nil on err
 ---@return string? error nil on success
 ---@return string? partial partial response if available, nil otherwise
+---@return ...
 function PhilipsHueApi.request_api_key(bridge_ip, socket_builder)
   local tx, rx = channel.new()
   rx:settimeout(10)

--- a/drivers/SmartThings/philips-hue/src/hue_debug/init.lua
+++ b/drivers/SmartThings/philips-hue/src/hue_debug/init.lua
@@ -1,4 +1,7 @@
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local log = require "log"
 local utils = require "utils"

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -22,7 +22,7 @@ local Driver = require "st.driver"
 local log = require "log"
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
----@type fun(val: table, name: string?, multi_line: boolean?): string
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
 
 local Discovery = require "disco"

--- a/drivers/SmartThings/philips-hue/src/init.lua
+++ b/drivers/SmartThings/philips-hue/src/init.lua
@@ -17,9 +17,13 @@
 --  Improvements to be made:
 --
 --  ===============================================================================================
-local Driver = require "st.driver"
+local logjam = require "logjam"
+logjam.enable_passthrough()
+logjam.inject_global()
 
 local log = require "log"
+
+local Driver = require "st.driver"
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
 ---@type fun(val: any?, name: string?, multi_line: boolean?): string

--- a/drivers/SmartThings/philips-hue/src/logjam.lua
+++ b/drivers/SmartThings/philips-hue/src/logjam.lua
@@ -1,9 +1,84 @@
 local log = require "log"
+local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local logjam = {}
+
+logjam.real_log = log.log
+
+logjam.enabled_modules = {}
+
+function logjam.inject_global()
+  for field_key, level_key in pairs(log) do
+    if
+        string.find(field_key, "LOG_LEVEL_") and
+        type(level_key) == "string" and
+        type(log[level_key]) == "function"
+    then
+      log[level_key] = logjam[level_key]
+      local level_with_key = string.format("%s_with", level_key)
+      if type(log[level_with_key]) == "function" then
+        log[level_with_key] = logjam[level_with_key]
+      end
+    end
+  end
+  log.log = logjam.log
+end
+
+function logjam.enable_passthrough()
+  logjam.passthrough = true
+end
+
+function logjam.disable_passthrough()
+  logjam.passthrough = false
+end
+
+function logjam.enable(module)
+  logjam.enabled_modules[module] = true
+end
+
+function logjam.disable(module)
+  logjam.enabled_modules[module] = nil
+end
+
 function logjam.log(opts, level, ...)
-  if opts.on == true then
-    log.log(opts, level, ...)
+  local call_info
+  if not opts.call_info then
+    call_info = debug.getinfo(2)
+  else
+    call_info = opts.call_info
+  end
+  opts.call_info = nil
+
+  local module_name = nil
+  if type(call_info.source) == "string" then
+    module_name =
+    call_info.source
+    :gsub("%.lua", "")
+    :gsub("/init", "")
+    :gsub("/", ".")
+    :gsub("^init$", "philips-hue")
+  end
+
+  local module_enabled = false
+  local module_prefix = ""
+  if type(module_name) == "string" and module_name:len() > 0 then
+    module_enabled = logjam.enabled_modules[module_name]
+    module_prefix = string.format("[%s] ", module_name)
+  end
+
+  -- explicit on/off log option takes precedence, so that we can allow
+  -- `false` to override passthrough/module_enabled flags.
+  if type(opts.on) == "boolean" then
+    if opts.on then
+      logjam.real_log(opts, level, module_prefix, ...)
+    end
+    return
+  end
+  if logjam.passthrough or module_enabled then
+    logjam.real_log(opts, level, module_prefix, ...)
   end
 end
 
@@ -16,16 +91,35 @@ for field_key, level_key in pairs(log) do
     local level_with_key = string.format("%s_with", level_key)
     logjam[level_key] = function(...)
       local first_arg = select(1, ...)
-      if first_arg == true or (type(first_arg) == "table" and first_arg.on == true) then
-        log[level_key](select(2, ...))
+      local opts = {}
+      local log_args_start_idx = 1
+      if type(first_arg) == "boolean" then
+        opts.on = first_arg
+        log_args_start_idx = 2
+      elseif type(first_arg) == "table" then
+        opts = first_arg
+        log_args_start_idx = 2
       end
+      local info = debug.getinfo(2)
+      opts.call_info = info
+      logjam.log(opts, level_key, select(log_args_start_idx, ...))
     end
 
     logjam[level_with_key] = function(opts, ...)
-      opts = opts or {}
-      if opts.on == true then
-        log[level_with_key](...)
+      local log_opts = {}
+      local log_args = table.pack(...)
+      if type(opts) == "table" then
+        for k, v in pairs(opts) do
+          log_opts[k] = v
+        end
+      elseif type(opts) == "boolean" then
+        log_opts.on = opts
+      elseif opts ~= nil then
+        log_args.insert(log_args, 1, opts)
       end
+      local info = debug.getinfo(2)
+      log_opts.call_info = info
+      logjam.log(log_opts, level_key, table.unpack(log_args))
     end
   end
 end

--- a/drivers/SmartThings/philips-hue/src/lunchbox/sse/eventsource.lua
+++ b/drivers/SmartThings/philips-hue/src/lunchbox/sse/eventsource.lua
@@ -5,6 +5,11 @@ local ssl = require "cosock.ssl"
 ---@type fun(sock: table, config: table?): table?, string?
 ssl.wrap = ssl.wrap
 
+local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
+
 local log = require "log"
 local util = require "lunchbox.util"
 local Request = require "luncheon.request"
@@ -474,7 +479,6 @@ function EventSource.new(url, extra_headers, sock_builder)
   }, EventSource)
 
   cosock.spawn(function()
-    local st_utils = require "st.utils"
     while true do
       if source.ready_state == EventSource.ReadyStates.CLOSED and
           not source._reconnect

--- a/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
+++ b/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
@@ -1,6 +1,9 @@
 local cosock = require "cosock"
 local log = require "log"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Discovery = require "disco"
 local Fields = require "fields"

--- a/drivers/SmartThings/philips-hue/src/test/spec/device_faker.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/device_faker.lua
@@ -2,6 +2,9 @@ local utils = require "utils"
 local lazy_fakers = utils.lazy_handler_loader("fakers")
 
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local test_helpers = require "test_helpers"
 

--- a/drivers/SmartThings/philips-hue/src/test/spec/fakers/light_faker.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/fakers/light_faker.lua
@@ -1,4 +1,7 @@
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local function make_migrated_device(faker_args, bridge_info)
   local device_network_id = faker_args.dni or st_utils.generate_uuid_v4()

--- a/drivers/SmartThings/philips-hue/src/utils/cie_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/cie_utils.lua
@@ -1,4 +1,8 @@
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
+
 local CieUtils = {}
 
 local DefaultGamut = {

--- a/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
@@ -2,6 +2,9 @@ local cosock = require "cosock"
 local log = require "log"
 local json = require "st.json"
 local st_utils = require "st.utils"
+-- trick to fix the VS Code Lua Language Server typechecking
+---@type fun(val: any?, name: string?, multi_line: boolean?): string
+st_utils.stringify_table = st_utils.stringify_table
 
 local Discovery = require "disco"
 local EventSource = require "lunchbox.sse.eventsource"

--- a/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
@@ -237,7 +237,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
   end
   bridge_device:set_field(Fields._INIT, true, { persist = false })
   local ids_to_remove = {}
-  for id, device in ipairs(driver._devices_pending_refresh) do
+  for id, device in pairs(driver._devices_pending_refresh) do
     local parent_bridge = utils.get_hue_bridge_for_device(driver, device)
     local bridge_id = parent_bridge and parent_bridge.id
     if bridge_id == bridge_device.id then


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

We've identified an issue in the Hue driver related to the way we handled device init on driver startup for child devices that were ahead of the parent bridge in database order.

The race condition primarily manifested in the non-primary component for multi-component devices (such as multi-button remotes) not emitting attribute events or being able to handle capability commands.

The actual bugfix change is here: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/commit/e4cc7a4d54608b6dbedf70f6342eaf9e193fb3bd

The other two commits are chore work that we tackled in the process of fixing the bug:

- Mostly updates type hints/annotations
- Fix one place where typechecks caught a missing nil checkCheck all that apply
- Updates to the cheekily named "logjam" module that this driver uses to wrangle its extensive/complicated logging.

Fixes #1674 

# Summary of Completed Tests

Tested with various multi-button remotes.
