### PR TITLE
Persist BooleanState Device Type to Endpoint Fields

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -87,7 +87,7 @@ local function set_boolean_device_type_per_endpoint(driver, device)
       for _, dt in ipairs(ep.device_types) do
           for dt_name, info in pairs(BOOLEAN_DEVICE_TYPE_INFO) do
               if dt.device_type_id == info.id then
-                  device:set_field(dt_name, ep.endpoint_id)
+                  device:set_field(dt_name, ep.endpoint_id, { persist = true })
                   device:send(clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(device, ep.endpoint_id))
               end
           end
@@ -188,13 +188,14 @@ end
 
 local function device_init(driver, device)
   log.info("device init")
+  set_boolean_device_type_per_endpoint(driver, device)
   device:subscribe()
 end
 
 local function info_changed(driver, device, event, args)
   if device.profile.id ~= args.old_st_store.profile.id then
-    device:subscribe()
     set_boolean_device_type_per_endpoint(driver, device)
+    device:subscribe()
   end
   if not device.preferences then
     return

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_freeze_leak_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_freeze_leak_sensor.lua
@@ -69,6 +69,8 @@ local function test_init_freeze_leak()
       subscribe_request:merge(cluster:subscribe(mock_device_freeze_leak))
     end
   end
+  test.socket.matter:__expect_send({mock_device_freeze_leak.id, clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(mock_device_freeze_leak, 1)})
+  test.socket.matter:__expect_send({mock_device_freeze_leak.id, clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(mock_device_freeze_leak, 2)})
   test.socket.matter:__expect_send({mock_device_freeze_leak.id, subscribe_request})
   test.mock_device.add_test_device(mock_device_freeze_leak)
   test.socket.device_lifecycle:__queue_receive({ mock_device_freeze_leak.id, "added" })

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_rain_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_rain_sensor.lua
@@ -61,6 +61,7 @@ local function test_init_rain()
       subscribe_request:merge(cluster:subscribe(mock_device_rain))
     end
   end
+  test.socket.matter:__expect_send({mock_device_rain.id, clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(mock_device_rain, 1)})
   test.socket.matter:__expect_send({mock_device_rain.id, subscribe_request})
   test.mock_device.add_test_device(mock_device_rain)
   test.socket.device_lifecycle:__queue_receive({ mock_device_rain.id, "added" })


### PR DESCRIPTION
# Description of Change
Though the Device type to endpoint mapping for BooleanState devices was correctly running in `device_added`, the fields holding this mapping information was not being persisted over a driver restart. To alleviate this, the persist flag was attached to the fields being created, and further, the setup logic was included in `device_init` to re-initialize the fields on the driver reset for all devices already onboarded whose fields are no longer set.  

# Summary of Completed Tests
- Unit tests updated.
- VDA continues to respond as expected for all functionality. The V3 Hub this device was connected to was restart and things continued to respond as expected. 

