### PR TITLE
Matter Switch: Remove Energy Setters in added

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -1318,14 +1318,6 @@ local function device_added(driver, device)
     device:send(req)
   end
 
-  -- Reset the values
-  if device:supports_capability(capabilities.powerMeter) then
-    device:emit_event(capabilities.powerMeter.power({ value = 0.0, unit = "W" }))
-  end
-  if device:supports_capability(capabilities.energyMeter) then
-    device:emit_event(capabilities.energyMeter.energy({ value = 0.0, unit = "Wh" }))
-  end
-
   -- call device init in case init is not called after added due to device caching
   device_init(driver, device)
 end

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -162,27 +162,6 @@ local function test_init_periodic()
   test.timer.__create_and_queue_test_time_advance_timer(60 * 15, "interval", "create_poll_report_schedule")
 end
 
-test.register_coroutine_test(
-  "Check the power and energy meter when the device is added", function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-    local subscribe_request = subscribed_attributes[1]:subscribe(mock_device)
-    for i, cluster in ipairs(subscribed_attributes) do
-        if i > 1 then
-            subscribe_request:merge(cluster:subscribe(mock_device))
-        end
-    end
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 0.0, unit = "W" }))
-    )
-
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 0.0, unit = "Wh" }))
-    )
-    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-    test.wait_for_events()
-  end
-)
-
 test.register_message_test(
 	"On command should send the appropriate commands",
   {


### PR DESCRIPTION
# Description of Change
Remove `emit_event` calls in added. In the case of `powerMeter`, this will be populated with a distinct value after `subscribe` occurs either in `device_init` or `info_changed`. It is the same in the case of `energyMeter`. In both cases, setting an initial value of 0 on added does not add any meaningful data to the capability handling, and so this is a wasted call.

# Summary of Completed Tests
One test removed related to ensuring this was running. 

