### PR TITLE
Enable SmartThings Energy to Aqara Light Switch H2

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -234,7 +234,7 @@ local function send_import_poll_report(device, latest_total_imported_energy_wh)
 end
 
 local function create_poll_report_schedule(device)
-  -- add (function() ~ end) so that timer callback function does not become nil
+  -- add "function() ~ end" so that timer callback function does not become nil
   local import_timer = device.thread:call_on_schedule(
     device:get_field(IMPORT_REPORT_TIMEOUT), function()
     send_import_poll_report(device, device:get_field(TOTAL_IMPORTED_ENERGY))

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -216,19 +216,29 @@ local function send_import_poll_report(device, latest_total_imported_energy_wh)
   end
 
   -- Report the energy consumed during the time interval. The unit of these values should be 'Wh'
-  device:emit_event(capabilities.powerConsumptionReport.powerConsumption({
-    start = iso8061Timestamp(last_time),
-    ["end"] = iso8061Timestamp(current_time - 1),
-    deltaEnergy = energy_delta_wh,
-    energy = latest_total_imported_energy_wh
-  }))
+  if not device:get_field(ENERGY_MANAGEMENT_ENDPOINT) then
+    device:emit_event(capabilities.powerConsumptionReport.powerConsumption({
+      start = iso8061Timestamp(last_time),
+      ["end"] = iso8061Timestamp(current_time - 1),
+      deltaEnergy = energy_delta_wh,
+      energy = latest_total_imported_energy_wh
+    }))
+  else
+    device:emit_event_for_endpoint(device:get_field(ENERGY_MANAGEMENT_ENDPOINT),capabilities.powerConsumptionReport.powerConsumption({
+      start = iso8061Timestamp(last_time),
+      ["end"] = iso8061Timestamp(current_time - 1),
+      deltaEnergy = energy_delta_wh,
+      energy = latest_total_imported_energy_wh
+    }))
+  end
 end
 
 local function create_poll_report_schedule(device)
+  -- add (function() ~ end) so that timer callback function does not become nil
   local import_timer = device.thread:call_on_schedule(
-    device:get_field(IMPORT_REPORT_TIMEOUT),
-    send_import_poll_report(device, device:get_field(TOTAL_IMPORTED_ENERGY)),
-    "polling_import_report_schedule_timer"
+    device:get_field(IMPORT_REPORT_TIMEOUT), function()
+    send_import_poll_report(device, device:get_field(TOTAL_IMPORTED_ENERGY))
+    end, "polling_import_report_schedule_timer"
   )
   device:set_field(RECURRING_IMPORT_REPORT_POLL_TIMER, import_timer)
 end
@@ -252,7 +262,9 @@ local function set_poll_report_timer_and_schedule(device, is_cumulative_report)
     local report_interval_secs = second_timestamp - first_timestamp
     device:set_field(IMPORT_REPORT_TIMEOUT, math.max(report_interval_secs, MINIMUM_ST_ENERGY_REPORT_INTERVAL))
     -- the poll schedule is only needed for devices that support powerConsumption
-    if device:supports_capability(capabilities.powerConsumptionReport) then
+    -- and enable powerConsumption when energy management is defined in root endpoint(0).
+    if device:supports_capability(capabilities.powerConsumptionReport) or
+       device:get_field(ENERGY_MANAGEMENT_ENDPOINT) then
       create_poll_report_schedule(device)
     end
     device:set_field(IMPORT_POLL_TIMER_SETTING_ATTEMPTED, true)
@@ -572,10 +584,6 @@ local function initialize_switch(driver, device)
   end
 
   for _, ep in ipairs(switch_eps) do
-    if _ == 1 then
-      -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
-      device:set_field(ENERGY_MANAGEMENT_ENDPOINT, ep)
-    end
     if device:supports_server_cluster(clusters.OnOff.ID, ep) then
       num_switch_server_eps = num_switch_server_eps + 1
       if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
@@ -592,6 +600,10 @@ local function initialize_switch(driver, device)
           }
         )
         parent_child_device = true
+        if _ == 1 and child_profile == "light-power-energy-powerConsumption" then
+          -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
+          device:set_field(ENERGY_MANAGEMENT_ENDPOINT, ep)
+        end
       end
     end
   end

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -234,7 +234,6 @@ local function send_import_poll_report(device, latest_total_imported_energy_wh)
 end
 
 local function create_poll_report_schedule(device)
-  -- add "function() ~ end" so that timer callback function does not become nil
   local import_timer = device.thread:call_on_schedule(
     device:get_field(IMPORT_REPORT_TIMEOUT), function()
     send_import_poll_report(device, device:get_field(TOTAL_IMPORTED_ENERGY))

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -164,6 +164,8 @@ local function test_init()
   end
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
   test.mock_device.add_test_device(aqara_mock_device)
+  -- to test powerConsumptionReport
+  test.timer.__create_and_queue_test_time_advance_timer(60 * 15, "interval", "create_poll_report_schedule")
 
   for _, child in pairs(aqara_mock_children) do
     test.mock_device.add_test_device(child)
@@ -303,7 +305,6 @@ test.register_coroutine_test(
         aqara_mock_children[aqara_child1_ep]:generate_test_message("main", capabilities.energyMeter.energy({ value = 29.0, unit = "Wh" }))
       )
 
-      test.mock_time.advance_time(2000)
       test.socket.matter:__queue_receive(
         {
           aqara_mock_device.id,
@@ -312,19 +313,20 @@ test.register_coroutine_test(
           )
         }
       )
---[[
-      -- To do : powerConsumptionReport
+
+      test.socket.capability:__expect_send(
+        aqara_mock_children[aqara_child1_ep]:generate_test_message("main", capabilities.energyMeter.energy({ value = 39.0, unit = "Wh" }))
+      )
+
+      -- to test powerConsumptionReport
+      test.mock_time.advance_time(2000)
       test.socket.capability:__expect_send(
         aqara_mock_children[aqara_child1_ep]:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
           start = "1970-01-01T00:00:00Z",
           ["end"] = "1970-01-01T00:33:19Z",
           deltaEnergy = 0.0,
-          energy = 29.0
+          energy = 39.0
         }))
-      )
---]]
-      test.socket.capability:__expect_send(
-        aqara_mock_children[aqara_child1_ep]:generate_test_message("main", capabilities.energyMeter.energy({ value = 39.0, unit = "Wh" }))
       )
     end
 )


### PR DESCRIPTION
 - Solve the problem that the timer callback function becomes nil.
 - Support powerConsumptionReport when energy management is at root endpoint(0).

Check all that apply

# Type of Change

- [X] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [X] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Fix assertion problem and support SmartThings Energy feature

# Summary of Completed Tests
Check that the powerConsumptionReport is transmitted normally at every set timer interval (15 minutes).

