### PR TITLE
Support the battery capability in smoke/co subdriver

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/co-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/co-battery.yml
@@ -1,0 +1,18 @@
+name: co-battery
+components:
+- id: main
+  capabilities:
+  - id: carbonMonoxideDetector
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: battery
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmokeDetector

--- a/drivers/SmartThings/matter-sensor/profiles/co-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/co-battery.yml
@@ -4,8 +4,6 @@ components:
   capabilities:
   - id: carbonMonoxideDetector
     version: 1
-  - id: batteryLevel
-    version: 1
   - id: battery
     version: 1
   - id: hardwareFault

--- a/drivers/SmartThings/matter-sensor/profiles/co-comeas-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/co-comeas-battery.yml
@@ -1,0 +1,20 @@
+name: co-comeas-battery
+components:
+- id: main
+  capabilities:
+  - id: carbonMonoxideDetector
+    version: 1
+  - id: carbonMonoxideMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: battery
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmokeDetector

--- a/drivers/SmartThings/matter-sensor/profiles/co-comeas-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/co-comeas-battery.yml
@@ -6,8 +6,6 @@ components:
     version: 1
   - id: carbonMonoxideMeasurement
     version: 1
-  - id: batteryLevel
-    version: 1
   - id: battery
     version: 1
   - id: hardwareFault

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-battery.yml
@@ -1,0 +1,21 @@
+name: smoke-battery
+components:
+- id: main
+  capabilities:
+  - id: smokeDetector
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmokeDetector
+preferences:
+  - preferenceId: certifiedpreferences.smokeSensorSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-battery.yml
@@ -4,9 +4,9 @@ components:
   capabilities:
   - id: smokeDetector
     version: 1
-  - id: hardwareFault
-    version: 1
   - id: battery
+    version: 1
+  - id: hardwareFault
     version: 1
   - id: firmwareUpdate
     version: 1

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-battery.yml
@@ -6,8 +6,6 @@ components:
     version: 1
   - id: hardwareFault
     version: 1
-  - id: batteryLevel
-    version: 1
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-battery.yml
@@ -1,0 +1,23 @@
+name: smoke-co-battery
+components:
+- id: main
+  capabilities:
+  - id: smokeDetector
+    version: 1
+  - id: carbonMonoxideDetector
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: battery
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmokeDetector
+preferences:
+  - preferenceId: certifiedpreferences.smokeSensorSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-battery.yml
@@ -6,8 +6,6 @@ components:
     version: 1
   - id: carbonMonoxideDetector
     version: 1
-  - id: batteryLevel
-    version: 1
   - id: battery
     version: 1
   - id: hardwareFault

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-comeas-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-comeas-battery.yml
@@ -8,8 +8,6 @@ components:
     version: 1
   - id: carbonMonoxideMeasurement
     version: 1
-  - id: batteryLevel
-    version: 1
   - id: battery
     version: 1
   - id: hardwareFault

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-comeas-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-comeas-battery.yml
@@ -1,0 +1,25 @@
+name: smoke-co-comeas-battery
+components:
+- id: main
+  capabilities:
+  - id: smokeDetector
+    version: 1
+  - id: carbonMonoxideDetector
+    version: 1
+  - id: carbonMonoxideMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: battery
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmokeDetector
+preferences:
+  - preferenceId: certifiedpreferences.smokeSensorSensitivity
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-temp-humidity-comeas-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-temp-humidity-comeas-battery.yml
@@ -1,0 +1,33 @@
+name: smoke-co-temp-humidity-comeas-battery
+components:
+- id: main
+  capabilities:
+  - id: smokeDetector
+    version: 1
+  - id: carbonMonoxideDetector
+    version: 1
+  - id: relativeHumidityMeasurement
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: carbonMonoxideMeasurement
+    version: 1
+  - id: batteryLevel
+    version: 1
+  - id: battery
+    version: 1
+  - id: hardwareFault
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmokeDetector
+preferences:
+  - preferenceId: certifiedpreferences.smokeSensorSensitivity
+    explicit: true
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: humidityOffset
+    explicit: true

--- a/drivers/SmartThings/matter-sensor/profiles/smoke-co-temp-humidity-comeas-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-co-temp-humidity-comeas-battery.yml
@@ -12,8 +12,6 @@ components:
     version: 1
   - id: carbonMonoxideMeasurement
     version: 1
-  - id: batteryLevel
-    version: 1
   - id: battery
     version: 1
   - id: hardwareFault

--- a/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
@@ -224,8 +224,8 @@ end
 
 local function power_source_attribute_list_handler(driver, device, ib, response)
   for _, attr in ipairs(ib.data.elements) do
-    -- Re-profile the device if BatPercentRemaining (Attribute ID 0x0C) is available
-    if attr.value == 0x0C then
+    -- Re-profile the device if BatPercentRemaining is available
+    if attr.value == clusters.PowerSource.attributes.BatPercentRemaining.ID then
       match_profile(device, battery_support.BATTERY_PERCENTAGE)
       return
     end

--- a/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
@@ -281,7 +281,7 @@ local matter_smoke_co_alarm_handler = {
     [capabilities.batteryLevel.ID] = {
       clusters.SmokeCoAlarm.attributes.BatteryAlert,
     },
-    [capabilities.batteryLevel.ID] = {
+    [capabilities.battery.ID] = {
       clusters.PowerSource.attributes.BatPercentRemaining,
     }
   },

--- a/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/smoke-co-alarm/init.lua
@@ -60,7 +60,7 @@ local supported_profiles =
   "co-comeas",
   "co-comeas-battery",
   "smoke",
-  "smoke-battey",
+  "smoke-battery",
   "smoke-co-comeas",
   "smoke-co-comeas-battery",
   "smoke-co-temp-humidity-comeas",

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm.lua
@@ -73,6 +73,8 @@ local cluster_subscribe_list = {
 }
 
 local function test_init()
+  local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -81,7 +83,6 @@ local function test_init()
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
-  mock_device:expect_metadata_update({ profile = "smoke-co-temp-humidity-comeas" })
 end
 
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
@@ -1,0 +1,133 @@
+-- Copyright 2024 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local t_utils = require "integration_test.utils"
+local uint32 = require "st.matter.data_types.Uint32"
+
+local clusters = require "st.matter.clusters"
+clusters.SmokeCoAlarm = require "SmokeCoAlarm"
+local version = require "version"
+if version.api < 10 then
+  clusters.SmokeCoAlarm = require "SmokeCoAlarm"
+  clusters.CarbonMonoxideConcentrationMeasurement = require "CarbonMonoxideConcentrationMeasurement"
+end
+
+local mock_device = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("smoke-co-temp-humidity-comeas-battery.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.SmokeCoAlarm.ID, cluster_type = "SERVER", feature_map = clusters.SmokeCoAlarm.types.Feature.CO_ALARM | clusters.SmokeCoAlarm.types.Feature.SMOKE_ALARM},
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.CarbonMonoxideConcentrationMeasurement.ID, cluster_type = "SERVER", feature_map = clusters.CarbonMonoxideConcentrationMeasurement.types.Feature.NUMERIC_MEASUREMENT},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = clusters.PowerSource.types.PowerSourceFeature.BATTERY},
+      },
+      device_types = {
+        {device_type_id = 0x0076, device_type_revision = 1} -- Smoke CO Alarm
+      }
+    }
+  }
+})
+
+local cluster_subscribe_list = {
+  clusters.SmokeCoAlarm.attributes.SmokeState,
+  clusters.SmokeCoAlarm.attributes.TestInProgress,
+  clusters.SmokeCoAlarm.attributes.COState,
+  clusters.SmokeCoAlarm.attributes.HardwareFaultAlert,
+  clusters.SmokeCoAlarm.attributes.BatteryAlert,
+  clusters.TemperatureMeasurement.attributes.MeasuredValue,
+  clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
+  clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+  clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasuredValue,
+  clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasurementUnit,
+  clusters.PowerSource.attributes.BatChargeLevel,
+  clusters.PowerSource.attributes.BatPercentRemaining,
+}
+
+local function test_init()
+  local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
+  test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+end
+
+test.set_test_init_function(test_init)
+
+test.register_coroutine_test(
+  "Test profile change when battery percent remaining attribute (attribute ID 12) is available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(12)})
+      }
+    )
+    mock_device:expect_metadata_update({ profile = "smoke-co-temp-humidity-comeas-battery" })
+  end
+)
+
+test.register_coroutine_test(
+  "Test that profile does not change when battery percent remaining attribute is not available",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(0)})
+      }
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Battery percent reports should generate correct messages",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(mock_device, 1, 150)
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.battery.battery(math.floor(150 / 2.0 + 0.5))
+      )
+    )
+  end
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
@@ -62,14 +62,12 @@ local cluster_subscribe_list = {
   clusters.SmokeCoAlarm.attributes.TestInProgress,
   clusters.SmokeCoAlarm.attributes.COState,
   clusters.SmokeCoAlarm.attributes.HardwareFaultAlert,
-  clusters.SmokeCoAlarm.attributes.BatteryAlert,
   clusters.TemperatureMeasurement.attributes.MeasuredValue,
   clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
   clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
   clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
   clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasuredValue,
   clusters.CarbonMonoxideConcentrationMeasurement.attributes.MeasurementUnit,
-  clusters.PowerSource.attributes.BatChargeLevel,
   clusters.PowerSource.attributes.BatPercentRemaining,
 }
 


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change adds support for the battery capability for devices that support the BatPercentRemaining attribute from the PowerSource cluster. If the attribute is not supported, use batteryLevel if supported, otherwise use a profile without a battery capability.

# Summary of Completed Tests

Tested with the VDA Smoke/CO Alarm device as well as new unit tests.