### PR TITLE
fix: Missing headers when querying Sonos for Presets

### DIFF
--- a/drivers/SmartThings/sonos/src/api/event_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/event_handlers.lua
@@ -9,7 +9,7 @@ CapEventHandlers.PlaybackStatus = {
   Buffering = "PLAYBACK_STATE_BUFFERING",
   Idle = "PLAYBACK_STATE_IDLE",
   Paused = "PLAYBACK_STATE_PAUSED",
-  Playing = "PLAYBACK_STATE_PLAYING"
+  Playing = "PLAYBACK_STATE_PLAYING",
 }
 
 function CapEventHandlers.handle_player_volume(device, new_volume, is_muted)
@@ -84,7 +84,12 @@ function CapEventHandlers.handle_playback_metadata_update(device, metadata_statu
     local is_linein = string.find(metadata_status_body.container.type, "linein", 1, true) ~= nil
     local is_station = string.find(metadata_status_body.container.type, "station", 1, true) ~= nil
     local is_show = string.find(metadata_status_body.container.type, "show", 1, true) ~= nil
-    local is_radio_tracklist = string.find(metadata_status_body.container.type, "trackList.program", 1, true) ~= nil
+    local is_radio_tracklist = string.find(
+      metadata_status_body.container.type,
+      "trackList.program",
+      1,
+      true
+    ) ~= nil
 
     if is_linein then
       audio_track_data.title = metadata_status_body.container.name
@@ -101,8 +106,7 @@ function CapEventHandlers.handle_playback_metadata_update(device, metadata_statu
   if metadata_status_body.track then
     track_info = metadata_status_body.track
   elseif metadata_status_body.currentItem and metadata_status_body.currentItem.track then
-    track_info = metadata_status_body
-        .currentItem.track
+    track_info = metadata_status_body.currentItem.track
   end
 
   if track_info ~= nil then

--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -466,8 +466,11 @@ function SonosConnection.new(driver, device)
             local base_url = lb_utils.force_url_table(
               string.format("https://%s:%s", url_ip, SonosApi.DEFAULT_SONOS_PORT)
             )
+            local _, api_key = driver:check_auth(device)
+            local maybe_token = driver:get_oauth_token()
+            local headers = SonosApi.make_headers(api_key, maybe_token and maybe_token.accessToken)
             local favorites_response, err, _ =
-              SonosRestApi.get_favorites(base_url, header.householdId)
+              SonosRestApi.get_favorites(base_url, header.householdId, headers)
 
             if err or not favorites_response then
               log.error("Error querying for favorites: " .. err)

--- a/drivers/SmartThings/sonos/src/api/sonos_ssdp_discovery.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_ssdp_discovery.lua
@@ -99,7 +99,6 @@ local function make_persistent_task_impl(
           interval_timer:handled()
           ssdp_search_handle:multicast_m_search()
         elseif receiver == control_rx then
-          ---@type ControlMessage?,string?
           local recv, recv_err = receiver:receive()
           if not recv then
             log.warn(string.format("control channel receive error: %s", recv_err))


### PR DESCRIPTION
# Type of Change

- [x] Bug fix

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing

# Description of Change

When we refactored the API Key so that it wasn't global state, we missed making sure it was properly constructed and injected in to the call for querying Favorites on notification that the list of favorites had changed.

# Summary of Completed Tests

Found while updating our internal regression test plan coverage, tested on my speakers.
