### PR TITLE
Update new-matter-lock driver

### DIFF
--- a/drivers/SmartThings/matter-lock/profiles/lock-battery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-battery.yml
@@ -1,0 +1,25 @@
+name: lock-battery
+components:
+- id: main
+  capabilities:
+  - id: lock
+    version: 1
+    config:
+      values:
+      - key: "lock.value"
+        enabledValues:
+        - locked
+        - unlocked
+        - not fully locked
+  - id: lockAlarm
+    version: 1
+  - id: remoteControlStatus
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock

--- a/drivers/SmartThings/matter-lock/profiles/lock-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-batteryLevel.yml
@@ -1,0 +1,25 @@
+name: lock-batteryLevel
+components:
+- id: main
+  capabilities:
+  - id: lock
+    version: 1
+    config:
+      values:
+      - key: "lock.value"
+        enabledValues:
+        - locked
+        - unlocked
+        - not fully locked
+  - id: lockAlarm
+    version: 1
+  - id: remoteControlStatus
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock

--- a/drivers/SmartThings/matter-lock/profiles/lock-unlatch-battery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-unlatch-battery.yml
@@ -36,7 +36,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-unlatch-battery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-unlatch-battery.yml
@@ -1,4 +1,4 @@
-name: lock-unlatch
+name: lock-unlatch-battery
 components:
 - id: main
   capabilities:
@@ -15,6 +15,8 @@ components:
   - id: lockAlarm
     version: 1
   - id: remoteControlStatus
+    version: 1
+  - id: battery
     version: 1
   - id: firmwareUpdate
     version: 1
@@ -73,6 +75,9 @@ deviceConfig:
   - component: main
     capability: remoteControlStatus
     version: 1
+  - component: main
+    capability: battery
+    version: 1
   automation:
     conditions:
     - component: main
@@ -95,6 +100,9 @@ deviceConfig:
       version: 1
     - component: main
       capability: remoteControlStatus
+      version: 1
+    - component: main
+      capability: battery
       version: 1
     actions:
     - component: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-unlatch-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-unlatch-batteryLevel.yml
@@ -36,7 +36,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-unlatch-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-unlatch-batteryLevel.yml
@@ -1,4 +1,4 @@
-name: lock-unlatch
+name: lock-unlatch-batteryLevel
 components:
 - id: main
   capabilities:
@@ -15,6 +15,8 @@ components:
   - id: lockAlarm
     version: 1
   - id: remoteControlStatus
+    version: 1
+  - id: batteryLevel
     version: 1
   - id: firmwareUpdate
     version: 1
@@ -73,6 +75,9 @@ deviceConfig:
   - component: main
     capability: remoteControlStatus
     version: 1
+  - component: main
+    capability: batteryLevel
+    version: 1
   automation:
     conditions:
     - component: main
@@ -95,6 +100,9 @@ deviceConfig:
       version: 1
     - component: main
       capability: remoteControlStatus
+      version: 1
+    - component: main
+      capability: batteryLevel
       version: 1
     actions:
     - component: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-unlatch.yml
@@ -34,7 +34,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-battery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-battery.yml
@@ -42,7 +42,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-battery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-battery.yml
@@ -1,4 +1,4 @@
-name: lock-unlatch
+name: lock-user-pin-schedule-unlatch-battery
 components:
 - id: main
   capabilities:
@@ -15,6 +15,14 @@ components:
   - id: lockAlarm
     version: 1
   - id: remoteControlStatus
+    version: 1
+  - id: lockUsers
+    version: 1
+  - id: lockCredentials
+    version: 1
+  - id: lockSchedules
+    version: 1
+  - id: battery
     version: 1
   - id: firmwareUpdate
     version: 1
@@ -73,6 +81,9 @@ deviceConfig:
   - component: main
     capability: remoteControlStatus
     version: 1
+  - component: main
+    capability: battery
+    version: 1
   automation:
     conditions:
     - component: main
@@ -95,6 +106,9 @@ deviceConfig:
       version: 1
     - component: main
       capability: remoteControlStatus
+      version: 1
+    - component: main
+      capability: battery
       version: 1
     actions:
     - component: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-batteryLevel.yml
@@ -42,7 +42,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch-batteryLevel.yml
@@ -1,4 +1,4 @@
-name: lock-unlatch
+name: lock-user-pin-schedule-unlatch-batteryLevel
 components:
 - id: main
   capabilities:
@@ -15,6 +15,14 @@ components:
   - id: lockAlarm
     version: 1
   - id: remoteControlStatus
+    version: 1
+  - id: lockUsers
+    version: 1
+  - id: lockCredentials
+    version: 1
+  - id: lockSchedules
+    version: 1
+  - id: batteryLevel
     version: 1
   - id: firmwareUpdate
     version: 1
@@ -73,6 +81,9 @@ deviceConfig:
   - component: main
     capability: remoteControlStatus
     version: 1
+  - component: main
+    capability: batteryLevel
+    version: 1
   automation:
     conditions:
     - component: main
@@ -95,6 +106,9 @@ deviceConfig:
       version: 1
     - component: main
       capability: remoteControlStatus
+      version: 1
+    - component: main
+      capability: batteryLevel
       version: 1
     actions:
     - component: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch.yml
@@ -40,7 +40,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-schedule-unlatch.yml
@@ -1,7 +1,6 @@
 name: lock-user-pin-schedule-unlatch
 components:
-- label: Main
-  id: main
+- id: main
   capabilities:
   - id: lock
     version: 1
@@ -39,6 +38,14 @@ deviceConfig:
     - component: main
       capability: lock
       version: 1
+      visibleCondition: {
+        "capability": "lock",
+        "version": 1,
+        "component": "main",
+        "value": "lock.value",
+        "operator": "DOES_NOT_EQUAL",
+        "operand": "unlatched"
+      }
   detailView:
   - component: main
     capability: lock
@@ -66,6 +73,12 @@ deviceConfig:
         displayType: pushButton
         pushButton:
           command: unlatch
+  - component: main
+    capability: lockAlarm
+    version: 1
+  - component: main
+    capability: remoteControlStatus
+    version: 1
   automation:
     conditions:
     - component: main
@@ -83,6 +96,12 @@ deviceConfig:
           value: '{{i18n.attributes.lock.i18n.value.unlatched.label}}'
         - key: not fully locked
           value: '{{i18n.attributes.lock.i18n.value.not fully locked.label}}'
+    - component: main
+      capability: lockAlarm
+      version: 1
+    - component: main
+      capability: remoteControlStatus
+      version: 1
     actions:
     - component: main
       capability: lock

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-unlatch.yml
@@ -38,7 +38,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-pin-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-pin-unlatch.yml
@@ -1,7 +1,6 @@
 name: lock-user-pin-unlatch
 components:
-- label: Main
-  id: main
+- id: main
   capabilities:
   - id: lock
     version: 1
@@ -37,6 +36,14 @@ deviceConfig:
     - component: main
       capability: lock
       version: 1
+      visibleCondition: {
+        "capability": "lock",
+        "version": 1,
+        "component": "main",
+        "value": "lock.value",
+        "operator": "DOES_NOT_EQUAL",
+        "operand": "unlatched"
+      }
   detailView:
   - component: main
     capability: lock
@@ -64,6 +71,12 @@ deviceConfig:
         displayType: pushButton
         pushButton:
           command: unlatch
+  - component: main
+    capability: lockAlarm
+    version: 1
+  - component: main
+    capability: remoteControlStatus
+    version: 1
   automation:
     conditions:
     - component: main
@@ -81,6 +94,12 @@ deviceConfig:
           value: '{{i18n.attributes.lock.i18n.value.unlatched.label}}'
         - key: not fully locked
           value: '{{i18n.attributes.lock.i18n.value.not fully locked.label}}'
+    - component: main
+      capability: lockAlarm
+      version: 1
+    - component: main
+      capability: remoteControlStatus
+      version: 1
     actions:
     - component: main
       capability: lock

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-schedule-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-schedule-unlatch.yml
@@ -38,7 +38,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-schedule-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-schedule-unlatch.yml
@@ -1,7 +1,6 @@
 name: lock-user-schedule-unlatch
 components:
-- label: Main
-  id: main
+- id: main
   capabilities:
   - id: lock
     version: 1
@@ -37,6 +36,14 @@ deviceConfig:
     - component: main
       capability: lock
       version: 1
+      visibleCondition: {
+        "capability": "lock",
+        "version": 1,
+        "component": "main",
+        "value": "lock.value",
+        "operator": "DOES_NOT_EQUAL",
+        "operand": "unlatched"
+      }
   detailView:
   - component: main
     capability: lock

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-unlatch.yml
@@ -36,7 +36,7 @@ deviceConfig:
       version: 1
       visibleCondition: {
         "capability": "lock",
-        "version": 1,
+        "version": "1",
         "component": "main",
         "value": "lock.value",
         "operator": "DOES_NOT_EQUAL",

--- a/drivers/SmartThings/matter-lock/profiles/lock-user-unlatch.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-user-unlatch.yml
@@ -1,7 +1,6 @@
 name: lock-user-unlatch
 components:
-- label: Main
-  id: main
+- id: main
   capabilities:
   - id: lock
     version: 1
@@ -35,6 +34,14 @@ deviceConfig:
     - component: main
       capability: lock
       version: 1
+      visibleCondition: {
+        "capability": "lock",
+        "version": 1,
+        "component": "main",
+        "value": "lock.value",
+        "operator": "DOES_NOT_EQUAL",
+        "operand": "unlatched"
+      }
   detailView:
   - component: main
     capability: lock
@@ -62,6 +69,15 @@ deviceConfig:
         displayType: pushButton
         pushButton:
           command: unlatch
+  - component: main
+    capability: lockAlarm
+    version: 1
+  - component: main
+    capability: remoteControlStatus
+    version: 1
+  - component: main
+    capability: batteryLevel
+    version: 1
   automation:
     conditions:
     - component: main
@@ -79,7 +95,13 @@ deviceConfig:
           value: '{{i18n.attributes.lock.i18n.value.unlatched.label}}'
         - key: not fully locked
           value: '{{i18n.attributes.lock.i18n.value.not fully locked.label}}'
-    actions:
+    - component: main
+      capability: lockAlarm
+      version: 1
+    - component: main
+      capability: remoteControlStatus
+      version: 1
+      actions:
     - component: main
       capability: lock
       version: 1

--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -164,7 +164,7 @@ local function do_configure(driver, device)
     req:merge(clusters.PowerSource.attributes.AttributeList:read())
     device:send(req)
   else
-    device.log.info(string.format("Updating device profile to %s.", profile_name))
+    device.log.info_with({hub_logs=true}, string.format("Updating device profile to %s.", profile_name))
     device:try_update_metadata({profile = profile_name})
   end
 end
@@ -396,7 +396,7 @@ local function handle_power_source_attribute_list(driver, device, ib, response)
     elseif support_battery_level then
       profile_name = profile_name .. "-batteryLevel"
     end
-    device.log.info(string.format("Updating device profile to %s.", profile_name))
+    device.log.info_with({hub_logs=true}, string.format("Updating device profile to %s.", profile_name))
     device:try_update_metadata({profile = profile_name})
   end
 end

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_battery.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_battery.lua
@@ -22,6 +22,82 @@ local uint32 = require "st.matter.data_types.Uint32"
 local DoorLock = clusters.DoorLock
 
 local mock_device = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("lock.yml"),
+  manufacturer_info = {
+    vendor_id = 0x147F,
+    product_id = 0x0001,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        { cluster_id = clusters.Basic.ID, cluster_type = "SERVER" },
+      },
+      device_types = {
+        { device_type_id = 0x0016, device_type_revision = 1 } -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = DoorLock.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 0x0,
+        },
+        {
+          cluster_id = clusters.PowerSource.ID,
+          cluster_type = "SERVER",
+          feature_map = 10
+        },
+      },
+      device_types = {
+        { device_type_id = 0x000A, device_type_revision = 1 } -- Door Lock
+      }
+    }
+  }
+})
+
+local mock_device_unlatch = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("lock-unlatch.yml"),
+  manufacturer_info = {
+    vendor_id = 0x147F,
+    product_id = 0x0001,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        { cluster_id = clusters.Basic.ID, cluster_type = "SERVER" },
+      },
+      device_types = {
+        { device_type_id = 0x0016, device_type_revision = 1 } -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = DoorLock.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 0x1000, -- UNLATCH
+        },
+        {
+          cluster_id = clusters.PowerSource.ID,
+          cluster_type = "SERVER",
+          feature_map = 10
+        },
+      },
+      device_types = {
+        { device_type_id = 0x000A, device_type_revision = 1 } -- Door Lock
+      }
+    }
+  }
+})
+
+local mock_device_user_pin = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("lock-user-pin.yml"),
   manufacturer_info = {
     vendor_id = 0x147F,
@@ -59,24 +135,98 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
+local mock_device_user_pin_schedule_unlatch = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("lock-user-pin-schedule-unlatch.yml"),
+  manufacturer_info = {
+    vendor_id = 0x147F,
+    product_id = 0x0001,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        { cluster_id = clusters.Basic.ID, cluster_type = "SERVER" },
+      },
+      device_types = {
+        { device_type_id = 0x0016, device_type_revision = 1 } -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = DoorLock.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 0x1591, -- PIN & USR & COTA & WDSCH & YDSCH & UNLATCH
+        },
+        {
+          cluster_id = clusters.PowerSource.ID,
+          cluster_type = "SERVER",
+          feature_map = 10
+        },
+      },
+      device_types = {
+        { device_type_id = 0x000A, device_type_revision = 1 } -- Door Lock
+      }
+    }
+  }
+})
+
 local function test_init()
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device))
-  subscribe_request:merge(DoorLock.attributes.NumberOfTotalUsersSupported:subscribe(mock_device))
-  subscribe_request:merge(DoorLock.attributes.NumberOfPINUsersSupported:subscribe(mock_device))
-  subscribe_request:merge(DoorLock.attributes.MaxPINCodeLength:subscribe(mock_device))
-  subscribe_request:merge(DoorLock.attributes.MinPINCodeLength:subscribe(mock_device))
-  subscribe_request:merge(DoorLock.attributes.RequirePINforRemoteOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
-  subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
 end
+
+local function test_init_unlatch()
+  local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device_unlatch)
+  subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device_unlatch))
+  subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device_unlatch))
+  subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device_unlatch))
+  test.socket["matter"]:__expect_send({mock_device_unlatch.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device_unlatch)
+end
+
+local function test_init_user_pin()
+  local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device_user_pin)
+  subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.attributes.NumberOfTotalUsersSupported:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.attributes.NumberOfPINUsersSupported:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.attributes.MaxPINCodeLength:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.attributes.MinPINCodeLength:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.attributes.RequirePINforRemoteOperation:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device_user_pin))
+  subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device_user_pin))
+  test.socket["matter"]:__expect_send({mock_device_user_pin.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device_user_pin)
+end
+
+local function test_init_user_pin_schedule_unlatch()
+  local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device_user_pin_schedule_unlatch)
+  subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.NumberOfTotalUsersSupported:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.NumberOfPINUsersSupported:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.MaxPINCodeLength:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.MinPINCodeLength:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.RequirePINforRemoteOperation:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.NumberOfWeekDaySchedulesSupportedPerUser:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.attributes.NumberOfYearDaySchedulesSupportedPerUser:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device_user_pin_schedule_unlatch))
+  subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device_user_pin_schedule_unlatch))
+  test.socket["matter"]:__expect_send({mock_device_user_pin_schedule_unlatch.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device_user_pin_schedule_unlatch)
+end
+
 test.set_test_init_function(test_init)
 
 test.register_coroutine_test(
-  "Test profile change when attributes related to BAT feature is not available.",
+  "Test lock profile change when attributes related to BAT feature is not available.",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -107,12 +257,12 @@ test.register_coroutine_test(
           })
       }
     )
-    mock_device:expect_metadata_update({ profile = "lock-user-pin" })
+    mock_device:expect_metadata_update({ profile = "lock" })
   end
 )
 
 test.register_coroutine_test(
-  "Test profile change when BatChargeLevel attribute is available",
+  "Test lock profile change when BatChargeLevel attribute is available",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -144,12 +294,12 @@ test.register_coroutine_test(
           })
       }
     )
-    mock_device:expect_metadata_update({ profile = "lock-user-pin-batteryLevel" })
+    mock_device:expect_metadata_update({ profile = "lock-batteryLevel" })
   end
 )
 
 test.register_coroutine_test(
-  "Test profile change when BatChargeLevel and BatPercentRemaining attributes are available",
+  "Test lock profile change when BatChargeLevel and BatPercentRemaining attributes are available",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -182,8 +332,350 @@ test.register_coroutine_test(
           })
       }
     )
-    mock_device:expect_metadata_update({ profile = "lock-user-pin-battery" })
+    mock_device:expect_metadata_update({ profile = "lock-battery" })
   end
+)
+
+test.register_coroutine_test(
+  "Test lock-unlatch profile change when attributes related to BAT feature is not available.",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
+    mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_unlatch, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_unlatch:expect_metadata_update({ profile = "lock-unlatch" })
+  end,
+  { test_init = test_init_unlatch }
+)
+
+test.register_coroutine_test(
+  "Test lock-unlatch profile change when BatChargeLevel attribute is available",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
+    mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_unlatch, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(14), -- BatChargeLevel
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_unlatch:expect_metadata_update({ profile = "lock-unlatch-batteryLevel" })
+  end,
+  { test_init = test_init_unlatch }
+)
+
+test.register_coroutine_test(
+  "Test lock-unlatch profile change when BatChargeLevel and BatPercentRemaining attributes are available",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
+    mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_unlatch, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(12), -- BatPercentRemaining
+            uint32(14), -- BatChargeLevel
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_unlatch:expect_metadata_update({ profile = "lock-unlatch-battery" })
+  end,
+  { test_init = test_init_unlatch }
+)
+
+test.register_coroutine_test(
+  "Test lock-user-pin profile change when attributes related to BAT feature is not available.",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
+    mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_user_pin.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_user_pin.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_user_pin, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_user_pin:expect_metadata_update({ profile = "lock-user-pin" })
+  end,
+  { test_init = test_init_user_pin }
+)
+
+test.register_coroutine_test(
+  "Test lock-user-pin profile change when BatChargeLevel attribute is available",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
+    mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_user_pin.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_user_pin.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_user_pin, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(14), -- BatChargeLevel
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_user_pin:expect_metadata_update({ profile = "lock-user-pin-batteryLevel" })
+  end,
+  { test_init = test_init_user_pin }
+)
+
+test.register_coroutine_test(
+  "Test lock-user-pin profile change when BatChargeLevel and BatPercentRemaining attributes are available",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
+    mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_user_pin.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_user_pin.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_user_pin, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(12), -- BatPercentRemaining
+            uint32(14), -- BatChargeLevel
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_user_pin:expect_metadata_update({ profile = "lock-user-pin-battery" })
+  end,
+  { test_init = test_init_user_pin }
+)
+
+test.register_coroutine_test(
+  "Test lock-user-pin-schedule-unlatch profile change when attributes related to BAT feature is not available.",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
+    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_user_pin_schedule_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_user_pin_schedule_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_user_pin_schedule_unlatch, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ profile = "lock-user-pin-schedule-unlatch" })
+  end,
+  { test_init = test_init_user_pin_schedule_unlatch }
+)
+
+test.register_coroutine_test(
+  "Test lock-user-pin-schedule-unlatch profile change when BatChargeLevel attribute is available",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
+    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_user_pin_schedule_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_user_pin_schedule_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_user_pin_schedule_unlatch, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(14), -- BatChargeLevel
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ profile = "lock-user-pin-schedule-unlatch-batteryLevel" })
+  end,
+  { test_init = test_init_user_pin_schedule_unlatch }
+)
+
+test.register_coroutine_test(
+  "Test lock-user-pin-schedule-unlatch profile change when BatChargeLevel and BatPercentRemaining attributes are available",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
+    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.capability:__expect_send(
+      mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device_user_pin_schedule_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:read()
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_user_pin_schedule_unlatch.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_user_pin_schedule_unlatch, 1,
+          {
+            uint32(0),
+            uint32(1),
+            uint32(2),
+            uint32(12), -- BatPercentRemaining
+            uint32(14), -- BatChargeLevel
+            uint32(31),
+            uint32(65528),
+            uint32(65529),
+            uint32(65531),
+            uint32(65532),
+            uint32(65533),
+          })
+      }
+    )
+    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ profile = "lock-user-pin-schedule-unlatch-battery" })
+  end,
+  { test_init = test_init_user_pin_schedule_unlatch }
 )
 
 test.run_registered_tests()


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
1. Issue
User is allowed to lock or unlock from the device card if door lock status is unlatched, but user is not allowed to do the same from Plugin.

2. Solution
Add Visible Condition to the profiles that have unlatched status

3. Changes
Add Visible Condition to the profiles that have unlatched status
Add some profiles for unlatch feature

# Summary of Completed Tests


