### PR TITLE
fix(sonos): Improved handling of bonded set membership changes.

### DIFF
--- a/drivers/SmartThings/sonos/src/api/event_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/event_handlers.lua
@@ -1,7 +1,11 @@
 local capabilities = require "st.capabilities"
+local swGenCapability = capabilities["stus.softwareGeneration"]
+
 local log = require "log"
 
 local st_utils = require "st.utils"
+
+local PlayerFields = require "fields".SonosPlayerFields
 
 local CapEventHandlers = {}
 
@@ -12,41 +16,52 @@ CapEventHandlers.PlaybackStatus = {
   Playing = "PLAYBACK_STATE_PLAYING",
 }
 
+local function _do_emit(device, attribute_event)
+  local bonded = device:get_field(PlayerFields.BONDED)
+  if not bonded then
+    device:emit_event(attribute_event)
+  end
+end
+
+function CapEventHandlers.handle_sw_gen(device, sw_gen)
+  _do_emit(device, swGenCapability.generation(string.format("%s", sw_gen)))
+end
+
 function CapEventHandlers.handle_player_volume(device, new_volume, is_muted)
-  device:emit_event(capabilities.audioVolume.volume(new_volume))
+  _do_emit(device, capabilities.audioVolume.volume(new_volume))
   if is_muted then
-    device:emit_event(capabilities.audioMute.mute.muted())
+    _do_emit(device, capabilities.audioMute.mute.muted())
   else
-    device:emit_event(capabilities.audioMute.mute.unmuted())
+    _do_emit(device, capabilities.audioMute.mute.unmuted())
   end
 end
 
 function CapEventHandlers.handle_group_volume(device, new_volume, is_muted)
-  device:emit_event(capabilities.mediaGroup.groupVolume(new_volume))
+  _do_emit(device, capabilities.mediaGroup.groupVolume(new_volume))
   if is_muted then
-    device:emit_event(capabilities.mediaGroup.groupMute.muted())
+    _do_emit(device, capabilities.mediaGroup.groupMute.muted())
   else
-    device:emit_event(capabilities.mediaGroup.groupMute.unmuted())
+    _do_emit(device, capabilities.mediaGroup.groupMute.unmuted())
   end
 end
 
 function CapEventHandlers.handle_group_role_update(device, group_role)
-  device:emit_event(capabilities.mediaGroup.groupRole(group_role))
+  _do_emit(device, capabilities.mediaGroup.groupRole(group_role))
 end
 
 function CapEventHandlers.handle_group_coordinator_update(device, coordinator_id)
-  device:emit_event(capabilities.mediaGroup.groupPrimaryDeviceId(coordinator_id))
+  _do_emit(device, capabilities.mediaGroup.groupPrimaryDeviceId(coordinator_id))
 end
 
 function CapEventHandlers.handle_group_id_update(device, group_id)
-  device:emit_event(capabilities.mediaGroup.groupId(group_id))
+  _do_emit(device, capabilities.mediaGroup.groupId(group_id))
 end
 
 function CapEventHandlers.handle_group_update(device, group_info)
   local groupRole, groupPrimaryDeviceId, groupId = table.unpack(group_info)
-  device:emit_event(capabilities.mediaGroup.groupRole(groupRole))
-  device:emit_event(capabilities.mediaGroup.groupPrimaryDeviceId(groupPrimaryDeviceId))
-  device:emit_event(capabilities.mediaGroup.groupId(groupId))
+  _do_emit(device, capabilities.mediaGroup.groupRole(groupRole))
+  _do_emit(device, capabilities.mediaGroup.groupPrimaryDeviceId(groupPrimaryDeviceId))
+  _do_emit(device, capabilities.mediaGroup.groupId(groupId))
 end
 
 function CapEventHandlers.handle_audio_clip_status(device, clips)
@@ -61,11 +76,11 @@ end
 
 function CapEventHandlers.handle_playback_status(device, playback_state)
   if playback_state == CapEventHandlers.PlaybackStatus.Playing then
-    device:emit_event(capabilities.mediaPlayback.playbackStatus.playing())
+    _do_emit(device, capabilities.mediaPlayback.playbackStatus.playing())
   elseif playback_state == CapEventHandlers.PlaybackStatus.Idle then
-    device:emit_event(capabilities.mediaPlayback.playbackStatus.stopped())
+    _do_emit(device, capabilities.mediaPlayback.playbackStatus.stopped())
   elseif playback_state == CapEventHandlers.PlaybackStatus.Paused then
-    device:emit_event(capabilities.mediaPlayback.playbackStatus.paused())
+    _do_emit(device, capabilities.mediaPlayback.playbackStatus.paused())
   elseif playback_state == CapEventHandlers.PlaybackStatus.Buffering then
     -- TODO the DTH doesn't currently do anything w/ buffering;
     -- might be worth figuring out what to do with this in the future.
@@ -74,7 +89,7 @@ function CapEventHandlers.handle_playback_status(device, playback_state)
 end
 
 function CapEventHandlers.update_favorites(device, new_favorites)
-  device:emit_event(capabilities.mediaPresets.presets(new_favorites))
+  _do_emit(device, capabilities.mediaPresets.presets(new_favorites))
 end
 
 function CapEventHandlers.handle_playback_metadata_update(device, metadata_status_body)
@@ -128,7 +143,7 @@ function CapEventHandlers.handle_playback_metadata_update(device, metadata_statu
   end
 
   if type(audio_track_data.title) == "string" then
-    device:emit_event(capabilities.audioTrackData.audioTrackData(audio_track_data))
+    _do_emit(device, capabilities.audioTrackData.audioTrackData(audio_track_data))
   end
 end
 

--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -166,8 +166,12 @@ local function _open_coordinator_socket(sonos_conn, household_id, self_player_id
       return
     end
 
-    _, err =
-      Router.open_socket_for_player(household_id, coordinator_id, coordinator.websocketUrl, api_key)
+    _, err = Router.open_socket_for_player(
+      household_id,
+      coordinator_id,
+      coordinator.player.websocketUrl,
+      api_key
+    )
     if err ~= nil then
       log.error(
         string.format(
@@ -302,10 +306,13 @@ end
 --- @return SonosConnection
 function SonosConnection.new(driver, device)
   log.debug(string.format("Creating new SonosConnection for %s", device.label))
-  local self = setmetatable(
-    { driver = driver, device = device, _listener_uuids = {}, _initialized = false, _reconnecting = false },
-    SonosConnection
-  )
+  local self = setmetatable({
+    driver = driver,
+    device = device,
+    _listener_uuids = {},
+    _initialized = false,
+    _reconnecting = false,
+  }, SonosConnection)
 
   -- capture the label here in case something goes wonky like a callback being fired after a
   -- device is removed
@@ -358,19 +365,28 @@ function SonosConnection.new(driver, device)
         local household_id, current_coordinator =
           self.driver.sonos:get_coordinator_for_device(self.device)
         local _, player_id = self.driver.sonos:get_player_for_device(self.device)
-        self.driver.sonos:update_household_info(header.householdId, body, self.device)
+        self.driver.sonos:update_household_info(header.householdId, body, self.driver)
         self.driver.sonos:update_device_record_from_state(header.householdId, self.device)
         local _, updated_coordinator = self.driver.sonos:get_coordinator_for_device(self.device)
 
-        Router.cleanup_unused_sockets(self.driver)
-
-        if not self:coordinator_running() then
-          --TODO this is not infallible
-          _open_coordinator_socket(self, household_id, player_id)
+        local bonded = self.device:get_field(PlayerFields.BONDED)
+        if bonded then
+          self:stop()
         end
 
-        if current_coordinator ~= updated_coordinator then
-          self:refresh_subscriptions()
+        Router.cleanup_unused_sockets(self.driver)
+
+        if not bonded then
+          if not self:coordinator_running() then
+            --TODO this is not infallible
+            _open_coordinator_socket(self, household_id, player_id)
+          end
+
+          if current_coordinator ~= updated_coordinator then
+            self:refresh_subscriptions()
+          end
+        else
+          self.device:offline()
         end
       elseif header.type == "playerVolume" then
         log.trace(string.format("PlayerVolume type message for %s", device_name))
@@ -477,7 +493,7 @@ function SonosConnection.new(driver, device)
               return
             end
 
-            local url_ip = lb_utils.force_url_table(coordinator_player.websocketUrl).host
+            local url_ip = lb_utils.force_url_table(coordinator_player.player.websocketUrl).host
             local base_url = lb_utils.force_url_table(
               string.format("https://%s:%s", url_ip, SonosApi.DEFAULT_SONOS_PORT)
             )
@@ -590,7 +606,7 @@ function SonosConnection:coordinator_running()
       )
     )
   end
-  return type(unique_key) == "string" and Router.is_connected(unique_key) and self._initialized
+  return type(unique_key) == "string" and Router.is_connected(unique_key)
 end
 
 function SonosConnection:refresh_subscriptions(maybe_reply_tx)

--- a/drivers/SmartThings/sonos/src/api/sonos_ssdp_discovery.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_ssdp_discovery.lua
@@ -300,7 +300,7 @@ function sonos_ssdp.spawn_persistent_ssdp_task()
     if info_to_send then
       if not (info_to_send.discovery_info and info_to_send.discovery_info.device) then
         log.error_with(
-          { hub_logs = true },
+          { hub_logs = false },
           st_utils.stringify_table(info_to_send, "Sonos Discovery Info has unexpected structure")
         )
         return

--- a/drivers/SmartThings/sonos/src/fields.lua
+++ b/drivers/SmartThings/sonos/src/fields.lua
@@ -5,6 +5,7 @@ local Fields = {}
 Fields.SonosPlayerFields = {
   _IS_INIT = "init",
   _IS_SCANNING = "scanning",
+  BONDED = "bonded",
   CONNECTION = "conn",
   UNIQUE_KEY = "unique_key",
   HOUSEHOLD_ID = "householdId",

--- a/drivers/SmartThings/sonos/src/init.lua
+++ b/drivers/SmartThings/sonos/src/init.lua
@@ -39,6 +39,6 @@ if api_version < 14 then
   driver:start_ssdp_event_task()
 end
 
-log.info "Starting Sonos run loop"
+log.info("Starting Sonos run loop")
 driver:run()
-log.info "Exiting Sonos run loop"
+log.info("Exiting Sonos run loop")

--- a/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
+++ b/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
@@ -164,10 +164,12 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
                   return
                 end
                 log.error_with(
-                  { hub_logs = true },
-                  "Error handling Sonos player initialization: %s, error code: %s",
-                  error,
-                  (error_code or "N/A")
+                  { hub_logs = false },
+                  string.format(
+                    "Error handling Sonos player initialization: %s, error code: %s",
+                    error,
+                    (error_code or "N/A")
+                  )
                 )
               end
             end

--- a/drivers/SmartThings/sonos/src/types.lua
+++ b/drivers/SmartThings/sonos/src/types.lua
@@ -28,7 +28,7 @@
 ---@field public controlApi { [1]: string }
 
 --- Lua representation of the Sonos `deviceInfo` JSON Object: https://developer.sonos.com/build/control-sonos-players-lan/discover-lan/#deviceInfo-object
---- @class SonosDeviceInfo
+--- @class SonosDeviceInfoObject
 --- @field public _objectType "deviceInfo"
 --- @field public id PlayerId The playerId. Also known as the deviceId. Used to address Sonos devices in the control API.
 --- @field public primaryDeviceId string Identifies the primary device in bonded sets. Primary devices leave the value blank, which omits the key from the message. The field is expected for secondary devices in stereo pairs and satellites in home theater configurations.
@@ -49,7 +49,7 @@
 --- Lua representation of the Sonos `discoveryInfo` JSON object: https://developer.sonos.com/build/control-sonos-players-lan/discover-lan/#discoveryInfo-object
 --- @class SonosDiscoveryInfo
 --- @field public _objectType "discoveryInfo"
---- @field public device SonosDeviceInfo The device object. This object presents immutable data that describes a Sonos device. Use this object to uniquely identify any Sonos device. See below for details.
+--- @field public device SonosDeviceInfoObject The device object. This object presents immutable data that describes a Sonos device. Use this object to uniquely identify any Sonos device. See below for details.
 --- @field public householdId HouseholdId An opaque identifier assigned to the device during registration. This field may be missing prior to registration.
 --- @field public playerId PlayerId The identifier used to address this particular device in the control API.
 --- @field public groupId GroupId The currently assigned groupId, an ephemeral opaque identifier. This value is always correct, including for group members.
@@ -141,6 +141,7 @@
 --- @field public softwareVersion string
 --- @field public websocketUrl string
 --- @field public capabilities SonosCapabilities[]
+--- @field public devices SonosDeviceInfoObject[]
 
 --- Sonos player local state
 --- @class PlayerDiscoveryState

--- a/drivers/SmartThings/sonos/src/utils.lua
+++ b/drivers/SmartThings/sonos/src/utils.lua
@@ -134,7 +134,7 @@ local function __case_insensitive_key_index(tbl, key)
       fmt_val = key or "<nil>"
     end
     log.warn_with(
-      { hub_logs = true },
+      { hub_logs = false },
       string.format(
         "Expected `string` key for CaseInsensitiveKeyTable, received (%s: %s)",
         fmt_val,
@@ -157,7 +157,7 @@ local function __case_insensitive_key_newindex(tbl, key, value)
       fmt_val = key or "<nil>"
     end
     log.warn_with(
-      { hub_logs = true },
+      { hub_logs = false },
       string.format(
         "Expected `string` key for CaseInsensitiveKeyTable, received (%s: %s)",
         fmt_val,
@@ -179,11 +179,11 @@ function utils.new_case_insensitive_table()
   return setmetatable({}, _case_insensitive_key_mt)
 end
 
----@param sonos_device_info SonosDeviceInfo
+---@param sonos_device_info SonosDeviceInfoObject
 function utils.extract_mac_addr(sonos_device_info)
   if type(sonos_device_info) ~= "table" or type(sonos_device_info.serialNumber) ~= "string" then
     log.error_with(
-      { hub_logs = true },
+      { hub_logs = false },
       string.format("Bad sonos device info passed to `extract_mac_addr`: %s", sonos_device_info)
     )
   end


### PR DESCRIPTION
# Type of Change

- [x] Bug fix

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing

# Description of Change

We have historically ignored non-primary devices in bonded sets during discovery/onboarding, going back to the pre-Edge days. 

Bonded sets are things like stereo pairs or home theater setups.

These devices cannot be controlled via the WSS LAN API at all, and they aren't treated as being part of a Group in the Sonos group model; the intent is for API consumers to treat the entire bonded set as a single "player". Only one of the devices in the set exposes an API endpoint, which differs from a Group where all the players expose an endpoint. While groups service most commands via calling the API endpoint on the Group Coordinator, certain commands like volume can be sent to non-coordinator players. This is not the case with bonded sets; the entire set always acts atomically, and only the primary device in the set can service commands. Hence, we treat non-primary devices as not controllable in a bonded set, and we don't onboard them.

However, we didn't really have very robust handling of devices that become part of a bonded set at runtime after onboarding. This led to unnecessary CPU and RAM usage by creating a few tight loops due to unexpected failure/edge cases when making certain calls.

Because we would fail to discover this device under normal circumstances, the preferred way to handle this transition is to mark the device as being offline. We discussed emitting a delete for these devices, but it seems that it wouldn't be too uncommon for some users to create and destroy bonded sets ephemerally the way one might do with a Group. For this reason we decided we would avoid deleting the records.

If a non-primary in a bonded set is removed from the bonded set, it will be marked as online again.

# Summary of Completed Tests

Tested on my personal setup by overriding the driver files directly. Will need to be regression tested by internal QA once this lands on Alpha; the OAuth stuff precludes this from being tested using the PR channel invite.
