### PR TITLE
Update Allowed Config Values for ThermostatOperatingState capability

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
@@ -37,6 +37,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: airConditionerFanMode
     version: 1
   - id: fanSpeedPercent

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-wind-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-wind-heating-cooling.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: airConditionerFanMode
     version: 1
   - id: fanSpeedPercent

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-heating-cooling.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-fan-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-fan-heating-cooling.yml
@@ -16,6 +16,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: airConditionerFanMode
     version: 1
   - id: fanSpeedPercent

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-heating-cooling.yml
@@ -16,6 +16,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: airConditionerFanMode
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner.yml
@@ -16,6 +16,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: airConditionerFanMode
     version: 1
   - id: fanSpeedPercent

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-batteryLevel.yml
@@ -12,6 +12,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: batteryLevel
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-batteryLevel.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: batteryLevel
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-batteryLevel.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: batteryLevel
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-batteryLevel.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: batteryLevel
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-batteryLevel.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: batteryLevel
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-batteryLevel.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: batteryLevel
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: battery
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-batteryLevel.yml
@@ -12,6 +12,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: batteryLevel

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-batteryLevel.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: relativeHumidityMeasurement
     version: 1
   - id: batteryLevel

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-batteryLevel.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: batteryLevel

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-batteryLevel.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: batteryLevel

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only.yml
@@ -12,6 +12,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan.yml
@@ -14,6 +14,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-batteryLevel.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-batteryLevel.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: batteryLevel

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only.yml
@@ -10,6 +10,12 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity.yml
@@ -12,6 +12,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: relativeHumidityMeasurement
     version: 1
   - id: battery

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat.yml
@@ -12,6 +12,13 @@ components:
     version: 1
   - id: thermostatOperatingState
     version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
   - id: battery
     version: 1
   - id: firmwareUpdate


### PR DESCRIPTION
# Description of Change
This change will ensure that only the expected and desired allowed values for the ThermsotatOperatingState capability will display on the routines/automations display. Because this is a read-only value from the device card, it will not affect anything on that front.

# Summary of Completed Tests
This has been tested on a VDA Room Air Conditioner to ensure only the config-specified values show up on the routines sub-page for this capabilty. It has also been tested on a physical device using this capability.

