### PR TITLE
Zigbee Window Shade set timer to nil after executed

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
@@ -90,6 +90,7 @@ end
 
 local huesat_timer_callback = function(driver, device, cmd)
   return function()
+    device:set_field(HUESAT_TIMER, nil)
     local hue = device:get_field(TARGET_HUE)
     local sat = device:get_field(TARGET_SAT)
     hue = hue ~= nil and hue or device:get_latest_state("main", capabilities.colorControl.ID, capabilities.colorControl.hue.NAME)

--- a/drivers/SmartThings/zigbee-window-treatment/src/invert-lift-percentage/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/invert-lift-percentage/init.lua
@@ -50,6 +50,7 @@ local function current_position_attr_handler(driver, device, value, zb_rx)
       device:set_field(SHADE_SET_STATUS, nil)
     end
     local set_window_shade_status = function()
+      device:set_field(SHADE_SET_STATUS, nil)
       local current_level = device:get_latest_state("main", capabilities.windowShadeLevel.ID, capabilities.windowShadeLevel.shadeLevel.NAME)
       if current_level == 0 then
         device:emit_event(windowShade.closed())

--- a/drivers/SmartThings/zigbee-window-treatment/src/somfy/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/somfy/init.lua
@@ -64,6 +64,7 @@ local function current_position_attr_handler(driver, device, value, zb_rx)
     elseif current_level ~= level then
       event = current_level < level and windowShade.opening() or windowShade.closing()
       local timer = device.thread:call_with_delay(2, function(d)
+        device:set_field(FINAL_STATE_POLL_TIMER, nil)
         local current_level = device:get_latest_state(device:get_component_id_for_endpoint(zb_rx.address_header.src_endpoint.value),
           capabilities.windowShadeLevel.ID, capabilities.windowShadeLevel.shadeLevel.NAME)
         if current_level > 0 and current_level < 100 then


### PR DESCRIPTION
We were seeing errors when attempting to cancel a timer that no longer existed caused by never setting the timer field to nil after executing the timer.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
There were errors happening from trying to cancel a timer that didn't exist
Fixes: https://smartthings.atlassian.net/issues/CHAD-14291

# Summary of Completed Tests


