### PR TITLE
Fix Thermostat Auto setting in Matter Thermostat 

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -819,7 +819,7 @@ local function sequence_of_operation_handler(driver, device, ib, response)
   -- or not the device supports emergency heat or fan only
   local supported_modes = {capabilities.thermostatMode.thermostatMode.off.NAME}
 
-  local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.auto})
+  local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE})
   if #auto > 0 then
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.auto.NAME)
   end

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
@@ -308,7 +308,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat" }, {visibility={displayed=false}}))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "cool", "heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -322,7 +322,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "heat" }, {visibility={displayed=false}}))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -336,7 +336,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto",  "cool" }, {visibility={displayed=false}}))
+        capabilities.thermostatMode.supportedThermostatModes({ "off",  "cool" }, {visibility={displayed=false}}))
     },
   }
 )
@@ -356,7 +356,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat" }, {visibility={displayed=false}}))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "cool", "heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -375,7 +375,7 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "auto", "cool", "heat", "emergency heat" }, {visibility={displayed=false}}))
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "cool", "heat", "emergency heat" }, {visibility={displayed=false}}))
     }
   }
 )


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Based on [MTR-878](https://smartthings.atlassian.net/browse/MTR-878) there is a typo in the thermostat driver for setting the automode feature.

# Summary of Completed Tests




[MTR-878]: https://smartthings.atlassian.net/browse/MTR-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ