### PR TITLE
Reapply "[Bar 300] Issues - device don't operate about 'stop' command…

### DIFF
--- a/drivers/SmartThings/jbl/profiles/jbl.yml
+++ b/drivers/SmartThings/jbl/profiles/jbl.yml
@@ -10,12 +10,10 @@ components:
           enabledValues:
             - 'playing'
             - 'paused'
-            - 'stopped'
         - key: "{{enumCommands}}"
           enabledValues:
             - 'play'
             - 'pause'
-            - 'stop'
   - id: mediaTrackControl
     version: 1
   - id: audioMute

--- a/drivers/SmartThings/jbl/src/init.lua
+++ b/drivers/SmartThings/jbl/src/init.lua
@@ -179,6 +179,16 @@ local function device_init(driver, device)
 
   refresh(driver, device, nil)
   device:set_field(fields._INIT, true, { persist = false })
+
+  device:emit_event(capabilities.mediaPlayback.supportedPlaybackCommands({
+    capabilities.mediaPlayback.commands.play.NAME,
+    capabilities.mediaPlayback.commands.pause.NAME,
+  }))
+
+  device:emit_event(capabilities.mediaTrackControl.supportedTrackControlCommands({
+    capabilities.mediaTrackControl.commands.nextTrack.NAME,
+    capabilities.mediaTrackControl.commands.previousTrack.NAME,
+  }))
 end
 
 local lan_driver = Driver("jbl",
@@ -204,7 +214,6 @@ local lan_driver = Driver("jbl",
       [capabilities.mediaPlayback.ID] = {
         [capabilities.mediaPlayback.commands.play.NAME] = jbl_capability_handler.playback_play_handler,
         [capabilities.mediaPlayback.commands.pause.NAME] = jbl_capability_handler.playback_pause_handler,
-        [capabilities.mediaPlayback.commands.stop.NAME] = jbl_capability_handler.playback_stop_handler,
       },
       [capabilities.audioNotification.ID] = {
         [capabilities.audioNotification.commands.playTrack.NAME] = jbl_capability_handler.audioNotification_handler,

--- a/drivers/SmartThings/jbl/src/jbl/api.lua
+++ b/drivers/SmartThings/jbl/src/jbl/api.lua
@@ -2,6 +2,7 @@ local log = require "log"
 local json = require "st.json"
 local RestClient = require "lunchbox.rest"
 local utils = require "utils"
+local st_utils = require "st.utils"
 local cosock = require "cosock"
 
 local jbl_api = {}
@@ -68,7 +69,7 @@ function jbl_api.new_device_manager(bridge_ip, bridge_info, socket_builder)
 
   return setmetatable(
       {
-        headers = ADDITIONAL_HEADERS,
+        headers = st_utils.deep_copy(ADDITIONAL_HEADERS),
         client = RestClient.new(base_url, socket_builder),
         base_url = base_url,
       }, jbl_api

--- a/drivers/SmartThings/jbl/src/jbl/capability_handler.lua
+++ b/drivers/SmartThings/jbl/src/jbl/capability_handler.lua
@@ -9,7 +9,6 @@ local function smartthings_playback_capability_handler(driver, device, capabilit
   local st_status_to_jbl_playback_status_table = {
     paused = "pause",
     playing = "play",
-    stopped = "stop",
   }
 
   local conn_info = device:get_field(fields.CONN_INFO)
@@ -32,10 +31,6 @@ end
 
 function capability_handler.playback_pause_handler(driver, device, args)
   smartthings_playback_capability_handler(driver, device, "paused")
-end
-
-function capability_handler.playback_stop_handler(driver, device, args)
-  smartthings_playback_capability_handler(driver, device, "stopped")
 end
 
 function capability_handler.next_track_handler(driver, device, args)

--- a/drivers/SmartThings/jbl/src/jbl/device_manager.lua
+++ b/drivers/SmartThings/jbl/src/jbl/device_manager.lua
@@ -28,7 +28,6 @@ end
 local jbl_playback_state_to_smartthings_playback_status_table = {
   paused = "paused",
   playing = "playing",
-  stopped = "stopped",
 }
 
 function device_manager.handle_status(driver, device, status)


### PR DESCRIPTION
… (#1797)"

This reverts commit 4dcce6db53b4f178596cc3d082961fede009d2a7.

This is adding back functionality from https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1797 which was reverted to avoid it being released to soon.

