### PR TITLE
Update Zwave Smoke Driver for 2025 First Alert Smoke Detector - SMCO410

### DIFF
--- a/drivers/SmartThings/zwave-smoke-alarm/fingerprints.yml
+++ b/drivers/SmartThings/zwave-smoke-alarm/fingerprints.yml
@@ -63,3 +63,15 @@ zwaveManufacturer:
     productType: 0x0004
     productId: 0x0003
     deviceProfileName: co-battery
+  - id: 041B/0001/0410
+    deviceLabel: First Alert Smoke & CO Alarm (SMCO410)
+    manufacturerId: 0x041B
+    productType: 0x0001
+    productId: 0x0410
+    deviceProfileName: smoke-co-battery
+  - id: 0x0138/0001/0410
+    deviceLabel: First Alert Smoke & CO Alarm (SMCO410)
+    manufacturerId: 0x0138
+    productType: 0x0001
+    productId: 0x0410
+    deviceProfileName: smoke-co-battery


### PR DESCRIPTION
Adds Support for First Alert Smoke & CO Alarm (SMCO410) with multiple manufacturer codes for compatibility

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [X] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

* **Support for the 2025 First Alert Smoke Detector - SMCO410**
https://products.z-wavealliance.org/products/5196

  * Added entries `0138/0001/0410` & `041B/0001/0410` for MFR compatibility
  * Both entries map to the same `smoke-co-battery` profile

# Summary of Completed Tests

* **Pairing with real SMCO410**
  * Excluded & re-included on a hub; driver matched and bound correctly

