### PR TITLE
Add initial driver support for HRAP devices

### DIFF
--- a/drivers/SmartThings/matter-hrap/capabilities/routerName.yml
+++ b/drivers/SmartThings/matter-hrap/capabilities/routerName.yml
@@ -1,0 +1,17 @@
+id: routerName
+version: 1
+status: proposed
+name: Router Name
+ephemeral: false
+attributes:
+  name:
+    schema:
+      type: object
+      properties:
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-hrap/capabilities/routerState.yml
+++ b/drivers/SmartThings/matter-hrap/capabilities/routerState.yml
@@ -1,0 +1,20 @@
+id: routerState
+version: 1
+status: proposed
+name: Router State
+ephemeral: false
+attributes:
+  state:
+    schema:
+      type: object
+      properties:
+        value:
+          type: string
+          enum:
+            - 'off'
+            - 'enabled'
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-hrap/capabilities/threadVersion.yml
+++ b/drivers/SmartThings/matter-hrap/capabilities/threadVersion.yml
@@ -1,0 +1,17 @@
+id: threadVersion
+version: 1
+status: proposed
+name: Thread Version
+ephemeral: false
+attributes:
+  version:
+    schema:
+      type: object
+      properties:
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-hrap/capabilities/wifiSsid.yml
+++ b/drivers/SmartThings/matter-hrap/capabilities/wifiSsid.yml
@@ -1,0 +1,17 @@
+id: wifiSsid
+version: 1
+status: proposed
+name: Wifi Ssid
+ephemeral: false
+attributes:
+  ssid:
+    schema:
+      type: object
+      properties:
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/matter-hrap/config.yml
+++ b/drivers/SmartThings/matter-hrap/config.yml
@@ -1,0 +1,6 @@
+name: 'Matter HRAP'
+packageKey: 'matter-hrap'
+permissions:
+  matter: {}
+description: "SmartThings driver for Matter HRAP devices"
+vendorSupportInformation: "https://support.smartthings.com"

--- a/drivers/SmartThings/matter-hrap/fingerprints.yml
+++ b/drivers/SmartThings/matter-hrap/fingerprints.yml
@@ -1,0 +1,11 @@
+matterGeneric:
+  - id: "matter/network-infrastructure-manager"
+    deviceLabel: Matter Network Infrastructure Manager
+    deviceTypes:
+      - id: 0x0090 # NIM
+    deviceProfileName: network-infrastructure-manager
+  - id: "matter/thread-border-router"
+    deviceLabel: Matter Thread Border Router
+    deviceTypes:
+      - id: 0x0091 # TBR
+    deviceProfileName: thread-border-router

--- a/drivers/SmartThings/matter-hrap/profiles/network-infrastructure-manager.yml
+++ b/drivers/SmartThings/matter-hrap/profiles/network-infrastructure-manager.yml
@@ -1,0 +1,18 @@
+name: network-infrastructure-manager
+components:
+- id: main
+  capabilities:
+  - id: routerName
+    version: 1
+  - id: threadVersion
+    version: 1
+  - id: wifiSsid
+    version: 1
+  - id: routerState
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Networking

--- a/drivers/SmartThings/matter-hrap/profiles/thread-border-router.yml
+++ b/drivers/SmartThings/matter-hrap/profiles/thread-border-router.yml
@@ -1,0 +1,16 @@
+name: thread-border-router
+components:
+- id: main
+  capabilities:
+  - id: routerName
+    version: 1
+  - id: threadVersion
+    version: 1
+  - id: routerState
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Networking

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/init.lua
@@ -1,0 +1,148 @@
+local cluster_base = require "st.matter.cluster_base"
+local ThreadBorderRouterManagementServerAttributes = require "ThreadBorderRouterManagement.server.attributes"
+local ThreadBorderRouterManagementServerCommands = require "ThreadBorderRouterManagement.server.commands"
+local ThreadBorderRouterManagementClientCommands = require "ThreadBorderRouterManagement.client.commands"
+local ThreadBorderRouterManagementTypes = require "ThreadBorderRouterManagement.types"
+
+local ThreadBorderRouterManagement = {}
+
+ThreadBorderRouterManagement.ID = 0x0452
+ThreadBorderRouterManagement.NAME = "ThreadBorderRouterManagement"
+ThreadBorderRouterManagement.server = {}
+ThreadBorderRouterManagement.client = {}
+ThreadBorderRouterManagement.server.attributes = ThreadBorderRouterManagementServerAttributes:set_parent_cluster(ThreadBorderRouterManagement)
+ThreadBorderRouterManagement.server.commands = ThreadBorderRouterManagementServerCommands:set_parent_cluster(ThreadBorderRouterManagement)
+ThreadBorderRouterManagement.client.commands = ThreadBorderRouterManagementClientCommands:set_parent_cluster(ThreadBorderRouterManagement)
+ThreadBorderRouterManagement.types = ThreadBorderRouterManagementTypes
+
+function ThreadBorderRouterManagement:get_attribute_by_id(attr_id)
+  local attr_id_map = {
+    [0x0000] = "BorderRouterName",
+    [0x0001] = "BorderAgentID",
+    [0x0002] = "ThreadVersion",
+    [0x0003] = "InterfaceEnabled",
+    [0x0004] = "ActiveDatasetTimestamp",
+    [0x0005] = "PendingDatasetTimestamp",
+    [0xFFF9] = "AcceptedCommandList",
+    [0xFFFA] = "EventList",
+    [0xFFFB] = "AttributeList",
+  }
+  local attr_name = attr_id_map[attr_id]
+  if attr_name ~= nil then
+    return self.attributes[attr_name]
+  end
+  return nil
+end
+
+function ThreadBorderRouterManagement:get_server_command_by_id(command_id)
+  local server_id_map = {
+    [0x0000] = "GetActiveDatasetRequest",
+    [0x0001] = "GetPendingDatasetRequest",
+    [0x0003] = "SetActiveDatasetRequest",
+    [0x0004] = "SetPendingDatasetRequest",
+  }
+  if server_id_map[command_id] ~= nil then
+    return self.server.commands[server_id_map[command_id]]
+  end
+  return nil
+end
+
+function ThreadBorderRouterManagement:get_client_command_by_id(command_id)
+  local client_id_map = {
+    [0x0002] = "DatasetResponse",
+  }
+  if client_id_map[command_id] ~= nil then
+    return self.client.commands[client_id_map[command_id]]
+  end
+  return nil
+end
+
+ThreadBorderRouterManagement.attribute_direction_map = {
+  ["BorderRouterName"] = "server",
+  ["BorderAgentID"] = "server",
+  ["ThreadVersion"] = "server",
+  ["InterfaceEnabled"] = "server",
+  ["ActiveDatasetTimestamp"] = "server",
+  ["PendingDatasetTimestamp"] = "server",
+  ["AcceptedCommandList"] = "server",
+  ["EventList"] = "server",
+  ["AttributeList"] = "server",
+}
+
+do
+  local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.ThreadBorderRouterManagement.server.attributes")
+  if has_aliases then
+    for alias, _ in pairs(aliases) do
+      ThreadBorderRouterManagement.attribute_direction_map[alias] = "server"
+    end
+  end
+end
+
+ThreadBorderRouterManagement.command_direction_map = {
+  ["GetActiveDatasetRequest"] = "server",
+  ["GetPendingDatasetRequest"] = "server",
+  ["SetActiveDatasetRequest"] = "server",
+  ["SetPendingDatasetRequest"] = "server",
+  ["DatasetResponse"] = "client",
+}
+
+do
+  local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.ThreadBorderRouterManagement.server.commands")
+  if has_aliases then
+    for alias, _ in pairs(aliases) do
+      ThreadBorderRouterManagement.command_direction_map[alias] = "server"
+    end
+  end
+end
+
+do
+  local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.ThreadBorderRouterManagement.client.commands")
+  if has_aliases then
+    for alias, _ in pairs(aliases) do
+      ThreadBorderRouterManagement.command_direction_map[alias] = "client"
+    end
+  end
+end
+
+ThreadBorderRouterManagement.FeatureMap = ThreadBorderRouterManagement.types.Feature
+
+function ThreadBorderRouterManagement.are_features_supported(feature, feature_map)
+  if (ThreadBorderRouterManagement.FeatureMap.bits_are_valid(feature)) then
+    return (feature & feature_map) == feature
+  end
+  return false
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = ThreadBorderRouterManagement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, ThreadBorderRouterManagement.NAME))
+  end
+  return ThreadBorderRouterManagement[direction].attributes[key]
+end
+ThreadBorderRouterManagement.attributes = {}
+setmetatable(ThreadBorderRouterManagement.attributes, attribute_helper_mt)
+
+local command_helper_mt = {}
+command_helper_mt.__index = function(self, key)
+  local direction = ThreadBorderRouterManagement.command_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown command %s on cluster %s", key, ThreadBorderRouterManagement.NAME))
+  end
+  return ThreadBorderRouterManagement[direction].commands[key]
+end
+ThreadBorderRouterManagement.commands = {}
+setmetatable(ThreadBorderRouterManagement.commands, command_helper_mt)
+
+local event_helper_mt = {}
+event_helper_mt.__index = function(self, key)
+  return ThreadBorderRouterManagement.server.events[key]
+end
+ThreadBorderRouterManagement.events = {}
+setmetatable(ThreadBorderRouterManagement.events, event_helper_mt)
+
+setmetatable(ThreadBorderRouterManagement, {__index = cluster_base})
+
+return ThreadBorderRouterManagement
+

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/BorderRouterName.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/BorderRouterName.lua
@@ -1,0 +1,69 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local BorderRouterName = {
+  ID = 0x0000,
+  NAME = "BorderRouterName",
+  base_type = require "st.matter.data_types.UTF8String1",
+}
+
+function BorderRouterName:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function BorderRouterName:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+
+function BorderRouterName:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function BorderRouterName:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function BorderRouterName:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function BorderRouterName:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(BorderRouterName, {__call = BorderRouterName.new_value, __index = BorderRouterName.base_type})
+return BorderRouterName
+

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/InterfaceEnabled.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/InterfaceEnabled.lua
@@ -1,0 +1,69 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local InterfaceEnabled = {
+  ID = 0x0003,
+  NAME = "InterfaceEnabled",
+  base_type = require "st.matter.data_types.Boolean",
+}
+
+function InterfaceEnabled:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function InterfaceEnabled:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+
+function InterfaceEnabled:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function InterfaceEnabled:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function InterfaceEnabled:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function InterfaceEnabled:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(InterfaceEnabled, {__call = InterfaceEnabled.new_value, __index = InterfaceEnabled.base_type})
+return InterfaceEnabled
+

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/ThreadVersion.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/ThreadVersion.lua
@@ -1,0 +1,68 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local ThreadVersion = {
+  ID = 0x0002,
+  NAME = "ThreadVersion",
+  base_type = require "st.matter.data_types.Uint16",
+}
+
+function ThreadVersion:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function ThreadVersion:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function ThreadVersion:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function ThreadVersion:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function ThreadVersion:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function ThreadVersion:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(ThreadVersion, {__call = ThreadVersion.new_value, __index = ThreadVersion.base_type})
+return ThreadVersion
+

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/server/attributes/init.lua
@@ -1,0 +1,29 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("ThreadBorderRouterManagement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local ThreadBorderRouterManagementServerAttributes = {}
+
+function ThreadBorderRouterManagementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(ThreadBorderRouterManagementServerAttributes, attr_mt)
+
+local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.ThreadBorderRouterManagement.server.attributes")
+if has_aliases then
+  aliases:add_to_class(ThreadBorderRouterManagementServerAttributes)
+end
+
+return ThreadBorderRouterManagementServerAttributes
+

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/types/Feature.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/types/Feature.lua
@@ -1,0 +1,59 @@
+local data_types = require "st.matter.data_types"
+local UintABC = require "st.matter.data_types.base_defs.UintABC"
+
+local Feature = {}
+local new_mt = UintABC.new_mt({NAME = "Feature", ID = data_types.name_to_id_map["Uint32"]}, 4)
+
+Feature.BASE_MASK = 0xFFFF
+Feature.PAN_CHANGE = 0x0001
+
+Feature.mask_fields = {
+  BASE_MASK = 0xFFFF,
+  PAN_CHANGE = 0x0001,
+}
+
+Feature.is_pan_change_set = function(self)
+  return (self.value & self.PAN_CHANGE) ~= 0
+end
+
+Feature.set_pan_change = function(self)
+  if self.value ~= nil then
+    self.value = self.value | self.PAN_CHANGE
+  else
+    self.value = self.PAN_CHANGE
+  end
+end
+
+Feature.unset_pan_change = function(self)
+  self.value = self.value & (~self.PAN_CHANGE & self.BASE_MASK)
+end
+
+function Feature.bits_are_valid(feature)
+  local max =
+    Feature.PAN_CHANGE
+  if (feature <= max) and (feature >= 1) then
+    return true
+  else
+    return false
+  end
+end
+
+Feature.mask_methods = {
+  is_pan_change_set = Feature.is_pan_change_set,
+  set_pan_change = Feature.set_pan_change,
+  unset_pan_change = Feature.unset_pan_change,
+}
+
+Feature.augment_type = function(cls, val)
+  setmetatable(val, new_mt)
+end
+
+setmetatable(Feature, new_mt)
+
+local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.ThreadBorderRouterManagement.types.Feature")
+if has_aliases then
+  aliases:add_to_class(Feature)
+end
+
+return Feature
+

--- a/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/types/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/ThreadBorderRouterManagement/types/init.lua
@@ -1,0 +1,20 @@
+local types_mt = {}
+types_mt.__types_cache = {}
+types_mt.__index = function(self, key)
+  if types_mt.__types_cache[key] == nil then
+    types_mt.__types_cache[key] = require("ThreadBorderRouterManagement.types." .. key)
+  end
+  return types_mt.__types_cache[key]
+end
+
+local ThreadBorderRouterManagementTypes = {}
+
+setmetatable(ThreadBorderRouterManagementTypes, types_mt)
+
+local status, aliases = pcall(require, "st.matter.clusters.aliases.ThreadBorderRouterManagement.types")
+if status then
+  aliases:add_to_class(ThreadBorderRouterManagementTypes)
+end
+
+return ThreadBorderRouterManagementTypes
+

--- a/drivers/SmartThings/matter-hrap/src/WiFiNetworkManagement/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/WiFiNetworkManagement/init.lua
@@ -1,0 +1,125 @@
+local cluster_base = require "st.matter.cluster_base"
+local WiFiNetworkManagementServerAttributes = require "WiFiNetworkManagement.server.attributes"
+local WiFiNetworkManagementServerCommands = require "WiFiNetworkManagement.server.commands"
+local WiFiNetworkManagementClientCommands = require "WiFiNetworkManagement.client.commands"
+local WiFiNetworkManagementTypes = require "WiFiNetworkManagement.types"
+
+local WiFiNetworkManagement = {}
+
+WiFiNetworkManagement.ID = 0x0451
+WiFiNetworkManagement.NAME = "WiFiNetworkManagement"
+WiFiNetworkManagement.server = {}
+WiFiNetworkManagement.client = {}
+WiFiNetworkManagement.server.attributes = WiFiNetworkManagementServerAttributes:set_parent_cluster(WiFiNetworkManagement)
+WiFiNetworkManagement.server.commands = WiFiNetworkManagementServerCommands:set_parent_cluster(WiFiNetworkManagement)
+WiFiNetworkManagement.client.commands = WiFiNetworkManagementClientCommands:set_parent_cluster(WiFiNetworkManagement)
+WiFiNetworkManagement.types = WiFiNetworkManagementTypes
+
+function WiFiNetworkManagement:get_attribute_by_id(attr_id)
+  local attr_id_map = {
+    [0x0000] = "Ssid",
+    [0x0001] = "PassphraseSurrogate",
+    [0xFFF9] = "AcceptedCommandList",
+    [0xFFFA] = "EventList",
+    [0xFFFB] = "AttributeList",
+  }
+  local attr_name = attr_id_map[attr_id]
+  if attr_name ~= nil then
+    return self.attributes[attr_name]
+  end
+  return nil
+end
+
+function WiFiNetworkManagement:get_server_command_by_id(command_id)
+  local server_id_map = {
+    [0x0000] = "NetworkPassphraseRequest",
+  }
+  if server_id_map[command_id] ~= nil then
+    return self.server.commands[server_id_map[command_id]]
+  end
+  return nil
+end
+
+function WiFiNetworkManagement:get_client_command_by_id(command_id)
+  local client_id_map = {
+    [0x0001] = "NetworkPassphraseResponse",
+  }
+  if client_id_map[command_id] ~= nil then
+    return self.client.commands[client_id_map[command_id]]
+  end
+  return nil
+end
+
+WiFiNetworkManagement.attribute_direction_map = {
+  ["Ssid"] = "server",
+  ["PassphraseSurrogate"] = "server",
+  ["AcceptedCommandList"] = "server",
+  ["EventList"] = "server",
+  ["AttributeList"] = "server",
+}
+
+do
+  local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.WiFiNetworkManagement.server.attributes")
+  if has_aliases then
+    for alias, _ in pairs(aliases) do
+      WiFiNetworkManagement.attribute_direction_map[alias] = "server"
+    end
+  end
+end
+
+WiFiNetworkManagement.command_direction_map = {
+  ["NetworkPassphraseRequest"] = "server",
+  ["NetworkPassphraseResponse"] = "client",
+}
+
+do
+  local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.WiFiNetworkManagement.server.commands")
+  if has_aliases then
+    for alias, _ in pairs(aliases) do
+      WiFiNetworkManagement.command_direction_map[alias] = "server"
+    end
+  end
+end
+
+do
+  local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.WiFiNetworkManagement.client.commands")
+  if has_aliases then
+    for alias, _ in pairs(aliases) do
+      WiFiNetworkManagement.command_direction_map[alias] = "client"
+    end
+  end
+end
+
+local attribute_helper_mt = {}
+attribute_helper_mt.__index = function(self, key)
+  local direction = WiFiNetworkManagement.attribute_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown attribute %s on cluster %s", key, WiFiNetworkManagement.NAME))
+  end
+  return WiFiNetworkManagement[direction].attributes[key]
+end
+WiFiNetworkManagement.attributes = {}
+setmetatable(WiFiNetworkManagement.attributes, attribute_helper_mt)
+
+local command_helper_mt = {}
+command_helper_mt.__index = function(self, key)
+  local direction = WiFiNetworkManagement.command_direction_map[key]
+  if direction == nil then
+    error(string.format("Referenced unknown command %s on cluster %s", key, WiFiNetworkManagement.NAME))
+  end
+  return WiFiNetworkManagement[direction].commands[key]
+end
+WiFiNetworkManagement.commands = {}
+setmetatable(WiFiNetworkManagement.commands, command_helper_mt)
+
+local event_helper_mt = {}
+event_helper_mt.__index = function(self, key)
+  return WiFiNetworkManagement.server.events[key]
+end
+WiFiNetworkManagement.events = {}
+setmetatable(WiFiNetworkManagement.events, event_helper_mt)
+
+setmetatable(WiFiNetworkManagement, {__index = cluster_base})
+
+return WiFiNetworkManagement
+

--- a/drivers/SmartThings/matter-hrap/src/WiFiNetworkManagement/server/attributes/Ssid.lua
+++ b/drivers/SmartThings/matter-hrap/src/WiFiNetworkManagement/server/attributes/Ssid.lua
@@ -1,0 +1,68 @@
+local cluster_base = require "st.matter.cluster_base"
+local data_types = require "st.matter.data_types"
+local TLVParser = require "st.matter.TLV.TLVParser"
+
+local Ssid = {
+  ID = 0x0000,
+  NAME = "Ssid",
+  base_type = require "st.matter.data_types.OctetString1",
+}
+
+function Ssid:new_value(...)
+  local o = self.base_type(table.unpack({...}))
+
+  return o
+end
+
+function Ssid:read(device, endpoint_id)
+  return cluster_base.read(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function Ssid:subscribe(device, endpoint_id)
+  return cluster_base.subscribe(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    nil
+  )
+end
+
+function Ssid:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+function Ssid:build_test_report_data(
+  device,
+  endpoint_id,
+  value,
+  status
+)
+  local data = data_types.validate_or_build_type(value, self.base_type)
+
+  return cluster_base.build_test_report_data(
+    device,
+    endpoint_id,
+    self._cluster.ID,
+    self.ID,
+    data,
+    status
+  )
+end
+
+function Ssid:deserialize(tlv_buf)
+  local data = TLVParser.decode_tlv(tlv_buf)
+
+  return data
+end
+
+setmetatable(Ssid, {__call = Ssid.new_value, __index = Ssid.base_type})
+return Ssid
+

--- a/drivers/SmartThings/matter-hrap/src/WiFiNetworkManagement/server/attributes/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/WiFiNetworkManagement/server/attributes/init.lua
@@ -1,0 +1,29 @@
+local attr_mt = {}
+attr_mt.__attr_cache = {}
+attr_mt.__index = function(self, key)
+  if attr_mt.__attr_cache[key] == nil then
+    local req_loc = string.format("WiFiNetworkManagement.server.attributes.%s", key)
+    local raw_def = require(req_loc)
+    local cluster = rawget(self, "_cluster")
+    raw_def:set_parent_cluster(cluster)
+    attr_mt.__attr_cache[key] = raw_def
+  end
+  return attr_mt.__attr_cache[key]
+end
+
+local WiFiNetworkManagementServerAttributes = {}
+
+function WiFiNetworkManagementServerAttributes:set_parent_cluster(cluster)
+  self._cluster = cluster
+  return self
+end
+
+setmetatable(WiFiNetworkManagementServerAttributes, attr_mt)
+
+local has_aliases, aliases = pcall(require, "st.matter.clusters.aliases.WiFiNetworkManagement.server.attributes")
+if has_aliases then
+  aliases:add_to_class(WiFiNetworkManagementServerAttributes)
+end
+
+return WiFiNetworkManagementServerAttributes
+

--- a/drivers/SmartThings/matter-hrap/src/embedded-cluster-utils.lua
+++ b/drivers/SmartThings/matter-hrap/src/embedded-cluster-utils.lua
@@ -1,0 +1,51 @@
+local clusters = require "st.matter.clusters"
+local utils = require "st.utils"
+
+-- Include driver-side definitions when lua libs api version is < 13
+local version = require "version"
+if version.api < 13 then
+  clusters.ThreadBorderRouterManagement = require "ThreadBorderRouterManagement"
+  clusters.WifiNetworkMangement = require "WifiNetworkMangement"
+end
+
+local embedded_cluster_utils = {}
+
+local embedded_clusters = {
+  [clusters.ThreadBorderRouterManagement.ID] = clusters.ThreadBorderRouterManagement,
+  [clusters.WifiNetworkMangement.ID] = clusters.WifiNetworkMangement,
+}
+
+function embedded_cluster_utils.get_endpoints(device, cluster_id, opts)
+  -- If using older lua libs and need to check for an embedded cluster feature,
+  -- we must use the embedded cluster definitions here
+  if version.api < 13 and embedded_clusters[cluster_id] ~= nil then
+    local embedded_cluster = embedded_clusters[cluster_id]
+    local opts = opts or {}
+    if utils.table_size(opts) > 1 then
+      device.log.warn_with({hub_logs = true}, "Invalid options for get_endpoints")
+      return
+    end
+    local clus_has_features = function(clus, feature_bitmap)
+      if not feature_bitmap or not clus then return false end
+      return embedded_cluster.are_features_supported(feature_bitmap, clus.feature_map)
+    end
+    local eps = {}
+    for _, ep in ipairs(device.endpoints) do
+      for _, clus in ipairs(ep.clusters) do
+        if ((clus.cluster_id == cluster_id)
+              and (opts.feature_bitmap == nil or clus_has_features(clus, opts.feature_bitmap))
+              and ((opts.cluster_type == nil and clus.cluster_type == "SERVER" or clus.cluster_type == "BOTH")
+                or (opts.cluster_type == clus.cluster_type))
+              or (cluster_id == nil)) then
+          table.insert(eps, ep.endpoint_id)
+          if cluster_id == nil then break end
+        end
+      end
+    end
+    return eps
+  else
+    return device:get_endpoints(cluster_id, opts)
+  end
+end
+
+return embedded_cluster_utils

--- a/drivers/SmartThings/matter-hrap/src/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/init.lua
@@ -1,0 +1,129 @@
+-- Copyright 2025 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local MatterDriver = require "st.matter.driver"
+local clusters = require "st.matter.clusters"
+
+local utils = require "lustre.utils"
+local log = require "log"
+
+local capabilities = require "st.capabilities"
+local threadVersion = capabilities["threadVersion"]
+local routerState = capabilities["routerState"]
+local routerName = capabilities["routerName"]
+local wifiSsid = capabilities["wifiSsid"]
+
+-- Include driver-side definitions when lua libs api version is <13
+local version = require "version"
+if version.api < 13 then
+  clusters.ThreadBorderRouterManagement = require "ThreadBorderRouterManagement"
+  clusters.WifiNetworkMangement = require "WiFiNetworkManagement"
+end
+
+
+--[[ ATTRIBUTE HANDLERS ]]--
+
+local function ssid_attribute_handler(driver, device, ib)
+  if ib.data.value == string.char(0x014) then -- TLV-encoded NULL
+    log.info("Ssid is null. Per the spec, no primary Wi-Fi network is available at the moment.")
+    return
+  end
+  local valid_utf8, utf8_err = utils.validate_utf8(ib.data.value)
+  if valid_utf8 then
+    device:emit_event_for_endpoint(ib.endpoint, wifiSsid.ssid({ value = ib.data.value }))
+  else
+    log.info("UTF8 validation of Ssid failed: Error: '"..utf8_err.."'. Raw Ssid data: "..ib.data.value)
+  end
+end
+
+local function border_router_name_attribute_handler(driver, device, ib)
+  local router_name = ib.data.value
+  device:emit_event_for_endpoint(ib.endpoint, routerName.name({ value = router_name }))
+end
+
+-- Spec uses TLV encoding of Thread Version, which should be mapped to a more user-friendly name
+VERSION_TLV_MAP = {
+  [1] = "1.0.0",
+  [2] = "1.1.0",
+  [3] = "1.2.0",
+  [4] = "1.3.0",
+  [5] = "1.4.0",
+}
+
+local function thread_version_attribute_handler(driver, device, ib)
+  local version_name = VERSION_TLV_MAP[ib.data.value]
+  if version_name then
+    device:emit_event_for_endpoint(ib.endpoint, threadVersion.version({ value = version_name }))
+  end
+end
+
+local function thread_interface_enabled_attribute_handler(driver, device, ib)
+    if ib.data.value then
+      device:emit_event_for_endpoint(ib.endpoint, routerState.state.enabled())
+    else
+      device:emit_event_for_endpoint(ib.endpoint, routerState.state.off())
+    end
+end
+
+
+--[[ LIFECYCLE HANLDERS ]]--
+
+local function device_init(driver, device)
+  device:subscribe()
+end
+
+
+--[[ MATTER DRIVER TEMPLATE ]]--
+
+local matter_driver_template = {
+  lifecycle_handlers = {
+    init = device_init,
+  },
+  matter_handlers = {
+    attr = {
+      [clusters.WifiNetworkMangement.ID] = {
+        [clusters.WifiNetworkMangement.attributes.Ssid.ID] = ssid_attribute_handler,
+      },
+      [clusters.ThreadBorderRouterManagement.ID] = {
+        [clusters.ThreadBorderRouterManagement.attributes.BorderRouterName.ID] = border_router_name_attribute_handler,
+        [clusters.ThreadBorderRouterManagement.attributes.ThreadVersion.ID] = thread_version_attribute_handler,
+        [clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled.ID] = thread_interface_enabled_attribute_handler,
+      }
+    }
+  },
+  subscribed_attributes = {
+    [routerName.ID] = {
+      clusters.ThreadBorderRouterManagement.attributes.BorderRouterName,
+    },
+    [routerState.ID] = {
+      clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled,
+    },
+    [threadVersion.ID] = {
+      clusters.ThreadBorderRouterManagement.attributes.ThreadVersion,
+    },
+    [wifiSsid.ID] = {
+      clusters.WifiNetworkMangement.attributes.Ssid,
+    },
+  },
+  supported_capabilities = {
+    threadVersion,
+    routerName,
+    routerState,
+    wifiSsid,
+  },
+}
+
+local matter_driver = MatterDriver("matter-hrap", matter_driver_template)
+log.info_with({hub_logs=true}, string.format("Starting %s driver, with dispatcher: %s", matter_driver.NAME, matter_driver.matter_dispatcher))
+matter_driver:run()

--- a/drivers/SmartThings/matter-hrap/src/init.lua
+++ b/drivers/SmartThings/matter-hrap/src/init.lua
@@ -53,7 +53,7 @@ local function border_router_name_attribute_handler(driver, device, ib)
 end
 
 -- Spec uses TLV encoding of Thread Version, which should be mapped to a more user-friendly name
-VERSION_TLV_MAP = {
+local VERSION_TLV_MAP = {
   [1] = "1.0.0",
   [2] = "1.1.0",
   [3] = "1.2.0",

--- a/drivers/SmartThings/matter-hrap/src/test/test_network_infrastructure_manager.lua
+++ b/drivers/SmartThings/matter-hrap/src/test/test_network_infrastructure_manager.lua
@@ -1,0 +1,229 @@
+-- Copyright 2025 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+
+local capabilities = require "st.capabilities"
+test.add_package_capability("routerState.yml")
+test.add_package_capability("routerName.yml")
+test.add_package_capability("threadVersion.yml")
+test.add_package_capability("wifiSsid.yml")
+
+local clusters = require "st.matter.clusters"
+clusters.ThreadBorderRouterManagement = require "ThreadBorderRouterManagement"
+clusters.WifiNetworkMangement = require "WiFiNetworkManagement"
+
+local mock_device = test.mock_device.build_test_matter_device({
+    profile = t_utils.get_profile_definition("network-infrastructure-manager.yml"),
+    manufacturer_info = {
+      vendor_id = 0x0000,
+      product_id = 0x0000,
+    },
+    endpoints = {
+      {
+        endpoint_id = 0,
+        clusters = {
+          {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+        },
+        device_types = {
+          {device_type_id = 0x0016, device_type_revision = 1,} -- RootNode
+        }
+      },
+      {
+        endpoint_id = 1,
+        clusters = {
+          {cluster_id = clusters.ThreadBorderRouterManagement.ID, cluster_type = "SERVER", feature_map = 0},
+          {cluster_id = clusters.WifiNetworkMangement.ID, cluster_type = "SERVER", feature_map = 0},
+        },
+        device_types = {
+          {device_type_id = 0x0090, device_type_revision = 1,} -- Network Infrastructure Manager
+        }
+      }
+    }
+})
+
+local cluster_subscribe_list = {
+    clusters.ThreadBorderRouterManagement.attributes.BorderRouterName,
+    clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled,
+    clusters.ThreadBorderRouterManagement.attributes.ThreadVersion,
+    clusters.WifiNetworkMangement.attributes.Ssid,
+}
+
+local function test_init()
+    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+    for i, cluster in ipairs(cluster_subscribe_list) do
+        if i > 1 then
+            subscribe_request:merge(cluster:subscribe(mock_device))
+        end
+    end
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+    test.mock_device.add_test_device(mock_device)
+end
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+    "ThreadVersion should display the correct stringified version",
+    function()
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 3
+            )
+        })
+        test.socket.capability:__expect_send(
+            mock_device:generate_test_message("main", capabilities.threadVersion.version({ value = "1.2.0" }))
+        )
+
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 4
+            )
+        })
+        test.socket.capability:__expect_send(
+            mock_device:generate_test_message("main", capabilities.threadVersion.version({ value = "1.3.0" }))
+        )
+
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 5
+            )
+        })
+        test.socket.capability:__expect_send(
+            mock_device:generate_test_message("main", capabilities.threadVersion.version({ value = "1.4.0" }))
+        )
+
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 6
+            )
+        })
+    end
+)
+
+test.register_message_test(
+  "InterfaceEnabled should correctly display on or off",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled:build_test_report_data(mock_device, 1, true)
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerState.state.enabled())
+    },
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled:build_test_report_data(mock_device, 1, false)
+        }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerState.state.off())
+      }
+  }
+)
+
+test.register_message_test(
+  "RouterName should correctly display the given name",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.BorderRouterName:build_test_report_data(mock_device, 1, "john foo")
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerName.name({ value = "john foo"}))
+    },
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.BorderRouterName:build_test_report_data(mock_device, 1, "jane bar")
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerName.name({ value = "jane bar"}))
+    },
+  }
+)
+
+test.register_message_test(
+  "WifiSsid should correctly display the Ssid",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.WifiNetworkMangement.attributes.Ssid:build_test_report_data(mock_device, 1, "test name for ssid!")
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.wifiSsid.ssid({ value = "test name for ssid!" }))
+    }
+  }
+)
+
+test.register_message_test(
+  "Null-valued ssid (TLV 0x14) should correctly fail",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.WifiNetworkMangement.attributes.Ssid:build_test_report_data(mock_device, 1, string.char(0x014))
+        }
+    }
+  }
+)
+
+test.register_message_test(
+  "Ssid inpits using non-UTF8 inputs should not display an Ssid",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.WifiNetworkMangement.attributes.Ssid:build_test_report_data(mock_device, 1, string.char(0xC0)) --  0xC0 never appears in utf8
+        }
+    }
+  }
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-hrap/src/test/test_thread_border_router.lua
+++ b/drivers/SmartThings/matter-hrap/src/test/test_thread_border_router.lua
@@ -1,0 +1,180 @@
+-- Copyright 2025 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+
+local capabilities = require "st.capabilities"
+test.add_package_capability("routerState.yml")
+test.add_package_capability("routerName.yml")
+test.add_package_capability("threadVersion.yml")
+
+local clusters = require "st.matter.clusters"
+clusters.ThreadBorderRouterManagement = require "ThreadBorderRouterManagement"
+clusters.WifiNetworkMangement = require "WiFiNetworkManagement"
+
+local mock_device = test.mock_device.build_test_matter_device({
+    profile = t_utils.get_profile_definition("thread-border-router.yml"),
+    manufacturer_info = {
+      vendor_id = 0x0000,
+      product_id = 0x0000,
+    },
+    endpoints = {
+      {
+        endpoint_id = 0,
+        clusters = {
+          {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+        },
+        device_types = {
+          {device_type_id = 0x0016, device_type_revision = 1,} -- RootNode
+        }
+      },
+      {
+        endpoint_id = 1,
+        clusters = {
+          {cluster_id = clusters.ThreadBorderRouterManagement.ID, cluster_type = "SERVER", feature_map = 0},
+          {cluster_id = clusters.WifiNetworkMangement.ID, cluster_type = "SERVER", feature_map = 0},
+        },
+        device_types = {
+          {device_type_id = 0x0090, device_type_revision = 1,} -- Network Infrastructure Manager
+        }
+      }
+    }
+})
+
+local cluster_subscribe_list = {
+    clusters.ThreadBorderRouterManagement.attributes.BorderRouterName,
+    clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled,
+    clusters.ThreadBorderRouterManagement.attributes.ThreadVersion,
+}
+
+local function test_init()
+    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+    for i, cluster in ipairs(cluster_subscribe_list) do
+        if i > 1 then
+            subscribe_request:merge(cluster:subscribe(mock_device))
+        end
+    end
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+    test.mock_device.add_test_device(mock_device)
+end
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+    "ThreadVersion should display the correct stringified version",
+    function()
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 3
+            )
+        })
+        test.socket.capability:__expect_send(
+            mock_device:generate_test_message("main", capabilities.threadVersion.version({ value = "1.2.0" }))
+        )
+
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 4
+            )
+        })
+        test.socket.capability:__expect_send(
+            mock_device:generate_test_message("main", capabilities.threadVersion.version({ value = "1.3.0" }))
+        )
+
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 5
+            )
+        })
+        test.socket.capability:__expect_send(
+            mock_device:generate_test_message("main", capabilities.threadVersion.version({ value = "1.4.0" }))
+        )
+
+        test.socket.matter:__queue_receive({
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.ThreadVersion:build_test_report_data(
+                mock_device, 1, 6
+            )
+        })
+    end
+)
+
+test.register_message_test(
+  "InterfaceEnabled should correctly display on or off",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled:build_test_report_data(mock_device, 1, true)
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerState.state.enabled())
+    },
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.InterfaceEnabled:build_test_report_data(mock_device, 1, false)
+        }
+      },
+      {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerState.state.off())
+      }
+  }
+)
+
+test.register_message_test(
+  "RouterName should correctly display the given name",
+  {
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.BorderRouterName:build_test_report_data(mock_device, 1, "john foo")
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerName.name({ value = "john foo"}))
+    },
+    {
+        channel = "matter",
+        direction = "receive",
+        message = {
+            mock_device.id,
+            clusters.ThreadBorderRouterManagement.attributes.BorderRouterName:build_test_report_data(mock_device, 1, "jane bar")
+        }
+    },
+    {
+        channel = "capability",
+        direction = "send",
+        message = mock_device:generate_test_message("main", capabilities.routerName.name({ value = "jane bar"}))
+    },
+  }
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
# Description of Change
This includes support for the device types Network Infrastructure Manager and Thread Border Router. 

It includes embedded definitions of two clusters- WifiNetworkManagement and ThreadBorderRouterManagement (with only the pertinent sections added, and four custom capabilities, including routerState, routerName, threadVersion, and wifiSsid. All four of these return a string, and routerState uses a single enum value (off, enabled). 

For SSID's handling, there is a check for if the reported name is TLV null, in which it returns nothing. Then, it checks whether the input is a valid utf8 input. If so, it emits a capability with the given Ssid. If not, it reports a failure. This is expected, as any other service disocvery system would also be unable to display an Ssid if it was not written using UTF-8 specified characters. Still, it is expected that SSIDs are not necessarily printable, so this check is necessary.

For Thread Version handling, there is a mapping table, based on the Thread specification, that takes the uint16 as an input and translates it to a more human-readable/expected versioning for the display.