### PR TITLE
Support greater profiling for parent/child switch devices

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -777,7 +777,7 @@ local function match_profile(driver, device)
   profile_name = assign_switch_profile(device, main_endpoint, false)
   -- ignore attempts to dynamically profile light-level-colorTemperature devices for now, since
   -- these may lose fingerprinted Kelvin ranges when dynamically profiled.
-  if profile_name and profile_name ~= "light-level-colorTemperature" then
+  if profile_name and profile_name ~= "light-level-colorTemperature" and profile_name ~= "light-color-level" then
     device:try_update_metadata({profile = profile_name})
   end
 end

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -524,15 +524,24 @@ local function assign_switch_profile(device, switch_ep, is_child_device)
       break
     end
   end
-  -- Add electrical support to the first switch ep if Electical Sensor is handled on a unique ep
-  local switch_eps = device:get_endpoints(clusters.OnOff.ID)
-  table.sort(switch_eps)
-  if switch_ep == switch_eps[1] and electrical_tags == "" and contains_device_type(device, ELECTRICAL_SENSOR_ID) then
-    if #embedded_cluster_utils.get_endpoints(device, clusters.ElectricalEnergyMeasurement.ID) > 0 then
-      electrical_tags = electrical_tags .. "-power"
-    end
-    if #embedded_cluster_utils.get_endpoints(device, clusters.ElectricalPowerMeasurement.ID) > 0 then
-      electrical_tags = electrical_tags .."-energy-powerConsumption"
+  -- Add electrical support to the switch ep if Electical Sensor is handled on a unique ep
+  if electrical_tags == "" and contains_device_type(device, ELECTRICAL_SENSOR_ID) then
+    local electrical_energy_eps = device:get_endpoints(clusters.ElectricalEnergyMeasurement.ID)
+    local electrical_power_eps = device:get_endpoints(clusters.ElectricalPowerMeasurement.ID)
+    local switch_eps = device:get_endpoints(clusters.OnOff.ID)
+    table.sort(electrical_energy_eps)
+    table.sort(electrical_power_eps)
+    table.sort(switch_eps)
+    for i, ep in ipairs(switch_eps) do
+      if ep == switch_ep then
+        if electrical_energy_eps[i] then
+          electrical_tags = electrical_tags .. "-power"
+        end
+        if electrical_power_eps[i] then
+          electrical_tags = electrical_tags .. "-energy-powerConsumption"
+        end
+        break
+      end
     end
     if electrical_tags ~= "" and (profile == "plug-binary" or profile == "plug-level" or profile == "light-binary") then
       profile = string.gsub(profile, "-binary", "") .. electrical_tags

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -480,11 +480,11 @@ local function check_field_name_updates(device)
   end
 end
 
-local function assign_child_profile(device, child_ep)
+local function assign_switch_profile(device, switch_ep, is_child_device)
   local profile
-
+  local electrical_tags = ""
   for _, ep in ipairs(device.endpoints) do
-    if ep.endpoint_id == child_ep then
+    if ep.endpoint_id == switch_ep then
       -- Some devices report multiple device types which are a subset of
       -- a superset device type (For example, Dimmable Light is a superset of
       -- On/Off light). This mostly applies to the four light types, so we will want
@@ -495,28 +495,88 @@ local function assign_child_profile(device, child_ep)
         id = math.max(id, dt.device_type_id)
       end
       profile = device_type_profile_map[id]
+      if profile == "plug-binary" or profile == "plug-level" then
+        local power_cluster_found, energy_cluster_found = false, false
+        for _, cluster in ipairs(ep.clusters) do
+          if cluster.cluster_id == clusters.ElectricalPowerMeasurement.ID then
+            power_cluster_found = true
+          elseif cluster.cluster_id == clusters.ElectricalEnergyMeasurement.ID then
+            energy_cluster_found = true
+          end
+        end
+        if power_cluster_found then
+          electrical_tags = electrical_tags .. "-power"
+        end
+        if energy_cluster_found then
+          electrical_tags = electrical_tags .."-energy-powerConsumption"
+        end
+        if electrical_tags ~= "" then
+          profile = string.gsub(profile, "-binary", "") -- remove the "-binary" in the plug-binary profile name
+          profile = profile .. electrical_tags
+        end
+      end
       break
     end
   end
 
-  -- Check if device has an overridden child profile that differs from the profile that would match
-  -- the child's device type for the following two cases:
-  --   1. To add Electrical Sensor only to the first EDGE_CHILD (light-power-energy-powerConsumption)
-  --      for the Aqara Light Switch H2. The profile of the second EDGE_CHILD for this device is
-  --      determined in the "for" loop above (e.g., light-binary)
-  --   2. The selected profile for the child device matches the initial profile defined in
-  --      child_device_profile_overrides
-  for id, vendor in pairs(child_device_profile_overrides_per_vendor_id) do
-    for _, fingerprint in ipairs(vendor) do
-      if device.manufacturer_info.product_id == fingerprint.product_id and
-         ((device.manufacturer_info.vendor_id == AQARA_MANUFACTURER_ID and child_ep == 1) or profile == fingerprint.initial_profile) then
-         return fingerprint.target_profile
+  -- If the device supports the Electrical Sensor Device Type
+  if electrical_tags == "" then
+    local electrical_sensor_found = false
+    for _, ep in ipairs(device.endpoints) do
+      for _, dt in ipairs(ep.device_types) do
+        if dt.device_type_id == ELECTRICAL_SENSOR_ID then
+          electrical_sensor_found = true
+        end
+      end
+    end
+    if electrical_sensor_found then
+      local switch_eps = device:get_endpoints(clusters.OnOff.ID)
+      table.sort(switch_eps)
+      local main_switch_ep = switch_eps[1]
+      for _, ep in ipairs(device.endpoints) do
+        if ep.endpoint_id == main_switch_ep and ep.endpoint_id == switch_ep then
+          -- Some devices report multiple device types which are a subset of
+          -- a superset device type (For example, Dimmable Light is a superset of
+          -- On/Off light). This mostly applies to the four light types, so we will want
+          -- to match the profile for the superset device type. This can be done by
+          -- matching to the device type with the highest ID
+          local id = 0
+          for _, dt in ipairs(ep.device_types) do
+            id = math.max(id, dt.device_type_id)
+          end
+          profile = device_type_profile_map[id]
+          if profile == "plug-binary" or profile == "plug-level" or profile == "light-binary" then
+            if #embedded_cluster_utils.get_endpoints(device, clusters.ElectricalEnergyMeasurement.ID) > 0 then
+              electrical_tags = electrical_tags .. "-power"
+            end
+            if #embedded_cluster_utils.get_endpoints(device, clusters.ElectricalPowerMeasurement.ID) > 0 then
+              electrical_tags = electrical_tags .."-energy-powerConsumption"
+            end
+            if electrical_tags ~= "" then
+              profile = string.gsub(profile, "-binary", "") -- remove the "-binary" in the plug-binary/light-binary profile name
+              profile = profile .. electrical_tags
+            end
+          end
+          break
+        end
       end
     end
   end
 
-  -- default to "switch-binary" if no profile is found
-  return profile or "switch-binary"
+  if is_child_device then
+    -- Check if child device has an overridden child profile that differs from the child's generic device type profile
+    for _, vendor in pairs(child_device_profile_overrides_per_vendor_id) do
+      for _, fingerprint in ipairs(vendor) do
+        if device.manufacturer_info.product_id == fingerprint.product_id and profile == fingerprint.initial_profile then
+          return fingerprint.target_profile
+        end
+      end
+    end
+    -- default to "switch-binary" if no child profile is found
+    return profile or "switch-binary"
+  end
+
+  return profile
 end
 
 local function configure_buttons(device)
@@ -598,7 +658,7 @@ local function build_child_switch_profiles(driver, device, main_endpoint)
       num_switch_server_eps = num_switch_server_eps + 1
       if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
         local name = string.format("%s %d", device.label, num_switch_server_eps)
-        local child_profile = assign_child_profile(device, ep)
+        local child_profile = assign_switch_profile(device, ep, true)
         driver:try_create_device(
           {
             type = "EDGE_CHILD",
@@ -728,22 +788,9 @@ local function match_profile(driver, device)
   end
 
   local fan_eps = device:get_endpoints(clusters.FanControl.ID)
-  local level_eps = device:get_endpoints(clusters.LevelControl.ID)
-  local energy_eps = embedded_cluster_utils.get_endpoints(device, clusters.ElectricalEnergyMeasurement.ID)
-  local power_eps = embedded_cluster_utils.get_endpoints(device, clusters.ElectricalPowerMeasurement.ID)
   local valve_eps = embedded_cluster_utils.get_endpoints(device, clusters.ValveConfigurationAndControl.ID)
   local profile_name = nil
-  local level_support = ""
-  if #level_eps > 0 then
-    level_support = "-level"
-  end
-  if #energy_eps > 0 and #power_eps > 0 then
-    profile_name = "plug" .. level_support .. "-power-energy-powerConsumption"
-  elseif #energy_eps > 0 then
-    profile_name = "plug" .. level_support .. "-energy-powerConsumption"
-  elseif #power_eps > 0 then
-    profile_name = "plug" .. level_support .. "-power"
-  elseif #valve_eps > 0 then
+  if #valve_eps > 0 then
     profile_name = "water-valve"
     if #embedded_cluster_utils.get_endpoints(device, clusters.ValveConfigurationAndControl.ID,
       {feature_bitmap = clusters.ValveConfigurationAndControl.types.Feature.LEVEL}) > 0 then
@@ -754,6 +801,15 @@ local function match_profile(driver, device)
   end
   if profile_name then
     device:try_update_metadata({ profile = profile_name })
+    return
+  end
+
+  -- after doing all previous profiling steps, attempt to re-profile main/parent switch/plug device
+  profile_name = assign_switch_profile(device, main_endpoint, false)
+  -- ignore attempts to dynamically profile light-level-colorTemperature devices for now, since
+  -- these may lose fingerprinted Kelvin ranges when dynamically profiled.
+  if profile_name and profile_name ~= "light-level-colorTemperature" then
+    device:try_update_metadata({profile = profile_name})
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -534,10 +534,10 @@ local function assign_switch_profile(device, switch_ep, is_child_device)
     table.sort(switch_eps)
     for i, ep in ipairs(switch_eps) do
       if ep == switch_ep then
-        if electrical_energy_eps[i] then
+        if electrical_power_eps[i] then
           electrical_tags = electrical_tags .. "-power"
         end
-        if electrical_power_eps[i] then
+        if electrical_energy_eps[i] then
           electrical_tags = electrical_tags .. "-energy-powerConsumption"
         end
         break

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -188,6 +188,7 @@ local function test_init()
 
   for _, child in pairs(aqara_mock_children) do
     test.mock_device.add_test_device(child)
+    print("abcd1")
   end
 
   aqara_mock_device:expect_device_create({

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -188,7 +188,6 @@ local function test_init()
 
   for _, child in pairs(aqara_mock_children) do
     test.mock_device.add_test_device(child)
-    print("abcd1")
   end
 
   aqara_mock_device:expect_device_create({

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -57,6 +57,25 @@ local mock_device = test.mock_device.build_test_matter_device({
         { device_type_id = 0x010B, device_type_revision = 1 }, -- OnOff Dimmable Plug
       }
     },
+        {
+      endpoint_id = 3,
+      clusters = {
+        { cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", feature_map = 14, },
+      },
+      device_types = {
+        { device_type_id = 0x0510, device_type_revision = 1 }, -- Electrical Sensor
+      }
+    },
+    {
+      endpoint_id = 4,
+      clusters = {
+        { cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 0, },
+        { cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
+      },
+      device_types = {
+        { device_type_id = 0x010B, device_type_revision = 1 }, -- OnOff Dimmable Plug
+      }
+    },
   },
 })
 
@@ -647,6 +666,13 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ profile = "plug-level-power-energy-powerConsumption" })
+    mock_device:expect_device_create({
+      type = "EDGE_CHILD",
+      label = "nil 2",
+      profile = "plug-level-energy-powerConsumption",
+      parent_device_id = mock_device.id,
+      parent_assigned_child_key = string.format("%d", 4)
+    })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   { test_init = test_init }

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -51,10 +51,10 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = 2,
       clusters = {
         { cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 0, },
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
+        { cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
       },
       device_types = {
-        { device_type_id = 0x010A, device_type_revision = 1 } -- OnOff Plug
+        { device_type_id = 0x010B, device_type_revision = 1 }, -- OnOff Dimmable Plug
       }
     },
   },
@@ -80,16 +80,18 @@ local mock_device_periodic = test.mock_device.build_test_matter_device({
     {
       endpoint_id = 1,
       clusters = {
+        { cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 0, },
         { cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", feature_map = 10, },
       },
       device_types = {
-        { device_type_id = 0x0510, device_type_revision = 1 } -- Electrical Sensor
+        { device_type_id = 0x010A, device_type_revision = 1 }, -- OnOff Plug
       }
     },
   },
 })
 
 local subscribed_attributes_periodic = {
+  clusters.OnOff.attributes.OnOff,
   clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported,
   clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported,
 }
@@ -713,7 +715,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 2)
+        clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -427,6 +427,7 @@ local function test_init_mounted_on_off_control()
   end
   test.socket.matter:__expect_send({mock_device_mounted_on_off_control.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "doConfigure" })
+  mock_device_mounted_on_off_control:expect_metadata_update({ profile = "switch-binary" })
   mock_device_mounted_on_off_control:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device_mounted_on_off_control)
 end
@@ -443,6 +444,7 @@ local function test_init_mounted_dimmable_load_control()
   end
   test.socket.matter:__expect_send({mock_device_mounted_dimmable_load_control.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "doConfigure" })
+  mock_device_mounted_dimmable_load_control:expect_metadata_update({ profile = "switch-level" })
   mock_device_mounted_dimmable_load_control:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device_mounted_dimmable_load_control)
 end
@@ -477,6 +479,7 @@ local function test_init_parent_child_different_types()
   test.socket.matter:__expect_send({mock_device_parent_child_different_types.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_different_types.id, "doConfigure" })
+  mock_device_parent_child_different_types:expect_metadata_update({ profile = "switch-binary" })
   mock_device_parent_child_different_types:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device_parent_child_different_types)

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -181,6 +181,7 @@ local function test_init()
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  mock_device:expect_metadata_update({ profile = "light-binary" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device)
@@ -247,6 +248,7 @@ local function test_init_parent_child_endpoints_non_sequential()
   test.socket.matter:__expect_send({mock_device_parent_child_endpoints_non_sequential.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_endpoints_non_sequential.id, "doConfigure" })
+  mock_device_parent_child_endpoints_non_sequential:expect_metadata_update({ profile = "light-binary" })
   mock_device_parent_child_endpoints_non_sequential:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device_parent_child_endpoints_non_sequential)

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -47,6 +47,8 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = parent_ep,
       clusters = {
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.ElectricalPowerMeasurement.ID, cluster_type = "SERVER"},
       },
       device_types = {
         {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
@@ -74,8 +76,6 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = child3_ep,
       clusters = {
         {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.ElectricalPowerMeasurement.ID, cluster_type = "SERVER"},
       },
       device_types = {
         {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
@@ -162,7 +162,7 @@ local function test_init()
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  mock_device:expect_metadata_update({ profile = "plug-binary" })
+  mock_device:expect_metadata_update({ profile = "plug-power-energy-powerConsumption" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device)
@@ -189,7 +189,7 @@ local function test_init()
   mock_device:expect_device_create({
     type = "EDGE_CHILD",
     label = "Matter Switch 4",
-    profile = "plug-power-energy-powerConsumption",
+    profile = "plug-binary",
     parent_device_id = mock_device.id,
     parent_assigned_child_key = string.format("%d", child3_ep)
   })


### PR DESCRIPTION
# Description of Change
This PR aims to improve the dynamic profile handling of switch devices, since we have seen cases of the fingerprint being incorrect in some cases, specifically for devices that are created as parent/child.

Adding to this, it also improves the ability of devices to profile with energy cluster support. This PR handles 2 main cases that we have seen in the field (all are supported with different unit tests):
1. The device supports the electrical sensor device types (or at least the associated cluster(s)) on specific plug endpoints. This is useful for outlets with energy measurements on each plug.
2. The device supports the electrical sensor device type on a non-plug endpoint, whether it be on the root node or on its own (there are examples of each of these). In this case, the current precedent is that the energy handling capabilities are attached to the first plug/light endpoint profile. 

# Summary of Completed Tests
Unit tests updated to support case 1. Otherwise, other tests handle these cases.
Tested on physical plug energy device.
Tested on physical multi-plug energy device.
