### PR TITLE
New Device (Matter Thermostat) Habi Thermostat

### DIFF
--- a/drivers/SmartThings/matter-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/matter-thermostat/fingerprints.yml
@@ -16,6 +16,12 @@ matterManufacturer:
     vendorId: 0x130A
     productId: 0x004F
     deviceProfileName: thermostat-heating-only-nostate
+#Habi
+  - id: "5415/1"
+    deviceLabel: habi Matter Wireless Room Thermsotat
+    vendorId: 0x1527
+    productId: 0x0001
+    deviceProfileName: thermostat-heating-only   
 
 
 matterGeneric:


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ X] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This is a fingerprint-only change to add a new device for Habi. 
According to the DCL the Matter device type id is: (0x301)

# Summary of Completed Tests
Additional testing in SRPOL is planned

