### PR TITLE
Revert energy profiling changes

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/light-level-power-energy-powerConsumption.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-power-energy-powerConsumption.yml
@@ -1,24 +1,24 @@
 name: light-level-power-energy-powerConsumption
 components:
-- id: main
-  capabilities:
-  - id: switch
-    version: 1
-  - id: switchLevel
-    version: 1
-    config:
-      values:
-      - key: "level.value"
-        range: [1, 100]
-  - id: powerMeter
-    version: 1
-  - id: energyMeter
-    version: 1
-  - id: powerConsumptionReport
-    version: 1
-  - id: firmwareUpdate
-    version: 1
-  - id: refresh
-    version: 1
-  categories:
-    - name: Light
+  - id: main
+    capabilities:
+      - id: switch
+        version: 1
+      - id: switchLevel
+        version: 1
+        config:
+          values:
+            - key: "level.value"
+              range: [1, 100]
+      - id: powerMeter
+        version: 1
+      - id: energyMeter
+        version: 1
+      - id: powerConsumptionReport
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: Light

--- a/drivers/SmartThings/matter-switch/profiles/light-power-energy-powerConsumption.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-power-energy-powerConsumption.yml
@@ -1,18 +1,18 @@
 name: light-power-energy-powerConsumption
 components:
-- id: main
-  capabilities:
-  - id: switch
-    version: 1
-  - id: powerMeter
-    version: 1
-  - id: energyMeter
-    version: 1
-  - id: powerConsumptionReport
-    version: 1
-  - id: firmwareUpdate
-    version: 1
-  - id: refresh
-    version: 1
-  categories:
-    - name: Light
+  - id: main
+    capabilities:
+      - id: switch
+        version: 1
+      - id: powerMeter
+        version: 1
+      - id: energyMeter
+        version: 1
+      - id: powerConsumptionReport
+        version: 1
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: Light

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -593,7 +593,7 @@ local function build_child_switch_profiles(driver, device, main_endpoint)
   local parent_child_device = false
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
   table.sort(switch_eps)
-  for _, ep in ipairs(switch_eps) do
+  for idx, ep in ipairs(switch_eps) do
     if device:supports_server_cluster(clusters.OnOff.ID, ep) then
       num_switch_server_eps = num_switch_server_eps + 1
       if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
@@ -610,7 +610,7 @@ local function build_child_switch_profiles(driver, device, main_endpoint)
           }
         )
         parent_child_device = true
-        if _ == 1 and string.find(child_profile, "energy") then
+        if idx == 1 and string.find(child_profile, "energy") then
           -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
           device:set_field(ENERGY_MANAGEMENT_ENDPOINT, ep, {persist = true})
         end
@@ -695,8 +695,15 @@ local function device_init(driver, device)
     end
     local main_endpoint = find_default_endpoint(device)
     -- ensure subscription to all endpoint attributes- including those mapped to child devices
-    for _, ep in ipairs(device.endpoints) do
+    for idx, ep in ipairs(device.endpoints) do
       if ep.endpoint_id ~= main_endpoint then
+        if device:supports_server_cluster(clusters.OnOff.ID, ep) then
+          local child_profile = assign_child_profile(device, ep)
+          if idx == 1 and string.find(child_profile, "energy") then
+            -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
+            device:set_field(ENERGY_MANAGEMENT_ENDPOINT, ep, {persist = true})
+          end
+        end
         local id = 0
         for _, dt in ipairs(ep.device_types) do
           id = math.max(id, dt.device_type_id)

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
@@ -141,7 +141,6 @@ local function test_init()
   end
 
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
-  aqara_mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "doConfigure" })
   local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
   test.socket.matter:__expect_send({aqara_mock_device.id, read_attribute_list})

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -38,8 +38,7 @@ local aqara_mock_device = test.mock_device.build_test_matter_device({
       clusters = {
         {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
         {cluster_id = clusters.ElectricalPowerMeasurement.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 2 },
-        {cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 5 },
-        {cluster_id = clusters.PowerTopology.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 1 } -- NODE_TOPOLOGY
+        {cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 5 }
       },
       device_types = {
         {device_type_id = 0x0016, device_type_revision = 1}, -- RootNode
@@ -178,12 +177,10 @@ local function test_init()
     end
   end
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
-
-  -- Test added -> doConfigure logic
-  test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "added" })
-  test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "doConfigure" })
-  aqara_mock_device:expect_metadata_update({ profile = "4-button" })
+  test.mock_devices_api._expected_device_updates[aqara_mock_device.device_id] = "00000000-1111-2222-3333-000000000001"
+  test.mock_devices_api._expected_device_updates[1] = {device_id = "00000000-1111-2222-3333-000000000001"}
+  test.mock_devices_api._expected_device_updates[1].metadata = {deviceId="00000000-1111-2222-3333-000000000001", profileReference="4-button"}
   aqara_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(aqara_mock_device)
   -- to test powerConsumptionReport
@@ -280,7 +277,7 @@ test.register_coroutine_test(
         {
           -- don't use "aqara_mock_children[aqara_child1_ep].id,"
           -- because energy management is at the root endpoint.
-          aqara_mock_children[aqara_child1_ep].id,
+          aqara_mock_device.id,
           clusters.ElectricalPowerMeasurement.attributes.ActivePower:build_test_report_data(aqara_mock_device, 1, 17000)
         }
       )
@@ -292,7 +289,7 @@ test.register_coroutine_test(
 
       test.socket.matter:__queue_receive(
         {
-          aqara_mock_children[aqara_child1_ep].id,
+          aqara_mock_device.id,
           clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_device, 1, cumulative_report_val_19)
         }
       )
@@ -305,7 +302,7 @@ test.register_coroutine_test(
       -- This is because related variable settings are required in set_poll_report_timer_and_schedule().
       test.socket.matter:__queue_receive(
         {
-          aqara_mock_children[aqara_child1_ep].id,
+          aqara_mock_device.id,
           clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_device, 1, cumulative_report_val_29)
         }
       )
@@ -316,8 +313,10 @@ test.register_coroutine_test(
 
       test.socket.matter:__queue_receive(
         {
-          aqara_mock_children[aqara_child1_ep].id,
-          clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_device, 1, cumulative_report_val_39)
+          aqara_mock_device.id,
+          clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(
+            aqara_mock_device, 1, cumulative_report_val_39
+          )
         }
       )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -15,7 +15,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local uint32 = require "st.matter.data_types.Uint32"
 
 local clusters = require "st.matter.clusters"
 
@@ -43,7 +42,6 @@ local mock_device = test.mock_device.build_test_matter_device({
       clusters = {
         { cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", feature_map = 14, },
         { cluster_id = clusters.ElectricalPowerMeasurement.ID, cluster_type = "SERVER", feature_map = 0, },
-        { cluster_id = clusters.PowerTopology.ID, cluster_type = "SERVER", feature_map = 4, }, -- SET_TOPOLOGY
       },
       device_types = {
         { device_type_id = 0x0510, device_type_revision = 1 }, -- Electrical Sensor
@@ -53,30 +51,10 @@ local mock_device = test.mock_device.build_test_matter_device({
       endpoint_id = 2,
       clusters = {
         { cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 0, },
-        { cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
       },
       device_types = {
-        { device_type_id = 0x010B, device_type_revision = 1 }, -- OnOff Dimmable Plug
-      }
-    },
-        {
-      endpoint_id = 3,
-      clusters = {
-        { cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", feature_map = 14, },
-        { cluster_id = clusters.PowerTopology.ID, cluster_type = "SERVER", feature_map = 4, }, -- SET_TOPOLOGY
-      },
-      device_types = {
-        { device_type_id = 0x0510, device_type_revision = 1 }, -- Electrical Sensor
-      }
-    },
-    {
-      endpoint_id = 4,
-      clusters = {
-        { cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 0, },
-        { cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2},
-      },
-      device_types = {
-        { device_type_id = 0x010B, device_type_revision = 1 }, -- OnOff Dimmable Plug
+        { device_type_id = 0x010A, device_type_revision = 1 } -- OnOff Plug
       }
     },
   },
@@ -102,20 +80,16 @@ local mock_device_periodic = test.mock_device.build_test_matter_device({
     {
       endpoint_id = 1,
       clusters = {
-        { cluster_id = clusters.OnOff.ID, cluster_type = "SERVER", cluster_revision = 1, feature_map = 0, },
         { cluster_id = clusters.ElectricalEnergyMeasurement.ID, cluster_type = "SERVER", feature_map = 10, },
-        { cluster_id = clusters.PowerTopology.ID, cluster_type = "SERVER", feature_map = 4, } -- SET_TOPOLOGY
       },
       device_types = {
-        { device_type_id = 0x010A, device_type_revision = 1 }, -- OnOff Plug
-        { device_type_id = 0x0510, device_type_revision = 1 }, -- Electrical Sensor
+        { device_type_id = 0x0510, device_type_revision = 1 } -- Electrical Sensor
       }
     },
   },
 })
 
 local subscribed_attributes_periodic = {
-  clusters.OnOff.attributes.OnOff,
   clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported,
   clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported,
 }
@@ -669,30 +643,9 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test profile change on init for Electrical Sensor device type",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-    local read_req = clusters.PowerTopology.attributes.AvailableEndpoints:read(mock_device.id, 1)
-    read_req:merge(clusters.PowerTopology.attributes.AvailableEndpoints:read(mock_device.id, 3))
-    test.socket.matter:__expect_send({ mock_device.id, read_req })
-    local subscribe_request = subscribed_attributes[1]:subscribe(mock_device)
-    for i, cluster in ipairs(subscribed_attributes) do
-        if i > 1 then
-            subscribe_request:merge(cluster:subscribe(mock_device))
-        end
-    end
-    test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.wait_for_events()
-    test.socket.matter:__queue_receive({ mock_device.id, clusters.PowerTopology.attributes.AvailableEndpoints:build_test_report_data(mock_device, 1, {uint32(2)})})
-    test.socket.matter:__queue_receive({ mock_device.id, clusters.PowerTopology.attributes.AvailableEndpoints:build_test_report_data(mock_device, 3, {uint32(4)})})
     mock_device:expect_metadata_update({ profile = "plug-level-power-energy-powerConsumption" })
-    mock_device:expect_device_create({
-      type = "EDGE_CHILD",
-      label = "nil 2",
-      profile = "plug-level-energy-powerConsumption",
-      parent_device_id = mock_device.id,
-      parent_assigned_child_key = string.format("%d", 4)
-    })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   { test_init = test_init }
 )
@@ -700,21 +653,9 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Test profile change on init for only Periodic Electrical Sensor device type",
   function()
-    test.socket.device_lifecycle:__queue_receive({ mock_device_periodic.id, "added" })
-    local read_req = clusters.PowerTopology.attributes.AvailableEndpoints:read(mock_device_periodic.id, 1)
-    test.socket.matter:__expect_send({ mock_device_periodic.id, read_req })
-    local subscribe_request = subscribed_attributes_periodic[1]:subscribe(mock_device_periodic)
-    for i, cluster in ipairs(subscribed_attributes_periodic) do
-        if i > 1 then
-            subscribe_request:merge(cluster:subscribe(mock_device_periodic))
-        end
-    end
-    test.socket.matter:__expect_send({ mock_device_periodic.id, subscribe_request })
     test.socket.device_lifecycle:__queue_receive({ mock_device_periodic.id, "doConfigure" })
-    mock_device_periodic:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-    test.wait_for_events()
-    test.socket.matter:__queue_receive({ mock_device_periodic.id, clusters.PowerTopology.attributes.AvailableEndpoints:build_test_report_data(mock_device_periodic, 1, {uint32(1)})})
     mock_device_periodic:expect_metadata_update({ profile = "plug-energy-powerConsumption" })
+    mock_device_periodic:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   { test_init = test_init_periodic }
 )
@@ -751,7 +692,7 @@ test.register_message_test(
       direction = "receive",
       message = {
         mock_device.id,
-        clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
+        clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 2)
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
@@ -63,7 +63,6 @@ local function test_init()
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device)

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -90,7 +90,6 @@ local function test_init()
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.mock_device.add_test_device(mock_device)
-  mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ profile = "light-color-level-fan" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
@@ -122,7 +122,6 @@ local function test_init()
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device)

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -198,7 +198,6 @@ local function test_init()
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   mock_device:expect_metadata_update({ profile = "light-level-3-button" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -237,7 +236,6 @@ local function test_init_mcd_unsupported_switch_device_type()
     end
   end
   test.socket.matter:__expect_send({mock_device_mcd_unsupported_switch_device_type.id, subscribe_request})
-  mock_device_mcd_unsupported_switch_device_type:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_mcd_unsupported_switch_device_type.id, "doConfigure" })
   mock_device_mcd_unsupported_switch_device_type:expect_metadata_update({ profile = "2-button" })
   mock_device_mcd_unsupported_switch_device_type:expect_metadata_update({ provisioning_state = "PROVISIONED" })

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -409,7 +409,6 @@ local function test_init_parent_child_switch_types()
   local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_child_switch_types)
   test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
 
-  mock_device_parent_child_switch_types:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "doConfigure" })
   mock_device_parent_child_switch_types:expect_metadata_update({ profile = "switch-level" })
   mock_device_parent_child_switch_types:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -427,7 +426,6 @@ end
 
 local function test_init_onoff()
   test.mock_device.add_test_device(mock_device_onoff)
-  mock_device_onoff:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_onoff.id, "doConfigure" })
   mock_device_onoff:expect_metadata_update({ profile = "switch-binary" })
   mock_device_onoff:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -440,7 +438,6 @@ end
 local function test_init_parent_client_child_server()
   local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_client_child_server)
   test.socket.matter:__expect_send({mock_device_parent_client_child_server.id, subscribe_request})
-  mock_device_parent_client_child_server:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "doConfigure" })
   mock_device_parent_client_child_server:expect_metadata_update({ profile = "switch-binary" })
   mock_device_parent_client_child_server:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -449,7 +446,6 @@ end
 
 local function test_init_dimmer()
   test.mock_device.add_test_device(mock_device_dimmer)
-  mock_device_dimmer:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_dimmer.id, "doConfigure" })
   mock_device_dimmer:expect_metadata_update({ profile = "switch-level" })
   mock_device_dimmer:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -457,7 +453,6 @@ end
 
 local function test_init_color_dimmer()
   test.mock_device.add_test_device(mock_device_color_dimmer)
-  mock_device_color_dimmer:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_color_dimmer.id, "doConfigure" })
   mock_device_color_dimmer:expect_metadata_update({ profile = "switch-color-level" })
   mock_device_color_dimmer:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -474,9 +469,7 @@ local function test_init_mounted_on_off_control()
     end
   end
   test.socket.matter:__expect_send({mock_device_mounted_on_off_control.id, subscribe_request})
-  mock_device_mounted_on_off_control:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "doConfigure" })
-  mock_device_mounted_on_off_control:expect_metadata_update({ profile = "switch-binary" })
   mock_device_mounted_on_off_control:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device_mounted_on_off_control)
 end
@@ -492,16 +485,13 @@ local function test_init_mounted_dimmable_load_control()
     end
   end
   test.socket.matter:__expect_send({mock_device_mounted_dimmable_load_control.id, subscribe_request})
-  mock_device_mounted_dimmable_load_control:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "doConfigure" })
-  mock_device_mounted_dimmable_load_control:expect_metadata_update({ profile = "switch-level" })
   mock_device_mounted_dimmable_load_control:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device_mounted_dimmable_load_control)
 end
 
 local function test_init_water_valve()
   test.mock_device.add_test_device(mock_device_water_valve)
-  mock_device_water_valve:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_water_valve.id, "doConfigure" })
   mock_device_water_valve:expect_metadata_update({ profile = "water-valve-level" })
   mock_device_water_valve:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -529,9 +519,7 @@ local function test_init_parent_child_different_types()
   end
   test.socket.matter:__expect_send({mock_device_parent_child_different_types.id, subscribe_request})
 
-  mock_device_parent_child_different_types:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_different_types.id, "doConfigure" })
-  mock_device_parent_child_different_types:expect_metadata_update({ profile = "switch-binary" })
   mock_device_parent_child_different_types:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device_parent_child_different_types)
@@ -546,7 +534,6 @@ local function test_init_parent_child_different_types()
 end
 
 local function test_init_parent_child_unsupported_device_type()
-  mock_device_parent_child_unsupported_device_type:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_unsupported_device_type.id, "doConfigure" })
   mock_device_parent_child_unsupported_device_type:expect_metadata_update({ profile = "switch-binary" })
   mock_device_parent_child_unsupported_device_type:expect_metadata_update({ provisioning_state = "PROVISIONED" })
@@ -575,12 +562,7 @@ local function test_init_light_level_motion()
       subscribe_request:merge(cluster:subscribe(mock_device_light_level_motion))
     end
   end
-
   test.socket.matter:__expect_send({mock_device_light_level_motion.id, subscribe_request})
-  mock_device_light_level_motion:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
-  test.socket.device_lifecycle:__queue_receive({ mock_device_light_level_motion.id, "doConfigure" })
-  mock_device_light_level_motion:expect_metadata_update({ profile = "light-level-motion" })
-  mock_device_light_level_motion:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   test.mock_device.add_test_device(mock_device_light_level_motion)
 end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -180,9 +180,7 @@ local function test_init()
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 
-  mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  mock_device:expect_metadata_update({ profile = "light-binary" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device)
@@ -248,9 +246,7 @@ local function test_init_parent_child_endpoints_non_sequential()
   end
   test.socket.matter:__expect_send({mock_device_parent_child_endpoints_non_sequential.id, subscribe_request})
 
-  mock_device_parent_child_endpoints_non_sequential:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_endpoints_non_sequential.id, "doConfigure" })
-  mock_device_parent_child_endpoints_non_sequential:expect_metadata_update({ profile = "light-binary" })
   mock_device_parent_child_endpoints_non_sequential:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device_parent_child_endpoints_non_sequential)

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -23,8 +23,6 @@ local child_profile_override = t_utils.get_profile_definition("switch-binary.yml
 local parent_ep = 10
 local child1_ep = 20
 local child2_ep = 30
-local child3_ep = 40
-local child4_ep = 50
 
 local mock_device = test.mock_device.build_test_matter_device({
   label = "Matter Switch",
@@ -70,24 +68,6 @@ local mock_device = test.mock_device.build_test_matter_device({
         {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
       }
     },
-    {
-      endpoint_id = child3_ep,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-      },
-      device_types = {
-        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
-      }
-    },
-    {
-      endpoint_id = child4_ep,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-      },
-      device_types = {
-        {device_type_id = 0x010A, device_type_revision = 2} -- On/Off Plug
-      }
-    }
   }
 })
 
@@ -158,9 +138,7 @@ local function test_init()
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 
-  mock_device:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  mock_device:expect_metadata_update({ profile = "plug-binary" })
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device)
@@ -182,22 +160,6 @@ local function test_init()
     profile = "plug-binary",
     parent_device_id = mock_device.id,
     parent_assigned_child_key = string.format("%d", child2_ep)
-  })
-
-  mock_device:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Switch 4",
-    profile = "plug-binary",
-    parent_device_id = mock_device.id,
-    parent_assigned_child_key = string.format("%d", child3_ep)
-  })
-
-  mock_device:expect_device_create({
-    type = "EDGE_CHILD",
-    label = "Matter Switch 5",
-    profile = "plug-binary",
-    parent_device_id = mock_device.id,
-    parent_assigned_child_key = string.format("%d", child4_ep)
   })
 end
 
@@ -221,9 +183,7 @@ local function test_init_child_profile_override()
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_child_profile_override)
   test.socket.matter:__expect_send({mock_device_child_profile_override.id, subscribe_request})
 
-  mock_device_child_profile_override:set_field("__ELECTRICAL_TOPOLOGY", {topology = false, tags_on_ep = {}}, {persist = false}) -- since we're assuming this would have happened during device_added in this case.
   test.socket.device_lifecycle:__queue_receive({ mock_device_child_profile_override.id, "doConfigure" })
-  mock_device_child_profile_override:expect_metadata_update({ profile = "plug-binary" })
   mock_device_child_profile_override:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
   test.mock_device.add_test_device(mock_device_child_profile_override)


### PR DESCRIPTION
Reverts https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2199 and adds a check on `init` to set the previously used `ENERGY_MANAGEMENT_ENDPOINT` field on init for energy devices with child devices.

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


