### PR TITLE
fix(hue): Inject refresh when transitioning online

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/button.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/button.lua
@@ -5,8 +5,6 @@ local st_utils = require "st.utils"
 ---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
 
-local refresh_handler = require("handlers.commands").refresh_handler
-
 local Discovery = require "disco"
 local Fields = require "fields"
 local HueDeviceTypes = require "hue_device_types"
@@ -160,7 +158,11 @@ function ButtonLifecycleHandlers.init(driver, device)
   end
   device:set_field(Fields._INIT, true, { persist = false })
   if device:get_field(Fields._REFRESH_AFTER_INIT) then
-    refresh_handler(driver, device)
+    driver:inject_capability_command(device, {
+      capability = capabilities.refresh.ID,
+      command = capabilities.refresh.commands.refresh.NAME,
+      args = {}
+    })
     device:set_field(Fields._REFRESH_AFTER_INIT, false, { persist = true })
   end
 end

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
@@ -1,10 +1,9 @@
+local capabilities = require "st.capabilities"
 local log = require "log"
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
 ---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
-
-local refresh_handler = require("handlers.commands").refresh_handler
 
 local Discovery = require "disco"
 local Fields = require "fields"
@@ -122,7 +121,11 @@ function ContactLifecycleHandlers.init(driver, device)
   end
   device:set_field(Fields._INIT, true, { persist = false })
   if device:get_field(Fields._REFRESH_AFTER_INIT) then
-    refresh_handler(driver, device)
+    driver:inject_capability_command(device, {
+      capability = capabilities.refresh.ID,
+      command = capabilities.refresh.commands.refresh.NAME,
+      args = {}
+    })
     device:set_field(Fields._REFRESH_AFTER_INIT, false, { persist = true })
   end
 end

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
@@ -1,6 +1,5 @@
 local log = require "log"
 local capabilities = require "st.capabilities"
-local refresh_handler = require("handlers.commands").refresh_handler
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
 ---@type fun(val: any?, name: string?, multi_line: boolean?): string
@@ -193,7 +192,11 @@ function LightLifecycleHandlers.added(driver, device, parent_device_id, resource
   driver.hue_identifier_to_device_record[device_light_resource_id] = device
 
   -- the refresh handler adds lights that don't have a fully initialized bridge to a queue.
-  refresh_handler(driver, device)
+  driver:inject_capability_command(device, {
+    capability = capabilities.refresh.ID,
+    command = capabilities.refresh.commands.refresh.NAME,
+    args = {}
+  })
 end
 
 ---@param driver HueDriver
@@ -218,7 +221,11 @@ function LightLifecycleHandlers.init(driver, device)
   device:emit_event(capabilities.switchLevel.levelRange({ minimum = 1, maximum = 100 }))
 
   if device:get_field(Fields._REFRESH_AFTER_INIT) then
-    refresh_handler(driver, device)
+    driver:inject_capability_command(device, {
+      capability = capabilities.refresh.ID,
+      command = capabilities.refresh.commands.refresh.NAME,
+      args = {}
+    })
     device:set_field(Fields._REFRESH_AFTER_INIT, false, { persist = true })
   end
   driver:check_waiting_grandchildren_for_device(device)

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
@@ -1,10 +1,9 @@
+local capabilities = require "st.capabilities"
 local log = require "log"
 local st_utils = require "st.utils"
 -- trick to fix the VS Code Lua Language Server typechecking
 ---@type fun(val: any?, name: string?, multi_line: boolean?): string
 st_utils.stringify_table = st_utils.stringify_table
-
-local refresh_handler = require("handlers.commands").refresh_handler
 
 local Discovery = require "disco"
 local Fields = require "fields"
@@ -125,7 +124,11 @@ function MotionLifecycleHandlers.init(driver, device)
   end
   device:set_field(Fields._INIT, true, { persist = false })
   if device:get_field(Fields._REFRESH_AFTER_INIT) then
-    refresh_handler(driver, device)
+    driver:inject_capability_command(device, {
+      capability = capabilities.refresh.ID,
+      command = capabilities.refresh.commands.refresh.NAME,
+      args = {}
+    })
     device:set_field(Fields._REFRESH_AFTER_INIT, false, { persist = true })
   end
 end

--- a/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
@@ -1,3 +1,4 @@
+local capabilities = require "st.capabilities"
 local cosock = require "cosock"
 local log = require "log"
 local json = require "st.json"
@@ -107,6 +108,11 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
                     child_device.log.info_with({ hub_logs = true }, "Marking Online after SSE Reconnect")
                     child_device:online()
                     child_device:set_field(Fields.IS_ONLINE, true)
+                    driver:inject_capability_command(child_device, {
+                      capability = capabilities.refresh.ID,
+                      command = capabilities.refresh.commands.refresh.NAME,
+                      args = {}
+                    })
                   elseif status.status == "connectivity_issue" then
                     child_device.log.info_with({ hub_logs = true }, "Marking Offline after SSE Reconnect")
                     child_device:set_field(Fields.IS_ONLINE, false)
@@ -244,6 +250,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
     local bridge_id = parent_bridge and parent_bridge.id
     if bridge_id == bridge_device.id then
       table.insert(ids_to_remove, id)
+      -- we call the handler directly here because we want to use the return value
       local refresh_info = command_handlers.refresh_handler(driver, device)
       if refresh_info and device:get_field(Fields.IS_MULTI_SERVICE) then
         local hue_device_type = utils.determine_device_type(device)


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

We had reports of an issue where a child device that onboards as offline, and then transitions to online, was in a state where it wouldn't be controllable due to the fact that no attribute events had been emitted for the device (since it onboarded as offline).

This change injects a refresh capability command event in to the device whenever it is marked `online` as a result of a connectivity event on the Hue Bridge's SSE stream.

We also clean up a few other places where we should be using injected refreshes instead of using the handlers directly, though there are a few places where using the handlers directly is still preferred.

# Summary of Completed Tests

Tested on my personal setup by onboarding my setup while a bulb is removed from the socket, then securing it back in the socket later.

Reproduction of the bug was confirmed prior to these changes, and the desired behavior was confirmed with these changes.