### PR TITLE
Fix wrong colorControl values emitted after device power cycle

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -65,9 +65,9 @@ local COLOR_TEMP_MAX = "__color_temp_max"
 local LEVEL_BOUND_RECEIVED = "__level_bound_received"
 local LEVEL_MIN = "__level_min"
 local LEVEL_MAX = "__level_max"
-local CURRENT_HUE_SAT = clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION
-local CURRENT_X_Y     = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
 local COLOR_MODE = "__color_mode"
+local HUE_SAT_COLOR_MODE = clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION
+local X_Y_COLOR_MODE = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
 
 local AGGREGATOR_DEVICE_TYPE_ID = 0x000E
 local ON_OFF_LIGHT_DEVICE_TYPE_ID = 0x0100
@@ -910,7 +910,7 @@ local function level_attr_handler(driver, device, ib, response)
 end
 
 local function hue_attr_handler(driver, device, ib, response)
-  if device:get_field(COLOR_MODE) == CURRENT_X_Y  or ib.data.value == nil then
+  if device:get_field(COLOR_MODE) == X_Y_COLOR_MODE  or ib.data.value == nil then
     return
   end
   local hue = math.floor((ib.data.value / 0xFE * 100) + 0.5)
@@ -918,7 +918,7 @@ local function hue_attr_handler(driver, device, ib, response)
 end
 
 local function sat_attr_handler(driver, device, ib, response)
-  if device:get_field(COLOR_MODE) == CURRENT_X_Y  or ib.data.value == nil then
+  if device:get_field(COLOR_MODE) == X_Y_COLOR_MODE  or ib.data.value == nil then
     return
   end
   local sat = math.floor((ib.data.value / 0xFE * 100) + 0.5)
@@ -1024,7 +1024,7 @@ end
 local color_utils = require "color_utils"
 
 local function x_attr_handler(driver, device, ib, response)
-  if device:get_field(COLOR_MODE) == CURRENT_HUE_SAT then
+  if device:get_field(COLOR_MODE) == HUE_SAT_COLOR_MODE then
     return
   end
   local y = device:get_field(RECEIVED_Y)
@@ -1042,7 +1042,7 @@ local function x_attr_handler(driver, device, ib, response)
 end
 
 local function y_attr_handler(driver, device, ib, response)
-  if device:get_field(COLOR_MODE) == CURRENT_HUE_SAT then
+  if device:get_field(COLOR_MODE) == HUE_SAT_COLOR_MODE then
     return
   end
   local x = device:get_field(RECEIVED_X)
@@ -1058,15 +1058,15 @@ local function y_attr_handler(driver, device, ib, response)
 end
 
 local function color_mode_attr_handler(driver, device, ib, response)
-  if ib.data.value == device:get_field(COLOR_MODE) or (ib.data.value ~= CURRENT_HUE_SAT and ib.data.value ~= CURRENT_X_Y) then
+  if ib.data.value == device:get_field(COLOR_MODE) or (ib.data.value ~= HUE_SAT_COLOR_MODE and ib.data.value ~= X_Y_COLOR_MODE) then
     return
   end
   device:set_field(COLOR_MODE, ib.data.value)
   local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
-  if ib.data.value == CURRENT_HUE_SAT then
+  if ib.data.value == HUE_SAT_COLOR_MODE then
     req:merge(clusters.ColorControl.attributes.CurrentHue:read())
     req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-  elseif ib.data.value == CURRENT_X_Y then
+  elseif ib.data.value == X_Y_COLOR_MODE then
     req:merge(clusters.ColorControl.attributes.CurrentX:read())
     req:merge(clusters.ColorControl.attributes.CurrentY:read())
   end

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -74,6 +74,22 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
+local function set_color_mode(device, endpoint, color_mode)
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
+      device, endpoint, color_mode)
+  })
+  local read_req
+  if color_mode == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
+    read_req = clusters.ColorControl.attributes.CurrentHue:read()
+    read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
+  else -- color_mode = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
+    read_req = clusters.ColorControl.attributes.CurrentX:read()
+    read_req:merge(clusters.ColorControl.attributes.CurrentY:read())
+  end
+  test.socket.matter:__expect_send({device.id, read_req})
+end
 
 local function test_init()
   local cluster_subscribe_list = {
@@ -85,14 +101,13 @@ local function test_init()
     clusters.ColorControl.attributes.CurrentSaturation,
     clusters.ColorControl.attributes.CurrentX,
     clusters.ColorControl.attributes.CurrentY,
+    clusters.ColorControl.attributes.ColorMode,
     clusters.ColorControl.attributes.ColorTemperatureMireds,
     clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
     clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
     clusters.IlluminanceMeasurement.attributes.MeasuredValue,
     clusters.OccupancySensing.attributes.Occupancy
   }
-  local read_color_mode = clusters.ColorControl.attributes.ColorMode:read()
-  test.socket.matter:__expect_send({mock_device.id, read_color_mode})
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -101,20 +116,37 @@ local function test_init()
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({
-    mock_device.id,
-    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
-      mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
-  })
-  local read_req = clusters.ColorControl.attributes.CurrentHue:read()
-  read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-  test.socket.matter:__expect_send({mock_device.id, read_req})
+  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
 end
 test.set_test_init_function(test_init)
+
+local function test_init_x_y_color_mode()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+    clusters.LevelControl.attributes.CurrentLevel,
+    clusters.LevelControl.attributes.MaxLevel,
+    clusters.LevelControl.attributes.MinLevel,
+    clusters.ColorControl.attributes.CurrentHue,
+    clusters.ColorControl.attributes.CurrentSaturation,
+    clusters.ColorControl.attributes.CurrentX,
+    clusters.ColorControl.attributes.CurrentY,
+    clusters.ColorControl.attributes.ColorMode,
+    clusters.ColorControl.attributes.ColorTemperatureMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+    clusters.IlluminanceMeasurement.attributes.MeasuredValue,
+    clusters.OccupancySensing.attributes.Occupancy
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
+end
 
 test.register_message_test(
 	"On command should send the appropriate commands",
@@ -413,101 +445,91 @@ test.register_message_test(
   }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "X and Y color values should report hue and saturation once both have been received",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+  function()
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
       }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+    )
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(72))
-    }
-  }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "X and Y color values have 0 value",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+  function()
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)
       }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+    )
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(33))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(100))
-    }
-  }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(33)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(100)
+      )
+    )
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
-
-test.register_message_test(
+test.register_coroutine_test(
   "Y and X color values should report hue and saturation once both have been received",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+  function()
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
       }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+    )
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(72))
-    }
-  }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
 test.register_message_test(

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -86,15 +86,30 @@ local cluster_subscribe_list = {
   clusters.ColorControl.attributes.CurrentSaturation,
   clusters.ColorControl.attributes.CurrentX,
   clusters.ColorControl.attributes.CurrentY,
+  clusters.ColorControl.attributes.ColorMode,
   clusters.ColorControl.attributes.ColorTemperatureMireds,
   clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
   clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
 }
 
-local function test_init()
-  local read_color_mode = clusters.ColorControl.attributes.ColorMode:read()
-  test.socket.matter:__expect_send({mock_device.id, read_color_mode})
+local function set_color_mode(device, endpoint, color_mode)
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
+      device, endpoint, color_mode)
+  })
+  local read_req
+  if color_mode == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
+    read_req = clusters.ColorControl.attributes.CurrentHue:read()
+    read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
+  else -- color_mode = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
+    read_req = clusters.ColorControl.attributes.CurrentX:read()
+    read_req:merge(clusters.ColorControl.attributes.CurrentY:read())
+  end
+  test.socket.matter:__expect_send({device.id, read_req})
+end
 
+local function test_init()
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -103,24 +118,23 @@ local function test_init()
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device.id, clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)})
-  test.socket.matter:__queue_receive({
-    mock_device.id,
-    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
-      mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
-  })
-  local read_req = clusters.ColorControl.attributes.CurrentHue:read()
-  read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-  test.socket.matter:__expect_send({mock_device.id, read_req})
+  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
 end
 test.set_test_init_function(test_init)
 
+local function test_init_x_y_color_mode()
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
+end
+
 local function test_init_no_hue_sat()
-  local read_color_mode = clusters.ColorControl.attributes.ColorMode:read()
-  test.socket.matter:__expect_send({mock_device_no_hue_sat.id, read_color_mode})
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_no_hue_sat)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -129,16 +143,7 @@ local function test_init_no_hue_sat()
   end
   test.socket.matter:__expect_send({mock_device_no_hue_sat.id, subscribe_request})
   test.mock_device.add_test_device(mock_device_no_hue_sat)
-  test.socket.matter:__queue_receive({mock_device_no_hue_sat.id, clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device_no_hue_sat, 1, 0)})
-  test.socket.matter:__queue_receive({mock_device_no_hue_sat.id, clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device_no_hue_sat, 1, 0)})
-  test.socket.matter:__queue_receive({
-    mock_device_no_hue_sat.id,
-    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
-      mock_device_no_hue_sat, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
-  })
-  local read_req = clusters.ColorControl.attributes.CurrentX:read()
-  read_req:merge(clusters.ColorControl.attributes.CurrentY:read())
-  test.socket.matter:__expect_send({mock_device_no_hue_sat.id, read_req})
+  set_color_mode(mock_device_no_hue_sat, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
 end
 
 test.register_message_test(
@@ -552,101 +557,91 @@ test.register_message_test(
   }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "X and Y color values should report hue and saturation once both have been received",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+  function()
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
       }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+    )
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(72))
-    }
-  }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
-test.register_message_test(
+test.register_coroutine_test(
   "X and Y color values have 0 value",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+  function()
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)
       }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+    )
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(33))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(100))
-    }
-  }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(33)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(100)
+      )
+    )
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
-
-test.register_message_test(
+test.register_coroutine_test(
   "Y and X color values should report hue and saturation once both have been received",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+  function()
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
       }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
+    )
+    test.socket.matter:__queue_receive(
+      {
         mock_device.id,
         clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
       }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(72))
-    }
-  }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
 test.register_message_test(
@@ -961,7 +956,8 @@ test.register_coroutine_test(
         "main", capabilities.colorControl.saturation(100)
       )
     )
-  end
+  end,
+  { test_init = test_init_x_y_color_mode }
 )
 
 test.register_coroutine_test(


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Following a device power cycle, hub power cycle, or device going offline and then back online, it sends a subscription report with Hue, Saturation, X, and Y values. The ColorMode needs to be checked before emitting the colorControl capability with the hue and saturation values. The issue is that the ColorMode attribute is not guaranteed to be processed by the driver before the other color attributes. Therefore, the ColorMode handler should send a read request for the proper color attributes after checking the ColorMode.

Changes were previously made by [PR 1772](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1772), but that only addressed hub power cycles. This PR handles every case in which the driver might receive a subscription report from the device where this problem could occur.

# Summary of Completed Tests

Tested with a Zemismart color bulb, IKEA color bulb, and by CN team.