### PR TITLE
Add batteryLevel to matter lock

### DIFF
--- a/drivers/SmartThings/matter-lock/src/init.lua
+++ b/drivers/SmartThings/matter-lock/src/init.lua
@@ -236,9 +236,13 @@ local function set_credential_response_handler(driver, device, ib, response)
       local battery_feature_eps = device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
       if #battery_feature_eps == 0 then
         profile_name = profile_name .. "-nobattery"
+        device.log.info(string.format("Updating device profile to %s.", profile_name))
+        device:try_update_metadata({profile = profile_name, provisioning_state = "PROVISIONED"})
+      else
+        local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
+        req:merge(clusters.PowerSource.attributes.AttributeList:read())
+        device:send(req)
       end
-      device.log.info(string.format("Updating device profile to %s.", profile_name))
-      device:try_update_metadata({profile = profile_name, provisioning_state = "PROVISIONED"})
     end
   elseif device:get_field(lock_utils.COTA_CRED) and credential_index == device:get_field(lock_utils.COTA_CRED_INDEX) then
     -- Handle failure to set a COTA credential

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_battery.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_battery.lua
@@ -1,0 +1,153 @@
+-- Copyright 2024 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+test.add_package_capability("lockAlarm.yml")
+local t_utils = require "integration_test.utils"
+local clusters = require "st.matter.clusters"
+local uint32 = require "st.matter.data_types.Uint32"
+
+local mock_device_record = {
+  profile = t_utils.get_profile_definition("base-lock.yml"),
+  manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
+  endpoints = {
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 10,
+      clusters = {
+        {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 10},
+      },
+    },
+  },
+}
+local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
+
+local mock_device_no_battery_record = {
+  profile = t_utils.get_profile_definition("base-lock.yml"),
+  manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
+  endpoints = {
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 10,
+      clusters = {
+        {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+    },
+  },
+}
+local mock_device_no_battery = test.mock_device.build_test_matter_device(mock_device_no_battery_record)
+
+local function test_init()
+  local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
+  subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
+  subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
+  subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device))
+  subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device))
+  test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
+end
+test.set_test_init_function(test_init)
+
+local function test_init_no_battery()
+  local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device_no_battery)
+  subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
+  subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device_no_battery))
+  subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device_no_battery))
+  subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device_no_battery))
+  test.socket["matter"]:__expect_send({mock_device_no_battery.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device_no_battery)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_no_battery.id, "doConfigure" })
+  mock_device_no_battery:expect_metadata_update({ profile = "base-lock-nobattery" })
+  mock_device_no_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+end
+
+test.register_coroutine_test(
+  "Test profile changes to base-lock when battery percent remaining attribute (attribute ID 12) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 2,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(12),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device:expect_metadata_update({ profile = "base-lock" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test that profile changes to base-lock-batteryLevel when battery level attribute (attribute ID 14) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 2,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(14),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device:expect_metadata_update({ profile = "base-lock-batteryLevel" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test that profile changes to base-lock-no-battery when battery feature is not available",
+  function()
+  end,
+  { test_init = test_init_no_battery }
+)
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -341,10 +341,8 @@ test.register_coroutine_test(
           .lockCodes(json.encode({["1"] = "ST Remote Operation Code"}), {visibility = {displayed = false}})
       )
     )
-    mock_device:expect_metadata_update({
-      profile = "base-lock",
-      provisioning_state = "PROVISIONED"
-    })
+    local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+    test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   end
 )
 
@@ -438,10 +436,8 @@ test.register_coroutine_test(
           .lockCodes(json.encode({["1"] = "ST Remote Operation Code"}), {visibility = {displayed = false}})
       )
     )
-    mock_device:expect_metadata_update({
-      profile = "base-lock",
-      provisioning_state = "PROVISIONED"
-    })
+    local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+    test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   end
 )
 
@@ -528,10 +524,8 @@ test.register_coroutine_test(
           .lockCodes(json.encode({["1"] = "ST Remote Operation Code"}), {visibility = {displayed = false}})
       )
     )
-    mock_device:expect_metadata_update({
-      profile = "base-lock",
-      provisioning_state = "PROVISIONED"
-    })
+    local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+    test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   end
 )
 


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

[CHAD-12161](https://smartthings.atlassian.net/browse/CHAD-12161)

Matter drivers currently assume that `BatPercentRemaining` is available if the `BAT` feature is supported, but this attribute is only optionally required if this feature is present. The changes in this PR improve the profile selection logic in matter-lock by reading the `AttributeList`, checking if `BatPercentRemaining` or `BatChargeLevel` is available, and then profiling the device as needed.

Note that these changes were originally in [PR 1796](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1796) but this PR was split up into 5 separate PRs, one for each affected driver.

# Summary of Completed Tests

Tested with a Yale lock. Relevant logs:
```
2025-01-30_19:39:40.041 | I | broker     | <Matter Lock (16735f98)> <MatterDevice: 97f5d543-11eb-4ce9-8655-a747abe9fe66 [7AE8C08425F969BF-D1B6AA3AC0443D26] (Yale Assure Matter Module)> sending InteractionRequest: <InteractionRequest || type: READ, info_blocks: [<InteractionInfoBlock || cluster: PowerSource, attribute: AttributeList>]>
2025-01-30_19:39:41.894 | I | broker     | <Matter Lock (16735f98)> <MatterDevice: 97f5d543-11eb-4ce9-8655-a747abe9fe66 [7AE8C08425F969BF-D1B6AA3AC0443D26] (Yale Assure Matter Module)> received InteractionResponse: <InteractionResponse || type: REPORT_DATA, response_blocks: [<InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || endpoint: 0x01, cluster: PowerSource, attribute: AttributeList, data: Array: [Uint8: \x00, Uint8: \x01, Uint8: \x02, Uint8: \x0C, Uint8: \x0E, Uint8: \x0F, Uint8: \x10, Uint8: \x13, Uint8: \x19, Uint16: \xFF\xF8, Uint16: \xFF\xF9, Uint16: \xFF\xFB, Uint16: \xFF\xFC, Uint16: \xFF\xFD]>>, <InteractionResponseInfoBlock || status: SUCCESS, <InteractionInfoBlock || cluster: PowerSource, attribute: AttributeList>>]>
```
This device supports `BatPercentRemaining` and so it's profile was not updated after receiving the AttributeList (it remained joined to the `base-lock` profile).

[CHAD-12161]: https://smartthings.atlassian.net/browse/CHAD-12161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ