### PR TITLE
Matter switch and zigbee fan switchLevel: Match default handlers behavior around small values

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -933,7 +933,10 @@ end
 
 local function level_attr_handler(driver, device, ib, response)
   if ib.data.value ~= nil then
-    local level = math.floor((ib.data.value / 254.0 * 100) + 0.5)
+    local level = ib.data.value
+    if level > 0 then
+      level = math.max(1, utils.round(level / 254.0 * 100))
+    end
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switchLevel.level(level))
     if type(device.register_native_capability_attr_handler) == "function" then
       device:register_native_capability_attr_handler("switchLevel", "level")

--- a/drivers/SmartThings/zigbee-fan/src/fan-light/init.lua
+++ b/drivers/SmartThings/zigbee-fan/src/fan-light/init.lua
@@ -74,7 +74,11 @@ local function zb_fan_control_handler(driver, device, value, zb_rx)
 end
 
 local function zb_level_handler(driver, device, value, zb_rx)
-  local evt = capabilities.switchLevel.level(math.floor((value.value / 254.0 * 100) + 0.5))
+  local level = value.value
+  if level > 0 then
+    level = math.max(1, math.floor((level / 254.0 * 100) + 0.5))
+  end
+  local evt = capabilities.switchLevel.level(level)
   device:emit_component_event(device.profile.components.light, evt)
 end
 


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Match the behavior around small values to the default handlers around switchLevel for matter-switch and zigbee fan.

# Summary of Completed Tests


