### PR TITLE
Aqara-FP2: Add error handling and modify offline logic

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/discovery.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/discovery.lua
@@ -1,10 +1,11 @@
 local log = require "log"
-local discovery = {}
 local fields = require "fields"
 local discovery_mdns = require "discovery_mdns"
 local socket = require "cosock.socket"
 
-local processing_devices = {}
+local discovery = {
+  last_try_time = {}
+}
 
 function discovery.set_device_field(driver, device)
   local device_cache_value = driver.datastore.discovery_cache[device.device_network_id]
@@ -36,6 +37,10 @@ local function try_add_device(driver, device_dni, device_ip)
 
   update_device_discovery_cache(driver, device_dni, device_ip, device_info)
   local create_device_msg = driver.discovery_helper.get_device_create_msg(driver, device_dni, device_ip, device_info)
+  if not create_device_msg then
+    log.error_with({ hub_logs = true }, string.format("Failed to get device info. dni= %s, ip= %s", device_dni, device_ip))
+    return "device info not found"
+  end
 
   local credential = driver.discovery_helper.get_credential(driver, device_dni, device_ip)
 
@@ -52,15 +57,20 @@ local function try_add_device(driver, device_dni, device_ip)
   end
 
   log.info_with({ hub_logs = true }, string.format("try_create_device. dni= %s, ip= %s", device_dni, device_ip))
-  processing_devices[device_dni] = true
-  driver:try_create_device(create_device_msg)
+
+  local success, ret = pcall(driver.try_create_device, driver, create_device_msg)
+  if success then
+    discovery.last_try_time[device_dni] = os.time()
+  else
+    log.error_with({ hub_logs = true }, string.format("Failed to try_create_device. dni= %s, %s", device_dni, ret))
+  end
   return nil
 end
 
 function discovery.device_added(driver, device)
   log.info_with({ hub_logs = true }, string.format("device_added. dni= %s", device.device_network_id))
   discovery.set_device_field(driver, device)
-  processing_devices[device.device_network_id] = nil
+  discovery.last_try_time[device.device_network_id] = nil
   driver.lifecycle_handlers.init(driver, device)
 end
 
@@ -100,14 +110,20 @@ local function discovery_device(driver)
         break
       end
     end
-    if (not processing_devices[dni]) and (not is_already_added) then
-      try_add_device(driver, dni, ip)
+    if not is_already_added then
+      local time_since_last_try = os.time() - (discovery.last_try_time[dni] or 0)
+      if (not discovery.last_try_time[dni]) or (time_since_last_try > 10) then
+        try_add_device(driver, dni, ip)
+      else
+        log.trace(string.format("skip adding device because it was tried recently. dni= %s, ip= %s, since %s sec", dni, ip, time_since_last_try))
+      end
     end
   end
 end
 
 function discovery.do_network_discovery(driver, _, should_continue)
   log.info_with({ hub_logs = true }, string.format("discovery start for Aqara FP2"))
+  discovery.last_try_time = {}
   while should_continue() do
     discovery_device(driver)
     socket.sleep(1)

--- a/drivers/Aqara/aqara-presence-sensor/src/fields.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/fields.lua
@@ -11,7 +11,7 @@ local fields = {
   MONITORING_TIMER = "monitoring_timer",
   CREDENTIAL = "credential",
   _INIT = "init",
-  CONNECTION_STATUS = "connection_status"
+  LAST_DISCONNECTED_TIME = "last_disconnected_time"
 }
 
 return fields

--- a/drivers/Aqara/aqara-presence-sensor/src/lunchbox/sse/eventsource.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/lunchbox/sse/eventsource.lua
@@ -427,6 +427,7 @@ local function closed_action(source)
 
     local sleep_time_secs = source._reconnect_time_millis / 1000.0
     socket.sleep(sleep_time_secs)
+
     if source._reconnect_time_millis  <= MAX_RECONNECT_TIME_SEC * 1000 then
       source._reconnect_time_millis = source._reconnect_time_millis + 1000.0
     end
@@ -506,7 +507,7 @@ function EventSource.new(url, extra_headers, sock_builder)
       local _, action_err, partial = state_actions[source.ready_state](source)
       if action_err ~= nil then
         if action_err ~= "timeout" or action_err ~= "wantread" then
-          log.error_with({ hub_logs = true }, "Event Source Coroutine State Machine error: " .. action_err)
+          log.error_with({ hub_logs = true }, "Event Source Coroutine State Machine error(" .. (source.url.host or "") .. "):" .. action_err)
           if partial ~= nil and #partial > 0 then
             log.error_with({ hub_logs = true }, st_utils.stringify_table(partial, "\tReceived Partial", true))
           end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

- Added error handling for potential errors that may occur when adding a device.
- Modified the offline detection logic to align with Aqara's logic.
- Reset the device exclusion list on every discovery

# Summary of Completed Tests

Verified operation with 3 FP2 devices connected at the same time to:
- SmartThings Hub V2
- SmartThings Hub V3
- SmartThings Station
- SmartMonitor M5's built-in hub