### PR TITLE
Add new profiles including thermostatOperatingState

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-cooling-only-nobattery.yml
@@ -1,0 +1,24 @@
+name: thermostat-cooling-only-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-heating-only-nobattery.yml
@@ -1,0 +1,24 @@
+name: thermostat-heating-only-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - heating
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat

--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-nobattery.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-nobattery.yml
@@ -1,0 +1,27 @@
+name: thermostat-nobattery
+components:
+- id: main
+  capabilities:
+  - id: temperatureMeasurement
+    version: 1
+  - id: thermostatMode
+    version: 1
+  - id: thermostatHeatingSetpoint
+    version: 1
+  - id: thermostatCoolingSetpoint
+    version: 1
+  - id: thermostatOperatingState
+    version: 1
+    config:
+      values:
+        - key: "thermostatOperatingState.value"
+          enabledValues:
+            - idle
+            - cooling
+            - heating
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Thermostat


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] New profile

# Description of Change

Adding new profiles for thermostats with no battery after support for thermostatOperatingState was added. Previously, devices would use `thermostat-heating-only-nostate-nobattery` (for example) whether or not they supported ThermostatRunningState.