### PR TITLE
Add reconfiguration for zigbee power meter to reduce reporting

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/init.lua
@@ -2,6 +2,7 @@ local device_lib = require "st.device"
 local capabilities = require "st.capabilities"
 local cluster_base = require "st.zigbee.cluster_base"
 local data_types = require "st.zigbee.data_types"
+local configurations = require "configurations"
 
 local PRIVATE_CLUSTER_ID = 0xFCC0
 local PRIVATE_ATTRIBUTE_ID = 0x0009
@@ -100,7 +101,7 @@ end
 local aqara_multi_switch_handler = {
   NAME = "Aqara Multi Switch Handler",
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     added = device_added
   },
   can_handle = is_aqara_products

--- a/drivers/SmartThings/zigbee-switch/src/configurations.lua
+++ b/drivers/SmartThings/zigbee-switch/src/configurations.lua
@@ -14,9 +14,15 @@
 
 local clusters = require "st.zigbee.zcl.clusters"
 local constants = require "st.zigbee.constants"
+local capabilities = require "st.capabilities"
+local device_def = require "st.device"
 
 local ColorControl = clusters.ColorControl
 local IASZone = clusters.IASZone
+local Status = require "st.zigbee.generated.types.ZclStatus"
+
+local CONFIGURATION_VERSION_KEY = "_configuration_version"
+local CONFIGURATION_ATTEMPTED = "_reconfiguration_attempted"
 
 local devices = {
   IKEA_RGB_BULB = {
@@ -60,7 +66,93 @@ local devices = {
   }
 }
 
+
 local configurations = {}
+
+local active_power_configuration = {
+  cluster = clusters.ElectricalMeasurement.ID,
+  attribute = clusters.ElectricalMeasurement.attributes.ActivePower.ID,
+  minimum_interval = 5,
+  maximum_interval = 3600,
+  data_type = clusters.ElectricalMeasurement.attributes.ActivePower.base_type,
+  reportable_change = 5
+}
+
+local instantaneous_demand_configuration = {
+  cluster = clusters.SimpleMetering.ID,
+  attribute = clusters.SimpleMetering.attributes.InstantaneousDemand.ID,
+  minimum_interval = 5,
+  maximum_interval = 3600,
+  data_type = clusters.SimpleMetering.attributes.InstantaneousDemand.base_type,
+  reportable_change = 5
+}
+
+configurations.check_and_reconfig_devices = function(driver)
+  for device_id, device in pairs(driver.device_cache) do
+    local config_version = device:get_field(CONFIGURATION_VERSION_KEY)
+    if config_version == nil or config_version < driver.current_config_version then
+      if device:supports_capability(capabilities.powerMeter) then
+        if device:supports_server_cluster(clusters.ElectricalMeasurement.ID) then
+          -- Increase minimum reporting interval to 5 seconds
+          device:send(clusters.ElectricalMeasurement.attributes.ActivePower:configure_reporting(device, 5, 600, 5))
+          device:add_configured_attribute(active_power_configuration)
+        end
+        if device:supports_server_cluster(clusters.SimpleMetering.ID) then
+          -- Increase minimum reporting interval to 5 seconds
+          device:send(clusters.SimpleMetering.attributes.InstantaneousDemand:configure_reporting(device, 5, 600, 5))
+          device:add_configured_attribute(instantaneous_demand_configuration)
+        end
+      end
+      device:set_field(CONFIGURATION_ATTEMPTED, true, {persist = true})
+    end
+  end
+  driver._reconfig_timer = nil
+end
+
+configurations.handle_reporting_config_response = function(driver, device, zb_mess)
+  local dev = device
+  local find_child_fn = device:get_field(device_def.FIND_CHILD_KEY)
+  if find_child_fn ~= nil then
+    local child = find_child_fn(device, zb_mess.address_header.src_endpoint.value)
+    if child ~= nil then
+      dev = child
+    end
+  end
+  if dev:get_field(CONFIGURATION_ATTEMPTED) == true then
+    if zb_mess.body.zcl_body.global_status ~= nil and zb_mess.body.zcl_body.global_status.value == Status.SUCCESS then
+      dev:set_field(CONFIGURATION_VERSION_KEY, driver.current_config_version, {persist = true})
+    elseif zb_mess.body.zcl_body.config_records ~= nil then
+      local config_records = zb_mess.body.zcl_body.config_records
+      for _, record in ipairs(config_records) do
+        if zb_mess.address_header.cluster.value == clusters.SimpleMetering.ID then
+          if record.attr_id.value == clusters.SimpleMetering.attributes.InstantaneousDemand.ID
+            and record.status.value == Status.SUCCESS then
+            dev:set_field(CONFIGURATION_VERSION_KEY, driver.current_config_version, {persist = true})
+          end
+        elseif zb_mess.address_header.cluster.value == clusters.ElectricalMeasurement.ID then
+          if record.attr_id.value == clusters.ElectricalMeasurement.attributes.ActivePower.ID
+            and record.status.value == Status.SUCCESS then
+            dev:set_field(CONFIGURATION_VERSION_KEY, driver.current_config_version, {persist = true})
+          end
+        end
+
+      end
+    end
+  end
+end
+
+configurations.power_reconfig_wrapper = function(orig_function)
+  local new_init = function(driver, device)
+    local config_version = device:get_field(CONFIGURATION_VERSION_KEY)
+    if config_version == nil or config_version < driver.current_config_version then
+      if driver._reconfig_timer == nil then
+        driver._reconfig_timer = driver:call_with_delay(5*60, configurations.check_and_reconfig_devices, "reconfig_power_devices")
+      end
+    end
+    orig_function(driver, device)
+  end
+  return new_init
+end
 
 configurations.get_device_configuration = function(zigbee_device)
   for _, device in pairs(devices) do

--- a/drivers/SmartThings/zigbee-switch/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ezex/init.lua
@@ -13,6 +13,7 @@
 -- limitations under the License.
 
 local zigbee_constants = require "st.zigbee.constants"
+local configurations = require "configurations"
 
 local ZIGBEE_METERING_SWITCH_FINGERPRINTS = {
   { model = "E240-KR116Z-HA" }
@@ -37,7 +38,7 @@ end
 local ezex_switch_handler = {
   NAME = "ezex switch handler",
   lifecycle_handlers = {
-    init = do_init
+    init = configurations.power_reconfig_wrapper(do_init)
   },
   can_handle = is_zigbee_ezex_switch
 }

--- a/drivers/SmartThings/zigbee-switch/src/hanssem/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/hanssem/init.lua
@@ -13,6 +13,7 @@
 -- limitations under the License.
 
 local stDevice = require "st.device"
+local configurations = require "configurations"
 
 local FINGERPRINTS = {
   { mfr = "Winners", model = "LSS1-101", children = 0 },
@@ -78,7 +79,7 @@ local HanssemSwitch = {
   NAME = "Zigbee Hanssem Switch",
   lifecycle_handlers = {
     added = device_added,
-    init = device_init
+    init = configurations.power_reconfig_wrapper(device_init)
   },
   can_handle = can_handle_hanssem_switch
 }

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -17,7 +17,9 @@ local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
 local clusters = require "st.zigbee.zcl.clusters"
 local configurationMap = require "configurations"
+local zcl_global_commands = require "st.zigbee.zcl.global_commands"
 local SimpleMetering = clusters.SimpleMetering
+local ElectricalMeasurement = clusters.ElectricalMeasurement
 local preferences = require "preferences"
 local device_lib = require "st.device"
 
@@ -127,6 +129,7 @@ local function device_added(driver, device, event)
   end
 end
 
+
 local zigbee_switch_driver_template = {
   supported_capabilities = {
     capabilities.switch,
@@ -164,8 +167,19 @@ local zigbee_switch_driver_template = {
     lazy_load_if_possible("laisiao"),
     lazy_load_if_possible("tuya-multi")
   },
+  zigbee_handlers = {
+    global = {
+      [SimpleMetering.ID] = {
+        [zcl_global_commands.CONFIGURE_REPORTING_RESPONSE_ID] = configurationMap.handle_reporting_config_response
+      },
+     [ElectricalMeasurement.ID] = {
+        [zcl_global_commands.CONFIGURE_REPORTING_RESPONSE_ID] = configurationMap.handle_reporting_config_response
+      }
+    }
+  },
+  current_config_version = 1,
   lifecycle_handlers = {
-    init = device_init,
+    init = configurationMap.power_reconfig_wrapper(device_init),
     added = device_added,
     infoChanged = info_changed,
     doConfigure = do_configure

--- a/drivers/SmartThings/zigbee-switch/src/inovelli-vzm31-sn/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli-vzm31-sn/init.lua
@@ -19,6 +19,7 @@ local st_device = require "st.device"
 local data_types = require "st.zigbee.data_types"
 local capabilities = require "st.capabilities"
 local device_management = require "st.zigbee.device_management"
+local configurations = require "configurations"
 
 local LATEST_CLOCK_SET_TIMESTAMP = "latest_clock_set_timestamp"
 
@@ -358,7 +359,7 @@ local inovelli_vzm31_sn = {
   NAME = "inovelli vzm31-sn handler",
   lifecycle_handlers = {
     doConfigure = do_configure,
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     infoChanged = info_changed
   },
   zigbee_handlers = {

--- a/drivers/SmartThings/zigbee-switch/src/laisiao/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/laisiao/init.lua
@@ -14,6 +14,7 @@
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
+local configurations = require "configurations"
 
 local FINGERPRINTS = {
   { mfr = "LAISIAO", model = "yuba" },
@@ -70,7 +71,7 @@ local laisiao_bath_heater = {
     capabilities.switch,
   },
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
   },
   capability_handlers = {
     [capabilities.switch.ID] = {

--- a/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
@@ -13,6 +13,7 @@
 -- limitations under the License.
 local st_device = require "st.device"
 local utils = require "st.utils"
+local configurations = require "configurations"
 
 local MULTI_SWITCH_NO_MASTER_FINGERPRINTS = {
   { mfr = "DAWON_DNS", model = "PM-S240-ZB", children = 1 },
@@ -113,7 +114,7 @@ end
 local multi_switch_no_master = {
   NAME = "multi switch no master",
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     added = device_added
   },
   can_handle = is_multi_switch_no_master

--- a/drivers/SmartThings/zigbee-switch/src/robb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/robb/init.lua
@@ -15,6 +15,7 @@
 local constants = require "st.zigbee.constants"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
+local configurations = require "configurations"
 local SimpleMetering = zcl_clusters.SimpleMetering
 
 local ROBB_DIMMER_FINGERPRINTS = {
@@ -57,7 +58,7 @@ local robb_dimmer_handler = {
     }
   },
   lifecycle_handlers = {
-    init = do_init
+    init = configurations.power_reconfig_wrapper(do_init)
   },
   can_handle = is_robb_dimmer
 }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -22,6 +22,13 @@ local ElectricalMeasurement = clusters.ElectricalMeasurement
 local SimpleMetering = clusters.SimpleMetering
 local capabilities = require "st.capabilities"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
+local messages = require "st.zigbee.messages"
+local config_reporting_response = require "st.zigbee.zcl.global_commands.configure_reporting_response"
+local zb_const = require "st.zigbee.constants"
+local zcl_messages = require "st.zigbee.zcl"
+local data_types = require "st.zigbee.data_types"
+local Status = require "st.zigbee.generated.types.ZclStatus"
+
 
 local zigbee_bulb_all_caps = {
   components = {
@@ -43,11 +50,42 @@ local mock_device = test.mock_device.build_test_zigbee_device({ profile = zigbee
 
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
   zigbee_test_utils.init_noop_health_check_timer()
 end
 
 test.set_test_init_function(test_init)
+
+local function build_config_response_msg(device, cluster, global_status, attribute, attr_status)
+  local addr_header = messages.AddressHeader(
+    device:get_short_address(),
+    device.fingerprinted_endpoint_id,
+    zb_const.HUB.ADDR,
+    zb_const.HUB.ENDPOINT,
+    zb_const.HA_PROFILE_ID,
+    cluster
+  )
+  local config_response_body
+  if global_status ~= nil then
+     config_response_body = config_reporting_response.ConfigureReportingResponse({}, global_status)
+  else
+    local individual_record = config_reporting_response.ConfigureReportingResponseRecord(attr_status, 0x01, attribute)
+    config_response_body = config_reporting_response.ConfigureReportingResponse({individual_record}, nil)
+  end
+  local zcl_header = zcl_messages.ZclHeader({
+    cmd = data_types.ZCLCommandId(config_response_body.ID)
+  })
+  local message_body = zcl_messages.ZclMessageBody({
+    zcl_header = zcl_header,
+    zcl_body = config_response_body
+  })
+  return messages.ZigbeeMessageRx({
+    address_header = addr_header,
+    body = message_body
+  })
+end
+
 
 test.register_message_test(
     "Reported level should be handled",
@@ -369,8 +407,103 @@ test.register_coroutine_test(
     end,
     {
       test_init = function()
+        mock_device:set_field("_configuration_version", 1, {persist = true})
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(30, "interval", "health_check")
+      end
+    }
+)
+
+test.register_coroutine_test(
+    "configuration version below 1",
+    function()
+      test.timer.__create_and_queue_test_time_advance_timer(5*60, "oneshot")
+      assert(mock_device:get_field("_configuration_version") == nil)
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.wait_for_events()
+      test.socket.zigbee:__expect_send({mock_device.id, ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 600, 5)})
+      test.socket.zigbee:__expect_send({mock_device.id, SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 600, 5)})
+      test.mock_time.advance_time(5*60 + 1)
+      test.wait_for_events()
+      test.socket.zigbee:__queue_receive({mock_device.id, build_config_response_msg(mock_device, ElectricalMeasurement.ID, Status.SUCCESS)})
+      test.socket.zigbee:__queue_receive({mock_device.id, build_config_response_msg(mock_device, SimpleMetering.ID, Status.SUCCESS)})
+      test.wait_for_events()
+      assert(mock_device:get_field("_configuration_version") == 1)
+    end,
+    {
+      test_init = function()
+        -- no op to override auto device add on startup
+      end
+    }
+)
+
+test.register_coroutine_test(
+    "configuration version below 1 config response not success",
+    function()
+      test.timer.__create_and_queue_test_time_advance_timer(5*60, "oneshot")
+      assert(mock_device:get_field("_configuration_version") == nil)
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.wait_for_events()
+      test.socket.zigbee:__expect_send({mock_device.id, ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 600, 5)})
+      test.socket.zigbee:__expect_send({mock_device.id, SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 600, 5)})
+      test.mock_time.advance_time(5*60 + 1)
+      test.wait_for_events()
+      test.socket.zigbee:__queue_receive({mock_device.id, build_config_response_msg(mock_device, ElectricalMeasurement.ID, Status.UNSUPPORTED_ATTRIBUTE)})
+      test.socket.zigbee:__queue_receive({mock_device.id, build_config_response_msg(mock_device, SimpleMetering.ID, Status.UNSUPPORTED_ATTRIBUTE)})
+      test.wait_for_events()
+      assert(mock_device:get_field("_configuration_version") == nil)
+    end,
+    {
+      test_init = function()
+        -- no op to override auto device add on startup
+      end
+    }
+)
+
+test.register_coroutine_test(
+    "configuration version below 1 individual config response records ElectricalMeasurement",
+    function()
+      test.timer.__create_and_queue_test_time_advance_timer(5*60, "oneshot")
+      assert(mock_device:get_field("_configuration_version") == nil)
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.wait_for_events()
+      test.socket.zigbee:__expect_send({mock_device.id, ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 600, 5)})
+      test.socket.zigbee:__expect_send({mock_device.id, SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 600, 5)})
+      test.mock_time.advance_time(5*60 + 1)
+      test.wait_for_events()
+      test.socket.zigbee:__queue_receive({mock_device.id, build_config_response_msg(mock_device, ElectricalMeasurement.ID, nil, ElectricalMeasurement.attributes.ActivePower.ID,  Status.SUCCESS)})
+      test.wait_for_events()
+      assert(mock_device:get_field("_configuration_version") == 1)
+    end,
+    {
+      test_init = function()
+        -- no op to override auto device add on startup
+      end
+    }
+)
+
+test.register_coroutine_test(
+    "configuration version below 1 individual config response records SimpleMetering",
+    function()
+      test.timer.__create_and_queue_test_time_advance_timer(5*60, "oneshot")
+      assert(mock_device:get_field("_configuration_version") == nil)
+      test.mock_device.add_test_device(mock_device)
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.wait_for_events()
+      test.socket.zigbee:__expect_send({mock_device.id, ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 600, 5)})
+      test.socket.zigbee:__expect_send({mock_device.id, SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 600, 5)})
+      test.mock_time.advance_time(5*60 + 1)
+      test.wait_for_events()
+      test.socket.zigbee:__queue_receive({mock_device.id, build_config_response_msg(mock_device, SimpleMetering.ID, nil, SimpleMetering.attributes.InstantaneousDemand.ID,  Status.SUCCESS)})
+      test.wait_for_events()
+      assert(mock_device:get_field("_configuration_version") == 1)
+    end,
+    {
+      test_init = function()
+        -- no op to override auto device add on startup
       end
     }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
@@ -70,7 +70,9 @@ local mock_standard = test.mock_device.build_test_zigbee_device(
 
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
+  mock_standard:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_standard)
   zigbee_test_utils.init_noop_health_check_timer()
 end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
@@ -71,7 +71,9 @@ local mock_standard = test.mock_device.build_test_zigbee_device(
 
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
+  mock_standard:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_standard)
   zigbee_test_utils.init_noop_health_check_timer()
 end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
@@ -35,6 +35,7 @@ local mock_device = test.mock_device.build_test_zigbee_device({
 })
 
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
@@ -34,6 +34,7 @@ local mock_device = test.mock_device.build_test_zigbee_device({
 })
 
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
@@ -33,6 +33,7 @@ local mock_device = test.mock_device.build_test_zigbee_device({
 })
 
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
@@ -20,6 +20,12 @@ local ElectricalMeasurement = clusters.ElectricalMeasurement
 local capabilities = require "st.capabilities"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local t_utils = require "integration_test.utils"
+local messages = require "st.zigbee.messages"
+local config_reporting_response = require "st.zigbee.zcl.global_commands.configure_reporting_response"
+local zb_const = require "st.zigbee.constants"
+local zcl_messages = require "st.zigbee.zcl"
+local data_types = require "st.zigbee.data_types"
+local Status = require "st.zigbee.generated.types.ZclStatus"
 
 local profile = t_utils.get_profile_definition("switch-power-smartplug.yml")
 
@@ -64,13 +70,91 @@ local mock_child_device = test.mock_device.build_test_child_device({
 zigbee_test_utils.prepare_zigbee_env_info()
 
 local function test_init()
+  mock_base_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_base_device)
+  mock_parent_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_parent_device)
+  mock_child_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_child_device)
   zigbee_test_utils.init_noop_health_check_timer()
 end
 
 test.set_test_init_function(test_init)
+
+local function build_config_response_msg(device, cluster, status)
+  local addr_header = messages.AddressHeader(
+    device:get_short_address(),
+    device.fingerprinted_endpoint_id,
+    zb_const.HUB.ADDR,
+    zb_const.HUB.ENDPOINT,
+    zb_const.HA_PROFILE_ID,
+    cluster
+  )
+  local config_response_body = config_reporting_response.ConfigureReportingResponse({}, status)
+  local zcl_header = zcl_messages.ZclHeader({
+    cmd = data_types.ZCLCommandId(config_response_body.ID)
+  })
+  local message_body = zcl_messages.ZclMessageBody({
+    zcl_header = zcl_header,
+    zcl_body = config_response_body
+  })
+  return messages.ZigbeeMessageRx({
+    address_header = addr_header,
+    body = message_body
+  })
+end
+
+test.register_coroutine_test(
+    "configuration version below 1",
+    function()
+      test.timer.__create_and_queue_test_time_advance_timer(5*60, "oneshot")
+      test.mock_device.add_test_device(mock_parent_device)
+      test.mock_device.add_test_device(mock_child_device)
+      assert(mock_parent_device:get_field("_configuration_version") == nil)
+      test.socket.device_lifecycle:__queue_receive({ mock_parent_device.id, "init" })
+      assert(mock_child_device:get_field("_configuration_version") == nil)
+      test.socket.device_lifecycle:__queue_receive({ mock_child_device.id, "init" })
+      test.wait_for_events()
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+      test.socket.zigbee:__expect_send({mock_parent_device.id, ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_parent_device, 5, 600, 5)})
+      test.socket.zigbee:__expect_send({mock_parent_device.id, ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_parent_device, 5, 600, 5):to_endpoint(0x02)})
+      test.mock_time.advance_time(50 * 60  + 1)
+      test.wait_for_events()
+      test.socket.zigbee:__queue_receive({mock_parent_device.id, build_config_response_msg(mock_parent_device, ElectricalMeasurement.ID, Status.SUCCESS)})
+      test.socket.zigbee:__queue_receive({mock_parent_device.id, build_config_response_msg(mock_parent_device, ElectricalMeasurement.ID, Status.SUCCESS):from_endpoint(0x02)})
+      test.wait_for_events()
+      assert(mock_child_device:get_field("_configuration_version") == 1, "config version for child should be 1")
+      assert(mock_parent_device:get_field("_configuration_version") == 1, "config version for parent should be 1")
+    end,
+    {
+      test_init = function()
+        -- no op to avoid auto device add and immediate init event on driver startup
+      end
+    }
+)
+
+test.register_coroutine_test(
+    "configuration version at 1 doesn't reconfigure",
+    function()
+      test.timer.__create_and_queue_test_time_advance_timer(5*60, "oneshot")
+      test.mock_device.add_test_device(mock_parent_device)
+      test.mock_device.add_test_device(mock_child_device)
+      mock_child_device:set_field("_configuration_version", 1, {persist = true})
+      mock_parent_device:set_field("_configuration_version", 1, {persist = true})
+      assert(mock_parent_device:get_field("_configuration_version") == 1)
+      assert(mock_child_device:get_field("_configuration_version") == 1)
+      test.socket.device_lifecycle:__queue_receive({ mock_parent_device.id, "init" })
+      test.socket.device_lifecycle:__queue_receive({ mock_child_device.id, "init" })
+      test.wait_for_events()
+      assert(mock_child_device:get_field("_configuration_version") == 1)
+      assert(mock_parent_device:get_field("_configuration_version") == 1)
+    end,
+    {
+      test_init = function()
+        -- no op to avoid auto device add and immediate init event on driver startup
+      end
+    }
+)
 
 test.register_message_test(
     "Refresh on parent device should read all necessary attributes",

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
@@ -39,6 +39,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
 
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
   zigbee_test_utils.init_noop_health_check_timer()
 end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
@@ -39,6 +39,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
 
 zigbee_test_utils.prepare_zigbee_env_info()
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
   zigbee_test_utils.init_noop_health_check_timer()
 end

--- a/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
@@ -38,6 +38,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
 zigbee_test_utils.prepare_zigbee_env_info()
 
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_dimmer_power_energy.lua
@@ -32,6 +32,7 @@ local mock_device = test.mock_device.build_test_zigbee_device({
 })
 
 local function test_init()
+  mock_device:set_field("_configuration_version", 1, {persist = true})
   test.mock_device.add_test_device(mock_device)
 end
 

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
@@ -18,6 +18,7 @@ local stDevice = require "st.device"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"
 local data_types = require "st.zigbee.data_types"
+local configurations = require "configurations"
 
 local Scenes = zcl_clusters.Scenes
 local PRIVATE_CLUSTER_ID = 0x0006
@@ -130,7 +131,7 @@ local wallheroswitch = {
   NAME = "Zigbee Wall Hero Switch",
   lifecycle_handlers = {
     added = device_added,
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     infoChanged = device_info_changed
   },
   zigbee_handlers = {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimmer-power-energy/enbrighten-metering-dimmer/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimmer-power-energy/enbrighten-metering-dimmer/init.lua
@@ -16,6 +16,7 @@ local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
 local constants = require "st.zigbee.constants"
 local SimpleMetering = clusters.SimpleMetering
+local configurations = require "configurations"
 
 local ENBRIGHTEN_METERING_DIMMER_FINGERPRINTS = {
   { mfr = "Jasco Products", model = "43082" }
@@ -57,7 +58,7 @@ local enbrighten_metering_dimmer = {
     }
   },
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     doConfigure = do_configure
   },
   can_handle = is_enbrighten_metering_dimmer

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
@@ -14,6 +14,7 @@
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
+local configurations = require "configurations"
 
 local OnOff = clusters.OnOff
 local Level = clusters.Level
@@ -97,7 +98,7 @@ end
 local zigbee_dimming_light = {
   NAME = "Zigbee Dimming Light",
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     added = device_added
   },
   sub_drivers = {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/init.lua
@@ -17,6 +17,7 @@ local clusters = require "st.zigbee.zcl.clusters"
 local OnOff = clusters.OnOff
 local ElectricalMeasurement = clusters.ElectricalMeasurement
 local utils = require "st.utils"
+local configurations = require "configurations"
 
 local CHILD_ENDPOINT = 2
 
@@ -76,7 +77,7 @@ local zigbee_dual_metering_switch = {
     }
   },
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     added = device_added
   },
   can_handle = can_handle_zigbee_dual_metering_switch

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
@@ -16,6 +16,7 @@ local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
 local zigbee_constants = require "st.zigbee.constants"
 local energy_meter_defaults = require "st.zigbee.defaults.energyMeter_defaults"
+local configurations = require "configurations"
 
 local SimpleMetering = clusters.SimpleMetering
 
@@ -50,7 +51,7 @@ local zigbee_metering_plug_power_conumption_report = {
     }
   },
   lifecycle_handlers = {
-    init = device_init,
+    init = configurations.power_reconfig_wrapper(device_init),
     doConfigure = do_configure
   },
   can_handle = function(opts, driver, device, ...)

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
@@ -170,7 +170,7 @@ end
 local ikea_xy_color_bulb = {
   NAME = "IKEA XY Color Bulb",
   lifecycle_handlers = {
-    init = device_init
+    init = configurationMap.power_reconfig_wrapper(device_init)
   },
   capability_handlers = {
     [capabilities.colorControl.ID] = {


### PR DESCRIPTION
This PR adds code to reconfigure devices supporting the powerMeter capability to reduce the minimum reporting interval.  This changes to 5 seconds instead of 1 second.  On device init, if a device is detected as having not performed this migration (based on a field set on the device datastore), and supporting the capability a 5 minute timer is started if one isn't already running.  At the end of the 5 minutes, all devices the driver knows about are checked and the reconfiguration is attempted.  When we hear a success back from the device, the migration is marked as complete.  This will be attempted at most once per device init, but won't be reattempted periodically without another eligible device being initted.  This means for offline devices, this won't be re-attempted until the driver restarts.  I think in a future release I'd like to consider a more general solution in the firmware to handle future configuration changes.