### PR TITLE
New Devices (Matter Switch)  Aqara H2 Switches

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -40,11 +40,6 @@ matterManufacturer:
     vendorId: 0x115F
     productId: 0x1806
     deviceProfileName: light-level-colorTemperature-2700K-6500K
-  - id: "4447/8196"
-    deviceLabel: Climate Sensor W100
-    vendorId: 0x115F
-    productId: 0x2004
-    deviceProfileName: 3-button-battery-temperature-humidity
 #AiDot
   - id: "Linkind/Smart/Light/Bulb/A19/RGBTW"
     deviceLabel: Linkind Smart Light Bulb A19 RGBTW

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -20,6 +20,11 @@ matterManufacturer:
     vendorId: 0x115F
     productId: 0x1806
     deviceProfileName: light-level-colorTemperature-2700K-6500K
+  - id: "4447/8196"
+    deviceLabel: Climate Sensor W100
+    vendorId: 0x115F
+    productId: 0x2004
+    deviceProfileName: 3-button-battery-temperature-humidity
 #AiDot
   - id: "Linkind/Smart/Light/Bulb/A19/RGBTW"
     deviceLabel: Linkind Smart Light Bulb A19 RGBTW

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,5 +1,25 @@
 matterManufacturer:
 #Aqara
+  - id: "4447/4100"
+    deviceLabel: Aqara Light Switch H2 US (2 Buttons 2 Channel)
+    vendorId: 0x115F
+    productId: 0x1004
+    deviceProfileName: light-power-energy-powerConsumption
+  - id: "4447/4101"
+    deviceLabel: Aqara Light Switch H2 US (4 Buttons 3 Channel)
+    vendorId: 0x115F
+    productId: 0x1005
+    deviceProfileName: light-power-energy-powerConsumption
+  - id: "4447/4104"
+    deviceLabel: Aqara Light Switch H2 EU (2 Buttons 1 Channel)
+    vendorId: 0x115F
+    productId: 0x1008
+    deviceProfileName: light-power-energy-powerConsumption
+  - id: "4447/4105"
+    deviceLabel: Aqara Light Switch H2 EU (4 Buttons 2 Channel)
+    vendorId: 0x115F
+    productId: 0x1009
+    deviceProfileName: light-power-energy-powerConsumption   
   - id: "4447/6145"
     deviceLabel: Aqara LED Bulb T2 RGB CCT
     vendorId: 0x115F

--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,5 +1,10 @@
 matterManufacturer:
 #Aqara
+  - id: "4447/4099"
+    deviceLabel: Aqara Light Switch H2 US (2 Buttons 1 Channel)
+    vendorId: 0x115F
+    productId: 0x1003
+    deviceProfileName: light-power-energy-powerConsumption
   - id: "4447/4100"
     deviceLabel: Aqara Light Switch H2 US (2 Buttons 2 Channel)
     vendorId: 0x115F


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ X ] WWST Certification Request
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ X ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Adding fingerprints for  multiple Aqara Devices that all share the same profile. 
They all are  requesting the profile of [light-power-energy-powerConsumption](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/main/drivers/SmartThings/matter-switch/profiles/light-power-energy-powerConsumption.yml) and have device names such as Aqara Light Switch H2 US (2 Buttons 2 Channel) . According to the DCL [they](https://csa-iot.org/csa_product/light-switch-h2-us2-button2-channel/) all have a Matter Device Type of (0x100). 

Please note: These devices will add children based on this [handling in the init file ](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/adde68f9993af4ca8dc0693ae2468f8a78622a9d/drivers/SmartThings/matter-switch/src/init.lua#L186)

# Summary of Completed Tests
SPROL will test

