### PR TITLE
Matter Thermostat: Use larger temperature range

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -1,3 +1,4 @@
+-- Copyright 2025 SmartThings
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -15,7 +16,6 @@ local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 local uint32 = require "st.matter.data_types.Uint32"
-
 local clusters = require "st.matter.clusters"
 
 local mock_device = test.mock_device.build_test_matter_device({
@@ -93,7 +93,7 @@ local function test_init()
   read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
   test.socket.matter:__expect_send({mock_device.id, read_req})
 
-  test.set_rpc_version(5)
+  test.set_rpc_version(6)
 end
 test.set_test_init_function(test_init)
 
@@ -120,13 +120,13 @@ local function configure(device)
     clusters.Thermostat.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, 1, 2667) --26.67 celcius
   })
   test.socket.capability:__expect_send(
-    device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 5.00, maximum = 40.00, step = 0.1 }, unit = "C" }))
+    device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 0.00, maximum = 100.00, step = 0.1 }, unit = "C" }))
   )
   test.socket.capability:__expect_send(
     device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 24.44, unit = "C" }))
   )
   test.socket.capability:__expect_send(
-    device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 5.00, maximum = 40.00, step = 0.1 }, unit = "C" }))
+    device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 0.00, maximum = 100.00, step = 0.1 }, unit = "C" }))
   )
   test.socket.capability:__expect_send(
     device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 26.67, unit = "C" }))


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

For RPC >= 6, the hub converts temperature values from capability commands to Celsius, meaning the driver no longer needs to use separate ranges for Celsius and Fahrenheit in order to determine the unit as Celsius can always be assumed. A range is still used, in order to filter out values received from the device that are likely to be erroneous, but it is now larger and will be able to accommodate the temperature range for more use cases.

A similar change was made to matter-appliance in https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/1757

# Summary of Completed Tests

Verified with unit tests and tested with VDA Thermostat.
