### PR TITLE
zigbee-contact: Remove incorrect device events from init handler

### DIFF
--- a/drivers/SmartThings/zigbee-contact/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/aqara/init.lua
@@ -55,17 +55,19 @@ local function device_init(driver, device)
     device:add_configured_attribute(attribute)
     device:add_monitored_attribute(attribute)
   end
-
-  device:emit_event(capabilities.batteryLevel.type("CR1632"))
-  device:emit_event(capabilities.batteryLevel.quantity(1))
-  device:emit_event(capabilities.batteryLevel.battery("normal"))
-  device:emit_event(capabilities.contactSensor.contact.open())
 end
 
 local function do_configure(self, device)
   device:configure()
   device:send(cluster_base.write_manufacturer_specific_attribute(device,
     PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0x01))
+end
+
+local function added_handler(driver, device)
+  device:emit_event(capabilities.batteryLevel.type("CR1632"))
+  device:emit_event(capabilities.batteryLevel.quantity(1))
+  device:emit_event(capabilities.batteryLevel.battery("normal"))
+  device:emit_event(capabilities.contactSensor.contact.open())
 end
 
 local function contact_status_handler(self, device, value, zb_rx)
@@ -126,7 +128,8 @@ local aqara_contact_handler = {
   },
   lifecycle_handlers = {
     init = device_init,
-    doConfigure = do_configure
+    doConfigure = do_configure,
+    added = added_handler,
   },
   can_handle = is_aqara_products
 }

--- a/drivers/SmartThings/zigbee-contact/src/test/test_aqara_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_aqara_contact_sensor.lua
@@ -47,12 +47,6 @@ zigbee_test_utils.prepare_zigbee_env_info()
 
 local function test_init()
   test.mock_device.add_test_device(mock_device)
-  test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.batteryLevel.type("CR1632")))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.batteryLevel.quantity(1)))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("main",
-    capabilities.batteryLevel.battery("normal")))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("main",
-    capabilities.contactSensor.contact.open()))
 end
 
 test.set_test_init_function(test_init)
@@ -81,6 +75,19 @@ test.register_coroutine_test(
       cluster_base.write_manufacturer_specific_attribute(mock_device, PRIVATE_CLUSTER_ID, PRIVATE_ATTRIBUTE_ID, MFG_CODE
       , data_types.Uint8, 1) })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
+)
+
+test.register_coroutine_test(
+  "added lifecycle handler",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.batteryLevel.type("CR1632")))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.batteryLevel.quantity(1)))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.batteryLevel.battery("normal")))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.contactSensor.contact.open()))
   end
 )
 


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This was a VOC bug that came in where the customer was reporting that there device was incorrectly reporting as open and triggering automations. The logs showed hubcore restarting, so the driver was also starting up, and the driver emitted these events without receiving any zigbee messages. The device record matched this subdriver which is unconditionally sending out `contactSensor:contact`  as `open` and `batteryLevel:battery` as `normal`.

# Summary of Completed Tests


