### PR TITLE
CHAD-15418 workaround

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/smartsense-multi/init.lua
@@ -37,7 +37,8 @@ local function can_handle(opts, driver, device, ...)
       return true
     end
   end
-  if device.zigbee_endpoints[1].profileId == SMARTSENSE_PROFILE_ID then return true end
+  local endpoint = device.zigbee_endpoints[1] or device.zigbee_endpoints["1"]
+  if endpoint.profile_id == SMARTSENSE_PROFILE_ID then return true end
   return false
 end
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/init.lua
@@ -44,8 +44,9 @@ local battery_table = {
 }
 
 local function can_handle(opts, driver, device, ...)
+  local endpoint = device.zigbee_endpoints[1] or device.zigbee_endpoints["1"]
   if (device:get_manufacturer() == SMARTSENSE_MFR and device:get_model() == SMARTSENSE_MODEL) or
-    device.zigbee_endpoints[1].profileId == SMARTSENSE_PROFILE_ID then
+    endpoint.profile_id == SMARTSENSE_PROFILE_ID then
     return true
   end
   return false

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
@@ -33,7 +33,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         id = 1,
         manufacturer = "SmartThings",
         model = "PGC314",
-        profileId = 0xFC01,
+        profile_id = 0xFC01,
         server_clusters = {}
       }
     }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
@@ -30,7 +30,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         manufacturer = "IKEA of Sweden",
         model = "TRADFRI bulb E26 WS clear 950lm",
         server_clusters = { 0x0006, 0x0008, 0x0300 },
-        profile = 0xC05E,
+        profile_id = 0xC05E,
       }
     }
   }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer.lua
@@ -30,7 +30,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         manufacturer = "Leviton",
         model = "DL6HD",
         server_clusters = { 0x0006, 0x0008 },
-        profile = 0xC05E,
+        profile_id = 0xC05E,
       }
     }
   }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
@@ -29,7 +29,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         manufacturer = "AduroSmart Eria",
         model = "ZLL-DimmableLight",
         server_clusters = { 0x0006, 0x0008 },
-        profile = 0xC05E,
+        profile_id = 0xC05E,
       }
     }
   }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
@@ -35,7 +35,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         manufacturer = "IKEA of Sweden",
         model = "TRADFRI bulb E27 CWS opal 600lm",
         server_clusters = { 0x0006, 0x0008, 0x0300 },
-        profile = 0xC05E,
+        profile_id = 0xC05E,
       }
     }
   }

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
@@ -30,7 +30,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
         manufacturer = "AduroSmart Eria",
         model = "ZLL-ExtendedColor",
         server_clusters = { 0x0006, 0x0008, 0x0300 },
-        profile = 0xC05E,
+        profile_id = 0xC05E,
       }
     }
   }

--- a/drivers/SmartThings/zigbee-switch/src/zll-polling/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-polling/init.lua
@@ -17,10 +17,12 @@ local constants = require "st.zigbee.constants"
 local clusters = require "st.zigbee.zcl.clusters"
 
 local function zll_profile(opts, driver, device, zb_rx, ...)
-  if (device.zigbee_endpoints[device.fingerprinted_endpoint_id].profile == constants.ZLL_PROFILE_ID) then
+  local endpoint = device.zigbee_endpoints[device.fingerprinted_endpoint_id] or device.zigbee_endpoints[tostring(device.fingerprinted_endpoint_id)]
+  if (endpoint.profile_id == constants.ZLL_PROFILE_ID) then
     local subdriver = require("zll-polling")
     return true, subdriver
-  else return false
+  else
+    return false
   end
 end
 


### PR DESCRIPTION
endpoint ids change from numbers to strings shortly after install. This also fixes some incorrectly-addressed fields for kickstarter sensors.
