### PR TITLE
New Device (Matter Switch) Shin Dong A ES  productId: 0x1000

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -534,6 +534,12 @@ matterManufacturer:
     vendorId: 0x137F
     productId: 0x027B
     deviceProfileName: plug-binary
+#Shin Dong-A ES
+  - id: 5483/4096
+    deviceLabel: Smart Wall Switch
+    vendorId: 0x156B
+    productId: 0x1000
+    deviceProfileName: switch-level 
 #SONOFF
   - id: "SONOFF MINIR4M"
     deviceLabel: Smart Plug-in Unit

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -153,6 +153,7 @@ local device_type_attribute_map = {
 local child_device_profile_overrides = {
   { vendor_id = 0x1321, product_id = 0x000C,  child_profile = "switch-binary" },
   { vendor_id = 0x1321, product_id = 0x000D,  child_profile = "switch-binary" },
+  { vendor_id = 0x156B, product_id = 0x1000,  child_profile = "switch-binary" }, -- Shin Dong-A ES Smart Switch
 }
 
 local detect_matter_thing


### PR DESCRIPTION

# Type of Change

- [ X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
The purpose of this PR is to add a device to SmartThings for WWST Certification. 



# Summary of Completed Tests
Further testing is planned as part of the WWST Process
Link to [CSA site on the Product](https://csa-iot.org/zh-CN/csa_%E4%BA%A7%E5%93%81/%E6%99%BA%E8%83%BD%E5%A2%99%E5%A3%81%E5%BC%80%E5%85%B32/).

The device is for a Shing Dong-A ES device that has multiple endpoints. 
VID: 0x156B
PID: 0x1000
Matter Device Type according to the CSA (103)

The changes I made include adding the fingerprint and also adding an override for end point 2 on the device so it shows up as a "switch" instead of a "plug". 
