### PR TITLE
Matter Sensor: Remove sensitivity preference from co profiles

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/co-comeas.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/co-comeas.yml
@@ -16,6 +16,3 @@ components:
     version: 1
   categories:
   - name: SmokeDetector
-preferences:
-  - preferenceId: certifiedpreferences.smokeSensorSensitivity
-    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/co.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/co.yml
@@ -14,6 +14,3 @@ components:
     version: 1
   categories:
   - name: SmokeDetector
-preferences:
-  - preferenceId: certifiedpreferences.smokeSensorSensitivity
-    explicit: true


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Sensitivity levels do not apply to CO detectors and can be removed from profiles.

# Summary of Completed Tests
