### PR TITLE
Include dynamic handling of the ThermostatOperatingState capability

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -1784,10 +1784,10 @@ local function power_source_attribute_list_handler(driver, device, ib, response)
     -- BatChargeLevel (Attribute ID 0x0E) is present and try profiling.
     if attr.value == 0x0C then
       device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_PERCENTAGE)
-      match_profile(driver, device)
+      return match_profile(driver, device)
     elseif attr.value == 0x0E then
       device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_LEVEL)
-      match_profile(driver, device)
+      return match_profile(driver, device)
     end
   end
 end
@@ -1797,8 +1797,7 @@ local function thermostat_attribute_list_handler(driver, device, ib, response)
     -- mark whether the optional attribute ThermostatRunningState (0x029) and try profiling
     if attr.value == 0x029 then
       device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, true)
-      match_profile(driver, device)
-      return
+      return match_profile(driver, device)
     end
   end
   device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, false)

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -1784,20 +1784,23 @@ local function power_source_attribute_list_handler(driver, device, ib, response)
     -- BatChargeLevel (Attribute ID 0x0E) is present and try profiling.
     if attr.value == 0x0C then
       device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_PERCENTAGE)
-      return match_profile(driver, device)
+      match_profile(driver, device)
+      return
     elseif attr.value == 0x0E then
       device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_LEVEL)
-      return match_profile(driver, device)
+      match_profile(driver, device)
+      return
     end
   end
 end
 
 local function thermostat_attribute_list_handler(driver, device, ib, response)
   for _, attr in ipairs(ib.data.elements) do
-    -- mark whether the optional attribute ThermostatRunningState (0x029) and try profiling
+    -- mark whether the optional attribute ThermostatRunningState (0x029) is present and try profiling
     if attr.value == 0x029 then
       device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, true)
-      return match_profile(driver, device)
+      match_profile(driver, device)
+      return
     end
   end
   device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, false)

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -650,7 +650,6 @@ end
 
 local function profiling_data_still_required(device)
   for _, field in pairs(profiling_data) do
-    print("field:", field)
     if device:get_field(field) == nil then
       return true -- data still required if a field is nil
     end
@@ -659,9 +658,7 @@ local function profiling_data_still_required(device)
 end
 
 local function match_profile(driver, device)
-  print("ADADF")
   if profiling_data_still_required(device) then return end
-  print("ADADF")
 
   local running_state_supported = device:get_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT)
   local battery_supported = device:get_field(profiling_data.BATTERY_SUPPORT)
@@ -789,7 +786,7 @@ local function match_profile(driver, device)
     device:try_update_metadata({profile = profile_name})
   end
   -- clear all profiling data fields after profiling is complete.
-  for field in pairs(profiling_data) do
+  for _, field in pairs(profiling_data) do
     device:set_field(field, nil)
   end
 end

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -143,6 +143,11 @@ local battery_support = {
   BATTERY_PERCENTAGE = "BATTERY_PERCENTAGE"
 }
 
+local profiling_data = {
+  BATTERY_SUPPORT = "__BATTERY_SUPPORT",
+  THERMOSTAT_RUNNING_STATE_SUPPORT = "__THERMOSTAT_RUNNING_STATE_SUPPORT"
+}
+
 local subscribed_attributes = {
   [capabilities.switch.ID] = {
     clusters.OnOff.attributes.OnOff
@@ -643,7 +648,24 @@ local function create_thermostat_modes_profile(device)
   return thermostat_modes
 end
 
-local function match_profile(driver, device, battery_supported)
+local function profiling_data_still_required(device)
+  for _, field in pairs(profiling_data) do
+    print("field:", field)
+    if device:get_field(field) == nil then
+      return true -- data still required if a field is nil
+    end
+  end
+  return false
+end
+
+local function match_profile(driver, device)
+  print("ADADF")
+  if profiling_data_still_required(device) then return end
+  print("ADADF")
+
+  local running_state_supported = device:get_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT)
+  local battery_supported = device:get_field(profiling_data.BATTERY_SUPPORT)
+
   local thermostat_eps = device:get_endpoints(clusters.Thermostat.ID)
   local humidity_eps = device:get_endpoints(clusters.RelativeHumidityMeasurement.ID)
   local device_type = get_device_type(driver, device)
@@ -701,7 +723,9 @@ local function match_profile(driver, device, battery_supported)
         profile_name = profile_name .. thermostat_modes
       end
 
-      profile_name = profile_name .. "-nostate"
+      if not running_state_supported then
+        profile_name = profile_name .. "-nostate"
+      end
 
       if battery_supported == battery_support.BATTERY_LEVEL then
         profile_name = profile_name .. "-batteryLevel"
@@ -746,10 +770,9 @@ local function match_profile(driver, device, battery_supported)
       profile_name = profile_name .. thermostat_modes
     end
 
-    -- TODO remove this in favor of reading Thermostat clusters AttributeList attribute
-    -- to determine support for ThermostatRunningState
-    -- Add nobattery profiles if updated
-    profile_name = profile_name .. "-nostate"
+    if not running_state_supported then
+      profile_name = profile_name .. "-nostate"
+    end
 
     if battery_supported == battery_support.BATTERY_LEVEL then
       profile_name = profile_name .. "-batteryLevel"
@@ -765,17 +788,14 @@ local function match_profile(driver, device, battery_supported)
     device.log.info_with({hub_logs=true}, string.format("Updating device profile to %s.", profile_name))
     device:try_update_metadata({profile = profile_name})
   end
+  -- clear all profiling data fields after profiling is complete.
+  for field in pairs(profiling_data) do
+    device:set_field(field, nil)
+  end
 end
 
 local function do_configure(driver, device)
-  local battery_feature_eps = device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
-  if #battery_feature_eps > 0 then
-    local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
-    req:merge(clusters.PowerSource.attributes.AttributeList:read())
-    device:send(req)
-  else
-    match_profile(driver, device, battery_support.NO_BATTERY)
-  end
+  match_profile(driver, device)
 end
 
 local function device_added(driver, device)
@@ -784,6 +804,19 @@ local function device_added(driver, device)
   req:merge(clusters.FanControl.attributes.FanModeSequence:read(device))
   req:merge(clusters.FanControl.attributes.WindSupport:read(device))
   req:merge(clusters.FanControl.attributes.RockSupport:read(device))
+
+  local thermostat_eps = device:get_endpoints(clusters.Thermostat.ID)
+  if #thermostat_eps > 0 then
+    req:merge(clusters.Thermostat.attributes.AttributeList:read(device))
+  else
+    device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, false)
+  end
+  local battery_feature_eps = device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
+  if #battery_feature_eps > 0 then
+    req:merge(clusters.PowerSource.attributes.AttributeList:read(device))
+  else
+    device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.NO_BATTERY)
+  end
   device:send(req)
   local heat_pump_eps = get_endpoints_for_dt(device, HEAT_PUMP_DEVICE_TYPE_ID) or {}
   if #heat_pump_eps > 0 then
@@ -1750,16 +1783,29 @@ end
 
 local function power_source_attribute_list_handler(driver, device, ib, response)
   for _, attr in ipairs(ib.data.elements) do
-    -- Re-profile the device if BatPercentRemaining (Attribute ID 0x0C) or
-    -- BatChargeLevel (Attribute ID 0x0E) is present.
+    -- mark if the device if BatPercentRemaining (Attribute ID 0x0C) or
+    -- BatChargeLevel (Attribute ID 0x0E) is present and try profiling.
     if attr.value == 0x0C then
-      match_profile(driver, device, battery_support.BATTERY_PERCENTAGE)
-      return
+      device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_PERCENTAGE)
+      match_profile(driver, device)
     elseif attr.value == 0x0E then
-      match_profile(driver, device, battery_support.BATTERY_LEVEL)
+      device:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_LEVEL)
+      match_profile(driver, device)
+    end
+  end
+end
+
+local function thermostat_attribute_list_handler(driver, device, ib, response)
+  for _, attr in ipairs(ib.data.elements) do
+    -- mark whether the optional attribute ThermostatRunningState (0x029) and try profiling
+    if attr.value == 0x029 then
+      device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, true)
+      match_profile(driver, device)
       return
     end
   end
+  device:set_field(profiling_data.THERMOSTAT_RUNNING_STATE_SUPPORT, false)
+  match_profile(driver, device)
 end
 
 local matter_driver_template = {
@@ -1787,6 +1833,7 @@ local matter_driver_template = {
         [clusters.Thermostat.attributes.AbsMinCoolSetpointLimit.ID] = cooling_setpoint_limit_handler_factory(setpoint_limit_device_field.MIN_COOL),
         [clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit.ID] = cooling_setpoint_limit_handler_factory(setpoint_limit_device_field.MAX_COOL),
         [clusters.Thermostat.attributes.MinSetpointDeadBand.ID] = min_deadband_limit_handler,
+        [clusters.Thermostat.attributes.AttributeList.ID] = thermostat_attribute_list_handler,
       },
       [clusters.FanControl.ID] = {
         [clusters.FanControl.attributes.FanModeSequence.ID] = fan_mode_sequence_handler,

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
@@ -434,6 +434,8 @@ end
 test.register_coroutine_test(
   "Test profile change on init for AP and AQS combined device type",
   function()
+    mock_device_ap_aqs:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
+    mock_device_ap_aqs:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false) -- since we're assuming this would have happened during device_added in this case.
     test.socket.device_lifecycle:__queue_receive({ mock_device_ap_aqs.id, "doConfigure" })
     mock_device_ap_aqs:expect_metadata_update({ profile = "air-purifier-hepa-ac-aqs-co2-tvoc-meas-co2-radon-level" })
     mock_device_ap_aqs:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -444,6 +446,8 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test profile change on init for AP and Thermo and AQS combined device type",
   function()
+    mock_device_ap_thermo_aqs:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
+    mock_device_ap_thermo_aqs:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false) -- since we're assuming this would have happened during device_added in this case.
     test.socket.device_lifecycle:__queue_receive({ mock_device_ap_thermo_aqs.id, "doConfigure" })
     mock_device_ap_thermo_aqs:expect_metadata_update({ profile = "air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level" })
     mock_device_ap_thermo_aqs:expect_metadata_update({ provisioning_state = "PROVISIONED" })

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_fan.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_fan.lua
@@ -112,6 +112,9 @@ end
 test.register_coroutine_test(
   "Test profile change on fan with rock and wind",
   function()
+    mock_device:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
+    mock_device:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false) -- since we're assuming this would have happened during device_added in this case.
+
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ profile = "fan-rock-wind" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -122,6 +125,8 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test profile change on fan with no features",
   function()
+    mock_device_generic:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
+    mock_device_generic:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false) -- since we're assuming this would have happened during device_added in this case.
     test.socket.device_lifecycle:__queue_receive({ mock_device_generic.id, "doConfigure" })
     mock_device_generic:expect_metadata_update({ profile = "fan-generic" })
     mock_device_generic:expect_metadata_update({ provisioning_state = "PROVISIONED" })

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
@@ -114,6 +114,7 @@ local test_init_common = function(device)
     clusters.FanControl.attributes.FanModeSequence,
     clusters.FanControl.attributes.WindSupport,
     clusters.FanControl.attributes.RockSupport,
+    clusters.Thermostat.attributes.AttributeList,
   }
   local read_request = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
   for _, clus in ipairs(read_request_on_added) do

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
@@ -202,6 +202,7 @@ test.register_coroutine_test(
     mock_device_configure:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
     test.socket.device_lifecycle:__queue_receive({ mock_device_configure.id, "doConfigure" })
     mock_device_configure:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_configure.id,

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
@@ -14,6 +14,7 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
+local uint32 = require "st.matter.data_types.Uint32"
 
 local clusters = require "st.matter.clusters"
 
@@ -198,10 +199,16 @@ end
 test.register_coroutine_test(
   "Test profile change on init for Room AC device type",
   function()
+    mock_device_configure:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
     test.socket.device_lifecycle:__queue_receive({ mock_device_configure.id, "doConfigure" })
-    mock_device_configure:expect_metadata_update({ profile = "room-air-conditioner" })
     mock_device_configure:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_configure.id,
+        clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device_configure, 1, {uint32(0x29)})
+      }
+    )
+    mock_device_configure:expect_metadata_update({ profile = "room-air-conditioner" })
   end,
   { test_init = test_init_configure }
 )

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
@@ -85,10 +85,11 @@ local function test_init()
   read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
   read_req:merge(clusters.FanControl.attributes.WindSupport:read())
   read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
+  read_req:merge(clusters.PowerSource.attributes.AttributeList:read())
   test.socket.matter:__expect_send({mock_device.id, read_req})
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  local attribute_list_read_req = clusters.PowerSource.attributes.AttributeList:read()
-  test.socket.matter:__expect_send({mock_device.id, attribute_list_read_req})
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
@@ -102,6 +103,12 @@ test.register_coroutine_test(
         clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(12)})
       }
     )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(28)})
+      }
+    )
     mock_device:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
   end
 )
@@ -109,6 +116,12 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test profile change when battery level attribute (attribute ID 14) is available",
   function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(28)})
+      }
+    )
     test.socket.matter:__queue_receive(
       {
         mock_device.id,

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -206,6 +206,16 @@ local function test_init()
   test.mock_device.add_test_device(mock_device)
   test.mock_device.add_test_device(mock_device_simple)
   test.mock_device.add_test_device(mock_device_no_battery)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
+  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
+  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.PowerSource.attributes.AttributeList:read())
+  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
+  test.socket.matter:__expect_send({mock_device.id, read_req})
 end
 test.set_test_init_function(test_init)
 
@@ -213,9 +223,7 @@ test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event due to cluster feature map",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    --TODO why does provisiong state get added in the do configure event handle, but not the refres?
-    local read_req = clusters.PowerSource.attributes.AttributeList:read()
-    test.socket.matter:__expect_send({mock_device.id, read_req})
+    --TODO why does provisiong state get added in the do configure event handle, but not the refres?)
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     test.wait_for_events()
     test.socket.matter:__queue_receive(
@@ -224,7 +232,13 @@ test.register_coroutine_test(
         clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(12)})
       }
     )
-    mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only-nostate" })
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(0x29)})
+      }
+    )
+    mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only" })
 end
 )
 
@@ -247,14 +261,18 @@ test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event due to cluster feature map",
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device_simple.id, "doConfigure" })
-    local read_req = clusters.PowerSource.attributes.AttributeList:read()
-    test.socket.matter:__expect_send({mock_device_simple.id, read_req})
     mock_device_simple:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_simple.id,
         clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_simple, 1, {uint32(12)})
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_simple.id,
+        clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device_simple, 1, {uint32(12)})
       }
     )
     mock_device_simple:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
@@ -264,9 +282,14 @@ end
 test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event no battery support",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_no_battery.id, "doConfigure" })
+    mock_device_no_battery:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_no_battery.id,
+        clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device_no_battery, 1, {uint32(12)})
+      }
+    )
     mock_device_no_battery:expect_metadata_update({ profile = "thermostat-cooling-only-nostate-nobattery" })
-    mock_device_no_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -70,7 +70,6 @@ local function test_init()
     clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
     clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
   }
-  -- test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -70,7 +70,7 @@ local function test_init()
     clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
     clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
+  -- test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -84,6 +84,16 @@ local function test_init()
 
   test.mock_device.add_test_device(mock_device)
 
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
+  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
+  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.PowerSource.attributes.AttributeList:read())
+  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
+  test.socket.matter:__expect_send({mock_device.id, read_req})
+
   test.set_rpc_version(5)
 end
 test.set_test_init_function(test_init)
@@ -95,13 +105,11 @@ local function configure(device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
-  local read_attribute_list_req = clusters.PowerSource.attributes.AttributeList:read()
-  test.socket.matter:__expect_send({mock_device.id, read_attribute_list_req})
-
   test.wait_for_events()
 
   test.socket.matter:__queue_receive({mock_device.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(0x0C)})})
-  mock_device:expect_metadata_update({ profile = "thermostat-nostate" })
+  test.socket.matter:__queue_receive({mock_device.id, clusters.Thermostat.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(0x29)})})
+  mock_device:expect_metadata_update({ profile = "thermostat" })
 
   --populate cached setpoint values. This would normally happen due to subscription setup.
   test.socket.matter:__queue_receive({


### PR DESCRIPTION
# Description of Change
This has been a TODO for a long time.
This change performs a read of the Thermostat AttributeList in added and checks whether the ThermostatRunningState attribute is included. Whether it is or isn't, the device is profiled accordingly.

Further, the powerSource attribute list read system was refactored a bit to play more nicely with this change, as well as any future changes. Both reads were moved to device_added with a cluster/feature gate, and a gating helper function was added to match_profile to ensure all reads have returned the necessary profiling information before profiling is completed.

# Summary of Completed Tests
Unit tests updated to handle these changes. Some include a positive read and others a negative read to get a variety of test coverage. 
Tested successfully on a physical device needing both a PowerSource and Thermostat AtrributeList read.