### PR TITLE
Enable native attribute handlers for Zigbee/Z-Wave/Matter drivers

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -919,12 +919,18 @@ local function on_off_attr_handler(driver, device, ib, response)
   else
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switch.switch.off())
   end
+  if type(device.register_native_capability_attr_handler) == "function" then
+    device:register_native_capability_attr_handler("switch", "switch")
+  end
 end
 
 local function level_attr_handler(driver, device, ib, response)
   if ib.data.value ~= nil then
     local level = math.floor((ib.data.value / 254.0 * 100) + 0.5)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switchLevel.level(level))
+    if type(device.register_native_capability_attr_handler) == "function" then
+      device:register_native_capability_attr_handler("switchLevel", "level")
+    end
   end
 end
 

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/init.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/init.lua
@@ -27,6 +27,7 @@ local zigbee_carbon_monoxide_driver_template = {
     sub_drivers = { require("ClimaxTechnology") }
 }
 
-defaults.register_for_default_handlers(zigbee_carbon_monoxide_driver_template, zigbee_carbon_monoxide_driver_template.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_carbon_monoxide_driver_template,
+    zigbee_carbon_monoxide_driver_template.supported_capabilities, {native_capability_attrs_enabled = true})
 local zigbee_carbon_monoxide_driver = ZigbeeDriver("zigbee-carbon-monoxide-detector", zigbee_carbon_monoxide_driver_template)
 zigbee_carbon_monoxide_driver:run()

--- a/drivers/SmartThings/zigbee-contact/src/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/init.lua
@@ -109,6 +109,7 @@ local zigbee_contact_driver_template = {
   ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE
 }
 
-defaults.register_for_default_handlers(zigbee_contact_driver_template, zigbee_contact_driver_template.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_contact_driver_template,
+  zigbee_contact_driver_template.supported_capabilities, {native_capability_attrs_enabled = true})
 local zigbee_contact = ZigbeeDriver("zigbee_contact", zigbee_contact_driver_template)
 zigbee_contact:run()

--- a/drivers/SmartThings/zigbee-motion-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/init.lua
@@ -133,6 +133,7 @@ local zigbee_motion_driver = {
   ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE
 }
 
-defaults.register_for_default_handlers(zigbee_motion_driver, zigbee_motion_driver.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_motion_driver,
+  zigbee_motion_driver.supported_capabilities, {native_capability_attrs_enabled = true})
 local motion = ZigbeeDriver("zigbee-motion", zigbee_motion_driver)
 motion:run()

--- a/drivers/SmartThings/zigbee-smoke-detector/src/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/init.lua
@@ -31,6 +31,7 @@ local zigbee_smoke_driver_template = {
   ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE,
 }
 
-defaults.register_for_default_handlers(zigbee_smoke_driver_template, zigbee_smoke_driver_template.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_smoke_driver_template,
+  zigbee_smoke_driver_template.supported_capabilities, {native_capability_attrs_enabled = true})
 local zigbee_smoke_driver = ZigbeeDriver("zigbee-smoke-detector", zigbee_smoke_driver_template)
 zigbee_smoke_driver:run()

--- a/drivers/SmartThings/zigbee-sound-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-sound-sensor/src/init.lua
@@ -130,6 +130,7 @@ local zigbee_sound_sensor_driver_template = {
   health_check = false,
 }
 
-defaults.register_for_default_handlers(zigbee_sound_sensor_driver_template, zigbee_sound_sensor_driver_template.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_sound_sensor_driver_template,
+  zigbee_sound_sensor_driver_template.supported_capabilities, {native_capability_attrs_enabled = true})
 local zigbee_sound_sensor = ZigbeeDriver("zigbee-sound-sensor", zigbee_sound_sensor_driver_template)
 zigbee_sound_sensor:run()

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -169,6 +169,8 @@ local zigbee_switch_driver_template = {
   }
 }
 defaults.register_for_default_handlers(zigbee_switch_driver_template,
-  zigbee_switch_driver_template.supported_capabilities,  {native_capability_cmds_enabled = true})
+  zigbee_switch_driver_template.supported_capabilities,
+  {native_capability_cmds_enabled = true, native_capability_attrs_enabled = true}
+)
 local zigbee_switch = ZigbeeDriver("zigbee_switch", zigbee_switch_driver_template)
 zigbee_switch:run()

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/init.lua
@@ -101,6 +101,7 @@ local zigbee_water_driver_template = {
   },
 }
 
-defaults.register_for_default_handlers(zigbee_water_driver_template, zigbee_water_driver_template.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_water_driver_template,
+  zigbee_water_driver_template.supported_capabilities, {native_capability_attrs_enabled = true})
 local zigbee_water_driver = ZigbeeDriver("zigbee-water", zigbee_water_driver_template)
 zigbee_water_driver:run()

--- a/drivers/SmartThings/zwave-switch/src/init.lua
+++ b/drivers/SmartThings/zwave-switch/src/init.lua
@@ -172,7 +172,9 @@ local driver_template = {
   }
 }
 
-defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities,  {native_capability_cmds_enabled = true})
+defaults.register_for_default_handlers(driver_template,
+  driver_template.supported_capabilities,
+  {native_capability_cmds_enabled = true, native_capability_attrs_enabled = true})
 --- @type st.zwave.Driver
 local switch = ZwaveDriver("zwave_switch", driver_template)
 switch:run()


### PR DESCRIPTION
This will be enabled in the next lua lib release (v14)

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


