### PR TITLE
fix(hue): Make rounding logic platform consistent

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -69,9 +69,9 @@ local function _emit_light_events_inner(light_device, light_repr)
       -- if the below is not intuitive.
       local color_temp_range = light_device:get_latest_state("main", capabilities.colorTemperature.ID, capabilities.colorTemperature.colorTemperatureRange.NAME);
       local min_kelvin = (color_temp_range and color_temp_range.minimum)
-      local api_min_kelvin = math.floor(utils.mirek_to_kelvin(mirek_schema.mirek_maximum) or Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE)
+      local api_min_kelvin = math.floor(utils.mirek_to_kelvin(mirek_schema.mirek_maximum, Consts.KELVIN_STEP_SIZE) or Consts.MIN_TEMP_KELVIN_COLOR_AMBIANCE)
       local max_kelvin = (color_temp_range and color_temp_range.maximum)
-      local api_max_kelvin = math.floor(utils.mirek_to_kelvin(mirek_schema.mirek_minimum) or Consts.MAX_TEMP_KELVIN)
+      local api_max_kelvin = math.floor(utils.mirek_to_kelvin(mirek_schema.mirek_minimum, Consts.KELVIN_STEP_SIZE) or Consts.MAX_TEMP_KELVIN)
 
       local update_range = false
       if min_kelvin ~= api_min_kelvin then

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
@@ -158,10 +158,10 @@ function LightLifecycleHandlers.added(driver, device, parent_device_id, resource
     if caps.colorTemperature then
       local min_ct_kelvin, max_ct_kelvin = nil, nil
       if type(light_info.color_temperature.mirek_schema.mirek_maximum) == "number" then
-        min_ct_kelvin = math.floor(utils.mirek_to_kelvin(light_info.color_temperature.mirek_schema.mirek_maximum))
+        min_ct_kelvin = math.floor(utils.mirek_to_kelvin(light_info.color_temperature.mirek_schema.mirek_maximum, Consts.KELVIN_STEP_SIZE))
       end
       if type(light_info.color_temperature.mirek_schema.mirek_minimum) == "number" then
-        max_ct_kelvin = math.floor(utils.mirek_to_kelvin(light_info.color_temperature.mirek_schema.mirek_minimum))
+        max_ct_kelvin = math.floor(utils.mirek_to_kelvin(light_info.color_temperature.mirek_schema.mirek_minimum, Consts.KELVIN_STEP_SIZE))
       end
       if not min_ct_kelvin then
         if caps.colorControl then

--- a/drivers/SmartThings/philips-hue/src/test/spec/unit/utils_spec.lua
+++ b/drivers/SmartThings/philips-hue/src/test/spec/unit/utils_spec.lua
@@ -16,13 +16,13 @@ describe("utility functions", function()
   describe("that perform mirek to kelvin conversions behave properly:", function()
     it("Common minimum mirek of 153 results in 6500 Kelvin", function()
       local expected_kelvin = 6500
-      local computed_kelvin = utils.mirek_to_kelvin(Consts.DEFAULT_MIN_MIREK)
+      local computed_kelvin = utils.mirek_to_kelvin(Consts.DEFAULT_MIN_MIREK, Consts.KELVIN_STEP_SIZE)
       assert.are.equal(expected_kelvin, computed_kelvin, string.format("Expected value of %s, got %s", expected_kelvin, computed_kelvin))
     end)
 
     it("Common maximum mirek of 500 results in 2000 Kelvin", function()
       local expected_kelvin = 2000
-      local computed_kelvin = utils.mirek_to_kelvin(Consts.DEFAULT_MAX_MIREK)
+      local computed_kelvin = utils.mirek_to_kelvin(Consts.DEFAULT_MAX_MIREK, Consts.KELVIN_STEP_SIZE)
       assert.are.equal(expected_kelvin, computed_kelvin, string.format("Expected value of %s, got %s", expected_kelvin, computed_kelvin))
     end)
   end)

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -1,6 +1,6 @@
 local log = require "log"
+local st_utils = require "st.utils"
 
-local Consts = require "consts"
 local Fields = require "fields"
 local HueDeviceTypes = require "hue_device_types"
 
@@ -72,9 +72,14 @@ end
 
 function utils.kelvin_to_mirek(kelvin) return 1000000 / kelvin end
 
-function utils.mirek_to_kelvin(mirek)
+function utils.mirek_to_kelvin(mirek, with_step_size)
   local raw_kelvin = 1000000 / mirek
-  return Consts.KELVIN_STEP_SIZE * math.floor(raw_kelvin / Consts.KELVIN_STEP_SIZE)
+
+  if type(with_step_size) == "number" then
+    return with_step_size * math.floor(raw_kelvin / with_step_size)
+  end
+
+  return st_utils.round(raw_kelvin)
 end
 
 function utils.str_starts_with(str, start)


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

There was a slight bug with the previous port of the rounding logic from Matter/Zigbee over to Hue because I was reading two different places in the code and getting them confused in my head.

This change does the following:

1. Only use the 100 step size constraint when computing the min/max values instead of everywhere. This is in line with how this is handled elsewhere on the platform.
2. Use normal rounding everywhere else.


# Summary of Completed Tests

- Busted tests still pass
- ThinkTank will be QA'ing after merge to Alpha
