### PR TITLE
Add batteryLevel to matter thermostat

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-cooling-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-batteryLevel.yml
@@ -1,0 +1,18 @@
+name: thermostat-cooling-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-batteryLevel.yml
@@ -1,0 +1,24 @@
+name: thermostat-fan-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-fan-cooling-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-fan-cooling-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-fan-heating-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-fan-heating-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-fan-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-heating-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-batteryLevel.yml
@@ -1,0 +1,18 @@
+name: thermostat-heating-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-batteryLevel.yml
@@ -1,0 +1,24 @@
+name: thermostat-humidity-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-cooling-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-humidity-cooling-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-batteryLevel.yml
@@ -1,0 +1,26 @@
+name: thermostat-humidity-fan-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-batteryLevel.yml
@@ -1,0 +1,24 @@
+name: thermostat-humidity-fan-heating-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-fan-heating-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-batteryLevel.yml
@@ -1,0 +1,24 @@
+name: thermostat-humidity-fan-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatFanMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-heating-only-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-humidity-heating-only-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: thermostat-humidity-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: thermostat-nostate-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
@@ -1,0 +1,134 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local clusters = require "st.matter.clusters"
+local uint32 = require "st.matter.data_types.Uint32"
+
+local mock_device = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("thermostat-batteryLevel.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1}  -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = clusters.PowerSource.types.PowerSourceFeature.BATTERY},
+        {
+          cluster_id = clusters.Thermostat.ID,
+          cluster_revision=5,
+          cluster_type="SERVER",
+          feature_map=2, -- Cool feature only.
+        },
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0301, device_type_revision = 1} -- Thermostat
+      }
+    }
+  }
+})
+
+local cluster_subscribe = {
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+  clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+  clusters.Thermostat.attributes.AbsMinCoolSetpointLimit,
+  clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit,
+  clusters.Thermostat.attributes.AbsMinHeatSetpointLimit,
+  clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit,
+  clusters.Thermostat.attributes.SystemMode,
+  clusters.Thermostat.attributes.ThermostatRunningState,
+  clusters.Thermostat.attributes.ControlSequenceOfOperation,
+  clusters.TemperatureMeasurement.attributes.MeasuredValue,
+  clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
+  clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
+  clusters.PowerSource.attributes.BatChargeLevel,
+}
+
+local function test_init()
+  local subscribe_request= cluster_subscribe[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
+  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
+  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  test.socket.matter:__expect_send({mock_device.id, read_req})
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  local attribute_list_read_req = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device.id, attribute_list_read_req})
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+end
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+  "Test profile change when battery percent remaining attribute (attribute ID 12) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(12)})
+      }
+    )
+    mock_device:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test profile change when battery level attribute (attribute ID 14) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(14)})
+      }
+    )
+    mock_device:expect_metadata_update({ profile = "thermostat-cooling-only-nostate-batteryLevel" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test that profile does not change when battery percent remaining and battery level attributes are not available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(10)})
+      }
+    )
+  end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -216,15 +216,15 @@ test.register_coroutine_test(
     --TODO why does provisiong state get added in the do configure event handle, but not the refres?
     local read_req = clusters.PowerSource.attributes.AttributeList:read()
     test.socket.matter:__expect_send({mock_device.id, read_req})
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
         clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(12)})
       }
     )
-    test.wait_for_events()
     mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only-nostate" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 )
 
@@ -249,6 +249,8 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device_simple.id, "doConfigure" })
     local read_req = clusters.PowerSource.attributes.AttributeList:read()
     test.socket.matter:__expect_send({mock_device_simple.id, read_req})
+    mock_device_simple:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_simple.id,
@@ -256,7 +258,6 @@ test.register_coroutine_test(
       }
     )
     mock_device_simple:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
-    mock_device_simple:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -14,6 +14,7 @@
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
+local uint32 = require "st.matter.data_types.Uint32"
 
 local clusters = require "st.matter.clusters"
 
@@ -213,6 +214,15 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     --TODO why does provisiong state get added in the do configure event handle, but not the refres?
+    local read_req = clusters.PowerSource.attributes.AttributeList:read()
+    test.socket.matter:__expect_send({mock_device.id, read_req})
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(12)})
+      }
+    )
+    test.wait_for_events()
     mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only-nostate" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
@@ -237,6 +247,14 @@ test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event due to cluster feature map",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device_simple.id, "doConfigure" })
+    local read_req = clusters.PowerSource.attributes.AttributeList:read()
+    test.socket.matter:__expect_send({mock_device_simple.id, read_req})
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_simple.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_simple, 1, {uint32(12)})
+      }
+    )
     mock_device_simple:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
     mock_device_simple:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -92,8 +92,11 @@ local cached_cooling_setpoint = capabilities.thermostatCoolingSetpoint.coolingSe
 
 local function configure(device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  mock_device:expect_metadata_update({ profile = "thermostat-nostate" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+
+  local read_attribute_list_req = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device.id, read_attribute_list_req})
+
   test.wait_for_events()
 
   --populate cached setpoint values. This would normally happen due to subscription setup.

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -14,6 +14,7 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
+local uint32 = require "st.matter.data_types.Uint32"
 
 local clusters = require "st.matter.clusters"
 
@@ -98,6 +99,9 @@ local function configure(device)
   test.socket.matter:__expect_send({mock_device.id, read_attribute_list_req})
 
   test.wait_for_events()
+
+  test.socket.matter:__queue_receive({mock_device.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(0x0C)})})
+  mock_device:expect_metadata_update({ profile = "thermostat-nostate" })
 
   --populate cached setpoint values. This would normally happen due to subscription setup.
   test.socket.matter:__queue_receive({


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-12161](https://smartthings.atlassian.net/browse/CHAD-12161)

Matter drivers currently assume that `BatPercentRemaining` is available if the `BAT` feature is supported, but this attribute is only optionally required if this feature is present. The changes in this PR improve the profile selection logic in matter-thermostat by reading the `AttributeList`, checking if `BatPercentRemaining` or `BatChargeLevel` is available, and then profiling the device as needed.

Note that these changes were originally in [PR 1796](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1796) but this PR was split up into 5 separate PRs, one for each affected driver.

# Summary of Completed Tests

Tested with an Eve Thermo, which supports `BatPercentRemaining`. Relevant logs:
```
2025-01-30_15:55:22.090 | I | broker     | <Matter Thermostat (a59d7bdf)> <MatterDevice: bbe0b417-4477-43f0-b9d9-4ff79ea441dd [7AE8C08425F969BF-08948B0FF0B0262E] (Eve Thermo)> received lifecycle event: doConfigure
2025-01-30_15:55:22.115 | I | broker     | <Matter Thermostat (a59d7bdf)> <MatterDevice: bbe0b417-4477-43f0-b9d9-4ff79ea441dd [7AE8C08425F969BF-08948B0FF0B0262E] (Eve Thermo)> sending InteractionRequest: <InteractionRequest || type: READ, info_blocks: [<InteractionInfoBlock || cluster: PowerSource, attribute: AttributeList>]>
2025-01-30_15:55:23.933 | I | broker     | <Matter Thermostat (a59d7bdf)> <MatterDevice: bbe0b417-4477-43f0-b9d9-4ff79ea441dd [7AE8C08425F969BF-08948B0FF0B0262E] (Eve Thermo)> received lifecycle event: infoChanged
2025-01-30_15:55:23.942 | I | broker     | <Matter Thermostat (a59d7bdf)> <MatterDevice: bbe0b417-4477-43f0-b9d9-4ff79ea441dd [7AE8C08425F969BF-08948B0FF0B0262E] (Eve Thermo)> received InteractionResponse: <InteractionResponse || type: REPORT_DATA, response_blocks: [<InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || endpoint: 0x00, cluster: PowerSource, attribute: AttributeList, data: Array: [Uint8: \x00, Uint8: \x01, Uint8: \x02, Uint8: \x0B, Uint8: \x0C, Uint8: \x0E, Uint8: \x0F, Uint8: \x10, Uint8: \x12, Uint8: \x13, Uint8: \x19, Uint8: \x1F, Uint16: \xFF\xF8, Uint16: \xFF\xF9, Uint16: \xFF\xFB, Uint16: \xFF\xFC, Uint16: \xFF\xFD]>>, <InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || cluster: PowerSource, attribute: AttributeList>>]>
2025-01-30_15:55:24.323 | I | broker     | <Matter Thermostat (a59d7bdf)> <MatterDevice: bbe0b417-4477-43f0-b9d9-4ff79ea441dd [7AE8C08425F969BF-08948B0FF0B0262E] (Eve Thermo)> Updating device profile to thermostat-heating-only-nostate.
```

[CHAD-12161]: https://smartthings.atlassian.net/browse/CHAD-12161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ