### PR TITLE
fix-an-issue-of-colormode-in-matter-switch

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -85,6 +85,7 @@ local function test_init()
     clusters.ColorControl.attributes.CurrentSaturation,
     clusters.ColorControl.attributes.CurrentX,
     clusters.ColorControl.attributes.CurrentY,
+    clusters.ColorControl.attributes.ColorMode,
     clusters.ColorControl.attributes.ColorTemperatureMireds,
     clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
     clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -86,6 +86,7 @@ local cluster_subscribe_list = {
   clusters.ColorControl.attributes.CurrentSaturation,
   clusters.ColorControl.attributes.CurrentX,
   clusters.ColorControl.attributes.CurrentY,
+  clusters.ColorControl.attributes.ColorMode,
   clusters.ColorControl.attributes.ColorTemperatureMireds,
   clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
   clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [x] I have reviewed the README.md file
          - [x] I have reviewed the CODE_OF_CONDUCT.md file
          - [x] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Once the device changed its color, it will report attributes CurrentX/CurrentY and CurrentHue/CurrentSaturation, each of which may affect the switch color. Generally, CurrentX/CurrentY can be converted to CurrentHue/CurrentSaturation and vice versa. 

However, some devices may report incorrect attributes, making it impossible to convert them to the correct values, which could lead to incorrect values being uploaded to the ST App. 

The ColorMode attribute indicates which attributes are currently determining the color of the device. Therefore, we modified the code to include a check for the ColorMode logic, ensuring that only one set of attributes will determine the switch's color

# Summary of Completed Tests


