### PR TITLE
fix(sonos): Fix crash calling wrong log table

### DIFF
--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -260,12 +260,12 @@ end
 local function emit_component_event_no_cache(device, component, capability_event)
     if not device:supports_capability(capability_event.capability, component.id) then
         local err_msg = string.format("Attempted to generate event for %s.%s but it does not support capability %s", device.id, component.id, capability_event.capability.NAME)
-        log.warn_with({ hub_logs = true }, err_msg)
+        old_log.warn_with({ hub_logs = true }, err_msg)
         return false, err_msg
     end
     local event, err = capabilities.emit_event(device, component.id, device.capability_channel, capability_event)
     if err ~= nil then
-        log.warn_with({ hub_logs = true }, err)
+        old_log.warn_with({ hub_logs = true }, err)
     end
     return event, err
 end


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

We're calling a non-existent method on a log table in the `init.lua` file because we added some extra diagnostics using a shadowing log table in that file.

This fixes the crash by calling the correct method on the correct table.

# Summary of Completed Tests


