### PR TITLE
fix an issue of Tuya button send duplicate event 

### DIFF
--- a/drivers/Unofficial/tuya-zigbee/src/button/init.lua
+++ b/drivers/Unofficial/tuya-zigbee/src/button/init.lua
@@ -39,12 +39,6 @@ local function added_handler(self, device)
   device:emit_event(capabilities.button.button.pushed({state_change = false}))
 end
 
-local function button_handler(event)
-  return function(driver, device, value, zb_rx)
-    device:emit_event(event)
-  end
-end
-
 local tuya_private_cluster_button_handler = function(driver, device, zb_rx)
   local event
   local additional_fields = {
@@ -79,9 +73,6 @@ local tuya_button_driver = {
   zigbee_handlers = {
     cluster = {
       [OnOff.ID] = {
-        [OnOff.server.commands.On.ID] = button_handler(capabilities.button.button.double({ state_change = true })),
-        [OnOff.server.commands.Off.ID] = button_handler(capabilities.button.button.held({ state_change = true })),
-        [OnOff.server.commands.Toggle.ID] = button_handler(capabilities.button.button.pushed({ state_change = true })),
         [PRESENT_ATTRIBUTE_ID] = tuya_private_cluster_button_handler
       }
     }

--- a/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_button.lua
+++ b/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_button.lua
@@ -91,50 +91,11 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "OnOff cluster any command (except On or Off) should result with sending pushed event",
-  function()
-    test.socket.zigbee:__queue_receive({
-      mock_device.id,
-      OnOff.server.commands.Toggle.build_test_rx(mock_device)
-    })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", button.button.pushed({ state_change = true }))
-    )
-  end
-)
-
-test.register_coroutine_test(
-  "OnOff cluster On command should result with sending double event",
-  function()
-    test.socket.zigbee:__queue_receive({
-      mock_device.id,
-      OnOff.server.commands.On.build_test_rx(mock_device)
-    })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", button.button.double({ state_change = true }))
-    )
-  end
-)
-
-test.register_coroutine_test(
   "OnOff cluster private command 0x01 should result with sending double event",
   function()
     test.socket.zigbee:__queue_receive({ mock_device.id, zigbee_test_utils.build_custom_command_id(mock_device, OnOff.ID, PRESENT_CMD_ID, MFG_CODE, "\x01") })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", button.button.double({ state_change = true }))
-    )
-  end
-)
-
-test.register_coroutine_test(
-  "OnOff cluster Off command should result with sending held event",
-  function()
-    test.socket.zigbee:__queue_receive({
-      mock_device.id,
-      OnOff.server.commands.Off.build_test_rx(mock_device)
-    })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", button.button.held({ state_change = true }))
     )
   end
 )


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Some Tuya button send two times message while button is pressed, causing duplicate event send to cloud. Therefore, we remove the duplicated capability handlers for tuya-button driver.

# Summary of Completed Tests


