### PR TITLE
Matter Thermostat: Avoid sending nil capability event

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -1558,7 +1558,7 @@ local function fan_mode_handler(driver, device, ib, response)
     device:supports_capability_by_id(capabilities.airConditionerFanMode.ID) and 2 or
     device:supports_capability_by_id(capabilities.airPurifierFanMode.ID) and 3 or
     device:supports_capability_by_id(capabilities.thermostatFanMode.ID) and 4
-  if fan_mode_idx ~= false then
+  if fan_mode_idx ~= false and fan_mode_event[ib.data.value][fan_mode_idx] then
     device:emit_event_for_endpoint(ib.endpoint_id, fan_mode_event[ib.data.value][fan_mode_idx])
   else
     log.warn(string.format("Invalid Fan Mode (%s)", ib.data.value))

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -615,7 +615,14 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.thermostatFanMode.thermostatFanMode.on())
     },
-
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        FanMode:build_test_report_data(mock_device, 1, FanMode.OFF)
+      }
+    }
   }
 )
 


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This is a follow on PR to #2205 to ensure that a capability event is not sent when a FanMode of OFF is reported for a device supporting the thermostatFanMode capability, which doesn't support an 'off' fan mode.