### PR TITLE
Remove Hue Flag Gating for Battery Support

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/init.lua
@@ -52,8 +52,6 @@ local TEMP_BOUND_RECEIVED = "__temp_bound_received"
 local TEMP_MIN = "__temp_min"
 local TEMP_MAX = "__temp_max"
 
-local HUE_MANUFACTURER_ID = 0x100B
-
 local battery_support = {
   NO_BATTERY = "NO_BATTERY",
   BATTERY_LEVEL = "BATTERY_LEVEL",
@@ -172,8 +170,7 @@ end
 
 local function do_configure(driver, device)
   local battery_feature_eps = device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY})
-  -- Hue devices support the PowerSource cluster but don't support reporting battery percentage remaining
-  if #battery_feature_eps > 0 and device.manufacturer_info.vendor_id ~= HUE_MANUFACTURER_ID then
+  if #battery_feature_eps > 0 then
     local attribute_list_read = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
     attribute_list_read:merge(clusters.PowerSource.attributes.AttributeList:read())
     device:send(attribute_list_read)

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -313,7 +313,6 @@ local TEMP_BOUND_RECEIVED = "__temp_bound_received"
 local TEMP_MIN = "__temp_min"
 local TEMP_MAX = "__temp_max"
 
-local HUE_MANUFACTURER_ID = 0x100B
 local AQARA_MANUFACTURER_ID = 0x115F
 local AQARA_CLIMATE_SENSOR_W100_ID = 0x2004
 
@@ -628,7 +627,6 @@ local function build_button_profile(device, main_endpoint, num_button_eps)
   else
     profile_name = num_button_eps .. "-button"
     battery_supported = #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY}) > 0
-    if device.manufacturer_info.vendor_id == HUE_MANUFACTURER_ID then battery_supported = false end -- no battery support in Hue case
     if battery_supported then
       local attribute_list_read = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
       attribute_list_read:merge(clusters.PowerSource.attributes.AttributeList:read())


### PR DESCRIPTION
# Description of Change
A Hue flag was previously introduced into some Matter drivers since they do not support the BatPercentRemaining attribute and that was our only battery handler. However, with the introduction of BatChargeLevel support across the Matter drivers, this gating is no longer required.

# Summary of Completed Tests


