### PR TITLE
Create new profile for Air Quality Sensor

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-co2-pm1-pm25-pm10-meas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/aqs-temp-humidity-co2-pm1-pm25-pm10-meas.yml
@@ -1,0 +1,29 @@
+name: aqs-temp-humidity-co2-pm1-pm25-pm10-meas
+components:
+  - id: main
+    capabilities:
+      - id: airQualityHealthConcern
+        version: 1
+      - id: temperatureMeasurement
+        version: 1
+      - id: relativeHumidityMeasurement
+        version: 1
+      - id: carbonDioxideMeasurement
+        version: 1
+      - id: veryFineDustSensor
+        version: 1
+      - id: fineDustSensor
+        version: 1
+      - id: dustSensor
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+    - name: AirQualityDetector
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
@@ -161,6 +161,7 @@ local supported_profiles =
   "aqs-temp-humidity-all-level",
   "aqs-temp-humidity-all-meas",
   "aqs-temp-humidity-co2-pm25-tvoc-meas",
+  "aqs-temp-humidity-co2-pm1-pm25-pm10-meas",
   "aqs-temp-humidity-tvoc-level-pm25-meas",
   "aqs-temp-humidity-tvoc-meas",
 }


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change adds a new profile in matter sensor to support an air quality sensor device with the following clusters:
- Air Quality Cluster
- PM 1.0 Measurement Cluster
- PM 2.5 Measurement Cluster
- PM 10 Measurement Cluster
- CO2 Measurement  Cluster
- Temperatrue Measurement Cluster
- Humidity Measurement Cluster

Needed by WWST cert request: [WWSTCERT-5427](https://smartthings.atlassian.net/browse/WWSTCERT-5427), but since this is a generic profile it may be used by other devices in the future as well.

# Summary of Completed Tests


[WWSTCERT-5427]: https://smartthings.atlassian.net/browse/WWSTCERT-5427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ