### PR TITLE
New Device (Matter Lock) Eufy C34 + E31 + E30

### DIFF
--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -11,15 +11,20 @@ matterManufacturer:
     productId: 0x2801
     deviceProfileName: lock-user-pin
   #Eufy
-  - id: "5427/3"
-    deviceLabel: eufy Smart Lock C34
-    vendorId: 0x1533
-    productId: 0x0003
-    deviceProfileName: lock-user-pin-battery
   - id: "5427/1"
     deviceLabel: eufy Smart Lock E31
     vendorId: 0x1533
     productId: 0x0001
+    deviceProfileName: lock-user-pin-battery
+  - id: "5427/2"
+    deviceLabel: eufy Smart Lock E30
+    vendorId: 0x1533
+    productId: 0x0002
+    deviceProfileName: lock-user-pin-battery
+  - id: "5427/3"
+    deviceLabel: eufy Smart Lock C34
+    vendorId: 0x1533
+    productId: 0x0003
     deviceProfileName: lock-user-pin-battery
   #Level
   - id: "4767/1"

--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -10,6 +10,12 @@ matterManufacturer:
     vendorId: 0x115F
     productId: 0x2801
     deviceProfileName: lock-user-pin
+  #Eufy
+  - id: "5427/3"
+    deviceLabel: eufy Smart Lock C34
+    vendorId: 0x1533
+    productId: 0x0003
+    deviceProfileName: lock-user-pin-battery
   #Level
   - id: "4767/1"
     deviceLabel: Level Lock Plus (Matter)

--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -16,6 +16,11 @@ matterManufacturer:
     vendorId: 0x1533
     productId: 0x0003
     deviceProfileName: lock-user-pin-battery
+  - id: "5427/1"
+    deviceLabel: eufy Smart Lock E31
+    vendorId: 0x1533
+    productId: 0x0001
+    deviceProfileName: lock-user-pin-battery
   #Level
   - id: "4767/1"
     deviceLabel: Level Lock Plus (Matter)


### PR DESCRIPTION
Check all that apply

# Type of Change

- [X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adding a new fingerprint for WWST, Matter Lock Eufy Device
These devices has support to use the new Matter door lock Experience as part of a previous PR [https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1851](url)
The Devices are in the DCL as a Matter Device Type 10 (0xa)

eufy Smart Lock C34
VID: 0x1533
PID: 0x0003

eufy Smart Lock E31
VID: 0x1533
PID: 0x0001



# Summary of Completed Tests


