### PR TITLE
【P250418-01789】fix bugs for zigbee-switch

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -84,6 +84,9 @@ local device_init = function(driver, device)
   if ias_zone_config_method ~= nil then
     device:set_ias_zone_config_method(ias_zone_config_method)
   end
+  if device.network_type == device_lib.NETWORK_TYPE_ZIGBEE then
+    device:set_find_child(find_child)
+  end
 end
 
 local function is_mcd_device(device)


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
We reproduced this issue by powering off and then powering on the SmartThings hub. After doing so, the child switch device of the multi-switch does not function correctly.

The root cause appears to be that, in the current `zigbee-switch` driver's `device_init` function, the `find_child` function is not called. As a result, when the hub is powered off and then powered on again, the driver is unable to locate the multi-switch's child device.

Therefore, we added the call to `find_child` in the `device_init` function, and it works as expected. We tested it multiple times, and it consistently functions correctly.
