### PR TITLE
Update Fan/Light profile min kelvin value

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-fan.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-fan.yml
@@ -15,7 +15,7 @@ components:
         config:
           values:
             - key: "colorTemperature.value"
-              range: [ 2200, 6500 ]
+              range: [ 2700, 6500 ]
       - id: colorControl
         version: 1
       - id: fanMode


### PR DESCRIPTION
Update Min Kelvin value to 2700K to reflect the minimum value supported by the Orein fan light device, needed for WWST certification.

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior