### PR TITLE
Use labels for keyboard profile

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/12-button-keyboard.yml
+++ b/drivers/SmartThings/matter-switch/profiles/12-button-keyboard.yml
@@ -1,6 +1,7 @@
 name: 12-button-keyboard
 components:
-  - id: F1
+  - id: main
+    label: F1
     capabilities:
       - id: button
         version: 1
@@ -10,67 +11,78 @@ components:
         version: 1
     categories:
     - name: RemoteController
-  - id: F2
+  - id: button2
+    label: F2
     capabilities:
       - id: button
         version: 1
     categories:
     - name: RemoteController
-  - id: F3
+  - id: button3
+    label: F3
     capabilities:
       - id: button
         version: 1
     categories:
     - name: RemoteController
-  - id: F4
+  - id: button4
+    label: F4
     capabilities:
       - id: button
         version: 1
     categories:
     - name: RemoteController
-  - id: F5
+  - id: button5
+    label: F5
     capabilities:
       - id: button
         version: 1
     categories:
     - name: RemoteController
-  - id: F6
+  - id: button6
+    label: F6
     capabilities:
       - id: button
         version: 1
     categories:
     - name: RemoteController
-  - id: F7
+  - id: button7
+    label: F7
     capabilities:
       - id: button
         version: 1
     categories:
     - name: RemoteController
-  - id: F8
+  - id: button8
+    label: F8
     capabilities:
       - id: button
         version: 1
     categories:
       - name: RemoteController
-  - id: F9
+  - id: button9
+    label: F9
     capabilities:
       - id: button
         version: 1
     categories:
       - name: RemoteController
-  - id: F10
+  - id: button10
+    label: F10
     capabilities:
       - id: button
         version: 1
     categories:
       - name: RemoteController
-  - id: F11
+  - id: button11
+    label: F11
     capabilities:
       - id: button
         version: 1
     categories:
       - name: RemoteController
-  - id: F12
+  - id: button12
+    label: F12
     capabilities:
       - id: button
         version: 1

--- a/drivers/SmartThings/matter-switch/src/test/test_third_reality_mk1.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_third_reality_mk1.lua
@@ -193,7 +193,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 
 local function configure_buttons()
   for key = 1, 12 do
-    local component = "F" .. key
+    local component = "button" .. key
+    if key == 1 then component = "main" end
     test.socket.capability:__expect_send(mock_device:generate_test_message(component, capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
     test.socket.capability:__expect_send(mock_device:generate_test_message(component, capabilities.button.button.pushed({state_change = false})))
   end
@@ -233,7 +234,7 @@ test.register_coroutine_test(
         clusters.Switch.events.InitialPress:build_test_event_report(mock_device, key, {new_position = 1})
       })
       test.socket.capability:__expect_send(
-        mock_device:generate_test_message("F" .. key, capabilities.button.button.pushed({state_change = true}))
+        mock_device:generate_test_message(key == 1 and "main" or "button" .. key, capabilities.button.button.pushed({state_change = true}))
       )
     end
   end

--- a/drivers/SmartThings/matter-switch/src/third-reality-mk1/init.lua
+++ b/drivers/SmartThings/matter-switch/src/third-reality-mk1/init.lua
@@ -43,7 +43,7 @@ local function endpoint_to_component(device, ep)
       return component
     end
   end
-  return "F1"
+  return "main"
 end
 
 -- override subscribe function to prevent subscribing to additional events from the main driver
@@ -58,12 +58,12 @@ local function configure_buttons(device)
   local ms_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
   for _, ep in ipairs(ms_eps) do
     if device.profile.components[endpoint_to_component(device, ep)] then
-      device.log.info_with({hub_logs=true}, string.format("Configuring Supported Values for generic switch endpoint %d", ep))
+      device.log.info(string.format("Configuring Supported Values for generic switch endpoint %d", ep))
       local supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})
       device:emit_event_for_endpoint(ep, supportedButtonValues_event)
       device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = false}))
     else
-      device.log.info_with({hub_logs=true}, string.format("Component not found for generic switch endpoint %d. Skipping Supported Value configuration", ep))
+      device.log.info(string.format("Component not found for generic switch endpoint %d. Skipping Supported Value configuration", ep))
     end
   end
 end
@@ -72,9 +72,9 @@ local function build_button_component_map(device)
   local button_eps = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
   table.sort(button_eps)
   local component_map = {}
-  for component_num, ep in ipairs(button_eps) do
-    local button_component = "F" .. component_num
-    component_map[button_component] = ep
+  component_map["main"] = button_eps[1]
+  for component_num = 2, 12 do
+    component_map["button" .. component_num] = button_eps[component_num]
   end
   device:set_field(COMPONENT_TO_ENDPOINT_MAP, component_map, {persist = true})
 end


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change uses labels to name the button components in the 12-button-keyboard profile. This is needed because the first component not being `main` may be the cause of an issue seen in the plugin for this device, and needs testing on device to confirm.

# Summary of Completed Tests


