### PR TITLE
58 unit test fixes

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/test/test_cook_top.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_cook_top.lua
@@ -70,33 +70,28 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.TemperatureMeasurement.attributes.MeasuredValue,
     clusters.TemperatureControl.attributes.SelectedTemperatureLevel,
     clusters.TemperatureControl.attributes.SupportedTemperatureLevels
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ profile = "cook-surface-one-tl-cook-surface-two-tl" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
-
-test.register_coroutine_test(
-  "Verify device profile update",
-  function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
-    mock_device:expect_metadata_update({ profile = "cook-surface-one-tl-cook-surface-two-tl" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  end
-)
 
 test.register_coroutine_test(
   "Assert component to endpoint map",

--- a/drivers/SmartThings/matter-appliance/src/test/test_laundry_dryer.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_laundry_dryer.lua
@@ -56,6 +56,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LaundryWasherMode.attributes.CurrentMode,
@@ -76,8 +78,9 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
   local read_req = clusters.TemperatureControl.attributes.MinTemperature:read()
   read_req:merge(clusters.TemperatureControl.attributes.MaxTemperature:read())

--- a/drivers/SmartThings/matter-appliance/src/test/test_laundry_washer.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_laundry_washer.lua
@@ -56,6 +56,8 @@ local mock_device_washer = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_washer)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LaundryWasherMode.attributes.CurrentMode,
@@ -69,7 +71,6 @@ local function test_init()
     clusters.TemperatureControl.attributes.SelectedTemperatureLevel,
     clusters.TemperatureControl.attributes.SupportedTemperatureLevels
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request_washer = cluster_subscribe_list[1]:subscribe(mock_device_washer)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -77,8 +78,9 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({ mock_device_washer.id, subscribe_request_washer })
-  test.mock_device.add_test_device(mock_device_washer)
   test.socket.device_lifecycle:__queue_receive({ mock_device_washer.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_washer.id, "init" })
+  test.socket.matter:__expect_send({ mock_device_washer.id, subscribe_request_washer })
   test.socket.device_lifecycle:__queue_receive({ mock_device_washer.id, "doConfigure"})
   local read_req = clusters.TemperatureControl.attributes.MinTemperature:read()
   read_req:merge(clusters.TemperatureControl.attributes.MaxTemperature:read())

--- a/drivers/SmartThings/matter-appliance/src/test/test_oven.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_oven.lua
@@ -112,6 +112,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.TemperatureMeasurement.attributes.MeasuredValue,
@@ -123,7 +125,6 @@ local function test_init()
     clusters.OvenMode.attributes.CurrentMode,
     clusters.OvenMode.attributes.SupportedModes,
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -131,8 +132,11 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_refrigerator.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_refrigerator.lua
@@ -67,6 +67,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.RefrigeratorAlarm.attributes.State,
     clusters.RefrigeratorAndTemperatureControlledCabinetMode.attributes.CurrentMode,
@@ -76,7 +78,6 @@ local function test_init()
     clusters.TemperatureControl.attributes.MinTemperature,
     clusters.TemperatureMeasurement.attributes.MeasuredValue
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
@@ -84,8 +85,9 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
   local read_req = clusters.TemperatureControl.attributes.MinTemperature:read()
   read_req:merge(clusters.TemperatureControl.attributes.MaxTemperature:read())

--- a/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
@@ -74,6 +74,7 @@ local CLUSTER_SUBSCRIBE_LIST ={
 }
 
 local function test_init()
+  test.set_rpc_version(0)
   local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end

--- a/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
@@ -62,6 +62,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.ElectricalPowerMeasurement.attributes.ActivePower,
     clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyExported,
@@ -69,16 +71,15 @@ local function test_init()
     clusters.PowerSource.attributes.BatPercentRemaining,
     clusters.PowerSource.attributes.BatChargeState
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
 
   test.socket.matter:__expect_send({
     mock_device.id,
@@ -90,6 +91,8 @@ local function test_init()
     clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyExported:read(mock_device, BATTERY_STORAGE_EP)
   })
 
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-energy/src/test/test_evse.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_evse.lua
@@ -75,6 +75,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.EnergyEvse.attributes.State,
     clusters.EnergyEvse.attributes.SupplyState,
@@ -90,19 +92,22 @@ local function test_init()
     clusters.DeviceEnergyManagementMode.attributes.CurrentMode,
     clusters.DeviceEnergyManagementMode.attributes.SupportedModes,
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
 
   test.socket.capability:__expect_send(mock_device:generate_test_message("main",
   capabilities.evseChargingSession.targetEndTime("1970-01-01T00:00:00Z")))
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ profile = "evse-power-meas" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-energy/src/test/test_evse_energy_meas.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_evse_energy_meas.lua
@@ -75,6 +75,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.EnergyEvse.attributes.State,
     clusters.EnergyEvse.attributes.SupplyState,
@@ -89,16 +91,15 @@ local function test_init()
     clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported,
     clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyExported,
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
 
   test.socket.matter:__expect_send({
     mock_device.id,
@@ -107,6 +108,10 @@ local function test_init()
 
   test.socket.capability:__expect_send(mock_device:generate_test_message("main",
   capabilities.evseChargingSession.targetEndTime("1970-01-01T00:00:00Z")))
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ profile = "evse-energy-meas" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-energy/src/test/test_solar_power.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_solar_power.lua
@@ -71,21 +71,22 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local cluster_subscribe_list = {
     clusters.ElectricalPowerMeasurement.attributes.ActivePower,
     clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyExported,
     clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
   local read_req = clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyExported:read(mock_device, SOLAR_POWER_EP_ONE)
   read_req:merge(clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyExported:read(mock_device, SOLAR_POWER_EP_TWO))
 
@@ -93,6 +94,9 @@ local function test_init()
     mock_device.id,
     read_req
   })
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
@@ -41,7 +41,8 @@ local mock_device = test.mock_device.build_test_matter_device({
           cluster_id = clusters.DoorLock.ID,
           cluster_type = "SERVER",
           cluster_revision = 1,
-          feature_map = 0x0001, --u32 bitmap
+          feature_map = clusters.DoorLock.types.Feature.PIN_CREDENTIAL |
+            clusters.DoorLock.types.Feature.USER
         }
       },
       device_types = {
@@ -52,6 +53,13 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lockAlarm.alarm.clear({state_change = true}))
+  )
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(clusters.DoorLock.attributes.OperatingMode:subscribe(mock_device))
   subscribe_request:merge(clusters.DoorLock.attributes.NumberOfTotalUsersSupported:subscribe(mock_device))
@@ -63,7 +71,12 @@ local function test_init()
   subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+  )
+  mock_device:expect_metadata_update({ profile = "lock-user-pin" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
@@ -15,6 +15,7 @@
 local test = require "integration_test"
 test.add_package_capability("lockAlarm.yml")
 local t_utils = require "integration_test.utils"
+local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 
 local mock_device_record = {
@@ -41,58 +42,75 @@ local mock_device_record = {
 local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
 
 local mock_device_record_level = {
-    profile = t_utils.get_profile_definition("lock-nocodes-notamper-batteryLevel.yml"),
-    manufacturer_info = {vendor_id = 0x129F, product_id = 0x0001}, -- Level Lock Plus
-    endpoints = {
-      {
-        endpoint_id = 2,
-        clusters = {
-          {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
-        },
-        device_types = {
-          device_type_id = 0x0016, device_type_revision = 1, -- RootNode
-        }
+  profile = t_utils.get_profile_definition("lock-nocodes-notamper-batteryLevel.yml"),
+  manufacturer_info = {vendor_id = 0x129F, product_id = 0x0001}, -- Level Lock Plus
+  endpoints = {
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
       },
-      {
-        endpoint_id = 10,
-        clusters = {
-          {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
-        },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 10,
+      clusters = {
+        {cluster_id = clusters.DoorLock.ID, cluster_type = "SERVER", feature_map = 0x0000},
       },
     },
+  },
 }
 
 local mock_device_level = test.mock_device.build_test_matter_device(mock_device_record_level)
 
 local function test_init()
-    local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
-    subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
-    subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device))
-    subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device))
-    test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
-    test.mock_device.add_test_device(mock_device)
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear())
+  )
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lockCodes.lockCodes("[]", {visibility = {displayed = false}}))
+  )
+  local req = clusters.DoorLock.attributes.MaxPINCodeLength:read(mock_device, 10)
+  req:merge(clusters.DoorLock.attributes.MinPINCodeLength:read(mock_device, 10))
+  req:merge(clusters.DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device, 10))
+  test.socket.matter:__expect_send({mock_device.id, req})
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  local subscribe_request = clusters.DoorLock.attributes.LockState:subscribe(mock_device)
+  subscribe_request:merge(clusters.DoorLock.events.DoorLockAlarm:subscribe(mock_device))
+  subscribe_request:merge(clusters.DoorLock.events.LockOperation:subscribe(mock_device))
+  subscribe_request:merge(clusters.DoorLock.events.LockUserChange:subscribe(mock_device))
+  test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
 
-    local subscribe_request_level = clusters.DoorLock.attributes.LockState:subscribe(mock_device_level)
-    test.socket["matter"]:__expect_send({mock_device_level.id, subscribe_request_level})
-    test.mock_device.add_test_device(mock_device_level)
+
+  test.mock_device.add_test_device(mock_device_level)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_level.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_level.id, "init" })
+  local subscribe_request_level = clusters.DoorLock.attributes.LockState:subscribe(mock_device_level)
+  test.socket["matter"]:__expect_send({mock_device_level.id, subscribe_request_level})
 end
 test.set_test_init_function(test_init)
 
 test.register_coroutine_test(
-    "doConfigure lifecycle event for base-lock-nobattery",
-    function()
-        test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-        mock_device:expect_metadata_update({ profile = "base-lock-nobattery" })
-        mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    end
+  "doConfigure lifecycle event for base-lock-nobattery",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    mock_device:expect_metadata_update({ profile = "base-lock-nobattery" })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
 )
 
 test.register_coroutine_test(
-    "doConfigure lifecycle event for Level Lock Plus profile",
-    function()
-        test.socket.device_lifecycle:__queue_receive({ mock_device_level.id, "doConfigure" })
-        mock_device_level:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    end
+  "doConfigure lifecycle event for Level Lock Plus profile",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_level.id, "doConfigure" })
+    mock_device_level:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -12,20 +12,6 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
--- Mock out globals
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 test.add_package_capability("lockAlarm.yml")
@@ -35,6 +21,7 @@ local clusters = require "st.matter.clusters"
 local DoorLock = clusters.DoorLock
 local im = require "st.matter.interaction_model"
 local types = DoorLock.types
+
 local mock_device_record = {
   profile = t_utils.get_profile_definition("base-lock.yml"),
   manufacturer_info = {vendor_id = 0xcccc, product_id = 0x1},
@@ -56,7 +43,7 @@ local mock_device_record = {
           cluster_type = "SERVER",
           feature_map = 0x0101, -- PIN & USR
         },
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 0},
       },
     },
   },
@@ -64,13 +51,18 @@ local mock_device_record = {
 local mock_device = test.mock_device.build_test_matter_device(mock_device_record)
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  mock_device:expect_metadata_update({ profile = "base-lock-nobattery" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 test.set_test_init_function(test_init)
@@ -189,11 +181,11 @@ local function init_code_slot(slot_number, name, device)
   )
 
   local credential = DoorLock.types.DlCredential(
-                       {
+    {
       credential_type = DoorLock.types.DlCredentialType.PIN,
       credential_index = slot_number,
     }
-                     )
+  )
   test.socket.matter:__expect_send(
     {
       device.id,

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_unlatch.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_unlatch.lua
@@ -54,27 +54,27 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lockAlarm.alarm("clear", {state_change = true}))
+  )
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  mock_device:expect_metadata_update({ profile = "lock-unlatch" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+  )
 end
 
 test.set_test_init_function(test_init)
-
-test.register_coroutine_test(
-  "Assert profile applied over doConfigure",
-  function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    mock_device:expect_metadata_update({ profile = "lock-unlatch" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-  end
-)
 
 test.register_coroutine_test(
   "Handle received OperatingMode(Normal, Vacation) from Matter device.",

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_battery.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_battery.lua
@@ -174,24 +174,55 @@ local mock_device_user_pin_schedule_unlatch = test.mock_device.build_test_matter
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lockAlarm.alarm.clear({state_change = true}))
+  )
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device)
   subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device))
   test.socket["matter"]:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+  )
+  test.socket.matter:__expect_send({mock_device.id, clusters.PowerSource.attributes.AttributeList:read()})
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_unlatch()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_unlatch)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device_unlatch:generate_test_message("main", capabilities.lockAlarm.alarm.clear({state_change = true}))
+  )
+  test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "init" })
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device_unlatch)
   subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device_unlatch))
   subscribe_request:merge(DoorLock.events.LockOperation:subscribe(mock_device_unlatch))
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device_unlatch))
   test.socket["matter"]:__expect_send({mock_device_unlatch.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_unlatch)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
+  test.socket.capability:__expect_send(
+    mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+  )
+  test.socket.matter:__expect_send({mock_device_unlatch.id, clusters.PowerSource.attributes.AttributeList:read()})
+  mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_user_pin()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_user_pin)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device_user_pin:generate_test_message("main", capabilities.lockAlarm.alarm.clear({state_change = true}))
+  )
+  test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "init" })
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device_user_pin)
   subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device_user_pin))
   subscribe_request:merge(DoorLock.attributes.NumberOfTotalUsersSupported:subscribe(mock_device_user_pin))
@@ -203,10 +234,22 @@ local function test_init_user_pin()
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device_user_pin))
   subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device_user_pin))
   test.socket["matter"]:__expect_send({mock_device_user_pin.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_user_pin)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
+  test.socket.capability:__expect_send(
+    mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+  )
+  test.socket.matter:__expect_send({mock_device_user_pin.id, clusters.PowerSource.attributes.AttributeList:read()})
+  mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_user_pin_schedule_unlatch()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_user_pin_schedule_unlatch)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lockAlarm.alarm.clear({state_change = true}))
+  )
+  test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "init" })
   local subscribe_request = DoorLock.attributes.LockState:subscribe(mock_device_user_pin_schedule_unlatch)
   subscribe_request:merge(DoorLock.attributes.OperatingMode:subscribe(mock_device_user_pin_schedule_unlatch))
   subscribe_request:merge(DoorLock.attributes.NumberOfTotalUsersSupported:subscribe(mock_device_user_pin_schedule_unlatch))
@@ -220,7 +263,12 @@ local function test_init_user_pin_schedule_unlatch()
   subscribe_request:merge(DoorLock.events.DoorLockAlarm:subscribe(mock_device_user_pin_schedule_unlatch))
   subscribe_request:merge(DoorLock.events.LockUserChange:subscribe(mock_device_user_pin_schedule_unlatch))
   test.socket["matter"]:__expect_send({mock_device_user_pin_schedule_unlatch.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_user_pin_schedule_unlatch)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
+  test.socket.capability:__expect_send(
+    mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
+  )
+  test.socket.matter:__expect_send({mock_device_user_pin_schedule_unlatch.id, clusters.PowerSource.attributes.AttributeList:read()})
+  mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 test.set_test_init_function(test_init)
@@ -228,18 +276,6 @@ test.set_test_init_function(test_init)
 test.register_coroutine_test(
   "Test lock profile change when attributes related to BAT feature is not available.",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
@@ -264,18 +300,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock profile change when BatChargeLevel attribute is available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
@@ -301,18 +325,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock profile change when BatChargeLevel and BatPercentRemaining attributes are available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device.id,
@@ -339,18 +351,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-unlatch profile change when attributes related to BAT feature is not available.",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
-    mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_unlatch.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_unlatch.id,
@@ -376,18 +376,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-unlatch profile change when BatChargeLevel attribute is available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
-    mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_unlatch.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_unlatch.id,
@@ -414,18 +402,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-unlatch profile change when BatChargeLevel and BatPercentRemaining attributes are available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_unlatch.id, "doConfigure" })
-    mock_device_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_unlatch.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_unlatch.id,
@@ -453,18 +429,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-user-pin profile change when attributes related to BAT feature is not available.",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
-    mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_user_pin.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_user_pin.id,
@@ -490,18 +454,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-user-pin profile change when BatChargeLevel attribute is available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
-    mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_user_pin.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_user_pin.id,
@@ -528,18 +480,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-user-pin profile change when BatChargeLevel and BatPercentRemaining attributes are available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin.id, "doConfigure" })
-    mock_device_user_pin:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_user_pin:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_user_pin.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_user_pin.id,
@@ -567,18 +507,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-user-pin-schedule-unlatch profile change when attributes related to BAT feature is not available.",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
-    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_user_pin_schedule_unlatch.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_user_pin_schedule_unlatch.id,
@@ -604,18 +532,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-user-pin-schedule-unlatch profile change when BatChargeLevel attribute is available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
-    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_user_pin_schedule_unlatch.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_user_pin_schedule_unlatch.id,
@@ -642,18 +558,6 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test lock-user-pin-schedule-unlatch profile change when BatChargeLevel and BatPercentRemaining attributes are available",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_user_pin_schedule_unlatch.id, "doConfigure" })
-    mock_device_user_pin_schedule_unlatch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.socket.capability:__expect_send(
-      mock_device_user_pin_schedule_unlatch:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock", "unlatch"}, {visibility = {displayed = false}}))
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_user_pin_schedule_unlatch.id,
-        clusters.PowerSource.attributes.AttributeList:read()
-      }
-    )
-    test.wait_for_events()
     test.socket.matter:__queue_receive(
       {
         mock_device_user_pin_schedule_unlatch.id,

--- a/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
+++ b/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
@@ -15,7 +15,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-
 local clusters = require "st.matter.clusters"
 
 local mock_device = test.mock_device.build_test_matter_device({
@@ -84,34 +83,88 @@ local mock_device_variable_speed = test.mock_device.build_test_matter_device({
   }
 })
 
+local supported_key_codes = {
+  "UP",
+  "DOWN",
+  "LEFT",
+  "RIGHT",
+  "SELECT",
+  "BACK",
+  "EXIT",
+  "MENU",
+  "SETTINGS",
+  "HOME",
+  "NUMBER0",
+  "NUMBER1",
+  "NUMBER2",
+  "NUMBER3",
+  "NUMBER4",
+  "NUMBER5",
+  "NUMBER6",
+  "NUMBER7",
+  "NUMBER8",
+  "NUMBER9"
+}
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.MediaPlayback.attributes.CurrentState
   }
-  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    print(i)
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device))
-    end
-    print(subscribe_request)
-  end
+  subscribe_request:merge(cluster_subscribe_list[2]:subscribe(mock_device))
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
 
-  subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_variable_speed)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    print(i)
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_variable_speed))
-    end
-    print(subscribe_request)
-  end
-  test.socket.matter:__expect_send({mock_device_variable_speed.id, subscribe_request})
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message(
+      "main", capabilities.mediaPlayback.supportedPlaybackCommands({"play", "pause", "stop"})
+    )
+  )
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message(
+      "main", capabilities.mediaTrackControl.supportedTrackControlCommands({"previousTrack", "nextTrack"})
+    )
+  )
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message(
+      "main", capabilities.keypadInput.supportedKeyCodes(supported_key_codes)
+    )
+  )
+
   test.mock_device.add_test_device(mock_device_variable_speed)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_variable_speed.id, "added" })
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_variable_speed.id, "init" })
+  subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_variable_speed)
+  subscribe_request:merge(cluster_subscribe_list[2]:subscribe(mock_device_variable_speed))
+  test.socket.matter:__expect_send({mock_device_variable_speed.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_variable_speed.id, "doConfigure" })
+  mock_device_variable_speed:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+
+  test.socket.capability:__expect_send(
+    mock_device_variable_speed:generate_test_message(
+      "main", capabilities.mediaPlayback.supportedPlaybackCommands({"play", "pause", "stop", "rewind", "fastForward"})
+    )
+  )
+  test.socket.capability:__expect_send(
+    mock_device_variable_speed:generate_test_message(
+      "main", capabilities.mediaTrackControl.supportedTrackControlCommands({"previousTrack", "nextTrack"})
+    )
+  )
+  test.socket.capability:__expect_send(
+    mock_device_variable_speed:generate_test_message(
+      "main", capabilities.keypadInput.supportedKeyCodes(supported_key_codes)
+    )
+  )
 end
 
 test.set_test_init_function(test_init)
@@ -557,28 +610,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(
         mock_device:generate_test_message(
           "main",
-          capabilities.keypadInput.supportedKeyCodes({
-            "UP",
-            "DOWN",
-            "LEFT",
-            "RIGHT",
-            "SELECT",
-            "BACK",
-            "EXIT",
-            "MENU",
-            "SETTINGS",
-            "HOME",
-            "NUMBER0",
-            "NUMBER1",
-            "NUMBER2",
-            "NUMBER3",
-            "NUMBER4",
-            "NUMBER5",
-            "NUMBER6",
-            "NUMBER7",
-            "NUMBER8",
-            "NUMBER9",
-          })
+          capabilities.keypadInput.supportedKeyCodes(supported_key_codes)
         )
       )
 
@@ -608,28 +640,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(
         mock_device_variable_speed:generate_test_message(
           "main",
-          capabilities.keypadInput.supportedKeyCodes({
-            "UP",
-            "DOWN",
-            "LEFT",
-            "RIGHT",
-            "SELECT",
-            "BACK",
-            "EXIT",
-            "MENU",
-            "SETTINGS",
-            "HOME",
-            "NUMBER0",
-            "NUMBER1",
-            "NUMBER2",
-            "NUMBER3",
-            "NUMBER4",
-            "NUMBER5",
-            "NUMBER6",
-            "NUMBER7",
-            "NUMBER8",
-            "NUMBER9",
-          })
+          capabilities.keypadInput.supportedKeyCodes(supported_key_codes)
         )
       )
 

--- a/drivers/SmartThings/matter-rvc/src/init.lua
+++ b/drivers/SmartThings/matter-rvc/src/init.lua
@@ -16,9 +16,6 @@ local MatterDriver = require "st.matter.driver"
 local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 
-local area_type = require "Global.types.AreaTypeTag"
-local landmark = require "Global.types.LandmarkTag"
-
 local embedded_cluster_utils = require "embedded_cluster_utils"
 
 -- Include driver-side definitions when lua libs api version is < 10
@@ -512,15 +509,15 @@ local function rvc_service_area_supported_areas_handler(driver, device, ib, resp
       if location_info.location_name.value ~= "" then
         area_name = location_info.location_name.value
       elseif location_info.floor_number.value ~= nil and location_info.area_type.value ~= nil then
-        area_name = location_info.floor_number.value .. "F " .. upper_to_camelcase(string.gsub(area_type.pretty_print(location_info.area_type),"AreaTypeTag: ",""))
+        area_name = location_info.floor_number.value .. "F " .. upper_to_camelcase(string.gsub(clusters.Global.types.AreaTypeTag.pretty_print(location_info.area_type),"AreaTypeTag: ",""))
       elseif location_info.floor_number.value ~= nil then
         area_name = location_info.floor_number.value .. "F"
       elseif location_info.area_type.value ~= nil then
-        area_name = upper_to_camelcase(string.gsub(area_type.pretty_print(location_info.area_type),"AreaTypeTag: ",""))
+        area_name = upper_to_camelcase(string.gsub(clusters.Global.types.AreaTypeTag.pretty_print(location_info.area_type),"AreaTypeTag: ",""))
       end
     end
     if area_name == "" then
-      area_name = upper_to_camelcase(string.gsub(landmark.pretty_print(landmark_info.landmark_tag),"LandmarkTag: ",""))
+      area_name = upper_to_camelcase(string.gsub(clusters.Global.types.LandmarkTag.pretty_print(landmark_info.landmark_tag),"LandmarkTag: ",""))
     end
     table.insert(supported_areas, {["areaId"] = area_id, ["areaName"] = area_name})
   end

--- a/drivers/SmartThings/matter-rvc/src/test/test_matter_rvc.lua
+++ b/drivers/SmartThings/matter-rvc/src/test/test_matter_rvc.lua
@@ -64,6 +64,8 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local subscribed_attributes = {
     [capabilities.mode.ID] = {
         clusters.RvcRunMode.attributes.SupportedModes,
@@ -90,9 +92,14 @@ local function test_init()
       end
     end
   end
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure"})
+  mock_device:expect_metadata_update({ profile = "rvc-clean-mode-service-area" })
+  test.socket.matter:__expect_send({mock_device.id, clusters.RvcOperationalState.attributes.AcceptedCommandList:read()})
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor.lua
@@ -249,6 +249,9 @@ local function initialize_mock_device(generic_mock_device, generic_subscribed_at
   test.mock_device.add_test_device(generic_mock_device)
 end
 
+-- TODO add tests for configuration using modular profiles
+test.set_rpc_version(7)
+
 local function test_init()
   local subscribed_attributes = {
     [capabilities.relativeHumidityMeasurement.ID] = {

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_flow_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_flow_sensor.lua
@@ -53,6 +53,7 @@ local subscribed_attributes = {
 }
 
 local function test_init()
+  test.mock_device.add_test_device(mock_device)
   local subscribe_request = subscribed_attributes[1]:subscribe(mock_device)
   for i, cluster in ipairs(subscribed_attributes) do
     if i > 1 then
@@ -60,8 +61,6 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_freeze_leak_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_freeze_leak_sensor.lua
@@ -19,72 +19,61 @@ local clusters = require "st.matter.clusters"
 clusters.BooleanStateConfiguration = require "BooleanStateConfiguration"
 
 local mock_device_freeze_leak = test.mock_device.build_test_matter_device({
-    profile = t_utils.get_profile_definition("freeze-leak-fault-freezeSensitivity-leakSensitivity.yml"),
-    manufacturer_info = {
-      vendor_id = 0x0000,
-      product_id = 0x0000,
+  profile = t_utils.get_profile_definition("freeze-leak-fault-freezeSensitivity-leakSensitivity.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
     },
-    endpoints = {
-      {
-        endpoint_id = 0,
-        clusters = {
-          {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
-        },
-        device_types = {
-          {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
-        }
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.BooleanState.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.BooleanStateConfiguration.ID, cluster_type = "SERVER", feature_map = 31},
       },
-      {
-        endpoint_id = 1,
-        clusters = {
-          {cluster_id = clusters.BooleanState.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.BooleanStateConfiguration.ID, cluster_type = "SERVER", feature_map = 31},
-        },
-        device_types = {
-          {device_type_id = 0x0043, device_type_revision = 1} -- Water Leak Detector
-        }
+      device_types = {
+        {device_type_id = 0x0043, device_type_revision = 1} -- Water Leak Detector
+      }
+    },
+    {
+      endpoint_id = 2,
+      clusters = {
+        {cluster_id = clusters.BooleanState.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.BooleanStateConfiguration.ID, cluster_type = "SERVER", feature_map = 31},
       },
-      {
-        endpoint_id = 2,
-        clusters = {
-          {cluster_id = clusters.BooleanState.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.BooleanStateConfiguration.ID, cluster_type = "SERVER", feature_map = 31},
-        },
-        device_types = {
-          {device_type_id = 0x0041, device_type_revision = 1} -- Water Freeze Detector
-        }
+      device_types = {
+        {device_type_id = 0x0041, device_type_revision = 1} -- Water Freeze Detector
       }
     }
+  }
 })
 
-local subscribed_attributes = {
-  clusters.BooleanState.attributes.StateValue,
-  clusters.BooleanStateConfiguration.attributes.SensorFault,
-}
-
 local function test_init_freeze_leak()
-  local subscribe_request = subscribed_attributes[1]:subscribe(mock_device_freeze_leak)
-  for i, cluster in ipairs(subscribed_attributes) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_freeze_leak))
-    end
-  end
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_freeze_leak)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_freeze_leak.id, "added" })
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_freeze_leak.id, "init" })
   test.socket.matter:__expect_send({mock_device_freeze_leak.id, clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(mock_device_freeze_leak, 1)})
   test.socket.matter:__expect_send({mock_device_freeze_leak.id, clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(mock_device_freeze_leak, 2)})
+  local subscribe_request = clusters.BooleanState.attributes.StateValue:subscribe(mock_device_freeze_leak)
+  subscribe_request:merge(clusters.BooleanStateConfiguration.attributes.SensorFault:subscribe(mock_device_freeze_leak))
   test.socket.matter:__expect_send({mock_device_freeze_leak.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_freeze_leak)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_freeze_leak.id, "doConfigure" })
+  mock_device_freeze_leak:expect_metadata_update({ profile = "freeze-leak-fault-freezeSensitivity-leakSensitivity" })
+  mock_device_freeze_leak:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init_freeze_leak)
-
-test.register_coroutine_test(
-  "Test profile change on init for Freeze and Leak combined device type",
-  function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_freeze_leak.id, "doConfigure" })
-    mock_device_freeze_leak:expect_metadata_update({ profile = "freeze-leak-fault-freezeSensitivity-leakSensitivity" })
-    mock_device_freeze_leak:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  end,
-  { test_init = test_init_freeze_leak }
-)
 
 test.register_message_test(
   "Boolean state freeze detection reports should generate correct messages",

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_pressure_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_pressure_sensor.lua
@@ -49,17 +49,11 @@ local mock_device = test.mock_device.build_test_matter_device({
   endpoints = matter_endpoints
 })
 
-local function subscribe_on_init(dev)
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
   local subscribe_request = PressureMeasurementCluster.attributes.MeasuredValue:subscribe(mock_device)
   subscribe_request:merge(clusters.PowerSource.attributes.BatPercentRemaining:subscribe(mock_device))
-  return subscribe_request
-end
-
-local function test_init()
-  test.socket.matter:__expect_send({mock_device.id, subscribe_on_init(mock_device)})
-  test.mock_device.add_test_device(mock_device)
-  -- don't check the battery for this device since we are just testing the "pressure-battery" profile specifically
-  mock_device:set_field("__battery_checked", 1, {persist = true})
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 end
 test.set_test_init_function(test_init)
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_rain_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_rain_sensor.lua
@@ -55,27 +55,23 @@ local subscribed_attributes = {
 }
 
 local function test_init_rain()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_rain)
   local subscribe_request = subscribed_attributes[1]:subscribe(mock_device_rain)
   for i, cluster in ipairs(subscribed_attributes) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device_rain))
     end
   end
+  test.socket.device_lifecycle:__queue_receive({ mock_device_rain.id, "init" })
   test.socket.matter:__expect_send({mock_device_rain.id, clusters.BooleanStateConfiguration.attributes.SupportedSensitivityLevels:read(mock_device_rain, 1)})
   test.socket.matter:__expect_send({mock_device_rain.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_rain)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_rain.id, "doConfigure" })
+  mock_device_rain:expect_metadata_update({ profile = "rain-fault-rainSensitivity" })
+  mock_device_rain:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init_rain)
-
-test.register_coroutine_test(
-  "Test profile change on init for Freeze and Leak combined device type",
-  function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_rain.id, "doConfigure" })
-    mock_device_rain:expect_metadata_update({ profile = "rain-fault-rainSensitivity" })
-    mock_device_rain:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  end,
-  { test_init = test_init_rain }
-)
 
 test.register_message_test(
   "Boolean state rain detection reports should generate correct messages",

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor.lua
@@ -118,7 +118,6 @@ end
 local function test_init()
   test.socket.matter:__expect_send({mock_device.id, subscribe_on_init(mock_device)})
   test.mock_device.add_test_device(mock_device)
-  test.set_rpc_version(5)
 end
 test.set_test_init_function(test_init)
 
@@ -134,8 +133,10 @@ local function subscribe_on_init_presence_sensor(dev)
 end
 
 local function test_init_presence_sensor()
-  test.socket.matter:__expect_send({mock_device_presence_sensor.id, subscribe_on_init_presence_sensor(mock_device_presence_sensor)})
+  test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device_presence_sensor)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_presence_sensor.id, "init" })
+  test.socket.matter:__expect_send({mock_device_presence_sensor.id, subscribe_on_init_presence_sensor(mock_device_presence_sensor)})
   test.socket.device_lifecycle:__queue_receive({ mock_device_presence_sensor.id, "doConfigure" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({mock_device_presence_sensor.id, read_attribute_list})

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_battery.lua
@@ -56,20 +56,21 @@ local cluster_subscribe_list_humidity_battery = {
 }
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_humidity_battery)
   local subscribe_request_humidity_battery = cluster_subscribe_list_humidity_battery[1]:subscribe(mock_device_humidity_battery)
   for i, cluster in ipairs(cluster_subscribe_list_humidity_battery) do
     if i > 1 then
       subscribe_request_humidity_battery:merge(cluster:subscribe(mock_device_humidity_battery))
     end
   end
-
   test.socket.matter:__expect_send({mock_device_humidity_battery.id, subscribe_request_humidity_battery})
-  test.mock_device.add_test_device(mock_device_humidity_battery)
 
-  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "init" })
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({mock_device_humidity_battery.id, read_attribute_list})
-  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
   mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
@@ -125,52 +125,52 @@ local cluster_subscribe_list_temp_humidity = {
 }
 
 local function test_init_humidity_battery()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_humidity_battery)
   local subscribe_request_humidity_battery = cluster_subscribe_list_humidity_battery[1]:subscribe(mock_device_humidity_battery)
   for i, cluster in ipairs(cluster_subscribe_list_humidity_battery) do
     if i > 1 then
       subscribe_request_humidity_battery:merge(cluster:subscribe(mock_device_humidity_battery))
     end
   end
-
+  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "init" })
   test.socket.matter:__expect_send({mock_device_humidity_battery.id, subscribe_request_humidity_battery})
-  test.mock_device.add_test_device(mock_device_humidity_battery)
 
-  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "added" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_battery.id, "doConfigure" })
-  mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({mock_device_humidity_battery.id, read_attribute_list})
+  mock_device_humidity_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_humidity_no_battery()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_humidity_no_battery)
   local subscribe_request_humidity_no_battery = cluster_subscribe_list_humidity_no_battery[1]:subscribe(mock_device_humidity_no_battery)
   for i, cluster in ipairs(cluster_subscribe_list_humidity_no_battery) do
     if i > 1 then
       subscribe_request_humidity_no_battery:merge(cluster:subscribe(mock_device_humidity_no_battery))
     end
   end
-
+  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_no_battery.id, "init" })
   test.socket.matter:__expect_send({mock_device_humidity_no_battery.id, subscribe_request_humidity_no_battery})
-  test.mock_device.add_test_device(mock_device_humidity_no_battery)
 
-  test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_no_battery.id, "added" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_humidity_no_battery.id, "doConfigure" })
   mock_device_humidity_no_battery:expect_metadata_update({ profile = "humidity" })
   mock_device_humidity_no_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_temp_humidity()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_temp_humidity)
   local subscribe_request_temp_humidity = cluster_subscribe_list_temp_humidity[1]:subscribe(mock_device_temp_humidity)
   for i, cluster in ipairs(cluster_subscribe_list_temp_humidity) do
     if i > 1 then
       subscribe_request_temp_humidity:merge(cluster:subscribe(mock_device_temp_humidity))
     end
   end
-
+  test.socket.device_lifecycle:__queue_receive({ mock_device_temp_humidity.id, "init" })
   test.socket.matter:__expect_send({mock_device_temp_humidity.id, subscribe_request_temp_humidity})
-  test.mock_device.add_test_device(mock_device_temp_humidity)
 
-  test.socket.device_lifecycle:__queue_receive({ mock_device_temp_humidity.id, "added" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_temp_humidity.id, "doConfigure" })
   mock_device_temp_humidity:expect_metadata_update({ profile = "temperature-humidity" })
   mock_device_temp_humidity:expect_metadata_update({ provisioning_state = "PROVISIONED" })

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_rpc.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_rpc.lua
@@ -57,8 +57,6 @@ end
 local function test_init()
   test.socket.matter:__expect_send({mock_device.id, subscribe_on_init(mock_device)})
   test.mock_device.add_test_device(mock_device)
-  -- don't check the battery for this device because we are using the catch-all "sensor.yml" profile just for testing
-  mock_device:set_field("__battery_checked", 1, {persist = true})
   test.set_rpc_version(3)
 end
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
@@ -72,18 +72,20 @@ local cluster_subscribe_list = {
 }
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(mock_device)
 end
 
 test.set_test_init_function(test_init)

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
@@ -18,7 +18,6 @@ local capabilities = require "st.capabilities"
 local utils = require "st.utils"
 local dkjson = require "dkjson"
 local uint32 = require "st.matter.data_types.Uint32"
-
 local clusters = require "st.matter.generated.zap_clusters"
 local button_attr = capabilities.button.button
 
@@ -121,6 +120,8 @@ local function configure_buttons()
 end
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(aqara_mock_device)
   local cluster_subscribe_list = {
     clusters.PowerSource.server.attributes.BatPercentRemaining,
     clusters.TemperatureMeasurement.attributes.MeasuredValue,
@@ -140,17 +141,17 @@ local function test_init()
     end
   end
 
+  test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "added" })
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "init" })
+  test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
+
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "doConfigure" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({aqara_mock_device.id, read_attribute_list})
   configure_buttons()
   aqara_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(aqara_mock_device)
-  test.set_rpc_version(5)
-
-  test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "added" })
-  test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
 
   local device_info_copy = utils.deep_copy(aqara_mock_device.raw_st_data)
   device_info_copy.profile.id = "3-button-battery-temperature-humidity"

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -14,12 +14,14 @@
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
-local t_utils = require "integration_test.utils"
-
 local clusters = require "st.matter.clusters"
+local t_utils = require "integration_test.utils"
+local version = require "version"
 
-clusters.ElectricalEnergyMeasurement = require "ElectricalEnergyMeasurement"
-clusters.ElectricalPowerMeasurement = require "ElectricalPowerMeasurement"
+if version.api < 11 then
+  clusters.ElectricalEnergyMeasurement = require "ElectricalEnergyMeasurement"
+  clusters.ElectricalPowerMeasurement = require "ElectricalPowerMeasurement"
+end
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("plug-level-power-energy-powerConsumption.yml"),
@@ -56,7 +58,7 @@ local mock_device = test.mock_device.build_test_matter_device({
       device_types = {
         { device_type_id = 0x010A, device_type_revision = 1 } -- OnOff Plug
       }
-    },
+    }
   },
 })
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
@@ -58,19 +58,24 @@ local function configure_buttons()
 end
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(mock_device)
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   configure_buttons()
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
   local device_info_copy = utils.deep_copy(mock_device.raw_st_data)
   device_info_copy.profile.id = "buttons-battery"
   local device_info_json = dkjson.encode(device_info_copy)

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -84,12 +84,19 @@ local CLUSTER_SUBSCRIBE_LIST ={
 }
 
 local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
   local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ profile = "light-color-level-fan" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -181,7 +181,7 @@ local CLUSTER_SUBSCRIBE_LIST ={
   clusters.Switch.server.events.MultiPressComplete,
 }
 
-local function configure_buttons()
+local function expect_configure_buttons()
   test.socket.capability:__expect_send(mock_device:generate_test_message("button1", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
   test.socket.capability:__expect_send(mock_device:generate_test_message("button1", button_attr.pushed({state_change = false})))
 
@@ -192,23 +192,29 @@ local function configure_buttons()
   test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = false})))
 end
 
+-- All messages queued and expectations set are done before the driver is actually run
 local function test_init()
+  -- we dont want the integration test framework to generate init/doConfigure, we are doing that here
+  -- so we can set the proper expectations on those events.
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device) -- make sure the cache is populated
+  test.mock_device.add_test_device(mock_child)
+
+  -- added sets a bunch of fields on the device, and calls init
   local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+
+  -- init results in subscription interaction
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+
+  --doConfigure sets the provisioning state to provisioned
   mock_device:expect_metadata_update({ profile = "light-level-3-button" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  local device_info_copy = utils.deep_copy(mock_device.raw_st_data)
-  device_info_copy.profile.id = "3-button"
-  local device_info_json = dkjson.encode(device_info_copy)
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "infoChanged", device_info_json })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  configure_buttons()
-  test.mock_device.add_test_device(mock_device)
-  test.mock_device.add_test_device(mock_child)
   mock_device:expect_device_create({
     type = "EDGE_CHILD",
     label = "Matter Switch 2",
@@ -216,37 +222,30 @@ local function test_init()
     parent_device_id = mock_device.id,
     parent_assigned_child_key = string.format("%d", mock_device_ep5)
   })
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  configure_buttons()
+  expect_configure_buttons()
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+
+  -- simulate the profile change update taking affect and the device info changing
+  local device_info_copy = utils.deep_copy(mock_device.raw_st_data)
+  device_info_copy.profile.id = "5-buttons-battery"
+  local device_info_json = dkjson.encode(device_info_copy)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "infoChanged", device_info_json })
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  expect_configure_buttons()
+
+  test.socket.matter:__expect_send({mock_device.id, clusters.OnOff.attributes.OnOff:read(mock_device)})
+  test.socket.device_lifecycle:__queue_receive({ mock_child.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_child.id, "init" })
+  mock_child:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.socket.device_lifecycle:__queue_receive({ mock_child.id, "doConfigure" })
 end
 
+-- All messages queued and expectations set are done before the driver is actually run
 local function test_init_mcd_unsupported_switch_device_type()
-  local cluster_subscribe_list = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.Switch.server.events.InitialPress,
-    clusters.Switch.server.events.LongPress,
-    clusters.Switch.server.events.ShortRelease,
-    clusters.Switch.server.events.MultiPressComplete,
-  }
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_mcd_unsupported_switch_device_type)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_mcd_unsupported_switch_device_type))
-    end
-  end
-  test.socket.matter:__expect_send({mock_device_mcd_unsupported_switch_device_type.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device_mcd_unsupported_switch_device_type.id, "doConfigure" })
-  mock_device_mcd_unsupported_switch_device_type:expect_metadata_update({ profile = "2-button" })
-  mock_device_mcd_unsupported_switch_device_type:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  mock_device_mcd_unsupported_switch_device_type:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Switch 1",
-    profile = "switch-binary",
-    parent_device_id = mock_device_mcd_unsupported_switch_device_type.id,
-    parent_assigned_child_key = string.format("%d", 7)
-  })
-  test.mock_device.add_test_device(mock_device_mcd_unsupported_switch_device_type)
+  -- we dont want the integration test framework to generate init/doConfigure, we are doing that here
+  -- so we can set the proper expectations on those events.
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_mcd_unsupported_switch_device_type) -- make sure the cache is populated
 end
 
 test.set_test_init_function(test_init)
@@ -404,7 +403,49 @@ test.register_message_test(
 test.register_coroutine_test(
   "Test MCD configuration not including switch for unsupported switch device type, create child device instead",
   function()
-  end,
+    -- added sets a bunch of fields on the device, and calls init
+    local cluster_subscribe_list = {
+      clusters.OnOff.attributes.OnOff,
+      clusters.Switch.server.events.InitialPress,
+      clusters.Switch.server.events.LongPress,
+      clusters.Switch.server.events.ShortRelease,
+      clusters.Switch.server.events.MultiPressComplete,
+    }
+    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_mcd_unsupported_switch_device_type)
+    for i, cluster in ipairs(cluster_subscribe_list) do
+      if i > 1 then
+        subscribe_request:merge(cluster:subscribe(mock_device_mcd_unsupported_switch_device_type))
+      end
+    end
+    test.socket.matter:__expect_send({mock_device_mcd_unsupported_switch_device_type.id, subscribe_request})
+    test.socket.device_lifecycle:__queue_receive({ mock_device_mcd_unsupported_switch_device_type.id, "added" })
+    test.wait_for_events()
+
+    -- init results in subscription interaction
+    test.socket.matter:__expect_send({mock_device_mcd_unsupported_switch_device_type.id, subscribe_request})
+    test.socket.device_lifecycle:__queue_receive({ mock_device_mcd_unsupported_switch_device_type.id, "init" })
+    test.wait_for_events()
+
+    -- doConfigure sets the provisioning state to provisioned
+    mock_device_mcd_unsupported_switch_device_type:expect_metadata_update({ profile = "2-button" })
+    mock_device_mcd_unsupported_switch_device_type:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    mock_device_mcd_unsupported_switch_device_type:expect_device_create({
+      type = "EDGE_CHILD",
+      label = "Matter Switch 1",
+      profile = "switch-binary",
+      parent_device_id = mock_device_mcd_unsupported_switch_device_type.id,
+      parent_assigned_child_key = string.format("%d", 7)
+    })
+    test.socket.device_lifecycle:__queue_receive({ mock_device_mcd_unsupported_switch_device_type.id, "doConfigure" })
+    test.wait_for_events()
+
+    -- simulate the profile change update taking affect and the device info changing
+    local device_info_copy = utils.deep_copy(mock_device_mcd_unsupported_switch_device_type.raw_st_data)
+    device_info_copy.profile.id = "5-buttons-battery"
+    local device_info_json = dkjson.encode(device_info_copy)
+    test.socket.device_lifecycle:__queue_receive({ mock_device_mcd_unsupported_switch_device_type.id, "infoChanged", device_info_json })
+    test.socket.matter:__expect_send({mock_device_mcd_unsupported_switch_device_type.id, subscribe_request})
+    end,
   { test_init = test_init_mcd_unsupported_switch_device_type }
 )
 
@@ -413,7 +454,7 @@ test.register_coroutine_test(
   function()
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "driverSwitched" })
     mock_device:expect_metadata_update({ profile = "light-level-3-button" })
-    configure_buttons()
+    expect_configure_buttons()
     mock_device:expect_device_create({
       type = "EDGE_CHILD",
       label = "Matter Switch 2",

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -1,7 +1,22 @@
+-- Copyright 2025 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
-
 local clusters = require "st.matter.clusters"
+
+test.disable_startup_messages()
 
 local mock_device_onoff = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("matter-thing.yml"),
@@ -406,14 +421,18 @@ local mock_device_light_level_motion = test.mock_device.build_test_matter_device
 })
 
 local function test_init_parent_child_switch_types()
+  test.mock_device.add_test_device(mock_device_parent_child_switch_types)
   local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_child_switch_types)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "added" })
+  test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "init" })
   test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "doConfigure" })
   mock_device_parent_child_switch_types:expect_metadata_update({ profile = "switch-level" })
   mock_device_parent_child_switch_types:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-
-  test.mock_device.add_test_device(mock_device_parent_child_switch_types)
 
   mock_device_parent_child_switch_types:expect_device_create({
     type = "EDGE_CHILD",
@@ -426,6 +445,8 @@ end
 
 local function test_init_onoff()
   test.mock_device.add_test_device(mock_device_onoff)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_onoff.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_onoff.id, "init" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_onoff.id, "doConfigure" })
   mock_device_onoff:expect_metadata_update({ profile = "switch-binary" })
   mock_device_onoff:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -436,12 +457,18 @@ local function test_init_onoff_client()
 end
 
 local function test_init_parent_client_child_server()
+  test.mock_device.add_test_device(mock_device_parent_client_child_server)
   local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_client_child_server)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "added" })
   test.socket.matter:__expect_send({mock_device_parent_client_child_server.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "init" })
+  test.socket.matter:__expect_send({mock_device_parent_client_child_server.id, subscribe_request})
+
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "doConfigure" })
   mock_device_parent_client_child_server:expect_metadata_update({ profile = "switch-binary" })
   mock_device_parent_client_child_server:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(mock_device_parent_client_child_server)
 end
 
 local function test_init_dimmer()
@@ -453,12 +480,15 @@ end
 
 local function test_init_color_dimmer()
   test.mock_device.add_test_device(mock_device_color_dimmer)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_color_dimmer.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_color_dimmer.id, "init" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_color_dimmer.id, "doConfigure" })
   mock_device_color_dimmer:expect_metadata_update({ profile = "switch-color-level" })
   mock_device_color_dimmer:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_mounted_on_off_control()
+  test.mock_device.add_test_device(mock_device_mounted_on_off_control)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
   }
@@ -468,13 +498,18 @@ local function test_init_mounted_on_off_control()
       subscribe_request:merge(cluster:subscribe(mock_device_mounted_on_off_control))
     end
   end
+  test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "added" })
   test.socket.matter:__expect_send({mock_device_mounted_on_off_control.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "init" })
+  test.socket.matter:__expect_send({mock_device_mounted_on_off_control.id, subscribe_request})
+
   test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "doConfigure" })
   mock_device_mounted_on_off_control:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(mock_device_mounted_on_off_control)
 end
 
 local function test_init_mounted_dimmable_load_control()
+  test.mock_device.add_test_device(mock_device_mounted_dimmable_load_control)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
   }
@@ -484,20 +519,27 @@ local function test_init_mounted_dimmable_load_control()
       subscribe_request:merge(cluster:subscribe(mock_device_mounted_dimmable_load_control))
     end
   end
+  test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "added" })
   test.socket.matter:__expect_send({mock_device_mounted_dimmable_load_control.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "init" })
+  test.socket.matter:__expect_send({mock_device_mounted_dimmable_load_control.id, subscribe_request})
+
   test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "doConfigure" })
   mock_device_mounted_dimmable_load_control:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(mock_device_mounted_dimmable_load_control)
 end
 
 local function test_init_water_valve()
   test.mock_device.add_test_device(mock_device_water_valve)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_water_valve.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_water_valve.id, "init" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_water_valve.id, "doConfigure" })
   mock_device_water_valve:expect_metadata_update({ profile = "water-valve-level" })
   mock_device_water_valve:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 local function test_init_parent_child_different_types()
+  test.mock_device.add_test_device(mock_device_parent_child_different_types)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LevelControl.attributes.CurrentLevel,
@@ -517,12 +559,14 @@ local function test_init_parent_child_different_types()
       subscribe_request:merge(cluster:subscribe(mock_device_parent_child_different_types))
     end
   end
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_different_types.id, "added" })
+  test.socket.matter:__expect_send({mock_device_parent_child_different_types.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_different_types.id, "init" })
   test.socket.matter:__expect_send({mock_device_parent_child_different_types.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_different_types.id, "doConfigure" })
   mock_device_parent_child_different_types:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-
-  test.mock_device.add_test_device(mock_device_parent_child_different_types)
 
   mock_device_parent_child_different_types:expect_device_create({
     type = "EDGE_CHILD",
@@ -534,10 +578,12 @@ local function test_init_parent_child_different_types()
 end
 
 local function test_init_parent_child_unsupported_device_type()
+  test.mock_device.add_test_device(mock_device_parent_child_unsupported_device_type)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_unsupported_device_type.id, "added" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_unsupported_device_type.id, "init" })
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_unsupported_device_type.id, "doConfigure" })
   mock_device_parent_child_unsupported_device_type:expect_metadata_update({ profile = "switch-binary" })
   mock_device_parent_child_unsupported_device_type:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.mock_device.add_test_device(mock_device_parent_child_unsupported_device_type)
 
   mock_device_parent_child_unsupported_device_type:expect_device_create({
     type = "EDGE_CHILD",
@@ -549,6 +595,7 @@ local function test_init_parent_child_unsupported_device_type()
 end
 
 local function test_init_light_level_motion()
+  test.mock_device.add_test_device(mock_device_light_level_motion)
   local cluster_subscribe_list = {
     clusters.OnOff.attributes.OnOff,
     clusters.LevelControl.attributes.CurrentLevel,
@@ -562,8 +609,15 @@ local function test_init_light_level_motion()
       subscribe_request:merge(cluster:subscribe(mock_device_light_level_motion))
     end
   end
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_light_level_motion.id, "added" })
   test.socket.matter:__expect_send({mock_device_light_level_motion.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_light_level_motion)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_light_level_motion.id, "init" })
+  test.socket.matter:__expect_send({mock_device_light_level_motion.id, subscribe_request})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_light_level_motion.id, "doConfigure" })
+  mock_device_light_level_motion:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
 test.register_coroutine_test(

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
@@ -12,6 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 local test = require "integration_test"
+test.set_rpc_version(0)
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 local SinglePrecisionFloat = require "st.matter.data_types.SinglePrecisionFloat"

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
@@ -83,6 +83,8 @@ local device_desc = {
 }
 
 local test_init_common = function(device)
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(device)
   local cluster_subscribe_list = {
     clusters.Thermostat.attributes.SystemMode,
     clusters.Thermostat.attributes.ControlSequenceOfOperation,
@@ -107,7 +109,6 @@ local test_init_common = function(device)
       subscribe_request:merge(cluster:subscribe(device))
     end
   end
-  test.socket.matter:__expect_send({ device.id, subscribe_request })
   test.socket.device_lifecycle:__queue_receive({ device.id, "added" })
   local read_request_on_added = {
     clusters.Thermostat.attributes.ControlSequenceOfOperation,
@@ -124,7 +125,8 @@ local test_init_common = function(device)
     device.id, read_request
   })
 
-  test.mock_device.add_test_device(device)
+  test.socket.device_lifecycle:__queue_receive({ device.id, "init" })
+  test.socket.matter:__expect_send({ device.id, subscribe_request })
 end
 
 local mock_device = test.mock_device.build_test_matter_device(device_desc)
@@ -184,6 +186,11 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
+      message = mock_device:generate_test_message("thermostatOne", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { maximum = 100.0, minimum = 0.0, step = 0.1 }, unit = "C" }))
+    },
+    {
+      channel = "capability",
+      direction = "send",
       message = mock_device:generate_test_message("thermostatOne", capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 40.0, unit = "C" }))
     },
     {
@@ -193,6 +200,11 @@ test.register_message_test(
         mock_device.id,
         clusters.Thermostat.server.attributes.OccupiedHeatingSetpoint:build_test_report_data(mock_device, THERMOSTAT_TWO_EP, 23*100)
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("thermostatTwo", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { maximum = 100.0, minimum = 0.0, step = 0.1 }, unit = "C" }))
     },
     {
       channel = "capability",
@@ -216,6 +228,11 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
+      message = mock_device:generate_test_message("thermostatOne", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { maximum = 100.0, minimum = 0.0, step = 0.1 }, unit = "C" }))
+    },
+    {
+      channel = "capability",
+      direction = "send",
       message = mock_device:generate_test_message("thermostatOne", capabilities.thermostatCoolingSetpoint.coolingSetpoint({ value = 39.0, unit = "C" }))
     },
     {
@@ -225,6 +242,11 @@ test.register_message_test(
         mock_device.id,
         clusters.Thermostat.server.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, THERMOSTAT_TWO_EP, 19*100)
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("thermostatTwo", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { maximum = 100.0, minimum = 0.0, step = 0.1 }, unit = "C" }))
     },
     {
       channel = "capability",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
@@ -12,10 +12,10 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 local test = require "integration_test"
+test.set_rpc_version(0)
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 local uint32 = require "st.matter.data_types.Uint32"
-
 local clusters = require "st.matter.clusters"
 
 local mock_device = test.mock_device.build_test_matter_device({
@@ -35,15 +35,15 @@ local mock_device = test.mock_device.build_test_matter_device({
       }
     },
     {
-        endpoint_id = 1,
-        clusters = {
-          {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-          {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER"},
-          {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
-          {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
-        }
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
       }
+    }
   }
 })
 
@@ -64,18 +64,18 @@ local mock_device_configure = test.mock_device.build_test_matter_device({
       }
     },
     {
-        endpoint_id = 1,
-        clusters = {
-          {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
-          {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 63},
-          {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
-        },
-        device_types = {
-          {device_type_id = 0x0072, device_type_revision = 1} -- Room Air Conditioner
-        }
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0072, device_type_revision = 1} -- Room Air Conditioner
       }
+    }
   }
 })
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac_modular.lua
@@ -16,9 +16,11 @@ local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 local utils = require "st.utils"
 local dkjson = require "dkjson"
-
 local clusters = require "st.matter.clusters"
+local im = require "st.matter.interaction_model"
+local uint32 = require "st.matter.data_types.Uint32"
 
+test.disable_startup_messages()
 test.set_rpc_version(8)
 
 local mock_device_basic = test.mock_device.build_test_matter_device({
@@ -38,18 +40,18 @@ local mock_device_basic = test.mock_device.build_test_matter_device({
       }
     },
     {
-        endpoint_id = 1,
-        clusters = {
-          {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
-          {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 63},
-          {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
-        },
-        device_types = {
-          {device_type_id = 0x0072, device_type_revision = 1} -- Room Air Conditioner
-        }
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0072, device_type_revision = 1} -- Room Air Conditioner
       }
+    }
   }
 })
 
@@ -70,22 +72,23 @@ local mock_device_no_state = test.mock_device.build_test_matter_device({
       }
     },
     {
-        endpoint_id = 1,
-        clusters = {
-          {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
-          {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 63},
-          {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
-          {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
-        },
-        device_types = {
-          {device_type_id = 0x0072, device_type_revision = 1} -- Room Air Conditioner
-        }
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.Thermostat.ID, cluster_type = "SERVER", feature_map = 63},
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER", feature_map = 0},
+      },
+      device_types = {
+        {device_type_id = 0x0072, device_type_revision = 1} -- Room Air Conditioner
       }
+    }
   }
 })
 
 local function initialize_mock_device(generic_mock_device, generic_subscribed_attributes)
+  test.mock_device.add_test_device(generic_mock_device)
   local subscribe_request = nil
   for _, attributes in pairs(generic_subscribed_attributes) do
     for _, attribute in ipairs(attributes) do
@@ -97,12 +100,27 @@ local function initialize_mock_device(generic_mock_device, generic_subscribed_at
     end
   end
   test.socket.matter:__expect_send({generic_mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(generic_mock_device)
   return subscribe_request
+end
+
+local function read_req_on_added(device)
+  local attributes = {
+    clusters.Thermostat.attributes.ControlSequenceOfOperation,
+    clusters.FanControl.attributes.FanModeSequence,
+    clusters.FanControl.attributes.WindSupport,
+    clusters.FanControl.attributes.RockSupport,
+    clusters.Thermostat.attributes.AttributeList,
+  }
+  local read_request = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
+  for _, clus in ipairs(attributes) do
+    read_request:merge(clus:read(device))
+  end
+  test.socket.matter:__expect_send({ device.id, read_request })
 end
 
 local subscribe_request_basic
 local function test_init_basic()
+  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribed_attributes = {
     [capabilities.switch.ID] = {
       clusters.OnOff.attributes.OnOff
@@ -145,6 +163,8 @@ local function test_init_basic()
       clusters.FanControl.attributes.WindSetting
     },
   }
+  test.socket.device_lifecycle:__queue_receive({ mock_device_basic.id, "added" })
+  read_req_on_added(mock_device_basic)
   subscribe_request_basic = initialize_mock_device(mock_device_basic, subscribed_attributes)
   local read_setpoint_deadband = clusters.Thermostat.attributes.MinSetpointDeadBand:read()
   test.socket.matter:__expect_send({mock_device_basic.id, read_setpoint_deadband})
@@ -204,8 +224,8 @@ for _, attributes in pairs(subscribed_attributes_no_state) do
   end
 end
 
-
 local function test_init_no_state()
+  test.socket.matter:__set_channel_ordering("relaxed")
   local subscribed_attributes = {
     [capabilities.switch.ID] = {
       clusters.OnOff.attributes.OnOff
@@ -249,6 +269,8 @@ local function test_init_no_state()
     },
   }
 
+  test.socket.device_lifecycle:__queue_receive({ mock_device_no_state.id, "added" })
+  read_req_on_added(mock_device_no_state)
   -- initially, device onboards WITH thermostatOperatingState, the test below will
   -- check if it is removed correctly when switching to modular profile. This is done
   -- to test that cases where the modular profile is different from the static profile
@@ -260,10 +282,16 @@ local function test_init_no_state()
 end
 
 -- run the profile configuration tests
-local function test_room_ac_device_type_update_modular_profile(generic_mock_device, expected_metadata, subscribe_request)
+local function test_room_ac_device_type_update_modular_profile(generic_mock_device, expected_metadata, subscribe_request, thermostat_attr_list_value)
   test.socket.device_lifecycle:__queue_receive({generic_mock_device.id, "doConfigure"})
-  generic_mock_device:expect_metadata_update(expected_metadata)
   generic_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.wait_for_events()
+  test.socket.matter:__queue_receive({
+    generic_mock_device.id,
+    clusters.Thermostat.attributes.AttributeList:build_test_report_data(generic_mock_device, 1, {thermostat_attr_list_value})
+  })
+  generic_mock_device:expect_metadata_update(expected_metadata)
+
   local device_info_copy = utils.deep_copy(generic_mock_device.raw_st_data)
   device_info_copy.profile.id = "room-air-conditioner-modular"
   local device_info_json = dkjson.encode(device_info_copy)
@@ -292,9 +320,7 @@ local expected_metadata_basic= {
 test.register_coroutine_test(
   "Device with modular profile should enable correct optional capabilities - basic",
   function()
-    mock_device_basic:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
-    mock_device_basic:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", true) -- since we're assuming this would have happened during device_added in this case.
-    test_room_ac_device_type_update_modular_profile(mock_device_basic, expected_metadata_basic, subscribe_request_basic)
+    test_room_ac_device_type_update_modular_profile(mock_device_basic, expected_metadata_basic, subscribe_request_basic, uint32(0x29))
   end,
   { test_init = test_init_basic }
 )
@@ -319,9 +345,7 @@ local expected_metadata_no_state = {
 test.register_coroutine_test(
   "Device with modular profile should enable correct optional capabilities - no thermo state",
   function()
-    mock_device_no_state:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
-    mock_device_no_state:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false) -- since we're assuming this would have happened during device_added in this case.
-    test_room_ac_device_type_update_modular_profile(mock_device_no_state, expected_metadata_no_state, subscribe_request_no_state)
+    test_room_ac_device_type_update_modular_profile(mock_device_no_state, expected_metadata_no_state, subscribe_request_no_state, uint32(0))
   end,
   { test_init = test_init_no_state }
 )

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
@@ -17,6 +17,8 @@ local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"
 local uint32 = require "st.matter.data_types.Uint32"
 
+test.set_rpc_version(7)
+
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("thermostat-batteryLevel.yml"),
   manufacturer_info = {

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -15,8 +15,9 @@
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 local uint32 = require "st.matter.data_types.Uint32"
-
 local clusters = require "st.matter.clusters"
+
+test.set_rpc_version(7)
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
@@ -14,8 +14,10 @@
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
-
 local clusters = require "st.matter.clusters"
+local dkjson = require "dkjson"
+local uint32 = require "st.matter.data_types.Uint32"
+local utils = require "st.utils"
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),
@@ -135,7 +137,89 @@ local cluster_subscribe_list = {
   clusters.FanControl.attributes.FanModeSequence,
 }
 
-local cluster_subscribe_list_disorder_endpoints = {
+local function get_subscribe_request(device, attribute_list)
+  local subscribe_request = attribute_list[1]:subscribe(device)
+  for i, cluster in ipairs(attribute_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(device))
+    end
+  end
+  return subscribe_request
+end
+
+local function test_init()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
+  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
+  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
+  test.socket.matter:__expect_send({mock_device.id, read_req})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+  test.socket.matter:__expect_send({mock_device.id, get_subscribe_request(mock_device, cluster_subscribe_list)})
+end
+test.set_test_init_function(test_init)
+
+local function test_init_disorder_endpoints()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_disorder_endpoints)
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_disorder_endpoints.id, "added" })
+  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
+  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
+  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
+  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
+  test.socket.matter:__expect_send({mock_device_disorder_endpoints.id, read_req})
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_disorder_endpoints.id, "init" })
+  test.socket.matter:__expect_send({mock_device_disorder_endpoints.id, get_subscribe_request(
+    mock_device_disorder_endpoints, cluster_subscribe_list)})
+end
+
+-- run the profile configuration tests
+local function test_thermostat_device_type_update_modular_profile(generic_mock_device, expected_metadata, subscribe_request)
+  test.socket.device_lifecycle:__queue_receive({generic_mock_device.id, "doConfigure"})
+  generic_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.wait_for_events()
+  test.socket.matter:__queue_receive({
+    generic_mock_device.id,
+    clusters.Thermostat.attributes.AttributeList:build_test_report_data(generic_mock_device, 1, {uint32(0)})
+  })
+  generic_mock_device:expect_metadata_update(expected_metadata)
+
+  test.wait_for_events()
+
+  local device_info_copy = utils.deep_copy(generic_mock_device.raw_st_data)
+  device_info_copy.profile.id = "thermostat-modular"
+  local device_info_json = dkjson.encode(device_info_copy)
+  test.socket.device_lifecycle:__queue_receive({ generic_mock_device.id, "infoChanged", device_info_json })
+  test.socket.matter:__expect_send({generic_mock_device.id, subscribe_request})
+end
+
+local expected_metadata = {
+  optional_component_capabilities={
+    {
+      "main",
+      {
+        "relativeHumidityMeasurement",
+        "fanMode",
+        "fanOscillationMode",
+        "thermostatHeatingSetpoint",
+        "thermostatCoolingSetpoint"
+      },
+    },
+  },
+  profile="thermostat-modular",
+}
+
+local new_cluster_subscribe_list = {
   clusters.Thermostat.attributes.LocalTemperature,
   clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
   clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
@@ -149,70 +233,23 @@ local cluster_subscribe_list_disorder_endpoints = {
   clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
   clusters.FanControl.attributes.FanMode,
   clusters.FanControl.attributes.FanModeSequence,
+  clusters.FanControl.attributes.RockSupport,  -- These two attributes will be subscribed to following the profile
+  clusters.FanControl.attributes.RockSetting,  -- change since the fanOscillationMode capability will be enabled.
 }
-
-local function test_init()
-  mock_device:set_field("MIN_SETPOINT_DEADBAND_CHECKED", 1, {persist = true})
-  test.socket.matter:__set_channel_ordering("relaxed")
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device))
-    end
-  end
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
-  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
-  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
-  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
-  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
-  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
-  test.socket.matter:__expect_send({mock_device.id, read_req})
-end
-test.set_test_init_function(test_init)
-
-local function test_init_disorder_endpoints()
-  mock_device_disorder_endpoints:set_field("MIN_SETPOINT_DEADBAND_CHECKED", 1, {persist = true})
-  test.socket.matter:__set_channel_ordering("relaxed")
-  local subscribe_request_disorder_endpoints = cluster_subscribe_list_disorder_endpoints[1]:subscribe(mock_device_disorder_endpoints)
-  for i, cluster in ipairs(cluster_subscribe_list_disorder_endpoints) do
-    if i > 1 then
-      subscribe_request_disorder_endpoints:merge(cluster:subscribe(mock_device_disorder_endpoints))
-    end
-  end
-  test.socket.matter:__expect_send({mock_device_disorder_endpoints.id, subscribe_request_disorder_endpoints})
-  test.mock_device.add_test_device(mock_device_disorder_endpoints)
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_disorder_endpoints.id, "added" })
-  local read_req = clusters.Thermostat.attributes.ControlSequenceOfOperation:read()
-  read_req:merge(clusters.FanControl.attributes.FanModeSequence:read())
-  read_req:merge(clusters.FanControl.attributes.WindSupport:read())
-  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
-  read_req:merge(clusters.FanControl.attributes.RockSupport:read())
-  read_req:merge(clusters.Thermostat.attributes.AttributeList:read())
-  test.socket.matter:__expect_send({mock_device_disorder_endpoints.id, read_req})
-end
 
 test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event no battery & state support",
   function()
-    mock_device:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false)
-    test.socket.device_lifecycle:__queue_receive({mock_device.id, "doConfigure"})
-    mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-nostate-nobattery" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test_thermostat_device_type_update_modular_profile(mock_device, expected_metadata,
+      get_subscribe_request(mock_device, new_cluster_subscribe_list))
   end
 )
 
 test.register_coroutine_test(
   "Profile change on doConfigure lifecycle event no battery & state support with disorder endpoints",
   function()
-    mock_device_disorder_endpoints:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false)
-    test.socket.device_lifecycle:__queue_receive({mock_device_disorder_endpoints.id, "doConfigure"})
-    mock_device_disorder_endpoints:expect_metadata_update({ profile = "thermostat-humidity-fan-nostate-nobattery" })
-    mock_device_disorder_endpoints:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test_thermostat_device_type_update_modular_profile(mock_device_disorder_endpoints, expected_metadata,
+      get_subscribe_request(mock_device_disorder_endpoints, new_cluster_subscribe_list))
   end,
   { test_init = test_init_disorder_endpoints }
 )

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -15,7 +15,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
 
 local clusters = require "st.matter.clusters"
 
@@ -222,6 +221,11 @@ test.register_message_test(
     {
       channel = "capability",
       direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { maximum = 100.0, minimum = 0.0, step = 0.1 }, unit = "C" }))
+    },
+    {
+      channel = "capability",
+      direction = "send",
       message = mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 40.0, unit = "C" }))
     }
   }
@@ -237,6 +241,11 @@ test.register_message_test(
         mock_device.id,
         clusters.Thermostat.server.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, 1, 40*100)
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { maximum = 100.0, minimum = 0.0, step = 0.1 }, unit = "C" }))
     },
     {
       channel = "capability",
@@ -698,28 +707,6 @@ test.register_message_test(
 			message = {
 				mock_device.id,
 				clusters.Thermostat.attributes.OccupiedCoolingSetpoint:write(mock_device, 1, 25*100)
-			}
-		}
-	}
-)
-
-test.register_message_test(
-	"Setting the heating setpoint to a Fahrenheit value should send the appropriate commands",
-	{
-		{
-			channel = "capability",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				{ capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 64 } }
-			}
-		},
-		{
-			channel = "matter",
-			direction = "send",
-			message = {
-				mock_device.id,
-				clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 1, utils.round((64 - 32) * (5 / 9.0) * 100))
 			}
 		}
 	}

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
@@ -15,8 +15,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
-
 local clusters = require "st.matter.clusters"
 
 local mock_device = test.mock_device.build_test_matter_device({
@@ -161,6 +159,12 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main",
+        capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 0.00, maximum = 100.00, step = 0.1 }, unit = "C" }))
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main",
         capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 40.0, unit = "C" }))
     }
   }
@@ -176,6 +180,12 @@ test.register_message_test(
         mock_device.id,
         clusters.Thermostat.server.attributes.OccupiedCoolingSetpoint:build_test_report_data(mock_device, 3, 40 * 100)
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main",
+        capabilities.thermostatCoolingSetpoint.coolingSetpointRange({ value = { minimum = 0.00, maximum = 100.00, step = 0.1 }, unit = "C" }))
     },
     {
       channel = "capability",
@@ -508,29 +518,6 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.Thermostat.attributes.OccupiedCoolingSetpoint:write(mock_device, 3, 25 * 100)
-      }
-    }
-  }
-)
-
-test.register_message_test(
-  "Setting the heating setpoint to a Fahrenheit value should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 64 } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 3,
-          utils.round((64 - 32) * (5 / 9.0) * 100))
       }
     }
   }

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_modular.lua
@@ -14,12 +14,13 @@
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
-local dkjson = require "dkjson"
-
 local clusters = require "st.matter.clusters"
+local dkjson = require "dkjson"
+local im = require "st.matter.interaction_model"
+local uint32 = require "st.matter.data_types.Uint32"
+local utils = require "st.utils"
 
-test.set_rpc_version(8)
+test.disable_startup_messages()
 
 local mock_device_basic = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),
@@ -49,10 +50,10 @@ local mock_device_basic = test.mock_device.build_test_matter_device({
         },
         {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
         {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 0},
       },
       device_types = {
-        {device_type_id = 0x0301, device_type_revision = 1}, -- Thermostat
+        {device_type_id = 0x0301, device_type_revision = 1} -- Thermostat
       }
     }
   }
@@ -67,12 +68,12 @@ local function initialize_mock_device(generic_mock_device, generic_subscribed_at
     end
   end
   test.socket.matter:__expect_send({generic_mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(generic_mock_device)
   return subscribe_request
 end
 
 local subscribe_request_basic
 local function test_init()
+  test.mock_device.add_test_device(mock_device_basic)
   local subscribed_attributes = {
     clusters.Thermostat.attributes.LocalTemperature,
     clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
@@ -92,14 +93,35 @@ local function test_init()
     clusters.FanControl.attributes.FanModeSequence,
     clusters.PowerSource.attributes.BatPercentRemaining,
   }
+  test.socket.device_lifecycle:__queue_receive({ mock_device_basic.id, "added" })
+  local read_attributes = {
+    clusters.Thermostat.attributes.ControlSequenceOfOperation,
+    clusters.FanControl.attributes.FanModeSequence,
+    clusters.FanControl.attributes.WindSupport,
+    clusters.FanControl.attributes.RockSupport,
+    clusters.Thermostat.attributes.AttributeList,
+  }
+  local read_request = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
+  for _, clus in ipairs(read_attributes) do
+    read_request:merge(clus:read(mock_device_basic))
+  end
+  test.socket.matter:__expect_send({ mock_device_basic.id, read_request })
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_basic.id, "init" })
   subscribe_request_basic = initialize_mock_device(mock_device_basic, subscribed_attributes)
 end
 
 -- run the profile configuration tests
 local function test_thermostat_device_type_update_modular_profile(generic_mock_device, expected_metadata, subscribe_request)
   test.socket.device_lifecycle:__queue_receive({generic_mock_device.id, "doConfigure"})
-  generic_mock_device:expect_metadata_update(expected_metadata)
   generic_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.wait_for_events()
+  test.socket.matter:__queue_receive({
+    generic_mock_device.id,
+    clusters.Thermostat.attributes.AttributeList:build_test_report_data(generic_mock_device, 1, {uint32(0)})
+  })
+  generic_mock_device:expect_metadata_update(expected_metadata)
+
   local device_info_copy = utils.deep_copy(generic_mock_device.raw_st_data)
   device_info_copy.profile.id = "thermostat-modular"
   local device_info_json = dkjson.encode(device_info_copy)
@@ -125,8 +147,6 @@ local expected_metadata = {
 test.register_coroutine_test(
   "Device with modular profile should enable correct optional capabilities",
   function()
-    mock_device_basic:set_field("__BATTERY_SUPPORT", "NO_BATTERY") -- since we're assuming this would have happened during device_added in this case.
-    mock_device_basic:set_field("__THERMOSTAT_RUNNING_STATE_SUPPORT", false) -- since we're assuming this would have happened during device_added in this case.
     test_thermostat_device_type_update_modular_profile(mock_device_basic, expected_metadata, subscribe_request_basic)
   end,
   { test_init = test_init }

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_rpc5.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_rpc5.lua
@@ -1,0 +1,145 @@
+-- Copyright 2022 SmartThings
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local clusters = require "st.matter.clusters"
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local utils = require "st.utils"
+
+-- Temperature values are converted to Celsius by the hub before reaching the driver for rpc > 5.
+-- This test file is meant to verify that the driver converts Fahrenheit values > 40 degrees from F to C for rpc <= 5.
+test.set_rpc_version(5)
+
+local mock_device = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        device_type_id = 0x0016, device_type_revision = 1, -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.FanControl.ID, cluster_type = "SERVER"},
+        {
+          cluster_id = clusters.Thermostat.ID,
+          cluster_revision=5,
+          cluster_type="SERVER",
+          feature_map=3, -- Heat and Cool features
+        },
+        {cluster_id = clusters.TemperatureMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.RelativeHumidityMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER"},
+      }
+    }
+  }
+})
+
+local function test_init()
+  local cluster_subscribe_list = {
+    clusters.Thermostat.attributes.LocalTemperature,
+    clusters.Thermostat.attributes.OccupiedCoolingSetpoint,
+    clusters.Thermostat.attributes.OccupiedHeatingSetpoint,
+    clusters.Thermostat.attributes.AbsMinCoolSetpointLimit,
+    clusters.Thermostat.attributes.AbsMaxCoolSetpointLimit,
+    clusters.Thermostat.attributes.AbsMinHeatSetpointLimit,
+    clusters.Thermostat.attributes.AbsMaxHeatSetpointLimit,
+    clusters.Thermostat.attributes.SystemMode,
+    clusters.Thermostat.attributes.ThermostatRunningState,
+    clusters.Thermostat.attributes.ControlSequenceOfOperation,
+    clusters.TemperatureMeasurement.attributes.MeasuredValue,
+    clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
+    clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
+    clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
+    clusters.FanControl.attributes.FanMode,
+    clusters.FanControl.attributes.FanModeSequence,
+    clusters.PowerSource.attributes.BatPercentRemaining,
+  }
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+end
+test.set_test_init_function(test_init)
+
+test.register_message_test(
+  "Setting the heating setpoint to a Fahrenheit value should send the appropriate commands",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 90 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 1,
+          utils.round((90 - 32) * (5 / 9.0) * 100))
+      }
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 41 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 1,
+          utils.round((41 - 32) * (5 / 9.0) * 100))
+      }
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 35 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 1, 35 * 100)
+      }
+    }
+  }
+)
+
+test.run_registered_tests()

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_water_heater.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_water_heater.lua
@@ -15,7 +15,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
 local version = require "version"
 local clusters = require "st.matter.clusters"
 
@@ -107,29 +106,6 @@ end
 test.set_test_init_function(test_init)
 
 test.register_message_test(
-  "Setting the heating setpoint to a Fahrenheit value should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 90 } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, WATER_HEATER_EP,
-          utils.round((90 - 32) * (5 / 9.0) * 100))
-      }
-    }
-  }
-)
-
-test.register_message_test(
   "Heating setpoint reports should generate correct messages",
   {
     {
@@ -139,6 +115,12 @@ test.register_message_test(
         mock_device.id,
         clusters.Thermostat.server.attributes.OccupiedHeatingSetpoint:build_test_report_data(mock_device, 1, 70*100)
       }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main",
+        capabilities.thermostatHeatingSetpoint.heatingSetpointRange({ value = { minimum = 0.00, maximum = 100.00, step = 0.1 }, unit = "C" }))
     },
     {
       channel = "capability",
@@ -165,28 +147,6 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, WATER_HEATER_EP, 80*100)
-      }
-    }
-  }
-)
-
-test.register_message_test(
-  "Setting the heating setpoint to a Fahrenheit value should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "thermostatHeatingSetpoint", component = "main", command = "setHeatingSetpoint", args = { 100 } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, WATER_HEATER_EP, utils.round((100 - 32) * (5 / 9.0) * 100))
       }
     }
   }

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -17,7 +17,10 @@ local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 local uint32 = require "st.matter.data_types.Uint32"
 local clusters = require "st.matter.clusters"
+
 local WindowCovering = clusters.WindowCovering
+
+test.disable_startup_messages()
 
 local mock_device = test.mock_device.build_test_matter_device(
   {
@@ -36,44 +39,12 @@ local mock_device = test.mock_device.build_test_matter_device(
       },
       {
         endpoint_id = 10,
-        clusters = { -- list the clusters
+        clusters = {
           {
             cluster_id = clusters.WindowCovering.ID,
             cluster_type = "SERVER",
             cluster_revision = 1,
             feature_map = 3,
-          },
-          {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"},
-          {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 0x0002}
-        },
-      },
-    },
-  }
-)
-
-local mock_device_switch_to_battery = test.mock_device.build_test_matter_device(
-  {
-    profile = t_utils.get_profile_definition("window-covering.yml"),
-    manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
-    preferences = { presetPosition = 30 },
-    endpoints = {
-      {
-        endpoint_id = 2,
-        clusters = {
-          {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
-        },
-        device_types = {
-          device_type_id = 0x0016, device_type_revision = 1, -- RootNode
-        }
-      },
-      {
-        endpoint_id = 10,
-        clusters = { -- list the clusters
-          {
-            cluster_id = clusters.WindowCovering.ID,
-            cluster_type = "SERVER",
-            cluster_revision = 1,
-            feature_map = 1,
           },
           {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"},
           {cluster_id = clusters.PowerSource.ID, cluster_type = "SERVER", feature_map = 0x0002}
@@ -100,7 +71,7 @@ local mock_device_mains_powered = test.mock_device.build_test_matter_device(
       },
       {
         endpoint_id = 10,
-        clusters = { -- list the clusters
+        clusters = {
           {
             cluster_id = clusters.WindowCovering.ID,
             cluster_type = "SERVER",
@@ -130,34 +101,45 @@ local CLUSTER_SUBSCRIBE_LIST_NO_BATTERY = {
 }
 
 local function test_init()
+  test.mock_device.add_test_device(mock_device)
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message(
+      "main", capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"},
+        {visibility = {displayed = false}})
+    )
+  )
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
-end
 
-local function test_init_switch_to_battery()
-  local subscribe_request = CLUSTER_SUBSCRIBE_LIST_NO_BATTERY[1]:subscribe(mock_device_switch_to_battery)
-  for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST_NO_BATTERY) do
-    if i > 1 then subscribe_request:merge(clus:subscribe(mock_device_switch_to_battery)) end
-  end
-  test.socket.matter:__expect_send({mock_device_switch_to_battery.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_switch_to_battery)
-  test.socket.device_lifecycle:__queue_receive({ mock_device_switch_to_battery.id, "doConfigure" })
-  mock_device_switch_to_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
-  test.socket.matter:__expect_send({mock_device_switch_to_battery.id, read_attribute_list})
+  test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
 end
 
 local function test_init_mains_powered()
+  test.mock_device.add_test_device(mock_device_mains_powered)
+  test.socket.device_lifecycle:__queue_receive({ mock_device_mains_powered.id, "added" })
+  test.socket.capability:__expect_send(
+    mock_device_mains_powered:generate_test_message(
+      "main", capabilities.windowShade.supportedWindowShadeCommands({"open", "close", "pause"},
+        {visibility = {displayed = false}})
+    )
+  )
+
+  test.socket.device_lifecycle:__queue_receive({ mock_device_mains_powered.id, "init" })
   local subscribe_request = CLUSTER_SUBSCRIBE_LIST_NO_BATTERY[1]:subscribe(mock_device_mains_powered)
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST_NO_BATTERY) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device_mains_powered)) end
   end
   test.socket.matter:__expect_send({mock_device_mains_powered.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_mains_powered)
+
   test.socket.device_lifecycle:__queue_receive({ mock_device_mains_powered.id, "doConfigure" })
   mock_device_mains_powered:expect_metadata_update({ profile = "window-covering" })
   mock_device_mains_powered:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -794,13 +776,12 @@ test.register_coroutine_test(
   function()
     test.socket.matter:__queue_receive(
       {
-        mock_device_switch_to_battery.id,
-        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_switch_to_battery, 10, {uint32(12)})
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 10, {uint32(12)})
       }
     )
-    mock_device_switch_to_battery:expect_metadata_update({ profile = "window-covering-battery" })
-  end,
-  { test_init = test_init_switch_to_battery }
+    mock_device:expect_metadata_update({ profile = "window-covering-tilt-battery" })
+  end
 )
 
 test.register_coroutine_test(
@@ -808,12 +789,11 @@ test.register_coroutine_test(
   function()
     test.socket.matter:__queue_receive(
       {
-        mock_device_switch_to_battery.id,
-        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_switch_to_battery, 10, {uint32(10)})
+        mock_device.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 10, {uint32(10)})
       }
     )
-  end,
-  { test_init = test_init_switch_to_battery }
+  end
 )
 
 test.register_coroutine_test(

--- a/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor_pro.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor_pro.lua
@@ -199,6 +199,14 @@ test.register_message_test(
                 channel = "capability",
                 direction = "send",
                 message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+            },
+            {
+            channel = "devices",
+            direction = "send",
+            message = {
+                "register_native_capability_attr_handler",
+                { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+            }
             }
         }
 )

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
@@ -147,6 +147,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact_tyco.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact_tyco.lua
@@ -80,6 +80,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )
@@ -97,6 +105,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" })))
+      mock_device:expect_native_attr_handler_registration("temperatureMeasurement", "temperature")
       test.wait_for_events()
     end
   )

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/init.lua
@@ -90,6 +90,6 @@ local zigbee_humidity_driver = {
   health_check = false,
 }
 
-defaults.register_for_default_handlers(zigbee_humidity_driver, zigbee_humidity_driver.supported_capabilities)
+defaults.register_for_default_handlers(zigbee_humidity_driver, zigbee_humidity_driver.supported_capabilities, {native_capability_attrs_enabled = true})
 local driver = ZigbeeDriver("zigbee-humidity-sensor", zigbee_humidity_driver)
 driver:run()

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_aqara_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_aqara_sensor.lua
@@ -167,6 +167,14 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main",
         capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -186,6 +194,7 @@ test.register_coroutine_test(
     )
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" })))
+    mock_device:expect_native_attr_handler_registration("temperatureMeasurement", "temperature")
     test.wait_for_events()
   end
 )

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_plaid_systems.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_plaid_systems.lua
@@ -116,6 +116,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -156,6 +164,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" })))
+      mock_device:expect_native_attr_handler_registration("temperatureMeasurement", "temperature")
       test.wait_for_events()
     end
 )

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature.lua
@@ -48,6 +48,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -151,6 +159,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" })))
+      mock_device:expect_native_attr_handler_registration("temperatureMeasurement", "temperature")
       test.wait_for_events()
       test.socket.zigbee:__queue_receive(
         {

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_battery.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_battery.lua
@@ -60,6 +60,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -171,6 +179,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" })))
+      mock_device:expect_native_attr_handler_registration("temperatureMeasurement", "temperature")
       test.wait_for_events()
       test.socket.zigbee:__queue_receive(
         {

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_sensor.lua
@@ -55,6 +55,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
@@ -143,6 +143,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )
@@ -407,6 +415,7 @@ test.register_coroutine_test(
         }
       )
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" })))
+      mock_device:expect_native_attr_handler_registration("temperatureMeasurement", "temperature")
       test.wait_for_events()
     end
 )

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor_pro.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor_pro.lua
@@ -156,6 +156,14 @@ test.register_message_test(
                 channel = "capability",
                 direction = "send",
                 message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+            },
+            {
+            channel = "devices",
+            direction = "send",
+            message = {
+                "register_native_capability_attr_handler",
+                { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+            }
             }
         }
 )

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter.lua
@@ -99,7 +99,7 @@ test.register_coroutine_test(
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
-                                         SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 1, 3600, 5)
+                                         SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 3600, 5)
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
@@ -113,7 +113,7 @@ test.register_coroutine_test(
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
-                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 1, 3600, 5)
+                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 3600, 5)
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_consumption_report.lua
@@ -145,7 +145,7 @@ test.register_coroutine_test(
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
-                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 1, 3600, 5)
+                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 3600, 5)
                                        })
       test.socket.zigbee:__expect_send({
                                         mock_device.id,

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_smoke_detector.lua
@@ -270,6 +270,14 @@ test.register_message_test(
                 channel = "capability",
                 direction = "send",
                 message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+            },
+            {
+            channel = "devices",
+            direction = "send",
+            message = {
+                "register_native_capability_attr_handler",
+                { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+            }
             }
         }
 )

--- a/drivers/SmartThings/zigbee-sound-sensor/src/test/test_zigbee_sound_sensor.lua
+++ b/drivers/SmartThings/zigbee-sound-sensor/src/test/test_zigbee_sound_sensor.lua
@@ -267,6 +267,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -202,6 +202,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 27.0, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )
@@ -340,7 +348,7 @@ test.register_coroutine_test(
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
-                                         SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 1, 3600, 5)
+                                         SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 3600, 5)
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
@@ -354,7 +362,7 @@ test.register_coroutine_test(
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
-                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 1, 3600, 5)
+                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 3600, 5)
                                        })
       test.socket.zigbee:__expect_send({
                                          mock_device.id,
@@ -552,6 +560,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     test.socket.zigbee:__queue_receive({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:build_test_attr_report(mock_device, 556)})
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorTemperature.colorTemperature(1800)))
+    mock_device:expect_native_attr_handler_registration("colorTemperature", "colorTemperature")
   end
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_frient_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_frient_switch.lua
@@ -222,6 +222,14 @@ test.register_message_test(
             channel = "capability",
             direction = "send",
             message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 2.7, unit = "W" }))
+        },
+        {
+        channel = "devices",
+        direction = "send",
+        message = {
+            "register_native_capability_attr_handler",
+            { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
         }
     }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
@@ -329,6 +329,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.powerMeter.power({ value = 27.0, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )
@@ -348,6 +356,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_device:generate_test_message("main", capabilities.powerMeter.power({ value = 27.0, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
@@ -105,6 +105,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 9.0, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
@@ -105,6 +105,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 9.0, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
@@ -72,7 +72,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send(
       {
         mock_device.id,
-        ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 1, 3600, 5)
+        ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 3600, 5)
       }
     )
     test.socket.zigbee:__expect_send(
@@ -90,7 +90,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send(
       {
         mock_device.id,
-        SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 1, 3600, 5)
+        SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 3600, 5)
       }
     )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
@@ -118,6 +118,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 9.766, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -120,7 +120,7 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C"}))
-      }
+      },
     }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua
@@ -247,6 +247,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_frient_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_frient_water_leak_sensor.lua
@@ -253,6 +253,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_samjin_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_samjin_water_leak_sensor.lua
@@ -215,6 +215,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_sinope_zigbee_water.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_sinope_zigbee_water.lua
@@ -135,6 +135,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_smartthings_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_smartthings_water_leak_sensor.lua
@@ -213,6 +213,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water.lua
@@ -141,6 +141,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 25.0, unit = "C" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
@@ -22,7 +22,6 @@ local SensorAlarm = (require "st.zwave.CommandClass.SensorAlarm")({ version = 1 
 --- @type st.zwave.CommandClass.SensorBinary
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
 --- @type st.zwave.CommandClass.SensorMultilevel
-local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version = 5 })
 
 local preferences = require "preferences"
 local configurations = require "configurations"
@@ -73,14 +72,6 @@ local function sensor_binary_report_handler(self, device, cmd)
   device:emit_event(event)
 end
 
-local function sensor_multilevel_report_handler(self, device, cmd)
-  if (cmd.args.sensor_type == SensorMultilevel.sensor_type.TEMPERATURE) then
-    local scale = 'C'
-    if (cmd.args.scale == SensorMultilevel.scale.temperature.FAHRENHEIT) then scale = 'F' end
-    device:emit_event(capabilities.temperatureMeasurement.temperature({value = cmd.args.sensor_value, unit = scale}))
-  end
-end
-
 local function do_configure(driver, device)
   configurations.initial_configuration(driver, device)
   -- The flood sensor can be hardwired, so update any preferences
@@ -101,9 +92,6 @@ local fibaro_flood_sensor = {
     [cc.SENSOR_BINARY] = {
       [SensorBinary.REPORT] = sensor_binary_report_handler
     },
-    [cc.SENSOR_MULTILEVEL] = {
-      [SensorMultilevel.REPORT] = sensor_multilevel_report_handler
-    }
   },
   lifecycle_handlers = {
     doConfigure = do_configure

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_1.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_1.lua
@@ -344,6 +344,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_fibaro_door_window_sensor1:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_fibaro_door_window_sensor1.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -363,6 +371,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_fibaro_door_window_sensor1:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 70.7, unit = 'F' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_fibaro_door_window_sensor1.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
@@ -232,6 +232,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_fibaro_door_window_sensor:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_fibaro_door_window_sensor.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -251,6 +259,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_fibaro_door_window_sensor:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 70.7, unit = 'F' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_fibaro_door_window_sensor.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor.lua
@@ -130,6 +130,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_sensor:generate_test_message("main", capabilities.temperatureMeasurement.temperature({value = 25, unit = 'C'}))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_sensor.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor.lua
@@ -312,6 +312,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -331,6 +339,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 70.7, unit = 'F' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-sensor/src/test/test_generic_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_generic_sensor.lua
@@ -173,7 +173,7 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "SensorMultilevel report temperature should be handled as temperature",
+  "SensorMultilevel report temperature (C) should be handled as temperature",
   {
     {
       channel = "zwave",
@@ -188,12 +188,20 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 30, unit = "C" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
 
 test.register_message_test(
-  "SensorMultilevel report temperature should be handled as temperature",
+  "SensorMultilevel report temperature (F) should be handled as temperature",
   {
     {
       channel = "zwave",
@@ -208,6 +216,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 70, unit = "F" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -266,6 +282,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 50, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )
@@ -286,6 +310,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 50, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-sensor/src/test/test_smartthings_water_leak_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_smartthings_water_leak_sensor.lua
@@ -200,6 +200,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21, unit = 'C' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )
@@ -220,6 +228,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 37, unit = 'F' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
@@ -296,6 +296,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
@@ -320,6 +320,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
@@ -214,6 +214,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_parent:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_parent.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )
@@ -387,6 +395,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_child:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_child.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_multichannel_device.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_multichannel_device.lua
@@ -2046,6 +2046,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_5:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 20, unit = "C" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
@@ -323,6 +323,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_2_relay.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_2_relay.lua
@@ -335,6 +335,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_parent_device:generate_test_message("main", capabilities.powerMeter.power({ value = 5, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )
@@ -359,6 +367,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_child_2_device:generate_test_message("main", capabilities.powerMeter.power({ value = 5, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_parent_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
@@ -314,6 +314,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
@@ -163,6 +163,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
@@ -493,6 +493,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_parent:generate_test_message("main", capabilities.powerMeter.power({ value = 89, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_parent.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )
@@ -514,6 +522,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_parent:generate_test_message("main", capabilities.powerMeter.power({ value = 89, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_parent.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
@@ -234,6 +234,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 55, unit = "W" }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_electric_meter.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_electric_meter.lua
@@ -57,6 +57,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_switch:generate_test_message("main", capabilities.powerMeter.power({ value = 27, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_switch.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_energy_meter.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_energy_meter.lua
@@ -64,6 +64,14 @@ test.register_message_test(
           meter_value = 27})
         )}
       },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_switch.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
+      }
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_power_meter.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_power_meter.lua
@@ -68,6 +68,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_switch:generate_test_message("main", capabilities.powerMeter.power({ value = 27, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_switch.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_aeotec_radiator_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_aeotec_radiator_thermostat.lua
@@ -146,6 +146,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
@@ -244,6 +244,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_popp_radiator_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_popp_radiator_thermostat.lua
@@ -95,7 +95,15 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
       }
+    }
     }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
@@ -471,6 +471,14 @@ test.register_message_test(
         channel = "capability",
         direction = "send",
         message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 5, unit = "W" }))
+      },
+      {
+        channel = "devices",
+        direction = "send",
+        message = {
+          "register_native_capability_attr_handler",
+          { device_uuid = mock_device.id, capability_id = "powerMeter", capability_attr_id = "power" }
+        }
       }
     }
 )

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
@@ -256,6 +256,14 @@ test.register_message_test(
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' }))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "temperatureMeasurement", capability_attr_id = "temperature" }
+      }
     }
   }
 )

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_fibaro_roller_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_fibaro_roller_shutter.lua
@@ -303,7 +303,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
           {
             mock_fibaro_roller_shutter.id,
-            { capability = "windowShadePreset", command = "presetPosition", args = {} }
+            { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
           }
       )
       test.socket.zwave:__expect_send(

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_qubino_flush_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_qubino_flush_shutter.lua
@@ -233,7 +233,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
           {
             mock_qubino_flush_shutter.id,
-            { capability = "windowShadePreset", command = "presetPosition", args = {} }
+            { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
           }
       )
       test.socket.zwave:__expect_send(

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_iblinds_window_treatment.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_iblinds_window_treatment.lua
@@ -214,7 +214,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
         {
           mock_blind.id,
-          { capability = "windowShadePreset", command = "presetPosition", args = {} }
+          { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
         }
       )
       test.socket.capability:__expect_send(
@@ -251,7 +251,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
         {
           mock_blind.id,
-          { capability = "windowShadePreset", command = "presetPosition", args = {} }
+          { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
         }
       )
       test.socket.capability:__expect_send(
@@ -374,7 +374,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
         {
           mock_blind_v3.id,
-          { capability = "windowShadePreset", command = "presetPosition", args = {} }
+          { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
         }
       )
       test.socket.capability:__expect_send(
@@ -415,7 +415,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
         {
           mock_blind_v3.id,
-          { capability = "windowShadePreset", command = "presetPosition", args = {} }
+          { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
         }
       )
       test.socket.capability:__expect_send(

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_springs_window_treatment.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_springs_window_treatment.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
           {
             mock_springs_window_fashion_shade.id,
-            { capability = "windowShadePreset", command = "presetPosition", args = {} }
+            { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
           }
       )
       test.socket.zwave:__expect_send(

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_window_treatment.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_window_treatment.lua
@@ -304,7 +304,7 @@ test.register_coroutine_test(
       test.socket.capability:__queue_receive(
           {
             mock_window_shade_switch_multilevel.id,
-            { capability = "windowShadePreset", command = "presetPosition", args = {} }
+            { capability = "windowShadePreset", component = "main", command = "presetPosition", args = {} }
           }
       )
       test.socket.zwave:__expect_send(


### PR DESCRIPTION
This contains unit test fixes for the following features that are changing in 0.58:
* Integration test lifecycle events are now more explicit. The test framework will queue init (and doConfigure if the mock device overrides the provisioning state) events for mock devices that are added in test init.
* Matter is using modular profiles
* New native handler registrations are available
* Reporting configurations for zigbee power meter are lengthened by default.