### PR TITLE
New Devices (Matter Switch) 2 Aqara 2 AiDot

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -9,7 +9,113 @@ matterManufacturer:
     deviceLabel: Aqara LED Bulb T2 CCT
     vendorId: 0x115F
     productId: 0x1802
-    deviceProfileName: light-level-colorTemperature-2700K-6500K  
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+  - id: "4447/6149"
+    deviceLabel: Aqara LED Bulb T2 RGB CCT
+    vendorId: 0x115F
+    productId: 0x1805
+    deviceProfileName: light-color-level  
+  - id: "4447/6150"
+    deviceLabel: Aqara LED Bulb T2 CCT
+    vendorId: 0x115F
+    productId: 0x1806
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+#AiDot
+  - id: "Linkind/Smart/Light/Bulb/A19/RGBTW"
+    deviceLabel: Linkind Smart Light Bulb A19 RGBTW
+    vendorId: 0x1168
+    productId: 0x03e8
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "OREiN/Smart/Light/Bulb/A19/RGBTW"
+    deviceLabel: OREiN Smart Light Bulb A19 RGBTW
+    vendorId: 0x1168
+    productId: 0x03ea
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "Linkind/Smart/Light/Bulb/BR30/RGBTW"
+    deviceLabel: Linkind Smart Light Bulb BR30 RGBTW
+    vendorId: 0x1168
+    productId: 0x03eb
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "OREiN/Smart/Light/Bulb/BR30/RGBTW"
+    deviceLabel: OREiN Smart Light Bulb BR30 RGBTW
+    vendorId: 0x1168
+    productId: 0x03ec
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "Consciot/Smart/Light/Bulb/A19/RGBT"
+    deviceLabel: Consciot Smart Light Bulb A19 RGBT
+    vendorId: 0x1168
+    productId: 0x0405
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1010"
+    deviceLabel: Aidot OREiN Matter Smart Light Bulb BR30 RGBTW 1200lm
+    vendorId: 0x1168
+    productId: 0x03F2
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1011"
+    deviceLabel: Smart Light Bulb A60
+    vendorId: 0x1168
+    productId: 0x03F3
+    deviceProfileName: light-color-level-1800K-6500K
+ - id: "4456/1012"
+    deviceLabel: Aidot Linkind Matter Smart Light Bulb BR30 RGBTW 1200lm
+    vendorId: 0x1168
+    productId: 0x03F4
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1013"
+    deviceLabel: Matter Smart Light Bulb A21 RGBTW 1600lm
+    vendorId: 0x1168
+    productId: 0x03F5
+    deviceProfileName: light-color-level-1800K-6500K  
+  - id: "AiDot/Smart/Light/Bulb/A19/RGBTW"
+    deviceLabel: AiDot Smart Light Bulb A19 RGBT
+    vendorId: 0x1168
+    productId: 0x03f8
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "Linkind/Smart/Light/Bulb/A19/CCT"
+    deviceLabel: Smart Light Bulb A19 CCT
+    vendorId: 0x1168
+    productId: 0x03f9
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+  - id: "4456/1024"
+    deviceLabel: Smart Plug
+    vendorId: 0x1168
+    productId: 0x0400
+    deviceProfileName: plug-binary  
+  - id: "4456/1007"
+    deviceLabel: Matter Smart Light Bulb A21 RGBTW 1600lm
+    vendorId: 0x1168
+    productId: 0x03EF
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1005"
+    deviceLabel: Matter Smart Light Bulb A19 RGBTW 1100lm
+    vendorId: 0x1168
+    productId: 0x03ED
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1006"
+    deviceLabel: Matter Smart Light Bulb A19 RGBTW 1100lm
+    vendorId: 0x1168
+    productId: 0x03EE
+    deviceProfileName: light-color-level-1800K-6500K
+  - id: "4456/1102"
+    deviceLabel: Matter Smart Plug
+    vendorId: 0x1168
+    productId: 0x044E
+    deviceProfileName: plug-binary
+  - id: "4456/1019"
+    deviceLabel: Matter Smart Filament  Bulb ST58 CCT
+    vendorId: 0x1168
+    productId: 0x03FB
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+  - id: "4456/1020"
+    deviceLabel: AiDot OREiN Matter Smart Filament Bulb ST58 CCT
+    vendorId: 0x1168
+    productId: 0x03FC
+    deviceProfileName: light-level-colorTemperature-2700K-6500K
+  - id: "5014/4096"
+    deviceLabel: Linkind LED Light Strip EL6
+    vendorId: 0x1396
+    productId: 0x1000
+    deviceProfileName: light-color-level-1800K-6500K 
 #Chengdu
   - id: "5218/8197"
     deviceLabel: Magic Cube DS001
@@ -467,92 +573,6 @@ matterManufacturer:
     productId: 0x9002
     deviceProfileName: light-color-level-2700K-6500K
 
-#AiDot
-  - id: "Linkind/Smart/Light/Bulb/A19/RGBTW"
-    deviceLabel: Linkind Smart Light Bulb A19 RGBTW
-    vendorId: 0x1168
-    productId: 0x03e8
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "OREiN/Smart/Light/Bulb/A19/RGBTW"
-    deviceLabel: OREiN Smart Light Bulb A19 RGBTW
-    vendorId: 0x1168
-    productId: 0x03ea
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "Linkind/Smart/Light/Bulb/BR30/RGBTW"
-    deviceLabel: Linkind Smart Light Bulb BR30 RGBTW
-    vendorId: 0x1168
-    productId: 0x03eb
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "OREiN/Smart/Light/Bulb/BR30/RGBTW"
-    deviceLabel: OREiN Smart Light Bulb BR30 RGBTW
-    vendorId: 0x1168
-    productId: 0x03ec
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "Consciot/Smart/Light/Bulb/A19/RGBT"
-    deviceLabel: Consciot Smart Light Bulb A19 RGBT
-    vendorId: 0x1168
-    productId: 0x0405
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "AiDot/Smart/Light/Bulb/A19/RGBTW"
-    deviceLabel: AiDot Smart Light Bulb A19 RGBT
-    vendorId: 0x1168
-    productId: 0x03f8
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "4456/1024"
-    deviceLabel: Smart Plug
-    vendorId: 0x1168
-    productId: 0x0400
-    deviceProfileName: plug-binary
-  - id: "4456/1011"
-    deviceLabel: Smart Light Bulb A60
-    vendorId: 0x1168
-    productId: 0x03F3
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "Linkind/Smart/Light/Bulb/A19/CCT"
-    deviceLabel: Smart Light Bulb A19 CCT
-    vendorId: 0x1168
-    productId: 0x03f9
-    deviceProfileName: light-level-colorTemperature-2700K-6500K
-  - id: "4456/1013"
-    deviceLabel: Matter Smart Light Bulb A21 RGBTW 1600lm
-    vendorId: 0x1168
-    productId: 0x03F5
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "4456/1007"
-    deviceLabel: Matter Smart Light Bulb A21 RGBTW 1600lm
-    vendorId: 0x1168
-    productId: 0x03EF
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "4456/1005"
-    deviceLabel: Matter Smart Light Bulb A19 RGBTW 1100lm
-    vendorId: 0x1168
-    productId: 0x03ED
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "4456/1006"
-    deviceLabel: Matter Smart Light Bulb A19 RGBTW 1100lm
-    vendorId: 0x1168
-    productId: 0x03EE
-    deviceProfileName: light-color-level-1800K-6500K
-  - id: "4456/1102"
-    deviceLabel: Matter Smart Plug
-    vendorId: 0x1168
-    productId: 0x044E
-    deviceProfileName: plug-binary
-  - id: "4456/1019"
-    deviceLabel: Matter Smart Filament  Bulb ST58 CCT
-    vendorId: 0x1168
-    productId: 0x03FB
-    deviceProfileName: light-level-colorTemperature-2700K-6500K
-  - id: "4456/1020"
-    deviceLabel: AiDot OREiN Matter Smart Filament Bulb ST58 CCT
-    vendorId: 0x1168
-    productId: 0x03FC
-    deviceProfileName: light-level-colorTemperature-2700K-6500K
-  - id: "5014/4096"
-    deviceLabel: Linkind LED Light Strip EL6
-    vendorId: 0x1396
-    productId: 0x1000
-    deviceProfileName: light-color-level-1800K-6500K
 #U-Tec
   - id: "5247/3"
     deviceLabel: U-tec Smart Matter Plug


### PR DESCRIPTION
# Type of Change

- [ X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This PR adds Four new Fingerprints for the following devices:
1. Aqara LED Bulb T2 CCT, Matter Device Type ID: 10c
2. Aqara LED Bulb T2 RGB CCT, Matter Device Type ID: 10d
3. Aidot OREiN Matter Smart Light Bulb BR30 RGBTW 1200lm, Matter Device Type ID: 10d
4. Aidot Linkind Matter Smart Light Bulb BR30 RGBTW 1200lm, Matter Device Type ID: 10d

Additionally I moved up the "AiDot fingerprints" to be in alphabetical order compared to the other MFG fingerprints and rearranged them to be ordered more by their ProductIDs.

# Summary of Completed Tests
No additional testing is planned

