### PR TITLE
Add eufy C34 to new-matter-lock driver

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -35,6 +35,7 @@ local NEW_MATTER_LOCK_PRODUCTS = {
   {0x147F, 0x0001}, -- U-tec
   {0x1533, 0x0001}, -- eufy, E31
   {0x1533, 0x0002}, -- eufy, E30
+  {0x1533, 0x0003}, -- eufy, C34
   {0x10E1, 0x2002}  -- VDA
 }
 


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
- Add VID/PID of eufy C34 to new-matter-lock sub-driver

# Summary of Completed Tests
- https://smartthings.atlassian.net/wiki/spaces/DLT/pages/3636429393/eufy+C34+door+lock+testing


