### PR TITLE
CHAD-15194 Zigbee locks: don't report code numbers if lock does not s…

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/init.lua
@@ -357,7 +357,7 @@ local lock_operation_event_handler = function(driver, device, zb_rx)
   local event = STATUS[event_code]
   if (event ~= nil) then
     event["data"] = {}
-    if (event_code == OperationEventCode.AUTO_LOCK or
+    if (source ~= 0 and event_code == OperationEventCode.AUTO_LOCK or
         event_code == OperationEventCode.SCHEDULE_LOCK or
         event_code == OperationEventCode.SCHEDULE_UNLOCK
       ) then

--- a/drivers/SmartThings/zigbee-lock/src/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/init.lua
@@ -365,7 +365,7 @@ local lock_operation_event_handler = function(driver, device, zb_rx)
     else
       event.data.method = METHOD[source]
     end
-    if (source == 0) then --keypad
+    if (source == 0 and device:supports_capability_by_id(capabilities.lockCodes.ID)) then --keypad
       local code_id = zb_rx.body.zcl_body.user_id.value
       local code_name = "Code "..code_id
       local lock_codes = device:get_field("lockCodes")

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
@@ -143,7 +143,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.locked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.locked({ data = { method = "keypad"} })
         )
       }
     }
@@ -169,7 +169,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.unlocked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.unlocked({ data = { method = "keypad"} })
         )
       }
     }
@@ -195,7 +195,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.locked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.locked({ data = { method = "keypad"} })
         )
       }
     }
@@ -221,7 +221,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.locked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.locked({ data = { method = "keypad"} })
         )
       }
     }
@@ -247,7 +247,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.unlocked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.unlocked({ data = { method = "keypad"} })
         )
       }
     }
@@ -273,7 +273,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.locked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.locked({ data = { method = "auto"} })
         )
       }
     }
@@ -299,7 +299,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.locked({data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.locked({data = { method = "keypad"} })
         )
       }
     }
@@ -325,7 +325,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.unlocked({ data = { codeId = "0", codeName = "Code 0", method = "keypad"} })
+          capabilities.lock.lock.unlocked({ data = { method = "keypad"} })
         )
       }
     }

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_samsungsds.lua
@@ -273,7 +273,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main",
-          capabilities.lock.lock.locked({ data = { method = "auto"} })
+          capabilities.lock.lock.locked({ data = { method = "keypad"} })
         )
       }
     }


### PR DESCRIPTION
…upport them

The lock/unlock event data field would include the code index reported by the lock, which was usually a default value, even if the lock didn't support lock codes, leading to confusing history messages



