### PR TITLE
BUG2-4037 Z-Wave Thermostat: Whole number workaround

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/src/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/init.lua
@@ -71,6 +71,9 @@ local function set_setpoint_factory(setpoint_type)
         size = 2
       })
     else
+      -- There have been issues with some thermostats failing to handle non-integer values
+      -- correctly. This rounding is intended to be removed.
+      value = utils.round(value)
       set = ThermostatSetpoint:Set({
         setpoint_type = setpoint_type,
         scale = scale,

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_stelpro_ki_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_stelpro_ki_thermostat.lua
@@ -62,7 +62,7 @@ test.register_coroutine_test(
           ThermostatSetpoint:Set({
             setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
             scale = 1,
-            value = 84.2
+            value = 84
           })
       )
     )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
@@ -635,4 +635,56 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Setting the heating setpoint should generate the appropriate commands and round values not at half-degree increments",
+  function()
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+
+    test.socket.zwave:__queue_receive(
+      {
+        mock_device.id,
+        zw_test_utilities.zwave_test_build_receive_command(
+          ThermostatSetpoint:Report(
+            {
+              setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
+              scale = 1,
+              value = 68
+            })
+        )
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main",
+        capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 68, unit = "F" })
+      )
+    )
+    test.wait_for_events()
+
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "thermostatHeatingSetpoint", command = "setHeatingSetpoint", args = { 70.2 } } })
+    test.socket.zwave:__expect_send(
+      zw_test_utilities.zwave_test_build_send_command(
+        mock_device,
+        ThermostatSetpoint:Set({
+                                setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1,
+                                value = 70,
+                                precision = 0,
+                                size = 1,
+                                scale = 1,
+                              })
+      )
+    )
+    test.wait_for_events()
+
+    test.mock_time.advance_time(1)
+    test.socket.zwave:__expect_send(
+      zw_test_utilities.zwave_test_build_send_command(
+        mock_device,
+        ThermostatSetpoint:Get({
+                                setpoint_type = ThermostatSetpoint.setpoint_type.HEATING_1
+                              })
+      )
+    )
+  end
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
Some z-wave thermostats are choking when told to be set to non-whole numbers. This fixes our base behavior for values that aren't half degrees (which are usually celsius).

Intended to be temporary

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


