### PR TITLE
Persist fields across multiple Drivers

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
@@ -103,7 +103,7 @@ local function match_profile(device)
     device.log.info_with({hub_logs=true}, string.format("Using generic device profile %s.", profile_name))
   end
   device:try_update_metadata({profile = profile_name})
-  device:set_field(PROFILE_MATCHED, 1)
+  device:set_field(PROFILE_MATCHED, 1 , {persist = true})
 end
 
 local function device_init(driver, device)

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -247,7 +247,7 @@ local function set_poll_report_timer_and_schedule(device, is_cumulative_report)
     clusters.ElectricalEnergyMeasurement.ID,
     {feature_bitmap = clusters.ElectricalEnergyMeasurement.types.Feature.CUMULATIVE_ENERGY })
   if #cumul_eps == 0 then
-    device:set_field(CUMULATIVE_REPORTS_NOT_SUPPORTED, true)
+    device:set_field(CUMULATIVE_REPORTS_NOT_SUPPORTED, true, {persist = true})
   end
   if #cumul_eps > 0 and not is_cumulative_report then
     return
@@ -600,7 +600,7 @@ local function try_build_child_switch_profiles(driver, device, switch_eps, main_
         parent_child_device = true
         if _ == 1 and child_profile == "light-power-energy-powerConsumption" then
           -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
-          device:set_field(ENERGY_MANAGEMENT_ENDPOINT, ep)
+          device:set_field(ENERGY_MANAGEMENT_ENDPOINT, ep, {persist = true})
         end
       end
     end
@@ -612,7 +612,7 @@ local function try_build_child_switch_profiles(driver, device, switch_eps, main_
     device:set_field(IS_PARENT_CHILD_DEVICE, true, {persist = true})
   end
 
-  device:set_field(SWITCH_INITIALIZED, true)
+  device:set_field(SWITCH_INITIALIZED, true, {persist = true})
 
   -- this is needed in initialize_buttons_and_switches
   return num_switch_server_eps
@@ -825,7 +825,7 @@ local function handle_set_color_temperature(driver, device, cmd)
     temp_in_mired = get_field_for_endpoint(device, COLOR_TEMP_BOUND_RECEIVED_MIRED..COLOR_TEMP_MIN, endpoint_id)
   end
   local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
-  device:set_field(MOST_RECENT_TEMP, cmd.args.temperature)
+  device:set_field(MOST_RECENT_TEMP, cmd.args.temperature, {persist = true})
   device:send(req)
 end
 
@@ -1041,7 +1041,7 @@ end
 local function cumul_energy_imported_handler(driver, device, ib, response)
   if ib.data.elements.energy then
     local watt_hour_value = ib.data.elements.energy.value / CONVERSION_CONST_MILLIWATT_TO_WATT
-    device:set_field(TOTAL_IMPORTED_ENERGY, watt_hour_value)
+    device:set_field(TOTAL_IMPORTED_ENERGY, watt_hour_value, {persist = true})
     if ib.endpoint_id ~= 0 then
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.energyMeter.energy({ value = watt_hour_value, unit = "Wh" }))
     else
@@ -1056,7 +1056,7 @@ local function per_energy_imported_handler(driver, device, ib, response)
     local watt_hour_value = ib.data.elements.energy.value / CONVERSION_CONST_MILLIWATT_TO_WATT
     local latest_energy_report = device:get_field(TOTAL_IMPORTED_ENERGY) or 0
     local summed_energy_report = latest_energy_report + watt_hour_value
-    device:set_field(TOTAL_IMPORTED_ENERGY, summed_energy_report)
+    device:set_field(TOTAL_IMPORTED_ENERGY, summed_energy_report, {persist = true})
     device:emit_event(capabilities.energyMeter.energy({ value = summed_energy_report, unit = "Wh" }))
   end
 end


### PR DESCRIPTION
# Description of Change
Matter Switch:
 - CUMULATIVE_REPORTS_NOT_SUPPORTED should be saved. This will not change after driver init.
 - ENERGY_MANAGEMENT_ENDPOINT should be saved. This will not be saved, or re-initialized due to gating after the first driver init.
 - SWITCH_INITIALIZED is used in init, but is set in init. A driver restart would not save this, and so the field is never being used.
 - MOST_RECENT_TEMP should be saved. Low importance, but this doesn't need to be made nil on a driver restart
 - TOTAL_IMPORTED_ENERGY must be persisted. This should never be reset on a driver restart.

Smoke Alarm Sub-Driver:
  - PROFILE_MATCHED is used in init, but is set in init. A driver restart would not save this, and so the field is never being used.
# Summary of Completed Tests
Hub restart attempted in Matter Switch to ensure that init continues to work as expected.

