### PR TITLE
fix: Another nil index along a REST response error handling path

### DIFF
--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -294,7 +294,7 @@ function SonosDriver:check_auth(info_or_device)
     local headers = SonosApi.make_headers(api_key, maybe_token and maybe_token.accessToken)
     local response, response_err = SonosApi.RestApi.get_groups_info(rest_url, household_id, headers)
 
-    if response._objectType == "globalError" then
+    if response and response._objectType == "globalError" then
       unauthorized = (response.errorCode == "ERROR_NOT_AUTHORIZED")
       if not unauthorized then
         return nil, string.format("Unexpected error body: %s", st_utils.stringify_table(response))


### PR DESCRIPTION
Check all that apply

# Type of Change

- [x] Bug fix

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

A follow-on to the previous fix, some crash log investigations show that some setups are getting further along than they were before but have run in to a new crash.
