### PR TITLE
Add Eve MotionBlinds to subdriver

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/matter-window-covering-position-updates-while-moving/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/matter-window-covering-position-updates-while-moving/init.lua
@@ -66,7 +66,7 @@ local function current_pos_handler(driver, device, ib, response)
     )
   end
   local state_machine = device:get_field(STATE_MACHINE)
-  -- When stat_machine is STATE_IDLE or STATE_CURRENT_POSITION_FIRED, nothing to do
+  -- When state_machine is STATE_IDLE or STATE_CURRENT_POSITION_FIRED, nothing to do
   if state_machine == StateMachineEnum.STATE_MOVING then
     device:set_field(STATE_MACHINE, StateMachineEnum.STATE_CURRENT_POSITION_FIRED)
   elseif state_machine == StateMachineEnum.STATE_OPERATIONAL_STATE_FIRED or state_machine == nil then
@@ -90,18 +90,17 @@ local function current_status_handler(driver, device, ib, response)
                      "main", capabilities.windowShadeLevel.ID,
                        capabilities.windowShadeLevel.shadeLevel.NAME
                    ) or DEFAULT_LEVEL
-  position = reverse_polarity_if_needed(device, position)
   for _, rb in ipairs(response.info_blocks) do
     if rb.info_block.attribute_id == clusters.WindowCovering.attributes.CurrentPositionLiftPercent100ths.ID and
-       rb.info_block.cluster_id == clusters.WindowCovering.ID and
-       rb.info_block.data ~= nil and
-       rb.info_block.data.value ~= nil then
+      rb.info_block.cluster_id == clusters.WindowCovering.ID and
+      rb.info_block.data ~= nil and
+      rb.info_block.data.value ~= nil then
       position = reverse_polarity_if_needed(device, math.floor((rb.info_block.data.value / 100)))
     end
   end
   local state = ib.data.value & clusters.WindowCovering.types.OperationalStatus.GLOBAL --Could use LIFT instead
   local state_machine = device:get_field(STATE_MACHINE)
-  -- When stat_machine is STATE_OPERATIONAL_STATE_FIRED, nothing to do
+  -- When state_machine is STATE_OPERATIONAL_STATE_FIRED, nothing to do
   if state_machine == StateMachineEnum.STATE_IDLE then
     if state == 1 then -- opening
       device:emit_event_for_endpoint(ib.endpoint_id, attr.opening())


### PR DESCRIPTION
Add Eve vid and pid to subdriver to account for position updates while the shade is in motion.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


