### PR TITLE
Add NetworkAudio category to bose audionotification profile

### DIFF
--- a/drivers/SmartThings/bose/profiles/soundtouch-notification.yml
+++ b/drivers/SmartThings/bose/profiles/soundtouch-notification.yml
@@ -21,4 +21,5 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: Speaker 
+  - name: Speaker
+  - name: NetworkAudio


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Add NetworkAudio category to bose audionotification profile

# Summary of Completed Tests

* Onboarded device with this profile, and validated basic functionality
