### PR TITLE
Early return and Re-read In Case of SystemMode Race Conditions

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
@@ -329,6 +329,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -339,6 +347,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("thermostatTwo", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
     {
       channel = "matter",
@@ -393,6 +409,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -403,6 +427,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("thermostatOne", capabilities.thermostatMode.supportedThermostatModes({"off", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
     {
       channel = "matter",
@@ -419,6 +451,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -429,6 +469,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("thermostatTwo", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
     {
       channel = "matter",
@@ -445,6 +493,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -455,6 +511,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("thermostatTwo", capabilities.thermostatMode.supportedThermostatModes({"off", "cool"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
   }
 )

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
@@ -541,6 +541,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -551,6 +559,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("thermostatOne", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
     {
       channel = "matter",
@@ -609,6 +625,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_with_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device_with_auto.id,
@@ -631,6 +655,14 @@ test.register_message_test(
       message = {
         mock_device_with_auto.id,
         clusters.Thermostat.server.attributes.ControlSequenceOfOperation:build_test_report_data(mock_device_with_auto, THERMOSTAT_TWO_EP, 5)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_with_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
       }
     },
     {

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -322,6 +322,8 @@ test.register_message_test(
   }
 )
 
+--   test.socket.matter:__expect_send({mock_device_auto.id, clusters.Thermostat.attributes.MinSetpointDeadBand:read(mock_device_auto)})
+
 test.register_message_test(
   "Thermostat mode reports should generate correct messages",
   {
@@ -337,6 +339,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
     {
       channel = "matter",
@@ -373,6 +383,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -386,6 +404,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -396,6 +422,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
   }
 )
@@ -418,6 +452,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device_auto.id,
@@ -431,6 +473,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device_auto.id,
@@ -441,6 +491,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
   },
   { test_init = test_init_auto }
@@ -461,6 +519,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
 		{
       channel = "matter",
@@ -498,6 +564,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "heat", "auto"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
 		{
       channel = "matter",
@@ -537,6 +611,14 @@ test.register_message_test(
       direction = "send",
       message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "heat", "auto"}, {visibility={displayed=false}}))
     },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
 		{
       channel = "matter",
       direction = "receive",
@@ -557,6 +639,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device_auto:generate_test_message("main", capabilities.thermostatMode.supportedThermostatModes({"off", "cool", "auto"}, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_auto.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
 		{
       channel = "matter",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
@@ -284,6 +284,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -319,6 +327,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -333,6 +349,14 @@ test.register_message_test(
     },
     {
       channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
+    },
+    {
+      channel = "matter",
       direction = "receive",
       message = {
         mock_device.id,
@@ -344,6 +368,14 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main",
         capabilities.thermostatMode.supportedThermostatModes({ "off",  "cool" }, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
   }
 )
@@ -364,6 +396,14 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main",
         capabilities.thermostatMode.supportedThermostatModes({ "off", "cool", "heat" }, {visibility={displayed=false}}))
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.SystemMode:read()
+      }
     },
     {
       channel = "matter",


### PR DESCRIPTION
# Description of Change
The current SystemMode / ControlSequenceofOperation handling expects for ControlSequenceofOperation to be handled first in all cases, but this is not necessarily the case. This change ensures a particular ordering by early exiting the SystemMode handler if a table that is initialized in the ControlSequenceofOperation handler has not been initialized yet. Then, in the ControlSequenceofOperation handler, it always does a read of SystemMode. At worst, this will cause a dual handling of a single SystemMode value, which will not do anything detrimental. Further, ControlSequenceofOperation should only be run on a subscription.  

# Summary of Completed Tests
Tested on device by SRPOL.
Uni tests updated.