### PR TITLE
fp2: During initialization, raise the init value instead of refresh

### DIFF
--- a/drivers/Aqara/aqara-presence-sensor/src/init.lua
+++ b/drivers/Aqara/aqara-presence-sensor/src/init.lua
@@ -220,7 +220,9 @@ local function device_init(driver, device)
     return
   end
 
-  do_refresh(driver, device, nil)
+  driver.device_manager.init_presence(driver, device)
+  driver.device_manager.init_movement(driver, device)
+  driver.device_manager.init_activity(driver, device)
 end
 
 local function device_info_changed(driver, device, event, args)


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

`do_refresh` operates in two parts:
1. `state_update` (updates values via REST API)
2. Initializes some capabilities (values not handled by state_update).

Currently, during initialization, `state_update()` is called redundantly:
1. `init` → `update_connection` → `create_sse` → (SSE) `on_create` → `state_update`
2. `init` → `do_refresh`→ `state_update`

This duplication may cause conflicts. This can cause more issues, especially if the network conditions are poor.
To prevent this, instead of performing `do_refresh` at the end of init, I propose updating only impotant initialization values.

# Summary of Completed Tests
Verified operation with 3 FP2 devices connected at the same time to:

- SmartThings Hub V2
- SmartThings Hub V3
- SmartThings Station
- SmartMonitor M5's built-in hub

