### PR TITLE
Fix/unit tests 57 beta

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -725,6 +725,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(20))
@@ -741,7 +749,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -257,6 +257,14 @@ test.register_message_test(
 			message = mock_device:generate_test_message("main", capabilities.switchLevel.level(20))
 		},
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
+    {
       channel = "matter",
       direction = "receive",
       message = {
@@ -268,7 +276,15 @@ test.register_message_test(
 			channel = "capability",
 			direction = "send",
 			message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-		}
+		},
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
 	}
 )
 
@@ -288,6 +304,14 @@ test.register_message_test(
 			direction = "send",
 			message = mock_device:generate_test_message("main", capabilities.switchLevel.level(math.floor((50 / 254.0 * 100) + 0.5)))
 		},
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
 	}
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -125,6 +125,13 @@ test.register_coroutine_test(
         clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, mock_device_ep1, true)
       }
     )
+    test.socket.devices:__expect_send(
+      {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    )
+
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
         "main", capabilities.switch.switch.on()

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -255,6 +255,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(20))
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
+    {
       channel = "matter",
       direction = "receive",
       message = {
@@ -266,7 +274,16 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+
   }
 )
 
@@ -285,6 +302,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(math.floor((50 / 254.0 * 100) + 0.5)))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
   }
 )

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -321,7 +321,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -364,7 +372,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_children[child1_ep]:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -407,7 +423,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_children[child2_ep]:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -426,6 +450,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_children[child1_ep]:generate_test_message("main", capabilities.switchLevel.level(math.floor((50 / 254.0 * 100) + 0.5)))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
   }
 )

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -249,7 +249,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -292,7 +300,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_children[child1_ep]:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -335,7 +351,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_children[child2_ep]:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_zigbee_carbon_monoxide.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_zigbee_carbon_monoxide.lua
@@ -46,7 +46,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.carbonMonoxideDetector.carbonMonoxide.detected())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "carbonMonoxideDetector", capability_attr_id = "carbonMonoxide" }
+        }
+      },
     }
 )
 
@@ -62,7 +70,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.carbonMonoxideDetector.carbonMonoxide.clear())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "carbonMonoxideDetector", capability_attr_id = "carbonMonoxide" }
+        }
+      },
     }
 )
 
@@ -78,7 +94,16 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.carbonMonoxideDetector.carbonMonoxide.detected())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "carbonMonoxideDetector", capability_attr_id = "carbonMonoxide" }
+        }
+      },
+
     }
 )
 
@@ -94,7 +119,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.carbonMonoxideDetector.carbonMonoxide.clear())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "carbonMonoxideDetector", capability_attr_id = "carbonMonoxide" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_aqara_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_aqara_contact_sensor.lua
@@ -175,7 +175,7 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "closed contact events - OnOff",
+  "open contact events - OnOff",
   function()
     local attr_report_data = {
       { OnOff.attributes.OnOff.ID, data_types.Boolean.ID, true }

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
@@ -48,7 +48,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.contactSensor.contact.open())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "contactSensor", capability_attr_id = "contact" }
+        }
+      },
     }
 )
 
@@ -64,7 +72,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.contactSensor.contact.closed())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "contactSensor", capability_attr_id = "contact" }
+        }
+      },
     }
 )
 
@@ -82,7 +98,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.contactSensor.contact.open())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "contactSensor", capability_attr_id = "contact" }
+        }
+      },
     }
 )
 
@@ -100,7 +124,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.contactSensor.contact.closed())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "contactSensor", capability_attr_id = "contact" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
@@ -49,7 +49,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.active())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 
@@ -65,7 +73,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 
@@ -81,7 +97,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.active())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 
@@ -97,7 +121,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aurora_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aurora_motion.lua
@@ -57,7 +57,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.active())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 
@@ -73,7 +81,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 
@@ -89,7 +105,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.active())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 
@@ -105,7 +129,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_zigbee_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_zigbee_smoke_detector.lua
@@ -47,7 +47,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.smokeDetector.smoke.detected())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "smokeDetector", capability_attr_id = "smoke" }
+        }
+      },
     }
 )
 
@@ -63,7 +71,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.smokeDetector.smoke.clear())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "smokeDetector", capability_attr_id = "smoke" }
+        }
+      },
     }
 )
 
@@ -79,7 +95,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.smokeDetector.smoke.detected())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "smokeDetector", capability_attr_id = "smoke" }
+        }
+      },
     }
 )
 
@@ -95,7 +119,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.smokeDetector.smoke.clear())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "smokeDetector", capability_attr_id = "smoke" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -65,7 +65,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.switchLevel.level(83))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -82,7 +90,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -99,7 +115,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
@@ -68,6 +68,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id,
       OnOff.attributes.OnOff:build_test_attr_report(mock_device, true):from_endpoint(0x01) })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.on()))
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
   end
 )
 
@@ -77,6 +78,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id,
       OnOff.attributes.OnOff:build_test_attr_report(mock_device, true):from_endpoint(0x02) })
     test.socket.capability:__expect_send(mock_child:generate_test_message("main", capabilities.switch.switch.on()))
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
   end
 )
 
@@ -86,6 +88,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id,
       OnOff.attributes.OnOff:build_test_attr_report(mock_device, false):from_endpoint(0x01) })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.off()))
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
   end
 )
 
@@ -95,6 +98,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id,
       OnOff.attributes.OnOff:build_test_attr_report(mock_device, false):from_endpoint(0x02) })
     test.socket.capability:__expect_send(mock_child:generate_test_message("main", capabilities.switch.switch.off()))
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
   end
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
@@ -129,7 +129,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(57))
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
@@ -130,7 +130,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -152,7 +160,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_first_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -174,7 +190,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_second_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -196,7 +220,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_third_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -218,7 +250,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_fourth_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_fourth_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -240,7 +280,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_fifth_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_fifth_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -262,7 +310,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -284,7 +340,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_first_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -306,7 +370,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_second_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -328,7 +400,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_third_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -350,7 +430,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_fourth_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_fourth_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -372,7 +460,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_fifth_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_fifth_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
@@ -107,7 +107,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -129,7 +137,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_first_child:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_first_child.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -151,7 +167,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_second_child:generate_test_message("main", capabilities.switch.switch.on())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_second_child.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -173,7 +197,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.off())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -195,7 +227,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_first_child:generate_test_message("main", capabilities.switch.switch.off())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_first_child.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -217,7 +257,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_second_child:generate_test_message("main", capabilities.switch.switch.off())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_second_child.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
@@ -145,7 +145,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_device:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_child_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -162,7 +170,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -179,7 +195,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_device:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_child_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -196,7 +220,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
@@ -49,7 +49,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_simple_device:generate_test_message("main", capabilities.switchLevel.level(83))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_simple_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -66,7 +74,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_simple_device:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_simple_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -83,7 +99,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_simple_device:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_simple_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sengled_dimmer_bulb_with_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sengled_dimmer_bulb_with_motion_sensor.lua
@@ -176,7 +176,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.active())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+      }
+    },
   }
 )
 
@@ -192,7 +200,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "motionSensor", capability_attr_id = "motion" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
@@ -165,7 +165,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -187,7 +195,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_first_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -209,7 +225,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_second_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -231,7 +255,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_third_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -253,7 +285,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -275,7 +315,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_first_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_first_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -297,7 +345,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_second_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_second_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -319,7 +375,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_third_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_third_child.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_dimmer_power_energy.lua
@@ -127,7 +127,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(57))
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_aqara_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_aqara_water_leak_sensor.lua
@@ -76,7 +76,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 
@@ -92,7 +100,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua
@@ -194,7 +194,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 
@@ -210,7 +218,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_frient_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_frient_water_leak_sensor.lua
@@ -200,7 +200,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 
@@ -216,7 +224,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_samjin_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_samjin_water_leak_sensor.lua
@@ -162,7 +162,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 
@@ -178,7 +186,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_smartthings_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_smartthings_water_leak_sensor.lua
@@ -160,7 +160,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 
@@ -176,7 +184,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water.lua
@@ -47,7 +47,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+        }
+      },
     }
 )
 
@@ -63,7 +71,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+        }
+      },
     }
 )
 
@@ -79,7 +95,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.waterSensor.water.wet())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+        }
+      },
     }
 )
 
@@ -95,7 +119,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.waterSensor.water.dry())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "waterSensor", capability_attr_id = "water" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
@@ -261,9 +261,20 @@ test.register_coroutine_test(
     test.socket.zwave:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle():__queue_receive({mock_fibaro_door_window_sensor.id, "init"})
     test.timer.__create_and_queue_test_time_advance_timer(11, "oneshot")
-    local _preferences = {}
-    _preferences.alarmStatus = 1 -- "Door/window opened"
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
+    local _preference_updates = { --all preferences changed from defaults
+      alarmStatus=1,
+      visualLedIndications=4,
+      delayOfTamperAlarmCancel=6,
+      highTempThreshold=600,
+      intervalOfTempReports=1,
+      lowTempThreshold=30,
+      reportTamperAlarmCancel=false,
+      tempMeasurementInterval=320,
+      tempReportsThreshold=11,
+      temperatureAlarmReports=1,
+      temperatureOffset=2,
+    }
+    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preference_updates }))
     test.wait_for_events()
     test.socket.zwave:__queue_receive(
       {
@@ -298,45 +309,12 @@ test.register_coroutine_test(
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 2 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 2, configuration_value = 1 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.visualLedIndications = 4 --"Indication of device tampering"
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
@@ -347,447 +325,150 @@ test.register_coroutine_test(
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 3 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 3, configuration_value = 4 })
-    })
-
-    test.mock_time.advance_time(1)
-    _preferences = {}
-    _preferences.delayOfTamperAlarmCancel = 5
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-        test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 30,
-          configuration_value = 5,
+          configuration_value = 6,
           size = 2
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 30 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 30, configuration_value = 5 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.reportTamperAlarmCancel = 1
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 31,
-          configuration_value = 1,
+          configuration_value = 0,
           size = 1
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 31 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 31, configuration_value = 1 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.tempMeasurementInterval = 300
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 50,
-          configuration_value = 300,
+          configuration_value = 320,
           size = 2
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 50 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 50, configuration_value = 300 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.tempReportsThreshold = 10
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 51,
-          configuration_value = 10,
+          configuration_value = 11,
           size = 2
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 51 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 51, configuration_value = 10 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.intervalOfTempReports = 0
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 52,
-          configuration_value = 0,
+          configuration_value = 1,
           size = 2
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 52 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 52, configuration_value = 0 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.temperatureOffset = 0
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 53,
-          configuration_value = 0,
+          configuration_value = 2,
           size = 4
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 53 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 53, configuration_value = 0 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.temperatureAlarmReports = 0
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 54,
-          configuration_value = 0,
+          configuration_value = 1,
           size = 1
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 54 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 54, configuration_value = 0 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.highTempThreshold = 540
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 55,
-          configuration_value = 540,
+          configuration_value = 600,
           size = 2
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Get({ parameter_number = 55 })
       )
     )
-
-    test.wait_for_events()
-
-    test.socket.zwave:__queue_receive({
-      mock_fibaro_door_window_sensor.id,
-      Configuration:Report({ parameter_number = 55, configuration_value = 540 })
-    })
-
-    test.mock_time.advance_time(1)
-
-    _preferences = {}
-    _preferences.lowTempThreshold = 40
-    test.socket.device_lifecycle():__queue_receive(mock_fibaro_door_window_sensor:generate_info_changed({ preferences = _preferences }))
-    test.wait_for_events()
-    test.socket.zwave:__queue_receive(
-      {
-        mock_fibaro_door_window_sensor.id,
-        WakeUp:Notification({})
-      }
-    )
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      Battery:Get({})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorMultilevel:Get({sensor_type = SensorMultilevel.sensor_type.TEMPERATURE})
-    ))
-    test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(
-      mock_fibaro_door_window_sensor,
-      SensorBinary:Get({})
-    ))
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
         Configuration:Set({
           parameter_number = 56,
-          configuration_value = 40,
+          configuration_value = 30,
           size = 2
         })
       )
     )
-
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
         mock_fibaro_door_window_sensor,
@@ -797,6 +478,50 @@ test.register_coroutine_test(
 
     test.wait_for_events()
 
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 2, configuration_value = 1 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 3, configuration_value = 4 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 31, configuration_value = 1 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 30, configuration_value = 5 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 31, configuration_value = 1 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 50, configuration_value = 300 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 51, configuration_value = 10 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 52, configuration_value = 0 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 53, configuration_value = 0 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 54, configuration_value = 0 })
+    })
+    test.socket.zwave:__queue_receive({
+      mock_fibaro_door_window_sensor.id,
+      Configuration:Report({ parameter_number = 55, configuration_value = 540 })
+    })
     test.socket.zwave:__queue_receive({
       mock_fibaro_door_window_sensor.id,
       Configuration:Report({ parameter_number = 56, configuration_value = 40 })

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
@@ -129,6 +129,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -136,9 +144,6 @@ test.register_message_test(
         Meter:Get({ scale = Meter.scale.electric_meter.WATTS })
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -161,6 +166,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -168,9 +181,6 @@ test.register_message_test(
         Meter:Get({ scale = Meter.scale.electric_meter.WATTS })
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -195,6 +205,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
     {
       channel = "zwave",
@@ -230,9 +248,25 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(5))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
     {
       channel = "zwave",
@@ -333,6 +367,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -399,6 +434,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
@@ -153,6 +153,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -160,9 +168,6 @@ test.register_message_test(
         Meter:Get({ scale = Meter.scale.electric_meter.WATTS })
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -185,6 +190,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -192,9 +205,6 @@ test.register_message_test(
         Meter:Get({ scale = Meter.scale.electric_meter.WATTS })
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -219,6 +229,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
     {
       channel = "zwave",
@@ -254,9 +272,25 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(5))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
     {
       channel = "zwave",
@@ -357,6 +391,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -423,6 +458,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_eaton_accessory_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_eaton_accessory_dimmer.lua
@@ -89,7 +89,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
-    }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_ecolink_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_ecolink_switch.lua
@@ -140,10 +140,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -164,10 +169,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -188,10 +198,23 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
   }
 )
 
@@ -212,10 +235,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_generic_zwave_device1.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_generic_zwave_device1.lua
@@ -101,13 +101,26 @@ test.register_message_test(
       message = mock_zwave_device1:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_zwave_device1.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_zwave_device1:generate_test_message("main", capabilities.switchLevel.level(100))
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_zwave_device1.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
   }
 )
 
@@ -126,10 +139,15 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_zwave_device1:generate_test_message("main", capabilities.switch.switch.off())
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_zwave_device1.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -150,13 +168,26 @@ test.register_message_test(
       message = mock_zwave_device1:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_zwave_device1.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_zwave_device1:generate_test_message("main", capabilities.switchLevel.level(49))
-    }
-  },
-  {
-    inner_block_ordering = "relaxed"
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_zwave_device1.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
+    },
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_multichannel_device.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_multichannel_device.lua
@@ -169,7 +169,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -195,7 +203,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -221,7 +237,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_2:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -247,7 +271,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -275,10 +307,26 @@ test.register_message_test(
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switchLevel.level(100))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -304,7 +352,23 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -330,7 +394,23 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_2:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -358,10 +438,26 @@ test.register_message_test(
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switchLevel.level(100))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -389,10 +485,26 @@ test.register_message_test(
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switchLevel.level(50))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -418,7 +530,23 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -444,7 +572,23 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_2:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -472,10 +616,26 @@ test.register_message_test(
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switchLevel.level(50))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -507,7 +667,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -539,7 +707,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -571,7 +747,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -603,7 +787,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -637,10 +829,26 @@ test.register_message_test(
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switchLevel.level(100))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -672,7 +880,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -706,10 +922,26 @@ test.register_message_test(
         message = mock_child_3:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_child_3:generate_test_message("main", capabilities.switchLevel.level(50))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -928,16 +1160,21 @@ test.register_message_test(
       {
         channel = "capability",
         direction = "send",
-        message = mock_child_4:generate_test_message("main", capabilities.waterSensor.water.dry())
+        message = mock_child_4:generate_test_message("main", capabilities.motionSensor.motion.inactive())
       },
       {
         channel = "capability",
         direction = "send",
-        message = mock_child_4:generate_test_message("main", capabilities.motionSensor.motion.inactive())
-      }
-    },
-    {
-      inner_block_ordering = "relaxed"
+        message = mock_child_4:generate_test_message("main", capabilities.waterSensor.water.dry())
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -966,16 +1203,29 @@ test.register_message_test(
       {
         channel = "capability",
         direction = "send",
-        message = mock_child_4:generate_test_message("main", capabilities.waterSensor.water.wet())
+        message = mock_child_4:generate_test_message("main", capabilities.motionSensor.motion.active())
       },
       {
         channel = "capability",
         direction = "send",
-        message = mock_child_4:generate_test_message("main", capabilities.motionSensor.motion.active())
-      }
-    },
-    {
-      inner_block_ordering = "relaxed"
+        message = mock_child_4:generate_test_message("main", capabilities.waterSensor.water.wet())
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
@@ -155,6 +155,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -162,9 +170,6 @@ test.register_message_test(
               Meter:Get({scale = Meter.scale.electric_meter.WATTS})
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -185,6 +190,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
     {
       channel = "zwave",
@@ -221,6 +234,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -254,9 +275,25 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(5))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
     {
       channel = "zwave",
@@ -373,6 +410,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -439,6 +477,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
@@ -146,6 +146,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -153,9 +161,6 @@ test.register_message_test(
               Meter:Get({scale = Meter.scale.electric_meter.WATTS})
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -176,6 +181,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
     {
       channel = "zwave",
@@ -212,6 +225,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -245,9 +266,25 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(5))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
     {
       channel = "zwave",
@@ -362,6 +399,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -428,6 +466,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
@@ -90,6 +90,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -97,9 +105,6 @@ test.register_message_test(
               Meter:Get({scale = Meter.scale.electric_meter.WATTS})
       )
     }
-  },
-  {
-    inner_block_ordering = "relaxed"
   }
 )
 
@@ -120,6 +125,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
     {
       channel = "zwave",
@@ -243,6 +256,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -309,6 +323,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_without_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_without_power.lua
@@ -61,9 +61,14 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
-  },
-  {
-    inner_block_ordering = "relaxed"
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
   }
 )
 
@@ -84,6 +89,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
   }
 )
@@ -156,6 +169,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
   end
 )
 
@@ -206,6 +220,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
   end
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay.lua
@@ -140,7 +140,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -161,7 +169,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -182,7 +198,23 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -205,10 +237,26 @@ test.register_message_test(
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switchLevel.level(100))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -235,14 +283,26 @@ test.register_message_test(
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switchLevel.level(100))
-      }
-
-    },
-    {
-      inner_block_ordering = "relaxed"
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 
@@ -267,7 +327,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -288,7 +356,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -309,7 +385,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -481,10 +565,26 @@ test.register_message_test(
         message = mock_parent:generate_test_message("main", capabilities.switch.switch.on())
       },
       {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
+      {
         channel = "capability",
         direction = "send",
         message = mock_parent:generate_test_message("main", capabilities.switchLevel.level(50))
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "switchLevel", capability_attr_id = "level" }
+        }
+      },
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
@@ -66,6 +66,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -93,6 +101,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
     },
     {
       channel = "zwave",
@@ -129,6 +145,14 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.off())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "zwave",
       direction = "send",
       message = zw_test_utils.zwave_test_build_send_command(
@@ -162,9 +186,25 @@ test.register_message_test(
       message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.switchLevel.level(5))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
+      }
     },
     {
       channel = "zwave",
@@ -265,6 +305,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.on())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(
@@ -330,6 +371,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.switch.switch.off())
     )
+    mock_device:expect_native_attr_handler_registration("switch", "switch")
 
     test.socket.zwave:__expect_send(
       zw_test_utils.zwave_test_build_send_command(

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch.lua
@@ -78,7 +78,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_switch_binary:generate_test_message("main", capabilities.switch.switch.on())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_switch_binary.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 
@@ -94,7 +102,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_switch_binary:generate_test_message("main", capabilities.switch.switch.off())
-      }
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_switch_binary.id, capability_id = "switch", capability_attr_id = "switch" }
+        }
+      },
     }
 )
 


### PR DESCRIPTION
57.x FW and lua libraries contain support for native attribute registration. This PR updates all the zb/zw/matter tests to include expectations for this new feature. One thing to note about the defaults is that when handling a protocol message that maps to a child device it is often the case that the parent will be registered to be handled natively; rather than was driver cycles determining if the device has a child to avoid the registration, we are relying on the hubs implementation which does not allow for parents or children to be handled natively.

There was also a bug fix in `utils.update` that required some unit test fixes due to the way the integration tests used the function.

I intend to do a 0.57 beta release artifact today and get this merged.
