### PR TITLE
Add batteryLevel to matter sensor

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/contact-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/contact-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: contact-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: contactSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: ContactSensor

--- a/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel-fault-freezeSensitivity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel-fault-freezeSensitivity.yml
@@ -1,0 +1,25 @@
+name: freeze-batteryLevel-fault-freezeSensitivity
+components:
+- id: main
+  capabilities:
+  - id: temperatureAlarm
+    version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+  - id: batteryLevel
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: WaterFreezeDetector
+preferences:
+  - preferenceId: freezeSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel-fault.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel-fault.yml
@@ -1,0 +1,23 @@
+name: freeze-batteryLevel-fault
+components:
+- id: main
+  capabilities:
+  - id: temperatureAlarm
+    version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+  - id: batteryLevel
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: WaterFreezeDetector
+

--- a/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel-freezeSensitivity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel-freezeSensitivity.yml
@@ -1,0 +1,23 @@
+name: freeze-batteryLevel-freezeSensitivity
+components:
+- id: main
+  capabilities:
+  - id: temperatureAlarm
+    version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: WaterFreezeDetector
+preferences:
+  - preferenceId: freezeSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/freeze-batteryLevel.yml
@@ -1,0 +1,20 @@
+name: freeze-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureAlarm
+    version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: WaterFreezeDetector

--- a/drivers/SmartThings/matter-sensor/profiles/humidity-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/humidity-batteryLevel.yml
@@ -1,0 +1,17 @@
+name: humidity-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: HumiditySensor
+preferences:
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/illuminance-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/illuminance-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: illuminance-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: illuminanceMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: LightSensor

--- a/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel-fault-leakSensitivity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel-fault-leakSensitivity.yml
@@ -1,0 +1,19 @@
+name: leak-batteryLevel-fault-leakSensitivity
+components:
+- id: main
+  capabilities:
+  - id: waterSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: LeakSensor
+preferences:
+  - preferenceId: leakSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel-fault.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel-fault.yml
@@ -1,0 +1,16 @@
+name: leak-batteryLevel-fault
+components:
+- id: main
+  capabilities:
+  - id: waterSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: LeakSensor

--- a/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel-leakSensitivity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel-leakSensitivity.yml
@@ -1,0 +1,17 @@
+name: leak-batteryLevel-leakSensitivity
+components:
+- id: main
+  capabilities:
+  - id: waterSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: LeakSensor
+preferences:
+  - preferenceId: leakSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/leak-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: leak-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: waterSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: LeakSensor

--- a/drivers/SmartThings/matter-sensor/profiles/matter-motion-batteryLevel-illuminance.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/matter-motion-batteryLevel-illuminance.yml
@@ -1,0 +1,16 @@
+name: matter-motion-batteryLevel-illuminance
+components:
+- id: main
+  capabilities:
+  - id: motionSensor
+    version: 1
+  - id: illuminanceMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MotionSensor

--- a/drivers/SmartThings/matter-sensor/profiles/matter-motion-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/matter-motion-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: matter-motion-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: motionSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MotionSensor

--- a/drivers/SmartThings/matter-sensor/profiles/motion-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: motion-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: motionSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MotionSensor

--- a/drivers/SmartThings/matter-sensor/profiles/motion-contact-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-contact-batteryLevel.yml
@@ -1,0 +1,16 @@
+name: motion-contact-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: motionSensor
+    version: 1
+  - id: contactSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MotionSensor

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-batteryLevel.yml
@@ -1,0 +1,16 @@
+name: motion-illuminance-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: motionSensor
+    version: 1
+  - id: illuminanceMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MotionSensor

--- a/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/motion-illuminance-temperature-batteryLevel.yml
@@ -1,0 +1,18 @@
+name: motion-illuminance-temperature-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: motionSensor
+    version: 1
+  - id: illuminanceMeasurement
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MotionSensor

--- a/drivers/SmartThings/matter-sensor/profiles/pressure-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/pressure-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: pressure-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: atmosphericPressureMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: GenericSensor

--- a/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel-fault-rainSensitivity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel-fault-rainSensitivity.yml
@@ -1,0 +1,19 @@
+name: rain-batteryLevel-fault-rainSensitivity
+components:
+- id: main
+  capabilities:
+  - id: rainSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: RainSensor
+preferences:
+  - preferenceId: rainSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel-fault.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel-fault.yml
@@ -1,0 +1,16 @@
+name: rain-batteryLevel-fault
+components:
+- id: main
+  capabilities:
+  - id: rainSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: RainSensor

--- a/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel-rainSensitivity.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel-rainSensitivity.yml
@@ -1,0 +1,17 @@
+name: rain-batteryLevel-rainSensitivity
+components:
+- id: main
+  capabilities:
+  - id: rainSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: RainSensor
+preferences:
+  - preferenceId: rainSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/rain-batteryLevel.yml
@@ -1,0 +1,14 @@
+name: rain-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: rainSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: RainSensor

--- a/drivers/SmartThings/matter-sensor/profiles/sensor-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/sensor-batteryLevel.yml
@@ -1,0 +1,22 @@
+name: sensor-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: illuminanceMeasurement
+    version: 1
+  - id: contactSensor
+    version: 1
+  - id: motionSensor
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: GenericSensor

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-batteryLevel.yml
@@ -1,0 +1,17 @@
+name: temperature-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat
+preferences:
+  - preferenceId: tempOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-batteryLevel.yml
@@ -1,0 +1,63 @@
+name: temperature-humidity-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: TempHumiditySensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: []
+    basicPlus: []
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: battery
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: battery
+        version: 1
+    actions: []

--- a/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-batteryLevel.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/temperature-humidity-pressure-batteryLevel.yml
@@ -1,0 +1,71 @@
+name: temperature-humidity-pressure-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: atmosphericPressureMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: TempHumiditySensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true
+deviceConfig:
+  dashboard:
+    states:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+        group: main
+        composite: true
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+        group: main
+        values:
+          - label: "  {{humidity.value}} {{humidity.unit}}"
+        composite: true
+    actions: []
+    basicPlus: []
+  detailView:
+    - component: main
+      capability: temperatureMeasurement
+      version: 1
+    - component: main
+      capability: relativeHumidityMeasurement
+      version: 1
+    - component: main
+      capability: atmosphericPressureMeasurement
+      version: 1
+    - component: main
+      capability: battery
+      version: 1
+    - component: main
+      capability: refresh
+      version: 1
+  automation:
+    conditions:
+      - component: main
+        capability: temperatureMeasurement
+        version: 1
+      - component: main
+        capability: relativeHumidityMeasurement
+        version: 1
+      - component: main
+        capability: atmosphericPressureMeasurement
+        version: 1
+      - component: main
+        capability: battery
+        version: 1
+    actions: []

--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -15,6 +15,7 @@
 local capabilities = require "st.capabilities"
 local log = require "log"
 local clusters = require "st.matter.clusters"
+local im = require "st.matter.interaction_model"
 local MatterDriver = require "st.matter.driver"
 local utils = require "st.utils"
 local embedded_cluster_utils = require "embedded-cluster-utils"
@@ -51,7 +52,11 @@ local TEMP_BOUND_RECEIVED = "__temp_bound_received"
 local TEMP_MIN = "__temp_min"
 local TEMP_MAX = "__temp_max"
 
-local HUE_MANUFACTURER_ID = 0x100B
+local battery_support = {
+  NO_BATTERY = "NO_BATTERY",
+  BATTERY_LEVEL = "BATTERY_LEVEL",
+  BATTERY_PERCENTAGE = "BATTERY_PERCENTAGE"
+}
 
 local function get_field_for_endpoint(device, field, endpoint)
   return device:get_field(string.format("%s_%d", field, endpoint))
@@ -88,16 +93,6 @@ local function set_boolean_device_type_per_endpoint(driver, device)
   end
 end
 
-local function supports_battery_percentage_remaining(device)
-  local battery_eps = device:get_endpoints(clusters.PowerSource.ID,
-          {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
-  -- Hue devices support the PowerSource cluster but don't support reporting battery percentage remaining
-  if #battery_eps > 0 and device.manufacturer_info.vendor_id ~= HUE_MANUFACTURER_ID then
-    return true
-  end
-  return false
-end
-
 local function supports_sensitivity_preferences(device)
   local preference_names = ""
   local sensitivity_eps = embedded_cluster_utils.get_endpoints(device, clusters.BooleanStateConfiguration.ID,
@@ -118,7 +113,7 @@ local function device_added(driver, device)
   set_boolean_device_type_per_endpoint(driver, device)
 end
 
-local function do_configure(driver, device)
+local function match_profile(driver, device, battery_supported)
   local profile_name = ""
 
   if device:supports_capability(capabilities.motionSensor) then
@@ -157,8 +152,10 @@ local function do_configure(driver, device)
     profile_name = profile_name .. "-leak"
   end
 
-  if supports_battery_percentage_remaining(device) then
+  if battery_supported == battery_support.BATTERY_PERCENTAGE then
     profile_name = profile_name .. "-battery"
+  elseif battery_supported == battery_support.BATTERY_LEVEL then
+    profile_name = profile_name .. "-batteryLevel"
   end
 
   if device:supports_capability(capabilities.hardwareFault) then
@@ -173,6 +170,18 @@ local function do_configure(driver, device)
 
   device.log.info_with({hub_logs=true}, string.format("Updating device profile to %s.", profile_name))
   device:try_update_metadata({profile = profile_name})
+end
+
+local function do_configure(driver, device)
+  local battery_feature_eps = device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
+  -- Hue devices support the PowerSource cluster but don't support reporting battery percentage remaining
+  if #battery_feature_eps > 0 and device.manufacturer_info.vendor_id ~= HUE_MANUFACTURER_ID then
+    local attribute_list_read = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
+    attribute_list_read:merge(clusters.PowerSource.attributes.AttributeList:read())
+    device:send(attribute_list_read)
+  else
+    match_profile(driver, device, battery_support.NO_BATTERY)
+  end
 end
 
 local function device_init(driver, device)
@@ -314,6 +323,30 @@ local function battery_percent_remaining_attr_handler(driver, device, ib, respon
   end
 end
 
+local function battery_charge_level_attr_handler(driver, device, ib, response)
+  if ib.data.value == clusters.PowerSource.types.BatChargeLevelEnum.OK then
+    device:emit_event(capabilities.batteryLevel.battery.normal())
+  elseif ib.data.value == clusters.PowerSource.types.BatChargeLevelEnum.WARNING then
+    device:emit_event(capabilities.batteryLevel.battery.warning())
+  elseif ib.data.value == clusters.PowerSource.types.BatChargeLevelEnum.CRITICAL then
+    device:emit_event(capabilities.batteryLevel.battery.critical())
+  end
+end
+
+local function power_source_attribute_list_handler(driver, device, ib, response)
+  for _, attr in ipairs(ib.data.elements) do
+    -- Re-profile the device if BatPercentRemaining (Attribute ID 0x0C) or
+    -- BatChargeLevel (Attribute ID 0x0E) is present.
+    if attr.value == 0x0C then
+      match_profile(driver, device, battery_support.BATTERY_PERCENTAGE)
+      return
+    elseif attr.value == 0x0E then
+      match_profile(driver, device, battery_support.BATTERY_LEVEL)
+      return
+    end
+  end
+end
+
 local function occupancy_attr_handler(driver, device, ib, response)
   device:emit_event(ib.data.value == 0x01 and capabilities.motionSensor.motion.active() or capabilities.motionSensor.motion.inactive())
 end
@@ -351,6 +384,8 @@ local matter_driver_template = {
         [clusters.BooleanState.attributes.StateValue.ID] = boolean_attr_handler
       },
       [clusters.PowerSource.ID] = {
+        [clusters.PowerSource.attributes.AttributeList.ID] = power_source_attribute_list_handler,
+        [clusters.PowerSource.attributes.BatChargeLevel.ID] = battery_charge_level_attr_handler,
         [clusters.PowerSource.attributes.BatPercentRemaining.ID] = battery_percent_remaining_attr_handler,
       },
       [clusters.OccupancySensing.ID] = {
@@ -387,6 +422,10 @@ local matter_driver_template = {
     },
     [capabilities.battery.ID] = {
       clusters.PowerSource.attributes.BatPercentRemaining
+    },
+    [capabilities.batteryLevel.ID] = {
+      clusters.PowerSource.attributes.BatChargeLevel,
+      clusters.SmokeCoAlarm.attributes.BatteryAlert,
     },
     [capabilities.atmosphericPressureMeasurement.ID] = {
       clusters.PressureMeasurement.attributes.MeasuredValue
@@ -478,17 +517,14 @@ local matter_driver_template = {
       clusters.SmokeCoAlarm.attributes.HardwareFaultAlert,
       clusters.BooleanStateConfiguration.attributes.SensorFault,
     },
-    [capabilities.batteryLevel.ID] = {
-      clusters.SmokeCoAlarm.attributes.BatteryAlert,
-    },
     [capabilities.waterSensor.ID] = {
-        clusters.BooleanState.attributes.StateValue,
+      clusters.BooleanState.attributes.StateValue,
     },
     [capabilities.temperatureAlarm.ID] = {
-        clusters.BooleanState.attributes.StateValue,
+      clusters.BooleanState.attributes.StateValue,
     },
     [capabilities.rainSensor.ID] = {
-        clusters.BooleanState.attributes.StateValue,
+      clusters.BooleanState.attributes.StateValue,
     },
   },
   capability_handlers = {
@@ -498,6 +534,7 @@ local matter_driver_template = {
     capabilities.contactSensor,
     capabilities.motionSensor,
     capabilities.battery,
+    capabilities.batteryLevel,
     capabilities.relativeHumidityMeasurement,
     capabilities.illuminanceMeasurement,
     capabilities.atmosphericPressureMeasurement,

--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -52,6 +52,8 @@ local TEMP_BOUND_RECEIVED = "__temp_bound_received"
 local TEMP_MIN = "__temp_min"
 local TEMP_MAX = "__temp_max"
 
+local HUE_MANUFACTURER_ID = 0x100B
+
 local battery_support = {
   NO_BATTERY = "NO_BATTERY",
   BATTERY_LEVEL = "BATTERY_LEVEL",

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_battery.lua
@@ -1,0 +1,150 @@
+-- Copyright 2023 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local clusters = require "st.matter.clusters"
+local uint32 = require "st.matter.data_types.Uint32"
+
+local mock_device_humidity_battery = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("humidity-batteryLevel.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
+      },
+      device_types = {}
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 2},
+      },
+      device_types = {}
+    }
+  }
+})
+
+local cluster_subscribe_list_humidity_battery = {
+  clusters.PowerSource.attributes.BatChargeLevel,
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+}
+
+local function test_init()
+  local subscribe_request_humidity_battery = cluster_subscribe_list_humidity_battery[1]:subscribe(mock_device_humidity_battery)
+  for i, cluster in ipairs(cluster_subscribe_list_humidity_battery) do
+    if i > 1 then
+      subscribe_request_humidity_battery:merge(cluster:subscribe(mock_device_humidity_battery))
+    end
+  end
+
+  test.socket.matter:__expect_send({mock_device_humidity_battery.id, subscribe_request_humidity_battery})
+  test.mock_device.add_test_device(mock_device_humidity_battery)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "added" })
+  local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device_humidity_battery.id, read_attribute_list})
+  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
+  mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+end
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+  "Test profile change when battery percent remaining attribute (attribute ID 12) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_humidity_battery.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_humidity_battery, 2,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(12),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-battery" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test profile change when battery level attribute (attribute ID 14) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_humidity_battery.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_humidity_battery, 2,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(14),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-batteryLevel" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test that profile does not change when battery percent remaining and battery level attributes are not available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_humidity_battery.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_humidity_battery, 2,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+  end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
@@ -17,7 +17,7 @@ local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"
 
 local mock_device_humidity_battery = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("humidity-battery.yml"),
+  profile = t_utils.get_profile_definition("humidity-batteryLevel.yml"),
   manufacturer_info = {
     vendor_id = 0x0000,
     product_id = 0x0000,
@@ -109,8 +109,8 @@ local mock_device_temp_humidity = test.mock_device.build_test_matter_device({
 })
 
 local cluster_subscribe_list_humidity_battery = {
+  clusters.PowerSource.attributes.BatChargeLevel,
   clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
-  clusters.PowerSource.attributes.BatPercentRemaining
 }
 
 local cluster_subscribe_list_humidity_no_battery = {
@@ -137,8 +137,9 @@ local function test_init_humidity_battery()
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "added" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
-  mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-battery" })
   mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device_humidity_battery.id, read_attribute_list})
 end
 
 local function test_init_humidity_no_battery()

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm.lua
@@ -69,6 +69,7 @@ local cluster_subscribe_list = {
   clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
   clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasuredValue,
   clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasurementUnit,
+  clusters.PowerSource.attributes.BatChargeLevel,
 }
 
 local function test_init()


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-12161](https://smartthings.atlassian.net/browse/CHAD-12161)

Matter drivers currently assume that `BatPercentRemaining` is available if the `BAT` feature is supported, but this attribute is only optionally required if this feature is present. The changes in this PR improve the profile selection logic in matter-sensor by reading the `AttributeList`, checking if `BatPercentRemaining` or `BatChargeLevel` is available, and then profiling the device as needed.

Note that these changes were originally in [PR 1796](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1796) but this PR was split up into 5 separate PRs, one for each affected driver.

# Summary of Completed Tests

Tested with a Contact Sensor device. This device supports `BatPercentRemaining` and so is profiled to `contact-battery`. See the relevant logs below:
```
2025-01-29_19:13:46.047 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> received lifecycle event: added
2025-01-29_19:13:46.067 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> sending InteractionRequest: <InteractionRequest || type: SUBSCRIBE, info_blocks: [<InteractionInfoBlock || cluster: PowerSource, attribute: BatPercentRemaining>, <InteractionInfoBlock || cluster: BooleanState, attribute: StateValue>]>
2025-01-29_19:13:46.107 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> received lifecycle event: doConfigure
2025-01-29_19:13:46.129 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> sending InteractionRequest: <InteractionRequest || type: READ, info_blocks: [<InteractionInfoBlock || cluster: PowerSource, attribute: AttributeList>]>
2025-01-29_19:13:50.692 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> received InteractionResponse: <InteractionResponse || type: REPORT_DATA, response_blocks: [<InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || endpoint: 0x01, cluster: BooleanState, attribute: StateValue, data: Boolean: true>>, <InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || endpoint: 0x01, cluster: PowerSource, attribute: BatPercentRemaining, data: Uint8: \xC8>>, <InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || endpoint: 0x00, cluster: BasicInformation, attribute: SoftwareVersion, data: Uint8: \x01>>]>
2025-01-29_19:13:50.708 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> emitting event: {"attribute_id":"contact","capability_id":"contactSensor","component_id":"main","state":{"value":"closed"}}
2025-01-29_19:13:50.768 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> emitting event: {"attribute_id":"battery","capability_id":"battery","component_id":"main","state":{"value":100}}
2025-01-29_19:13:50.842 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> received InteractionResponse: <InteractionResponse || type: REPORT_DATA, response_blocks: [<InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || endpoint: 0x01, cluster: PowerSource, attribute: AttributeList, data: Array: [Uint8: \x00, Uint8: \x01, Uint8: \x02, Uint8: \x0C, Uint8: \x0E, Uint8: \x0F, Uint8: \x10, Uint8: \x13, Uint8: \x19, Uint16: \xFF\xF8, Uint16: \xFF\xF9, Uint16: \xFF\xFB, Uint16: \xFF\xFC, Uint16: \xFF\xFD]>>, <InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || cluster: PowerSource, attribute: AttributeList>>]>
2025-01-29_19:13:50.848 | I | broker     | <Matter Sensor (a687db78)> <MatterDevice: e236c578-a7be-4dc3-a5be-48e994ed5aff [E3BA971501FF2304-62C81BCFBD013D86] (Tuo Contact Sensor)> Updating device profile to contact-battery.
```

[CHAD-12161]: https://smartthings.atlassian.net/browse/CHAD-12161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ