### PR TITLE
Use Persisted State cache for Thermostat SystemMode attribute

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -440,7 +440,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
     },
   },
   { test_init = test_init_auto }
@@ -556,7 +556,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
     },
 		{
       channel = "matter",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -440,7 +440,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}, {visibility={displayed=false}}))
     },
   },
   { test_init = test_init_auto }
@@ -556,7 +556,7 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
-      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
+      message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "auto", "cool"}, {visibility={displayed=false}}))
     },
 		{
       channel = "matter",


### PR DESCRIPTION
# Description of Change
As it stands, any optional added SystemMode value will be removed from the SupportedModes table on a driver restart. This PR introduces a persisted table that records all of the mode values added in `system_mode_handler`. Then, on a driver restart, the persisted table (`ALLOWED_OPTIONAL_THERMOSTAT_MODES`) is read in `sequence_of_operation_handler` as the base values to be added to the `supportedThermostatModes` table. 

To note: two similar checks are added, one under the `COOLING_WITH_REHEAT` if-else branch that specifically removes the `emergency heat` and `heat` value if they're found (since this would no longer be allowed) and vice versa with the `HEATING_WITH_REHEAT` branch and the `precooling` and `cool` values. This accounts for the case where the `ControlSequenceOfOperation` attribute is changed, and thus the device no longer supports the same optional values it once did. 

Further, new logic is added to prevent anything from being added to the table twice.

# Summary of Completed Tests
- VDA Room Air Conditioner (which _does_ include optional values) was tested on the previous main driver and the optional values were reset as expected. Then, this updated driver was applied, and its' optional values (`precooling`, `emergency heat`) were persisted over the restart.  
- Unit tests continue to pass.
- VDA Thermostat (which doesn't include any optional values) was tested and runs as expected, including over a restart.

