### PR TITLE
philips-hue: Fix batched command handling for grandchildren devices

### DIFF
--- a/drivers/SmartThings/philips-hue/src/utils/batched_command_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/batched_command_utils.lua
@@ -114,20 +114,20 @@ function batched_command_utils.sort_batch(driver, batch)
   for _, to_inspect in ipairs(batch) do
     -- Check if we can handle this in a batch
     if not batched_command_utils.get_handler(to_inspect) then
-      misfits.insert(to_inspect)
+      table.insert(misfits, to_inspect)
       goto continue
     end
 
     -- First key off bridge.
     local device = driver:get_device_info(to_inspect.device_uuid)
     if not device then
-      misfits.insert(to_inspect)
+      table.insert(misfits, to_inspect)
       goto continue
     end
     local parent_id = device.parent_device_id or device:get_field(Fields.PARENT_DEVICE_ID)
     local bridge_device = utils.get_hue_bridge_for_device(driver, device, parent_id, true)
     if not bridge_device then
-      misfits.insert(to_inspect)
+      table.insert(misfits, to_inspect)
       goto continue
     end
     sorted_batch[bridge_device] = sorted_batch[bridge_device] or KVCounter()

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -368,7 +368,7 @@ function utils.get_hue_bridge_for_device(driver, device, parent_device_id, quiet
     return parent_device --[[ @as HueBridgeDevice ]]
   end
 
-  return utils.get_hue_bridge_for_device(driver, parent_device, quiet)
+  return utils.get_hue_bridge_for_device(driver, parent_device, nil, quiet)
 end
 
 --- build a exponential backoff time value generator


### PR DESCRIPTION
Check all that apply

# Type of Change

- [x] Bug fix

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

There were two issues here:

1. Trying to call `insert` on the table directly was incorrect and causing the misfit handling to not work.
2. `get_hue_bridge_for_device` call recursively was incorrect when `quiet` was true because it was being passed in an incorrect position which meant it thought the parent id was `true`.

```
2025-06-16T18:33:15.595155835Z INFO Philips Hue  [hue_driver_template] 	Sorting batch of 4 commands
2025-06-16T18:33:15.597561882Z TRACE Philips Hue  [utils] 	------------------------ Looking for bridge for Dymera 1 Up with parent_device_id 918250d0-c87d-4620-83a2-a8eac94bcb1e
2025-06-16T18:33:15.600138509Z TRACE Philips Hue  [utils] 	------------------------- get_device_info for true was nil
2025-06-16T18:33:15.600343615Z WARN Philips Hue  [st.driver] 	hue encountered error: [string "utils/batched_command_utils.lua"]:130: attempt to call a nil value (field 'insert')
```



# Summary of Completed Tests

I have reproduced this with a dymera light and have tested and confirmed that things work with these changes.
