### PR TITLE
deploy: Update Sonos secret injection/packaging.

### DIFF
--- a/tools/deploy.py
+++ b/tools/deploy.py
@@ -27,7 +27,14 @@ VERSION = "version"
 PACKAGEKEY = "packageKey"
 
 BOSE_APPKEY = os.environ.get("BOSE_AUDIONOTIFICATION_APPKEY")
-SONOS_API_KEY = os.environ.get("SONOS_API_KEY")
+
+SONOS_API_KEY = os.environ.get("SONOS_API_KEY") or "N/A"
+SONOS_OAUTH_API_KEY = os.environ.get("SONOS_OAUTH_API_KEY") or "N/A"
+SONOS_API_KEY_LUA_TEMPLATE = f"""return {{
+  s1_key = "{SONOS_API_KEY}",
+  oauth_key = "{SONOS_OAUTH_API_KEY}",
+}}
+"""
 
 print(ENVIRONMENT_URL)
 
@@ -116,8 +123,13 @@ for partner in partners:
       if package_key == "bose" and BOSE_APPKEY:
         # write the app key into a app_key.lua (overwrite if exists already)
         subprocess.run(["touch -a ./src/app_key.lua && echo \'return \"" + BOSE_APPKEY +  "\"\n\' > ./src/app_key.lua"], cwd=driver, shell=True, capture_output=True)
-      if package_key == "sonos" and SONOS_API_KEY:
-        subprocess.run(["echo \'return \"" + SONOS_API_KEY +  "\"\n\' > ./src/app_key.lua"], cwd=driver, shell=True, capture_output=True)
+      if package_key == "sonos":
+          subprocess.run(
+              [f"echo -n '{SONOS_API_KEY_LUA_TEMPLATE}' > ./src/app_key.lua"],
+              cwd=driver,
+              shell=True,
+              capture_output=True,
+          )
       retries = 0
       while not os.path.exists(driver+".zip") and retries < 5:
         try:


### PR DESCRIPTION
We now need to inject two different API keys in to the Sonos driver. The changes for the driver have already landed, and they have landed in a way that is backwards compatible with the previous deploy script as well: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/blob/8b2d6f571eda5b8a5ce31db5e3094d23af38d2de/drivers/SmartThings/sonos/src/api/init.lua#L6-L23