### PR TITLE
Use PPB for TVOC measurement units

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
@@ -309,7 +309,7 @@ local unit_default = {
   [capabilities.fineDustSensor.NAME] = units.UGM3,
   [capabilities.dustSensor.NAME] = units.UGM3,
   [capabilities.radonMeasurement.NAME] = units.BQM3,
-  [capabilities.tvocMeasurement.NAME] = units.PPM
+  [capabilities.tvocMeasurement.NAME] = units.PPB
 }
 
 -- All ConcentrationMesurement clusters inherit from the same base cluster definitions,
@@ -325,7 +325,8 @@ local level_strings = {
 
 local conversion_tables = {
   [units.PPM] = {
-    [units.PPM] = function(value) return utils.round(value) end
+    [units.PPM] = function(value) return utils.round(value) end,
+    [units.PPB] = function(value) return utils.round(value * (10^3)) end
   },
   [units.PPB] = {
     [units.PPM] = function(value) return utils.round(value/(10^3)) end
@@ -473,7 +474,7 @@ local matter_air_quality_sensor_handler = {
         [clusters.RadonConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.radonHealthConcern.radonHealthConcern)
       },
       [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID] = {
-        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.tvocMeasurement.NAME, capabilities.tvocMeasurement.tvocLevel, units.PPM),
+        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.tvocMeasurement.NAME, capabilities.tvocMeasurement.tvocLevel, units.PPB),
         [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.tvocMeasurement.NAME),
         [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.tvocHealthConcern.tvocHealthConcern)
       }

--- a/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
@@ -309,7 +309,7 @@ local unit_default = {
   [capabilities.fineDustSensor.NAME] = units.UGM3,
   [capabilities.dustSensor.NAME] = units.UGM3,
   [capabilities.radonMeasurement.NAME] = units.BQM3,
-  [capabilities.tvocMeasurement.NAME] = units.PPB
+  [capabilities.tvocMeasurement.NAME] = units.PPB  -- TVOC is typically within the range of 0-5500 ppb, with good to moderate values being < 660 ppb
 }
 
 -- All ConcentrationMeasurement clusters inherit from the same base cluster definitions,

--- a/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
@@ -329,7 +329,8 @@ local conversion_tables = {
     [units.PPB] = function(value) return utils.round(value * (10^3)) end
   },
   [units.PPB] = {
-    [units.PPM] = function(value) return utils.round(value/(10^3)) end
+    [units.PPM] = function(value) return utils.round(value/(10^3)) end,
+    [units.PPB] = function(value) return utils.round(value) end
   },
   [units.PPT] = {
     [units.PPM] = function(value) return utils.round(value/(10^6)) end

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor.lua
@@ -634,6 +634,21 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.dustSensor.dustLevel({value = 18, unit = "μg/m^3"}))
     )
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasurementUnit:build_test_report_data(
+        mock_device, 1, clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.types.MeasurementUnitEnum.PPM
+      )
+    })
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue:build_test_report_data(
+        mock_device, 1, SinglePrecisionFloat(0, -1, .5) -- 0.750 ppm
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.tvocMeasurement.tvocLevel({value = 750, unit = "ppb"}))
+    )
   end
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -590,7 +590,7 @@ local unit_default = {
   [capabilities.fineDustSensor.NAME] = units.UGM3,
   [capabilities.dustSensor.NAME] = units.UGM3,
   [capabilities.radonMeasurement.NAME] = units.BQM3,
-  [capabilities.tvocMeasurement.NAME] = units.PPM
+  [capabilities.tvocMeasurement.NAME] = units.PPB
 }
 
 -- All ConcentrationMesurement clusters inherit from the same base cluster definitions,
@@ -620,6 +620,7 @@ local molecular_weights = {
 local conversion_tables = {
   [units.PPM] = {
     [units.PPM] = function(value) return utils.round(value) end,
+    [units.PPB] = function(value) return utils.round(value * (10^3)) end,
     [units.UGM3] = function(value, molecular_weight) return utils.round((value * molecular_weight * 10^3) / MGM3_PPM_CONVERSION_FACTOR) end,
     [units.MGM3] = function(value, molecular_weight) return utils.round((value * molecular_weight) / MGM3_PPM_CONVERSION_FACTOR) end,
   },
@@ -1429,7 +1430,7 @@ local matter_driver_template = {
         [clusters.RadonConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.radonHealthConcern.radonHealthConcern)
       },
       [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.ID] = {
-        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.tvocMeasurement.NAME, capabilities.tvocMeasurement.tvocLevel, units.PPM),
+        [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasuredValue.ID] = measurementHandlerFactory(capabilities.tvocMeasurement.NAME, capabilities.tvocMeasurement.tvocLevel, units.PPB),
         [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.MeasurementUnit.ID] = store_unit_factory(capabilities.tvocMeasurement.NAME),
         [clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.attributes.LevelValue.ID] = levelHandlerFactory(capabilities.tvocHealthConcern.tvocHealthConcern)
       }

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -590,7 +590,7 @@ local unit_default = {
   [capabilities.fineDustSensor.NAME] = units.UGM3,
   [capabilities.dustSensor.NAME] = units.UGM3,
   [capabilities.radonMeasurement.NAME] = units.BQM3,
-  [capabilities.tvocMeasurement.NAME] = units.PPB
+  [capabilities.tvocMeasurement.NAME] = units.PPB  -- TVOC is typically within the range of 0-5500 ppb, with good to moderate values being < 660 ppb
 }
 
 -- All ConcentrationMesurement clusters inherit from the same base cluster definitions,

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -625,7 +625,8 @@ local conversion_tables = {
     [units.MGM3] = function(value, molecular_weight) return utils.round((value * molecular_weight) / MGM3_PPM_CONVERSION_FACTOR) end,
   },
   [units.PPB] = {
-    [units.PPM] = function(value) return utils.round(value/(10^3)) end
+    [units.PPM] = function(value) return utils.round(value/(10^3)) end,
+    [units.PPB] = function(value) return utils.round(value) end,
   },
   [units.PPT] = {
     [units.PPM] = function(value) return utils.round(value/(10^6)) end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-14452](https://smartthings.atlassian.net/browse/CHAD-14452)

TVOC measurements are typically under 1 ppm for normal conditions for indoor air quality (see [here](https://smartthings.atlassian.net/wiki/spaces/STSE/pages/2556166348/airQualitySensor+enhancement+-+cancelled#Indoor-Air-Quality-(IAQ))). Rounding to the nearest 0.5 ppm is therefore not the most accurate representation and ppb should be used instead.

# Summary of Completed Tests

See testing info in the ticket as well as new unit test.


[CHAD-14452]: https://smartthings.atlassian.net/browse/CHAD-14452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ