### PR TITLE
fix: Sonos – routing non-group commands to the correct speaker

### DIFF
--- a/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
@@ -11,10 +11,10 @@ local CapCommandHandlers = {}
 
 local QUEUE_ACTION_PREF = "queueAction"
 
-local function _do_send(device, payload)
+local function _do_send(device, payload, use_coordinator)
   local conn = device:get_field(PlayerFields.CONNECTION)
   if conn and conn:is_running() then
-    conn:send_command(payload)
+    conn:send_command(payload, use_coordinator)
   else
     log.warn("No sonos connection for handling capability command")
   end
@@ -33,7 +33,7 @@ local function _do_send_to_group(driver, device, payload)
     payload[1].authorization = string.format("Bearer %s", maybe_token.accessToken)
   end
 
-  _do_send(device, payload)
+  _do_send(device, payload, true)
 end
 
 local function _do_send_to_self(driver, device, payload)
@@ -48,7 +48,7 @@ local function _do_send_to_self(driver, device, payload)
   if maybe_token then
     payload[1].authorization = string.format("Bearer %s", maybe_token.accessToken)
   end
-  _do_send(device, payload)
+  _do_send(device, payload, false)
 end
 
 function CapCommandHandlers.handle_play(driver, device, _cmd)

--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -586,15 +586,21 @@ end
 
 --- Send a Sonos command object to the player for this connection
 --- @param cmd SonosCommand
-function SonosConnection:send_command(cmd)
+--- @param use_coordinator boolean
+function SonosConnection:send_command(cmd, use_coordinator)
   log.debug("Sending command over websocket channel for device " .. self.device.label)
-  local household_id, coordinator_id = self.driver.sonos:get_coordinator_for_device(self.device)
+  local household_id, target_id
+  if use_coordinator then
+    household_id, target_id = self.driver.sonos:get_coordinator_for_device(self.device)
+  else
+    household_id, target_id = self.driver.sonos:get_player_for_device(self.device)
+  end
   local json_payload, err = json.encode(cmd)
 
   if err or not json_payload then
     log.error("Json encoding error: " .. err)
   else
-    local unique_key, bad_key_part = utils.sonos_unique_key(household_id, coordinator_id)
+    local unique_key, bad_key_part = utils.sonos_unique_key(household_id, target_id)
     if not unique_key then
       self.device.log.error(string.format("Invalid Sonos Unique Key Part: %s", bad_key_part))
       return


### PR DESCRIPTION
# Type of Change

- [x] Bug fix

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing

# Description of Change

I'm not sure if this is a Sonos WebSocket API Behavior Change, or if this bug has always been here, but the driver was routing all outgoing websocket commands to the group coordinator at all times.

This was causing non-group addressed commands, such as individual player volume when in a group, to be sent over the wrong connection.

The net result was a no-op, because the JSON payload also includes a target player ID, and when that ID doesn't match the player that received the command, it gets ignored.

# Summary of Completed Tests

Tested on multiple One SL speakers in varying group configs.