### PR TITLE
Sort EPs before get device type and add unit test

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -534,7 +534,14 @@ local function get_endpoints_for_dt(device, device_type)
 end
 
 local function get_device_type(device)
+  local device_types = {}
   for _, ep in ipairs(device.endpoints) do
+    if ep.device_types ~= nil then
+      table.insert(device_types, { endpoint_id = ep.endpoint_id, device_types = ep.device_types })
+    end
+  end
+  table.sort(device_types, function(a, b) return a.endpoint_id < b.endpoint_id end)
+  for _, ep in ipairs(device_types) do
     if ep.device_types ~= nil then
       for _, dt in ipairs(ep.device_types) do
         if dt.device_type_id == RAC_DEVICE_TYPE_ID then

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
@@ -68,7 +68,74 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
+local mock_device_disorder_endpoints = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 7}
+      },
+      device_types = {
+        {device_type_id = 0x002B, device_type_revision = 1} -- Fan
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = clusters.Thermostat.ID,
+          cluster_revision = 5,
+          cluster_type = "SERVER",
+          feature_map = 3, -- Heat and Cool features
+        }
+      },
+      device_types = {
+        {device_type_id = 0x0301, device_type_revision = 1} -- Thermostat
+      }
+    },
+    {
+      endpoint_id = 3,
+      clusters = {
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0307, device_type_revision = 1} -- Humidity Sensor
+      }
+    }
+  }
+})
+
 local cluster_subscribe_list = {
+  clusters.Thermostat.attributes.LocalTemperature,
+  clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+  clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+  clusters.Thermostat.attributes.AbsMinCoolSetpointLimit,
+  clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit,
+  clusters.Thermostat.attributes.AbsMinHeatSetpointLimit,
+  clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit,
+  clusters.Thermostat.attributes.SystemMode,
+  clusters.Thermostat.attributes.ThermostatRunningState,
+  clusters.Thermostat.attributes.ControlSequenceOfOperation,
+  clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+  clusters.FanControl.attributes.FanMode,
+  clusters.FanControl.attributes.FanModeSequence,
+}
+
+local cluster_subscribe_list_disorder_endpoints = {
   clusters.Thermostat.attributes.LocalTemperature,
   clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
   clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
@@ -107,6 +174,28 @@ local function test_init()
 end
 test.set_test_init_function(test_init)
 
+local function test_init_disorder_endpoints()
+  mock_device_disorder_endpoints:set_field("MIN_SETPOINT_DEADBAND_CHECKED", 1, {persist = true})
+  test.socket.matter:__set_channel_ordering("relaxed")
+  local subscribe_request_disorder_endpoints = cluster_subscribe_list_disorder_endpoints[1]:subscribe(mock_device_disorder_endpoints)
+  for i, cluster in ipairs(cluster_subscribe_list_disorder_endpoints) do
+    if i > 1 then
+      subscribe_request_disorder_endpoints:merge(cluster:subscribe(mock_device_disorder_endpoints))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_disorder_endpoints.id, subscribe_request_disorder_endpoints})
+  test.mock_device.add_test_device(mock_device_disorder_endpoints)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_disorder_endpoints.id, "added" })
+  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
+  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
+  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
+  test.socket.matter:__expect_send({mock_device_disorder_endpoints.id, read_req})
+end
+
 test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event no battery & state support",
   function()
@@ -115,6 +204,17 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-nostate-nobattery" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
+)
+
+test.register_coroutine_test(
+  "Profile change on doConfigure lifecycle event no battery & state support with disorder endpoints",
+  function()
+    mock_device_disorder_endpoints:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false)
+    test.socket.device_lifecycle:__queue_receive({mock_device_disorder_endpoints.id, "doConfigure"})
+    mock_device_disorder_endpoints:expect_metadata_update({ profile = "thermostat-humidity-fan-nostate-nobattery" })
+    mock_device_disorder_endpoints:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  { test_init = test_init_disorder_endpoints }
 )
 
 test.run_registered_tests()


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
 We find `device.endpoints` sometimes is disordered, like “ep0, ep5, ep1, ep3, ep4, ep2“. So we plan to sort device endpoints in ASC before judging the device type of equipment,  

# Summary of Completed Tests
 We added Unit Test and tested with real device.

