### PR TITLE
Remove Offset Preferences in Thermostat Driver

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/air-purifier-hepa-ac-rock-wind-thermostat-humidity-fan-heating-only-nostate-nobattery-aqs-pm10-pm25-ch2o-meas-pm10-pm25-ch2o-no2-tvoc-level.yml
@@ -49,11 +49,6 @@ components:
     version: 1
   categories:
   - name: AirPurifier
-  preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
 - id: hepaFilter
   label: Hepa Filter
   capabilities:

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling-nostate.yml
@@ -22,6 +22,3 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-heating-cooling.yml
@@ -31,6 +31,3 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-wind-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-fan-wind-heating-cooling.yml
@@ -33,6 +33,3 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-heating-cooling.yml
@@ -27,6 +27,3 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-fan-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-fan-heating-cooling.yml
@@ -33,8 +33,3 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-heating-cooling.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner-humidity-heating-cooling.yml
@@ -31,8 +31,4 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/room-air-conditioner.yml
@@ -35,8 +35,4 @@ components:
     version: 1
   categories:
   - name: AirConditioner
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate-nobattery.yml
@@ -14,6 +14,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nostate.yml
@@ -16,6 +16,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only.yml
@@ -24,6 +24,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate-nobattery.yml
@@ -16,6 +16,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only-nostate.yml
@@ -18,6 +18,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-cooling-only.yml
@@ -26,6 +26,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate-nobattery.yml
@@ -16,6 +16,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only-nostate.yml
@@ -18,6 +18,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-heating-only.yml
@@ -26,6 +26,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate-nobattery.yml
@@ -18,6 +18,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan-nostate.yml
@@ -20,6 +20,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-fan.yml
@@ -29,6 +29,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate-nobattery.yml
@@ -14,6 +14,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nostate.yml
@@ -16,6 +16,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only.yml
@@ -24,6 +24,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate-nobattery.yml
@@ -16,8 +16,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only-nostate.yml
@@ -18,8 +18,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-cooling-only.yml
@@ -26,8 +26,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate-nobattery.yml
@@ -18,8 +18,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only-nostate.yml
@@ -20,8 +20,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-cooling-only.yml
@@ -28,8 +28,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate-nobattery.yml
@@ -18,8 +18,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only-nostate.yml
@@ -20,8 +20,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-heating-only.yml
@@ -28,8 +28,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate-nobattery.yml
@@ -20,8 +20,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan-nostate.yml
@@ -22,8 +22,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-fan.yml
@@ -31,8 +31,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate-nobattery.yml
@@ -16,8 +16,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only-nostate.yml
@@ -18,8 +18,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-heating-only.yml
@@ -26,8 +26,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate-nobattery.yml
@@ -18,8 +18,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity-nostate.yml
@@ -20,8 +20,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-humidity.yml
@@ -29,8 +29,4 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true
-  - preferenceId: humidityOffset
-    explicit: true
+

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate-nobattery.yml
@@ -16,6 +16,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nostate.yml
@@ -18,6 +18,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat.yml
@@ -27,6 +27,3 @@ components:
     version: 1
   categories:
   - name: Thermostat
-preferences:
-  - preferenceId: tempOffset
-    explicit: true


### PR DESCRIPTION
# Description of Change
Creating an offset in a thermostat device which includes a display will result in a different value shown on the SmartThings app vs the device itself, since no device-side functionality is changed. For sensors where there is no display, this is not an issue, but it is not the same for thermostats and other similar devices with a display.  

# Summary of Completed Tests


