### PR TITLE
fix: backwards compat bugs around offline speakers

### DIFF
--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -1,3 +1,4 @@
+local api_version = require "version".api
 local cosock = require "cosock"
 local json = require "st.json"
 local log = require "log"
@@ -74,7 +75,13 @@ local _update_subscriptions_helper = function(
       {},
     }
     local payload = json.encode(payload_table)
-    Router.send_message_to_player(utils.sonos_unique_key(householdId, playerId), payload, reply_tx)
+    local unique_key, bad_key_part = utils.sonos_unique_key(householdId, playerId)
+    if not unique_key then
+      local err_msg = string.format("Invalid Sonos Unique Key Part: %s", bad_key_part)
+      reply_tx:send(table.pack(nil, err_msg))
+      return
+    end
+    Router.send_message_to_player(unique_key, payload, reply_tx)
   end
 end
 
@@ -168,10 +175,13 @@ local function _open_coordinator_socket(sonos_conn, household_id, self_player_id
     end
 
     local listener_id
-    listener_id, err = Router.register_listener_for_socket(
-      sonos_conn,
-      utils.sonos_unique_key(household_id, coordinator_id)
-    )
+    local unique_key, bad_key_part = utils.sonos_unique_key(household_id, coordinator_id)
+
+    if not unique_key then
+      log.error(string.format("Invalid Sonos Unique Key Part: %s", bad_key_part))
+    end
+
+    listener_id, err = Router.register_listener_for_socket(sonos_conn, unique_key)
     if err ~= nil or not listener_id then
       log.error(err)
     else
@@ -208,7 +218,22 @@ local function backoff_builder(max, inc, rand)
 end
 
 ---@param sonos_conn SonosConnection
-local function _spawn_reconnect_task(sonos_conn)
+local function _legacy_reconnect_task(sonos_conn)
+  log.debug("Spawning reconnect task for ", sonos_conn.device.label)
+  cosock.spawn(function()
+    local backoff = backoff_builder(60, 1, 0.1)
+    while not sonos_conn:is_running() do
+      local start_success = sonos_conn:start()
+      if start_success then
+        return
+      end
+      cosock.socket.sleep(backoff())
+    end
+  end, string.format("%s Reconnect Task", sonos_conn.device.label))
+end
+
+---@param sonos_conn SonosConnection
+local function _oauth_reconnect_task(sonos_conn)
   log.debug("Spawning reconnect task for ", sonos_conn.device.label)
   if not sonos_conn.driver:is_waiting_for_oauth_token() then
     sonos_conn.driver:request_oauth_token()
@@ -241,6 +266,15 @@ local function _spawn_reconnect_task(sonos_conn)
       cosock.socket.sleep(backoff())
     end
   end, string.format("%s Reconnect Task", sonos_conn.device.label))
+end
+
+---@param sonos_conn SonosConnection
+local function _spawn_reconnect_task(sonos_conn)
+  if type(api_version) == "number" and api_version >= 14 then
+    _oauth_reconnect_task(sonos_conn)
+  else
+    _legacy_reconnect_task(sonos_conn)
+  end
 end
 
 --- Create a new Sonos connection to manage the given device
@@ -276,15 +310,29 @@ function SonosConnection.new(driver, device)
       local header, body = table.unpack(table.unpack(json_result))
       if header.type == "globalError" then
         if body.errorCode == "ERROR_NOT_AUTHORIZED" then
-          local household_id, player_id = driver.sonos:get_player_for_device(device)
-          device.log.warn(string.format("WebSocket connection no longer authorized, disconnecting"))
-          local _, security_err = driver:request_oauth_token()
-          if security_err then
-            log.warn(string.format("Error during request for oauth token: %s", security_err))
+          if api_version < 14 then
+            log.error(
+              "Unable to authenticate Sonos WebSocket Connection, and current API does not support Sonos OAuth"
+            )
+            self:stop()
+          else
+            local household_id, player_id = driver.sonos:get_player_for_device(device)
+            device.log.warn(
+              string.format("WebSocket connection no longer authorized, disconnecting")
+            )
+            local _, security_err = driver:request_oauth_token()
+            if security_err then
+              log.warn(string.format("Error during request for oauth token: %s", security_err))
+            end
+            -- closing the socket directly without calling `:stop()` triggers the reconnect loop,
+            -- which is where we wait for the token to come in.
+            local unique_key, bad_key_part = utils.sonos_unique_key(household_id, player_id)
+            if not unique_key then
+              log.error(string.format("Invalid Sonos Unique Key Part: %s", bad_key_part))
+            else
+              Router.close_socket_for_player(unique_key)
+            end
           end
-          -- closing the socket directly without calling `:stop()` triggers the reconnect loop,
-          -- which is where we wait for the token to come in.
-          Router.close_socket_for_player(utils.sonos_unique_key(household_id, player_id))
         end
       elseif header.type == "groups" then
         log.trace(string.format("Groups type message for %s", device_name))
@@ -494,15 +542,32 @@ end
 function SonosConnection:self_running()
   local household_id = self.device:get_field(PlayerFields.HOUSEHOLD_ID)
   local player_id = self.device:get_field(PlayerFields.PLAYER_ID)
-  return Router.is_connected(utils.sonos_unique_key(household_id, player_id)) and self._initialized
+  local unique_key, bad_key_part = utils.sonos_unique_key(household_id, player_id)
+  if bad_key_part then
+    self.device.log.warn(
+      string.format(
+        "Bad Unique Key Part While Inspecting Connections in 'self_running': %s",
+        bad_key_part
+      )
+    )
+  end
+  return type(unique_key) == "string" and Router.is_connected(unique_key) and self._initialized
 end
 
 --- Whether or not the connection has a live websocket connection to its coordinator
 --- @return boolean
 function SonosConnection:coordinator_running()
   local household_id, coordinator_id = self.driver.sonos:get_coordinator_for_device(self.device)
-  return Router.is_connected(utils.sonos_unique_key(household_id, coordinator_id))
-    and self._initialized
+  local unique_key, bad_key_part = utils.sonos_unique_key(household_id, coordinator_id)
+  if bad_key_part then
+    self.device.log.warn(
+      string.format(
+        "Bad Unique Key Part While Inspecting Connections in 'coordinator_running': %s",
+        bad_key_part
+      )
+    )
+  end
+  return unique_key and Router.is_connected(unique_key) and self._initialized
 end
 
 function SonosConnection:refresh_subscriptions(maybe_reply_tx)
@@ -524,10 +589,12 @@ function SonosConnection:send_command(cmd)
   if err or not json_payload then
     log.error("Json encoding error: " .. err)
   else
-    Router.send_message_to_player(
-      utils.sonos_unique_key(household_id, coordinator_id),
-      json_payload
-    )
+    local unique_key, bad_key_part = utils.sonos_unique_key(household_id, coordinator_id)
+    if not unique_key then
+      self.device.log.error(string.format("Invalid Sonos Unique Key Part: %s", bad_key_part))
+      return
+    end
+    Router.send_message_to_player(unique_key, json_payload)
   end
 end
 
@@ -562,12 +629,17 @@ function SonosConnection:start()
       return false
     end
 
-    local listener_id, register_listener_err =
-      Router.register_listener_for_socket(self, utils.sonos_unique_key(household_id, player_id))
-    if register_listener_err ~= nil or not listener_id then
-      log.error(register_listener_err)
+    local unique_key, bad_key_part = utils.sonos_unique_key(household_id, player_id)
+    if bad_key_part then
+      self.device.log.error(string.format("Invalid Sonos Unique Key Part: %s", bad_key_part))
     else
-      self._self_listener_uuid = listener_id
+      local listener_id, register_listener_err =
+        Router.register_listener_for_socket(self, unique_key)
+      if register_listener_err ~= nil or not listener_id then
+        log.error(register_listener_err)
+      else
+        self._self_listener_uuid = listener_id
+      end
     end
   end
 
@@ -578,14 +650,37 @@ function SonosConnection:start()
 
   self:refresh_subscriptions()
   local coordinator_id = self.driver.sonos:get_coordinator_for_player(household_id, player_id)
+  local self_unique_key, self_bad_key_part = utils.sonos_unique_key(household_id, player_id)
+  local coordinator_unique_key, coordinator_bad_key_part =
+    utils.sonos_unique_key(household_id, coordinator_id)
   if
-    Router.is_connected(utils.sonos_unique_key(household_id, player_id))
-    and Router.is_connected(utils.sonos_unique_key(household_id, coordinator_id))
+    self_unique_key
+    and Router.is_connected(self_unique_key)
+    and coordinator_unique_key
+    and Router.is_connected(coordinator_unique_key)
   then
     self.device:online()
     self._initialized = true
     self._keepalive = true
     return true
+  end
+
+  if self_bad_key_part then
+    self.device.log.error(
+      string.format(
+        "Invalid Unique Key Part for 'self' Player during connection bring-up: %s",
+        self_bad_key_part
+      )
+    )
+  end
+
+  if coordinator_bad_key_part then
+    self.device.log.error(
+      string.format(
+        "Invalid Unique Key Part for 'coordinator' Player during connection bring-up: %s",
+        coordinator_bad_key_part
+      )
+    )
   end
 
   return false
@@ -601,7 +696,12 @@ function SonosConnection:stop()
   local coordinator_id = self.driver.sonos:get_coordinator_for_group(household_id, group_id)
 
   if player_id ~= coordinator_id then
-    Router.close_socket_for_player(utils.sonos_unique_key(household_id, player_id))
+    local unique_key, bad_key_part = utils.sonos_unique_key(household_id, player_id)
+    if not unique_key then
+      self.device.log.error(string.format("Invalid Sonos Unique Key Part: %s", bad_key_part))
+      return
+    end
+    Router.close_socket_for_player(unique_key)
   end
 end
 

--- a/drivers/SmartThings/sonos/src/api/sonos_ssdp_discovery.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_ssdp_discovery.lua
@@ -200,16 +200,19 @@ function SonosPersistentSsdpTask:get_player_info(reply_tx, ...)
   local household_id_or_mac = select(1, ...)
   local player_id = select(2, ...)
 
-  local lookup_table, lookup_key
+  local lookup_table, lookup_key, bad_key_part
 
   if player_id ~= nil and type(player_id) == "string" then
     lookup_table = self.player_info_by_sonos_ids
-    lookup_key = utils.sonos_unique_key(household_id_or_mac, player_id)
+    lookup_key, bad_key_part = utils.sonos_unique_key(household_id_or_mac, player_id)
   else
     lookup_table = self.player_info_by_mac_addrs
     lookup_key = household_id_or_mac
   end
 
+  if not lookup_key and bad_key_part then
+    log.error(string.format("Invalid Unique Key Part: %s", bad_key_part))
+  end
   local maybe_existing = lookup_table[lookup_key]
   if maybe_existing and maybe_existing.ssdp_info.expires_at > os.time() then
     reply_tx:send(maybe_existing)

--- a/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
+++ b/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
@@ -71,7 +71,7 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
             local auth_success, api_key_or_err = driver:check_auth(info)
             if not auth_success then
               device:offline()
-              if auth_success == false then
+              if auth_success == false and api_version >= 14 then
                 local token_event_receive = driver:oauth_token_event_subscribe()
                 if not token_event_receive then
                   log.error("token event bus closed, aborting initialization")

--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -1,3 +1,4 @@
+local api_version = require "version".api
 local capabilities = require "st.capabilities"
 local cosock = require "cosock"
 local json = require "st.json"
@@ -93,11 +94,15 @@ end
 
 ---@return boolean
 function SonosDriver:is_waiting_for_oauth_token()
-  return self.waiting_for_oauth_token
+  return (api_version >= 14) and self.waiting_for_oauth_token
 end
 
 ---@return (cosock.Bus.Subscription)? receiver the subscription receiver if the bus hasn't been closed, nil if closed
+---@return nil|"not supported"|"closed" err_msg "not supported" on old API versions, "closed" if the bus is closed, nil on success
 function SonosDriver:oauth_token_event_subscribe()
+  if api_version < 14 then
+    return nil, "not supported"
+  end
   return self.oauth_token_bus:subscribe()
 end
 
@@ -194,11 +199,15 @@ function SonosDriver:handle_startup_state_received()
 end
 
 function SonosDriver:get_fallback_api_key()
-  if self.oauth and self.oauth.force_oauth then
-    return SonosApi.api_keys.oauth_key
-  else
+  if api_version < 14 then
     return SonosApi.api_keys.s1_key
   end
+
+  if self.oauth and self.oauth.force_oauth then
+    return SonosApi.api_keys.oauth_key
+  end
+
+  return SonosApi.api_keys.s1_key
 end
 
 --- Check if the driver is able to authenticate against the given household_id
@@ -209,7 +218,8 @@ end
 function SonosDriver:check_auth(info_or_device)
   local maybe_token, _ = self:get_oauth_token()
 
-  local token_valid = self.oauth
+  local token_valid = (api_version >= 14)
+    and self.oauth
     and self.oauth.endpoint_app_info
     and self.oauth.endpoint_app_info.state == "connected"
     and maybe_token ~= nil
@@ -278,6 +288,9 @@ end
 ---@return any? ret nil on permissions violation
 ---@return string? error nil on success
 function SonosDriver:request_oauth_token()
+  if api_version < 14 then
+    return nil, "not supported"
+  end
   local maybe_token, maybe_err = self:get_oauth_token()
   if maybe_err then
     log.warn(string.format("get oauth token error: %s", maybe_err))
@@ -294,8 +307,11 @@ function SonosDriver:request_oauth_token()
 end
 
 ---@return { accessToken: string, expiresAt: number }? the token if a currently valid token is available, nil if not
----@return "token expired"|"no token"|nil reason the reason a token was not provided, nil if there is a valid token available
+---@return "token expired"|"no token"|"not supported"|nil reason the reason a token was not provided, nil if there is a valid token available
 function SonosDriver:get_oauth_token()
+  if api_version < 14 then
+    return nil, "not supported"
+  end
   self.hub_augmented_driver_data = self.hub_augmented_driver_data or {}
   local decode_success, maybe_token =
     pcall(json.decode, self.hub_augmented_driver_data.sonosOAuthToken)
@@ -334,7 +350,7 @@ end
 ---Create a cosock task that handles events from the persistent SSDP task.
 ---@param driver SonosDriver
 ---@param discovery_event_subscription cosock.Bus.Subscription
----@param oauth_token_subscription cosock.Bus.Subscription
+---@param oauth_token_subscription cosock.Bus.Subscription?
 local function make_ssdp_event_handler(
   driver,
   discovery_event_subscription,
@@ -343,13 +359,16 @@ local function make_ssdp_event_handler(
   return function()
     local unauthorized = {}
     local discovered = {}
+    local receivers = { discovery_event_subscription }
+    if oauth_token_subscription ~= nil then
+      table.insert(receivers, oauth_token_subscription)
+    end
     while true do
-      local recv_ready, _, select_err =
-        cosock.socket.select({ discovery_event_subscription, oauth_token_subscription }, nil, nil)
+      local recv_ready, _, select_err = cosock.socket.select(receivers, nil, nil)
 
       if recv_ready then
         for _, receiver in ipairs(recv_ready) do
-          if receiver == oauth_token_subscription then
+          if oauth_token_subscription ~= nil and receiver == oauth_token_subscription then
             local token_evt, receive_err = oauth_token_subscription:receive()
             if not token_evt then
               log.warn(string.format("Error on token event bus receive: %s", receive_err))
@@ -402,7 +421,10 @@ function SonosDriver:start_ssdp_event_task()
   if ssdp_task then
     self.ssdp_task = ssdp_task
     local ssdp_task_subscription = ssdp_task:subscribe()
-    local oauth_token_subscription = self:oauth_token_event_subscribe()
+    local oauth_token_subscription, subscribe_err = self:oauth_token_event_subscribe()
+    if subscribe_err then
+      log.warn(string.format("Couldn't subscribe to OAuth Token Events: %s", subscribe_err))
+    end
     self.ssdp_event_thread_handle =
       cosock.spawn(make_ssdp_event_handler(self, ssdp_task_subscription, oauth_token_subscription))
   end

--- a/drivers/SmartThings/sonos/src/utils.lua
+++ b/drivers/SmartThings/sonos/src/utils.lua
@@ -8,9 +8,18 @@ local utils = {}
 --- Returns the properly concatenated and formatted string for the a key that
 --- uniquely identifies a Sonos speaker on the network via its household ID and
 --- player ID.
----@param household_id HouseholdId
----@param player_id PlayerId
+---@param household_id HouseholdId?
+---@param player_id PlayerId?
+---@return UniqueKey? unique_key the unique key, as long as the inputs are valid, nil otherwise
+---@return "HouseholdId"|"PlayerId"|nil invalid_key_name which key argument was bad, nil otherwise
 function utils.sonos_unique_key(household_id, player_id)
+  if type(household_id) ~= "string" then
+    return nil, "HouseholdId"
+  end
+  if type(player_id) ~= "string" then
+    return nil, "PlayerId"
+  end
+
   return string.format("%s/%s", household_id:lower(), player_id:lower())
 end
 ---
@@ -65,14 +74,25 @@ end
 ---@param opts table?
 ---@return boolean
 function utils.update_field_if_changed(device, field_key, new_value, opts)
-  if not (device and device.id and type(device.get_field) == "function" and type(device.set_field) == "function") then
+  if
+    not (
+      device
+      and device.id
+      and type(device.get_field) == "function"
+      and type(device.set_field) == "function"
+    )
+  then
     log.error(
-      string.format("[device %s] table is incomplete", (device and device.label or device.id or "<unknown device>"))
+      string.format(
+        "[device %s] table is incomplete",
+        (device and device.label or device.id or "<unknown device>")
+      )
     )
   end
 
   local old_value = device:get_field(field_key)
-  local changed = (type(old_value) ~= type(new_value)) or (not utils.deep_table_eq(old_value, new_value))
+  local changed = (type(old_value) ~= type(new_value))
+    or (not utils.deep_table_eq(old_value, new_value))
   if changed then
     device:set_field(field_key, new_value, opts)
     return true
@@ -207,7 +227,8 @@ function utils.labeled_socket_builder(label)
 
     if wrap_ssl then
       log.trace(string.format("%sCreating SSL wrapper for for REST Connection", label))
-      sock, err = ssl.wrap(sock, { mode = "client", protocol = "any", verify = "none", options = "all" })
+      sock, err =
+        ssl.wrap(sock, { mode = "client", protocol = "any", verify = "none", options = "all" })
       if err ~= nil then
         return nil, "SSL wrap error: " .. err
       end


### PR DESCRIPTION
# Type of Change

- [x] Bug fix


# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing

# Description of Change

A few of the code paths around offline speakers were hitting OAuth code paths, which was causing issues on API versions that don't support Sonos OAuth.


# Summary of Completed Tests

Rollback testing with real devices
