### PR TITLE
change one button categories from RemoteController to Button

### DIFF
--- a/drivers/SmartThings/zigbee-button/profiles/button-profile.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/button-profile.yml
@@ -11,4 +11,4 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: RemoteController
+  - name: Button

--- a/drivers/SmartThings/zigbee-button/profiles/iris-one-button-battery.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/iris-one-button-battery.yml
@@ -11,7 +11,7 @@ components:
   - id: refresh
     version: 1
   categories:
-  - name: RemoteController
+  - name: Button
 preferences:
 - name: "holdTime"
   title: "Hold time"

--- a/drivers/SmartThings/zigbee-button/profiles/one-button-battery.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/one-button-battery.yml
@@ -11,4 +11,4 @@ components:
       - id: refresh
         version: 1
     categories:
-      - name: RemoteController
+      - name: Button

--- a/drivers/SmartThings/zigbee-button/profiles/one-button.yml
+++ b/drivers/SmartThings/zigbee-button/profiles/one-button.yml
@@ -9,4 +9,5 @@ components:
       - id: refresh
         version: 1
     categories:
-      - name: RemoteController
+      - name: Button
+


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [o] Refactor

# Checklist

- [o] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
This change is similar to the previous PR. 

> The icon for the RemoteController category is not a button icon. This commit changes the category for the single button profile among the matter-button profiles from RemoteController to Button.

https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1163

# Summary of Completed Tests


