### PR TITLE
Add default enum value to supportedAlarmvalues

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -204,6 +204,8 @@ local function info_changed(driver, device, event, args)
     end
   end
   device:subscribe()
+  device:emit_event(capabilities.lockAlarm.alarm.clear({state_change = true}))
+  device:emit_event(capabilities.lockAlarm.supportedAlarmValues({"unableToLockTheDoor"})) -- lockJammed is madatory
 end
 
 -- This function check busy_state and if busy_state is false, set it to true(current time)

--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -205,7 +205,7 @@ local function info_changed(driver, device, event, args)
   end
   device:subscribe()
   device:emit_event(capabilities.lockAlarm.alarm.clear({state_change = true}))
-  device:emit_event(capabilities.lockAlarm.supportedAlarmValues({"unableToLockTheDoor"})) -- lockJammed is madatory
+  device:emit_event(capabilities.lockAlarm.supportedAlarmValues({"unableToLockTheDoor"}, {visibility = {displayed = false}})) -- lockJammed is madatory
 end
 
 -- This function check busy_state and if busy_state is false, set it to true(current time)


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
DoorLockAlarm event is manadatory event in Matter spec and LockJammed is mandatory enum value.
So this patch add unableToLockTheDoor value that is mapped to LockJammed of Matter spec to supportedAlarmValues.

supportedAlarmValues is used in Routine. If supportedAlarmValues is nil, user can select all of lockAlarm Enum value. Even if device does not support some enum values, user can select those values. So we decide to add default value(unableToLockTheDoor) to supportedAlarmVlaues.

# Summary of Completed Tests


