### PR TITLE
feat(sonos): Add reporting for Sonos App `swGen`

### DIFF
--- a/drivers/SmartThings/sonos/capabilities/softwareGeneration.yaml
+++ b/drivers/SmartThings/sonos/capabilities/softwareGeneration.yaml
@@ -1,0 +1,17 @@
+id: stus.softwareGeneration
+version: 1
+status: proposed
+name: Software Generation
+ephemeral: false
+attributes:
+  generation:
+    schema:
+      type: object
+      properties:
+        value:
+          type: string
+      additionalProperties: false
+      required:
+        - value
+    enumCommands: []
+commands: {}

--- a/drivers/SmartThings/sonos/profiles/sonos-player.yml
+++ b/drivers/SmartThings/sonos/profiles/sonos-player.yml
@@ -30,6 +30,8 @@ components:
     version: 1
   - id: audioVolume
     version: 1
+  - id: stus.softwareGeneration
+    version: 1
   - id: refresh
     version: 1
   categories:

--- a/drivers/SmartThings/sonos/src/disco.lua
+++ b/drivers/SmartThings/sonos/src/disco.lua
@@ -13,18 +13,18 @@ local ssdp_discovery_callback = function(driver, ssdp_group_info, known_devices_
   if not found_ip_addrs[ssdp_group_info.ip] then
     found_ip_addrs[ssdp_group_info.ip] = true
 
+    ---@type DiscoCallback
     local function add_device_callback(dni, inner_ssdp_group_info, player_info, group_info)
       if not known_devices_dnis[dni] then
         local name = player_info.device.name or player_info.device.modelDisplayName or "Unknown Sonos Player"
         local model = player_info.device.modelDisplayName or "Unknown Sonos Model"
 
-        local field_cache = {
+        driver._field_cache[dni] = {
           household_id = inner_ssdp_group_info.household_id,
           player_id = player_info.playerId,
-          wss_url = player_info.websocketUrl
+          wss_url = player_info.websocketUrl,
+          swGen = player_info.device.swGen
         }
-
-        driver._field_cache[dni] = field_cache
 
         driver.sonos:update_household_info(player_info.householdId, group_info)
 

--- a/drivers/SmartThings/sonos/src/fields.lua
+++ b/drivers/SmartThings/sonos/src/fields.lua
@@ -9,6 +9,7 @@ Fields.SonosPlayerFields = {
   HOUSEHOULD_ID = "householdId",
   PLAYER_ID = "playerId",
   WSS_URL = "wss_url",
+  SW_GEN = "sw_gen",
 }
 
 return Fields

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -38,6 +38,8 @@ local SonosState = require "types".SonosState
 local SSDP = require "ssdp"
 local utils = require "utils"
 
+local swGenCapability = capabilities["stus.softwareGeneration"]
+
 --- @param driver SonosDriver
 --- @param device SonosDevice
 --- @param should_continue function|nil
@@ -65,13 +67,12 @@ local function find_player_for_device(driver, device, should_continue)
         if dni_equal(dni, device.device_network_id) then
           device.log.info(string.format("Found Sonos Player match for device"))
 
-          local field_cache = {
+          driver._field_cache[dni] = {
             household_id = inner_ssdp_group_info.household_id,
             player_id = player_info.playerId,
-            wss_url = player_info.websocketUrl
+            wss_url = player_info.websocketUrl,
+            swGen = player_info.device.swGen
           }
-
-          driver._field_cache[dni] = field_cache
 
           driver.sonos:update_household_info(player_info.householdId, group_info)
           player_found = true
@@ -83,17 +84,21 @@ local function find_player_for_device(driver, device, should_continue)
   return player_found
 end
 
+---@param driver SonosDriver
+---@param device SonosDevice
+---@param fields SonosFieldCacheTable
 local function update_fields_from_ssdp_scan(driver, device, fields)
   device.log.debug("Updating fields from SSDP scan")
   local is_initialized = device:get_field(PlayerFields._IS_INIT)
 
-  local current_player_id, current_url, current_household_id, sonos_conn
+  local current_player_id, current_url, current_household_id, sonos_conn, sw_gen
 
   if is_initialized then
      current_player_id =device:get_field(PlayerFields.PLAYER_ID)
      current_url = device:get_field(PlayerFields.WSS_URL)
      current_household_id = device:get_field(PlayerFields.HOUSEHOULD_ID)
      sonos_conn = device:get_field(PlayerFields.CONNECTION)
+     sw_gen = device:get_field(PlayerFields.SW_GEN)
   end
 
   local already_connected = sonos_conn ~= nil
@@ -127,6 +132,11 @@ local function update_fields_from_ssdp_scan(driver, device, fields)
     device:set_field(PlayerFields.WSS_URL, fields.wss_url, { persist = true })
   end
 
+  if sw_gen ~= fields.swGen then
+    device:set_field(PlayerFields.SW_GEN, fields.swGen, {persist = true})
+    device:emit_event(swGenCapability.generation(string.format("%s", fields.swGen)))
+  end
+
   if refresh and already_connected then
     if not sonos_conn then
       sonos_conn = SonosConnection.new(driver, device)
@@ -140,14 +150,19 @@ local function update_fields_from_ssdp_scan(driver, device, fields)
   end
 end
 
+
+---@param driver SonosDriver
 local function scan_for_ssdp_updates(driver)
   SSDP.search(SONOS_SSDP_SEARCH_TERM, function(ssdp_group_info)
     driver:handle_ssdp_discovery(ssdp_group_info, function(dni, inner_ssdp_group_info, player_info, group_info)
       local current_cached_fields = driver._field_cache[dni] or {}
+
+      ---@type SonosFieldCacheTable
       local updated_fields = {
         household_id = inner_ssdp_group_info.household_id,
         player_id = player_info.playerId,
-        wss_url = player_info.websocketUrl
+        wss_url = player_info.websocketUrl,
+        swGen = player_info.device.swGen
       }
 
       driver._field_cache[dni] = updated_fields
@@ -315,7 +330,7 @@ end
 
 --- @param self SonosDriver
 --- @param ssdp_group_info SonosSSDPInfo
---- @param callback? fun(dni: string, ssdp_group_info: SonosSSDPInfo, player_info: SonosDiscoveryInfo, group_info: SonosGroupsResponseBody)
+--- @param callback? DiscoCallback
 local function handle_ssdp_discovery(self, ssdp_group_info, callback)
   log.debug(string.format("Looking for player info for SSDP search results %s", st_utils.stringify_table(ssdp_group_info)))
   local player_info, err = SonosRestApi.get_player_info(ssdp_group_info.ip, SonosApi.DEFAULT_SONOS_PORT)

--- a/drivers/SmartThings/sonos/src/types.lua
+++ b/drivers/SmartThings/sonos/src/types.lua
@@ -380,10 +380,18 @@ Types.SonosState = SonosState
 
 --- @alias DiscoCallback fun(dni: string, ssdp_group_info: SonosSSDPInfo, player_info: SonosDiscoveryInfo, group_info: SonosGroupsResponseBody)
 
+---@class SonosFieldCacheTable
+---@field public swGen number
+---@field public household_id string
+---@field public player_id string
+---@field public wss_url string
+
+
 --- Sonos Edge Driver extensions
 --- @class SonosDriver : Driver
 --- @field public sonos SonosState Local state related to the sonos systems
---- @field private _player_id_to_device table<string,SonosDevice>
+--- @field public _player_id_to_device table<string,SonosDevice>
+--- @field public _field_cache table<string,SonosFieldCacheTable>
 --- @field public update_group_state fun(self: SonosDriver, header: SonosResponseHeader, body: SonosGroupsResponseBody)
 --- @field public handle_ssdp_discovery fun(self: SonosDriver, ssdp_group_info: SonosSSDPInfo, callback?: DiscoCallback)
 --- @field public is_same_mac_address fun(dni: string, other: string): boolean


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Adds support for the `stus` custom capability `softwareGeneration`, which allow for reporting of the `swGen` field on the Sonos Player Info.

This field reports whether or not the speaker has been onboarded to Sonos via the S1 app or the modern Sonos app.


# Summary of Completed Tests

Tested locally on a hubv3.

cc @bflorian would we be able to get the capability published to the lower envs for `stus`? I was only able to do it to Production, and I think it'll break packaging of the driver if they don't exist in the lower environments.