### PR TITLE
fix(hue): Various nil index crashes for "stale" devices

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco/button.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/button.lua
@@ -70,7 +70,7 @@ local function _do_update(driver, api_instance, device_service_info, bridge_netw
     button_remote_description.power_state = battery.data[1].power_state
   end
 
-  if type(cache) == "table" then
+  if type(cache) == "table" and button_remote_description and button_remote_description.id then
     cache[button_remote_description.id] = button_remote_description
     if device_service_info.id_v1 then
       cache[device_service_info.id_v1] = button_remote_description

--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -146,6 +146,18 @@ local function _emit_light_events_inner(light_device, light_repr)
 end
 
 function AttributeEmitters.connectivity_update(child_device, zigbee_status)
+  if child_device == nil or (child_device and child_device.id == nil) then
+    log.warn("Tried to emit attribute events for a device that has been deleted")
+    return
+  end
+
+  if zigbee_status == nil then
+    log.error_with({ hub_logs = true },
+    string.format("nil zigbee_status sent to connectivity_update for %s",
+        (child_device and (child_device.label or child_device.id)) or "unknown device"))
+    return
+  end
+
   if zigbee_status.status == "connected" then
     child_device.log.info_with({hub_logs=true}, "Device zigbee status event, marking device online")
     child_device:online()
@@ -160,6 +172,13 @@ end
 function AttributeEmitters.emit_button_attribute_events(button_device, button_info)
   if button_device == nil or (button_device and button_device.id == nil) then
     log.warn("Tried to emit attribute events for a device that has been deleted")
+    return
+  end
+
+  if button_info == nil then
+    log.error_with({ hub_logs = true },
+    string.format("nil button info sent to emit_button_attribute_events for %s",
+        (button_device and (button_device.label or button_device.id)) or "unknown device"))
     return
   end
 
@@ -218,6 +237,13 @@ function AttributeEmitters.emit_contact_sensor_attribute_events(sensor_device, s
     return
   end
 
+  if sensor_info == nil then
+    log.error_with({ hub_logs = true },
+    string.format("nil sensor_info sent to emit_contact_sensor_attribute_events for %s",
+        (sensor_device and (sensor_device.label or sensor_device.id)) or "unknown device"))
+    return
+  end
+
   if sensor_info.power_state  and type(sensor_info.power_state.battery_level) == "number" then
     log.debug("emit power")
     sensor_device:emit_event(capabilities.battery.battery(st_utils.clamp_value(sensor_info.power_state.battery_level, 0, 100)))
@@ -253,6 +279,13 @@ end
 function AttributeEmitters.emit_motion_sensor_attribute_events(sensor_device, sensor_info)
   if sensor_device == nil or (sensor_device and sensor_device.id == nil) then
     log.warn("Tried to emit attribute events for a device that has been deleted")
+    return
+  end
+
+  if sensor_info == nil then
+    log.error_with({ hub_logs = true },
+    string.format("nil sensor_info sent to emit_motion_sensor_attribute_events for %s",
+        (sensor_device and (sensor_device.label or sensor_device.id)) or "unknown device"))
     return
   end
 
@@ -293,6 +326,13 @@ end
 function AttributeEmitters.emit_light_attribute_events(light_device, light_repr)
   if light_device == nil or (light_device and light_device.id == nil) then
     log.warn("Tried to emit light status event for device that has been deleted")
+    return
+  end
+
+  if light_repr == nil then
+    log.error_with({ hub_logs = true },
+    string.format("nil light_repr sent to emit_light_attribute_events for %s",
+        (light_device and (light_device.label or light_device.id)) or "unknown device"))
     return
   end
   local success, maybe_err = pcall(_emit_light_events_inner, light_device, light_repr)

--- a/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/refresh_handlers.lua
@@ -44,8 +44,11 @@ local function _refresh_zigbee(device, hue_api, zigbee_status)
       end
     end
 
-    if zigbee_resource_id ~= nil then
-      rest_resp, rest_err = hue_api:get_zigbee_connectivity_by_id(zigbee_resource_id)
+    if not zigbee_resource_id then
+      log.error_with({ hub_logs = true }, string.format("could not find zigbee_resource_id for device %s", (device and (device.label or device.id)) or "unknown device"))
+      return
+    end
+    rest_resp, rest_err = hue_api:get_zigbee_connectivity_by_id(zigbee_resource_id)
       if rest_err ~= nil then
         log.error_with({ hub_logs = true }, rest_err)
         return
@@ -66,10 +69,9 @@ local function _refresh_zigbee(device, hue_api, zigbee_status)
           end
         end
       end
-    end
   end
 
-  if zigbee_status.status == "connected" then
+  if zigbee_status and zigbee_status.status == "connected" then
     device.log.debug(string.format("Zigbee Status for %s is connected", device.label))
     device:online()
     device:set_field(Fields.IS_ONLINE, true)

--- a/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
@@ -141,8 +141,10 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
         local events, err = table.unpack(json_result, 1, json_result.n)
 
         if not success then
-          log.error_with({ hub_logs = true, },
-            "Couldn't decode JSON in SSE callback: " .. (events or "unexpected nil from pcall catch"))
+          log.error_with(
+            { hub_logs = true, },
+            string.format("Couldn't decode JSON in SSE callback: %s", (events or "unexpected nil from pcall catch"))
+          )
           return
         end
 

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -212,6 +212,13 @@ end
 ---@return string? resource_id the Hue RID, or nil on error
 ---@return string? err
 function utils.get_hue_rid(device)
+  if
+    device == nil
+    or (device and (device.id == nil or device.get_field == nil or device.device_network_id == nil))
+  then
+    return nil, string.format("nil or incomplete device record passed to get_hue_rid, device has likely been deleted")
+  end
+
   local resource_id = device:get_field(Fields.RESOURCE_ID)
   if resource_id then
     return resource_id


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

The recent release that un-stuck the onboarding of multi-component devices has revealed that there are several setups on the platform where users have "stale" multi-component devices in their inventories. These devices appear to no longer be joined to the Hue Bridge topology (perhaps they were deleted then re-onboarded), but have not been deleted from the Edge Driver. We're not sure what causes this yet, but we have seen it happen rarely. These crashes can impede proper driver functionality, as well as preventing cleanup code that *could* fix the inconsistent state from executing.

It's unclear how hubs ended up in this state, and it is difficult to reproduce. So this PR avoids crashing the driver when devices are in this state, so that the driver or the user will at least have some opportunity to attempt cleanup.

# Summary of Completed Tests
