### PR TITLE
matter-lock: Update weekdays -> weekDays

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -672,7 +672,7 @@ local function add_week_schedule_to_table(device, userIdx, scheduleIdx, schedule
       new_schedule_table,
       {
         scheduleIndex = scheduleIdx,
-        weekdays = weekDayList,
+        weekDays = weekDayList,
         startHour = schedule.startHour,
         startMinute = schedule.startMinute,
         endHour = schedule.endHour,
@@ -688,7 +688,7 @@ local function add_week_schedule_to_table(device, userIdx, scheduleIdx, schedule
         userIndex = userIdx,
         schedules = {{
           scheduleIndex = scheduleIdx,
-          weekdays = weekDayList,
+          weekDays = weekDayList,
           startHour = schedule.startHour,
           startMinute = schedule.startMinute,
           endHour = schedule.endHour,

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
@@ -1799,7 +1799,7 @@ test.register_coroutine_test(
             userIndex=1,
             schedules={{
               scheduleIndex=1,
-              weekdays={"Monday"},
+              weekDays={"Monday"},
               startHour=12,
               startMinute=30,
               endHour=17,


### PR DESCRIPTION
https://github.ecodesamsung.com/iot/SmartThingsCapabilities/pull/651 changed the weekdays attribute to weekDays. This applies the same change to the new lock subdriver.

