### PR TITLE
Fix reverse preference in matter window covering

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/init.lua
+++ b/drivers/SmartThings/matter-window-covering/src/init.lua
@@ -48,13 +48,6 @@ local function component_to_endpoint(device, component_name)
   return find_default_endpoint(device, clusters.WindowCovering.ID)
 end
 
-local function reverse_polarity_if_needed(device, value)
-  if device:get_field(REVERSE_POLARITY) then
-    return value
-  end
-  return 100 - value
-end
-
 local function match_profile(device, battery_supported)
   local lift_eps = device:get_endpoints(clusters.WindowCovering.ID, {feature_bitmap = clusters.WindowCovering.types.Feature.LIFT})
   local tilt_eps = device:get_endpoints(clusters.WindowCovering.ID, {feature_bitmap = clusters.WindowCovering.types.Feature.TILT})
@@ -129,7 +122,7 @@ local function handle_preset(driver, device, cmd)
   local lift_eps = device:get_endpoints(clusters.WindowCovering.ID, {feature_bitmap = clusters.WindowCovering.types.Feature.LIFT})
   local tilt_eps = device:get_endpoints(clusters.WindowCovering.ID, {feature_bitmap = clusters.WindowCovering.types.Feature.TILT})
   if #lift_eps > 0 then
-    local lift_value = reverse_polarity_if_needed(device, device.preferences.presetPosition)
+    local lift_value = 100 - device.preferences.presetPosition
     local hundredths_lift_percent = lift_value * 100
     local req = clusters.WindowCovering.server.commands.GoToLiftPercentage(
       device, endpoint_id, hundredths_lift_percent
@@ -149,6 +142,9 @@ end
 local function handle_close(driver, device, cmd)
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local req = clusters.WindowCovering.server.commands.DownOrClose(device, endpoint_id)
+  if device:get_field(REVERSE_POLARITY) then
+    req = clusters.WindowCovering.server.commands.UpOrOpen(device, endpoint_id)
+  end
   device:send(req)
 end
 
@@ -156,6 +152,9 @@ end
 local function handle_open(driver, device, cmd)
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local req = clusters.WindowCovering.server.commands.UpOrOpen(device, endpoint_id)
+  if device:get_field(REVERSE_POLARITY) then
+    req = clusters.WindowCovering.server.commands.DownOrClose(device, endpoint_id)
+  end
   device:send(req)
 end
 
@@ -169,7 +168,7 @@ end
 -- move to shade level between 0-100
 local function handle_shade_level(driver, device, cmd)
   local endpoint_id = device:component_to_endpoint(cmd.component)
-  local lift_percentage_value = reverse_polarity_if_needed(device, cmd.args.shadeLevel)
+  local lift_percentage_value = 100 - cmd.args.shadeLevel
   local hundredths_lift_percentage = lift_percentage_value * 100
   local req = clusters.WindowCovering.server.commands.GoToLiftPercentage(
                 device, endpoint_id, hundredths_lift_percentage
@@ -180,7 +179,7 @@ end
 -- move to shade tilt level between 0-100
 local function handle_shade_tilt_level(driver, device, cmd)
   local endpoint_id = device:component_to_endpoint(cmd.component)
-  local tilt_percentage_value = reverse_polarity_if_needed(device, cmd.args.level)
+  local tilt_percentage_value = 100 - cmd.args.level
   local hundredths_tilt_percentage = tilt_percentage_value * 100
   local req = clusters.WindowCovering.server.commands.GoToTiltPercentage(
     device, endpoint_id, hundredths_tilt_percentage
@@ -195,7 +194,8 @@ local current_pos_handler = function(attribute)
       return
     end
     local windowShade = capabilities.windowShade.windowShade
-    local position = reverse_polarity_if_needed(device, math.floor((ib.data.value / 100)))
+    local position = 100 - math.floor(ib.data.value / 100)
+    local reverse = device:get_field(REVERSE_POLARITY)
     device:emit_event_for_endpoint(ib.endpoint_id, attribute(position))
 
     if attribute == capabilities.windowShadeLevel.shadeLevel then
@@ -222,22 +222,22 @@ local current_pos_handler = function(attribute)
 
     if lift_position == nil then
       if tilt_position == 0 then
-        device:emit_event_for_endpoint(ib.endpoint_id, windowShade.closed())
+        device:emit_event_for_endpoint(ib.endpoint_id, reverse and windowShade.open() or windowShade.closed())
       elseif tilt_position == 100 then
-        device:emit_event_for_endpoint(ib.endpoint_id, windowShade.open())
+        device:emit_event_for_endpoint(ib.endpoint_id, reverse and windowShade.closed() or windowShade.open())
       else
         device:emit_event_for_endpoint(ib.endpoint_id, windowShade.partially_open())
       end
 
     elseif lift_position == 100 then
-      device:emit_event_for_endpoint(ib.endpoint_id, windowShade.open())
+      device:emit_event_for_endpoint(ib.endpoint_id, reverse and windowShade.closed() or windowShade.open())
 
     elseif lift_position > 0 then
       device:emit_event_for_endpoint(ib.endpoint_id, windowShade.partially_open())
 
     elseif lift_position == 0 then
       if tilt_position == nil or tilt_position == 0 then
-        device:emit_event_for_endpoint(ib.endpoint_id, windowShade.closed())
+        device:emit_event_for_endpoint(ib.endpoint_id, reverse and windowShade.open() or windowShade.closed())
       elseif tilt_position > 0 then
         device:emit_event_for_endpoint(ib.endpoint_id, windowShade.partially_open())
       end
@@ -248,11 +248,12 @@ end
 -- checks the current position of the shade
 local function current_status_handler(driver, device, ib, response)
   local windowShade = capabilities.windowShade.windowShade
+  local reverse = device:get_field(REVERSE_POLARITY)
   local state = ib.data.value & clusters.WindowCovering.types.OperationalStatus.GLOBAL
   if state == 1 then -- opening
-    device:emit_event_for_endpoint(ib.endpoint_id, windowShade.opening())
+    device:emit_event_for_endpoint(ib.endpoint_id, reverse and windowShade.closing() or windowShade.opening())
   elseif state == 2 then -- closing
-    device:emit_event_for_endpoint(ib.endpoint_id, windowShade.closing())
+    device:emit_event_for_endpoint(ib.endpoint_id, reverse and windowShade.opening() or windowShade.closing())
   elseif state ~= 0 then -- unknown
     device:emit_event_for_endpoint(ib.endpoint_id, windowShade.unknown())
   end

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -1017,110 +1017,110 @@ test.register_coroutine_test(
 
 test.register_coroutine_test(
   "Check that preference updates to reverse polarity after being set to true and that the shade lift operates as expected when opening and closing", function()
-    test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle():__queue_receive(mock_device:generate_info_changed({ preferences = { reverse = "true" } }))
     test.wait_for_events()
     local reverse_preference_set = mock_device:get_field("__reverse_polarity")
     assert(reverse_preference_set == true, "reverse_preference_set is True")
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-          mock_device, 10, ((100 - 25) *100)
-        ),
-      }
-    )
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
+        mock_device, 10, 100 * 100
+      )
+    })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
-        "main", capabilities.windowShadeLevel.shadeLevel(75)
+        "main", capabilities.windowShadeLevel.shadeLevel(0)
       )
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
-        "main", capabilities.windowShade.windowShade.partially_open()
+        "main", capabilities.windowShade.windowShade.open()
       )
     )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
-          mock_device, 10, ((100 - 40) *100)
-        ),
-      }
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      WindowCovering.attributes.CurrentPositionLiftPercent100ths:build_test_report_data(
+        mock_device, 10, 0
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.windowShadeLevel.shadeLevel(100)
+      )
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
-        "main", capabilities.windowShadeLevel.shadeLevel(60)
+        "main", capabilities.windowShade.windowShade.closed()
       )
     )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.windowShade.windowShade.partially_open()
-      )
-    )
-    test.socket.capability:__queue_receive(
-      {
-        mock_device.id,
-        {capability = "windowShadeLevel", component = "main", command = "setShadeLevel", args = { 85 }},
-      }
-    )
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      {capability = "windowShadeLevel", component = "main", command = "setShadeLevel", args = { 85 }},
+    })
     test.socket.matter:__expect_send(
-      {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 10, 8500)}
+      {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 10, 1500)}
+    )
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      {capability = "windowShadeLevel", component = "main", command = "setShadeLevel", args = { 100 }},
+    })
+    test.socket.matter:__expect_send(
+      {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 10, 0)}
     )
   end
 )
 
 test.register_coroutine_test(
   "Check that preference updates to reverse polarity after being set to true and that the shade tilt operates as expected when opening and closing", function()
-    test.socket.capability:__set_channel_ordering("relaxed")
     test.socket.device_lifecycle():__queue_receive(mock_device:generate_info_changed({ preferences = { reverse = "true" } }))
     test.wait_for_events()
     local reverse_preference_set = mock_device:get_field("__reverse_polarity")
     assert(reverse_preference_set == true, "reverse_preference_set is True")
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        WindowCovering.attributes.CurrentPositionTiltPercent100ths:build_test_report_data(
-          mock_device, 10, ((100 - 30) *100)
-        ),
-      }
-    )
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      WindowCovering.attributes.CurrentPositionTiltPercent100ths:build_test_report_data(
+        mock_device, 10, 100 * 100
+      )
+    })
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
-        "main", capabilities.windowShadeTiltLevel.shadeTiltLevel(70)
+        "main", capabilities.windowShadeTiltLevel.shadeTiltLevel(0)
       )
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
-        "main", capabilities.windowShade.windowShade.partially_open()
+        "main", capabilities.windowShade.windowShade.open()
       )
     )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        WindowCovering.attributes.CurrentPositionTiltPercent100ths:build_test_report_data(
-          mock_device, 10, ((100 - 65) *100)
-        ),
-      }
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      WindowCovering.attributes.CurrentPositionTiltPercent100ths:build_test_report_data(
+        mock_device, 10, 0
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.windowShadeTiltLevel.shadeTiltLevel(100)
+      )
     )
     test.socket.capability:__expect_send(
       mock_device:generate_test_message(
-        "main", capabilities.windowShadeTiltLevel.shadeTiltLevel(35)
+        "main", capabilities.windowShade.windowShade.closed()
       )
     )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.windowShade.windowShade.partially_open()
-      )
-    )
-    test.socket.capability:__queue_receive(
-      {
-        mock_device.id,
-        {capability = "windowShadeTiltLevel", component = "main", command = "setShadeTiltLevel", args = { 15 }},
-      }
-    )
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      {capability = "windowShadeTiltLevel", component = "main", command = "setShadeTiltLevel", args = { 15 }},
+    })
     test.socket.matter:__expect_send(
-      {mock_device.id, WindowCovering.server.commands.GoToTiltPercentage(mock_device, 10, 1500)}
+      {mock_device.id, WindowCovering.server.commands.GoToTiltPercentage(mock_device, 10, 8500)}
+    )
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      {capability = "windowShadeTiltLevel", component = "main", command = "setShadeTiltLevel", args = { 0 }},
+    })
+    test.socket.matter:__expect_send(
+      {mock_device.id, WindowCovering.server.commands.GoToTiltPercentage(mock_device, 10, 10000)}
     )
   end
 )


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change inverts the interpretation of open/closed when the Reverse preference is set. This means that when the preference is set, a `windowShadeLevel` of 100% is interpreted as Closed and 0% as Open. This approach replaces a previous change that inverted the percentage values received from the device, which was more complex and has some edge cases that caused occasional issues.

# Summary of Completed Tests

Tested with VDA window covering, Zemismart MotionBlinds, and updated unit tests.