### PR TITLE
Conditionally override child profiles

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -79,7 +79,6 @@ local device_type_profile_map = {
   [ON_OFF_SWITCH_ID] = "switch-binary",
   [ON_OFF_DIMMER_SWITCH_ID] = "switch-level",
   [ON_OFF_COLOR_DIMMER_SWITCH_ID] = "switch-color-level",
-  [GENERIC_SWITCH_ID] = "button"
 }
 
 local device_type_attribute_map = {
@@ -436,22 +435,6 @@ end
 local function assign_child_profile(device, child_ep)
   local profile
 
-  -- check if device has an overridden child profile that differs from the profile
-  -- that would match the child's device type
-  for _, fingerprint in ipairs(child_device_profile_overrides) do
-    if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
-       device.manufacturer_info.product_id == fingerprint.product_id then
-      if device.manufacturer_info.vendor_id == AQARA_MANUFACTURER_ID then
-        if child_ep ~= 1 then
-          -- To add Electrical Sensor only to the first EDGE_CHILD(light-power-energy-powerConsumption)
-          -- The profile of the second EDGE_CHILD is determined in the "for" loop below (e.g., light-binary)
-          break
-        end
-      end
-      return fingerprint.child_profile
-    end
-  end
-
   for _, ep in ipairs(device.endpoints) do
     if ep.endpoint_id == child_ep then
       -- Some devices report multiple device types which are a subset of
@@ -464,8 +447,26 @@ local function assign_child_profile(device, child_ep)
         id = math.max(id, dt.device_type_id)
       end
       profile = device_type_profile_map[id]
+      break
     end
   end
+
+  -- Check if device has an overridden child profile that differs from the profile that would match
+  -- the child's device type for the following two cases:
+  --   1. The selected profile for the child device is plug-binary, or
+  --   2. To add Electrical Sensor only to the first EDGE_CHILD (light-power-energy-powerConsumption)
+  --      for the Aqara Light Switch H2. The profile of the second EDGE_CHILD for this device is
+  --      determined in the "for" loop above (e.g., light-binary)
+  if profile == "plug-binary" or (device.manufacturer_info.vendor_id == AQARA_MANUFACTURER_ID and child_ep == 1) then
+    for _, fingerprint in ipairs(child_device_profile_overrides) do
+      if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
+        device.manufacturer_info.product_id == fingerprint.product_id then
+        profile = fingerprint.child_profile
+        break
+      end
+    end
+  end
+
   -- default to "switch-binary" if no profile is found
   return profile or "switch-binary"
 end

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -159,10 +159,10 @@ local device_type_attribute_map = {
 }
 
 local child_device_profile_overrides = {
-  { vendor_id = 0x1321, product_id = 0x000C,  child_profile = "switch-binary" },
-  { vendor_id = 0x1321, product_id = 0x000D,  child_profile = "switch-binary" },
-  { vendor_id = 0x115F, product_id = 0x1008,  child_profile = "light-power-energy-powerConsumption" }, -- 2 switch
-  { vendor_id = 0x115F, product_id = 0x1009,  child_profile = "light-power-energy-powerConsumption" }, -- 4 switch
+  { vendor_id = 0x1321, product_id = 0x000C, target_profile = "switch-binary", initial_profile = "plug-binary" },
+  { vendor_id = 0x1321, product_id = 0x000D, target_profile = "switch-binary", initial_profile = "plug-binary" },
+  { vendor_id = 0x115F, product_id = 0x1008, target_profile = "light-power-energy-powerConsumption" }, -- 2 switch
+  { vendor_id = 0x115F, product_id = 0x1009, target_profile = "light-power-energy-powerConsumption" }, -- 4 switch
 }
 
 local detect_matter_thing
@@ -453,17 +453,17 @@ local function assign_child_profile(device, child_ep)
 
   -- Check if device has an overridden child profile that differs from the profile that would match
   -- the child's device type for the following two cases:
-  --   1. The selected profile for the child device is plug-binary, or
-  --   2. To add Electrical Sensor only to the first EDGE_CHILD (light-power-energy-powerConsumption)
+  --   1. To add Electrical Sensor only to the first EDGE_CHILD (light-power-energy-powerConsumption)
   --      for the Aqara Light Switch H2. The profile of the second EDGE_CHILD for this device is
   --      determined in the "for" loop above (e.g., light-binary)
-  if profile == "plug-binary" or (device.manufacturer_info.vendor_id == AQARA_MANUFACTURER_ID and child_ep == 1) then
-    for _, fingerprint in ipairs(child_device_profile_overrides) do
-      if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
-        device.manufacturer_info.product_id == fingerprint.product_id then
-        profile = fingerprint.child_profile
-        break
-      end
+  --   2. The selected profile for the child device matches the initial profile defined in
+  --      child_device_profile_overrides
+  for _, fingerprint in ipairs(child_device_profile_overrides) do
+    if device.manufacturer_info.vendor_id == fingerprint.vendor_id and
+       device.manufacturer_info.product_id == fingerprint.product_id and
+       ((device.manufacturer_info.vendor_id == AQARA_MANUFACTURER_ID and child_ep == 1) or profile == fingerprint.initial_profile) then
+      profile = fingerprint.target_profile
+      break
     end
   end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -84,8 +84,8 @@ local mock_device_parent_child_endpoints_non_sequential = test.mock_device.build
   label = "Matter Switch",
   profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
   manufacturer_info = {
-    vendor_id = 0x0000,
-    product_id = 0x0000,
+    vendor_id = 0x1321,
+    product_id = 0x000C,
   },
   endpoints = {
     {
@@ -132,11 +132,9 @@ local mock_device_parent_child_endpoints_non_sequential = test.mock_device.build
       endpoint_id = child3_ep_non_sequential,
       clusters = {
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
-        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
       },
       device_types = {
-        {device_type_id = 0x010D, device_type_revision = 2} -- Extended Color Light
+        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
       }
     },
   }
@@ -258,10 +256,11 @@ local function test_init_parent_child_endpoints_non_sequential()
     parent_assigned_child_key = string.format("%d", child2_ep_non_sequential)
   })
 
+  -- switch-binary will be selected as an overridden child device profile
   mock_device_parent_child_endpoints_non_sequential:expect_device_create({
     type = "EDGE_CHILD",
     label = "Matter Switch 3",
-    profile = "light-color-level",
+    profile = "switch-binary",
     parent_device_id = mock_device_parent_child_endpoints_non_sequential.id,
     parent_assigned_child_key = string.format("%d", child3_ep_non_sequential)
   })


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Devices that utilize the child_device_profile_overrides table may contain other endpoints that should not have their profile overridden when the child device is created. This PR ensures that the profile is only overridden for profiles listed in  child_device_profile_overrides. See the discussion from [PR 1872](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1872/files#r1915492561).

Note that `GENERIC_SWITCH_ID` was removed from `device_type_profile_map`. This is because it is never used in this table and also to make it clear that device types in this table may have their child device profile overridden (buttons do not use parent-child).

# Summary of Completed Tests

Unit test update to verify child device profile override works as intended.
