### PR TITLE
Matter Thermostat: Update system_mode_handler

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -42,16 +42,18 @@ if version.api < 10 then
   clusters.Thermostat.types.ThermostatSystemMode.SLEEP = 0x9
 end
 
+local DISALLOWED_THERMOSTAT_MODES = "__DISALLOWED_CONTROL_OPERATIONS"
+
 local THERMOSTAT_MODE_MAP = {
-  [clusters.Thermostat.types.ThermostatSystemMode.OFF]            = capabilities.thermostatMode.thermostatMode.off,
-  [clusters.Thermostat.types.ThermostatSystemMode.AUTO]           = capabilities.thermostatMode.thermostatMode.auto,
-  [clusters.Thermostat.types.ThermostatSystemMode.COOL]           = capabilities.thermostatMode.thermostatMode.cool,
-  [clusters.Thermostat.types.ThermostatSystemMode.HEAT]           = capabilities.thermostatMode.thermostatMode.heat,
+  [clusters.Thermostat.types.ThermostatSystemMode.OFF]               = capabilities.thermostatMode.thermostatMode.off,
+  [clusters.Thermostat.types.ThermostatSystemMode.AUTO]              = capabilities.thermostatMode.thermostatMode.auto,
+  [clusters.Thermostat.types.ThermostatSystemMode.COOL]              = capabilities.thermostatMode.thermostatMode.cool,
+  [clusters.Thermostat.types.ThermostatSystemMode.HEAT]              = capabilities.thermostatMode.thermostatMode.heat,
   [clusters.Thermostat.types.ThermostatSystemMode.EMERGENCY_HEATING] = capabilities.thermostatMode.thermostatMode.emergency_heat,
-  [clusters.Thermostat.types.ThermostatSystemMode.PRECOOLING]     = capabilities.thermostatMode.thermostatMode.precooling,
-  [clusters.Thermostat.types.ThermostatSystemMode.FAN_ONLY]       = capabilities.thermostatMode.thermostatMode.fanonly,
-  [clusters.Thermostat.types.ThermostatSystemMode.DRY]            = capabilities.thermostatMode.thermostatMode.dryair,
-  [clusters.Thermostat.types.ThermostatSystemMode.SLEEP]          = capabilities.thermostatMode.thermostatMode.asleep
+  [clusters.Thermostat.types.ThermostatSystemMode.PRECOOLING]        = capabilities.thermostatMode.thermostatMode.precooling,
+  [clusters.Thermostat.types.ThermostatSystemMode.FAN_ONLY]          = capabilities.thermostatMode.thermostatMode.fanonly,
+  [clusters.Thermostat.types.ThermostatSystemMode.DRY]               = capabilities.thermostatMode.thermostatMode.dryair,
+  [clusters.Thermostat.types.ThermostatSystemMode.SLEEP]             = capabilities.thermostatMode.thermostatMode.asleep,
 }
 
 local THERMOSTAT_OPERATING_MODE_MAP = {
@@ -788,22 +790,27 @@ local function humidity_attr_handler(driver, device, ib, response)
 end
 
 local function system_mode_handler(driver, device, ib, response)
-  if THERMOSTAT_MODE_MAP[ib.data.value] then
-    device:emit_event_for_endpoint(ib.endpoint_id, THERMOSTAT_MODE_MAP[ib.data.value]())
-    local supported_modes = device:get_latest_state(device:endpoint_to_component(ib.endpoint_id), capabilities.thermostatMode.ID, capabilities.thermostatMode.supportedThermostatModes.NAME) or {}
-    -- TODO: remove -- this has been fixed upstream
-    local sm = utils.deep_copy(supported_modes)
-    -- if we get a mode report from the thermostat that isn't in the supported modes, then we need to update the supported modes
-    for _, mode in ipairs(supported_modes) do
-      if mode == THERMOSTAT_MODE_MAP[ib.data.value].NAME then
-        return
-      end
+  local supported_modes = device:get_latest_state(device:endpoint_to_component(ib.endpoint_id), capabilities.thermostatMode.ID, capabilities.thermostatMode.supportedThermostatModes.NAME) or {}
+  -- check that the given mode was in the supported modes list
+  for _, mode in ipairs(supported_modes) do
+    if mode == THERMOSTAT_MODE_MAP[ib.data.value].NAME then
+      device:emit_event_for_endpoint(ib.endpoint_id, THERMOSTAT_MODE_MAP[ib.data.value]())
+      return
     end
-    -- if we get here, then the reported mode was not in our mode map
-    table.insert(sm, THERMOSTAT_MODE_MAP[ib.data.value].NAME)
-    local event = capabilities.thermostatMode.supportedThermostatModes(sm, {visibility = {displayed = false}})
-    device:emit_event_for_endpoint(ib.endpoint_id, event)
   end
+  -- if the value is not found in the supported modes list, check if it's disallowed
+  local disallowed_thermostat_modes = device:get_field(DISALLOWED_THERMOSTAT_MODES) or {}
+  for _, mode in pairs(disallowed_thermostat_modes) do
+    if mode == ib.data.value then
+      return
+    end
+  end
+  -- if we get here, then the reported mode is allowed and not in our mode map
+  local sm_copy = utils.deep_copy(supported_modes)
+  table.insert(sm_copy, THERMOSTAT_MODE_MAP[ib.data.value].NAME)
+  local supported_modes_event = capabilities.thermostatMode.supportedThermostatModes(sm_copy, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, supported_modes_event)
+  device:emit_event_for_endpoint(ib.endpoint_id, THERMOSTAT_MODE_MAP[ib.data.value]())
 end
 
 local function running_state_handler(driver, device, ib, response)
@@ -817,25 +824,34 @@ local function running_state_handler(driver, device, ib, response)
 end
 
 local function sequence_of_operation_handler(driver, device, ib, response)
-  -- the values reported here are kind of limited in terms of our mapping, i.e. there's no way to know about whether
-  -- or not the device supports emergency heat or fan only
+  -- The ControlSequenceofOperation attribute only directly specifies what can't be operated by the operating environment, not what can.
+  -- However, we assert here that a Cooling enum value implies that SystemMode supports cooling, and the same for a Heating enum.
+  -- We also assert that Off is supported, though per spec this is optional.
+  local disallowed_mode_operations = {}
   local supported_modes = {capabilities.thermostatMode.thermostatMode.off.NAME}
-
-  local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE})
-  if #auto > 0 then
-    table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.auto.NAME)
-  end
 
   if ib.data.value <= clusters.Thermostat.attributes.ControlSequenceOfOperation.COOLING_WITH_REHEAT then
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.cool.NAME)
-    -- table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.precooling.NAME)
+    table.insert(disallowed_mode_operations, clusters.Thermostat.types.ThermostatSystemMode.HEAT)
+    table.insert(disallowed_mode_operations, clusters.Thermostat.types.ThermostatSystemMode.EMERGENCY_HEATING)
   elseif ib.data.value <= clusters.Thermostat.attributes.ControlSequenceOfOperation.HEATING_WITH_REHEAT then
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.heat.NAME)
-    -- table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.emergencyheat.NAME)
+    table.insert(disallowed_mode_operations, clusters.Thermostat.types.ThermostatSystemMode.COOL)
+    table.insert(disallowed_mode_operations, clusters.Thermostat.types.ThermostatSystemMode.PRECOOLING)
   elseif ib.data.value <= clusters.Thermostat.attributes.ControlSequenceOfOperation.COOLING_AND_HEATING_WITH_REHEAT then
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.cool.NAME)
     table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.heat.NAME)
   end
+
+  -- check whether the Auto Mode should be supported in SystemMode, though this is unrelated to ControlSequenceofOperation
+  local auto = device:get_endpoints(clusters.Thermostat.ID, {feature_bitmap = clusters.Thermostat.types.ThermostatFeature.AUTOMODE})
+  if #auto > 0 then
+    table.insert(supported_modes, capabilities.thermostatMode.thermostatMode.auto.NAME)
+  else
+    table.insert(disallowed_mode_operations, clusters.Thermostat.types.ThermostatSystemMode.AUTO)
+  end
+
+  device:set_field(DISALLOWED_THERMOSTAT_MODES, disallowed_mode_operations, {persist = true})
   local event = capabilities.thermostatMode.supportedThermostatModes(supported_modes, {visibility = {displayed = false}})
   device:emit_event_for_endpoint(ib.endpoint_id, event)
 end

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -330,18 +330,26 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device, 1, 5)
+        clusters.Thermostat.server.attributes.ControlSequenceOfOperation:build_test_report_data(mock_device, 1, 5)
       }
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
     },
-		{
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device, 1, 3)
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"emergency heat"}, {visibility={displayed=false}}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.cool())
     },
   }
 )
@@ -406,7 +414,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat", "auto"}, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -419,7 +427,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "heat"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "heat", "auto"}, {visibility={displayed=false}}))
     },
     {
       channel = "matter",
@@ -432,7 +440,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
     },
   },
   { test_init = test_init_auto }
@@ -462,15 +470,15 @@ test.register_message_test(
         clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device, 1, 5)
       }
     },
-		{
+    {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat", "emergency heat"}, {visibility={displayed=false}}))
     },
 		{
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat", "emergency heat"}, {visibility={displayed=false}}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
     }
   }
 )
@@ -489,7 +497,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat", "auto"}, {visibility={displayed=false}}))
     },
 		{
       channel = "matter",
@@ -499,16 +507,65 @@ test.register_message_test(
         clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device_auto, 1, 5)
       }
     },
-		{
+    {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat", "auto", "emergency heat"}, {visibility={displayed=false}}))
     },
 		{
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool", "heat", "emergency heat"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
     }
+  },
+  { test_init = test_init_auto }
+)
+
+test.register_message_test(
+  "Additional mode reports should not extend the supported modes if they are disallowed",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.server.attributes.ControlSequenceOfOperation:build_test_report_data(mock_device_auto, 1, 3)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "heat", "auto"}, {visibility={displayed=false}}))
+    },
+		{
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device_auto, 1, 3)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.server.attributes.ControlSequenceOfOperation:build_test_report_data(mock_device_auto, 1, 1)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
+    },
+		{
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device_auto, 1, 5)
+      }
+    },
   },
   { test_init = test_init_auto }
 )

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
@@ -274,19 +274,26 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device, 3, 5)
+        clusters.Thermostat.server.attributes.ControlSequenceOfOperation:build_test_report_data(mock_device, 1, 5)
       }
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.server.attributes.SystemMode:build_test_report_data(mock_device, 3, 3)
+      }
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "emergency heat" }, {visibility={displayed=false}}))
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.cool())
     },
   }
 )
@@ -369,14 +376,14 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
+      message = mock_device:generate_test_message("main",
+        capabilities.thermostatMode.supportedThermostatModes({ "off", "cool", "heat", "emergency heat" }, {visibility={displayed=false}}))
     },
     {
       channel = "capability",
       direction = "send",
-      message = mock_device:generate_test_message("main",
-        capabilities.thermostatMode.supportedThermostatModes({ "off", "cool", "heat", "emergency heat" }, {visibility={displayed=false}}))
-    }
+      message = mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.emergency_heat())
+    },
   }
 )
 


### PR DESCRIPTION
# Description of Change
 The ControlSequenceOfOperations attribute handling defines which operations are disallowed for the thermostat. Per the spec: 
- “This attribute SHALL indicate the overall operating environment of the thermostat, and thus the possible system modes that the thermostat can operate in.”

From a spec perspective, the different values in ControlSequenceOfOperationsEnum only specify what is disallowed. Everything else is optional.

The SystemMode attribute, which is handled with system_mode_handler should be limited by this "disallow" list . Per the spec:
- “This attribute SHALL indicate the current operating mode of the thermostat. Its value SHALL be limited by the ControlSequenceOfOperation attribute.”

We currently update the supported modes with whatever is sent, without regard to the ControlSequenceOfOperations. This change will enforce the spec more closely by disallowing certain values, rather than expecting the devices to do this of their own accord.

Lastly, this change makes a small change that puts the AUTO mode on the disallow list as well if that feature bit is not supported.

# Summary of Completed Tests
Unit tests were updated to handle this, ensuring that allowed mode changes could pass the disallow list check, and a new test case was added to ensure the disallow list was correctly disallowing what should not be permitted.
VDA Device and a Physical Thermostat device were tested to ensure systems continue to function as expected.

[MTR-878]: https://smartthings.atlassian.net/browse/MTR-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ