### PR TITLE
fix: Two Sonos edge cases that can result in nil index crashes

### DIFF
--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -78,7 +78,11 @@ local _update_subscriptions_helper = function(
     local unique_key, bad_key_part = utils.sonos_unique_key(householdId, playerId)
     if not unique_key then
       local err_msg = string.format("Invalid Sonos Unique Key Part: %s", bad_key_part)
-      reply_tx:send(table.pack(nil, err_msg))
+      if reply_tx then
+        reply_tx:send(table.pack(nil, err_msg))
+      else
+        log.warn(string.format("Update Subscriptions Error: %s", err_msg))
+      end
       return
     end
     Router.send_message_to_player(unique_key, payload, reply_tx)

--- a/drivers/SmartThings/sonos/src/sonos_state.lua
+++ b/drivers/SmartThings/sonos/src/sonos_state.lua
@@ -183,8 +183,9 @@ end
 function SonosState:update_device_record_group_info(household, group, device)
   local player_id = device:get_field(PlayerFields.PLAYER_ID)
   local group_role
-  if player_id == group.coordinatorId then
-    if #household.groups[group.id].playerIds > 1 then
+  if (player_id and group and group.id and group.coordinatorId) and player_id == group.coordinatorId then
+    local player_ids_list = household.groups[group.id].playerIds or {}
+    if #player_ids_list > 1 then
       group_role = "primary"
     else
       group_role = "ungrouped"
@@ -248,7 +249,7 @@ end
 --- @param household_id HouseholdId
 --- @param device SonosDevice
 function SonosState:update_device_record_from_state(household_id, device)
-  local current_mapping = _STATE.device_record_map[device.id]
+  local current_mapping = _STATE.device_record_map[device.id] or {}
   local household = _STATE.households:get_or_init(household_id)
   self:update_device_record_group_info(household, current_mapping.group, device)
 end


### PR DESCRIPTION
# Type of Change

- [x] Bug fix

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing

# Description of Change

These were found during release monitoring of the Beta driver hotfix on Friday. These are edge cases that aren't guaranteed to get hit, but if they do get it, they will cause a crash. The state does seem to recover eventually, but in some cases a hub can hit it more than once.

- A previous refactor that made the "Unique Key" constructor fallible also added sending the error condition back over the optional reply tx channel argument, which is allowed to be nil. The nil check over this argument was omitted, though, which can lead to crashes in some situations.

- Fix against a nil index race condition around groups by guarding against nils in certain spots related to group role introspection.
