### PR TITLE
Revert "philips-hue: Fix bug where `added` handler fails for migrated…

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
@@ -135,15 +135,12 @@ local valid_migration_kwargs = {
   "force_migrate_type"
 }
 function LifecycleHandlers.migrate_device(driver, device, ...)
+  local migration_kwargs = select(-1, ...)
   local opts = {}
-  local args = table.pack(...)
-  if #args > 0 then
-    local migration_kwargs = select(-1, ...)
-    if type(migration_kwargs) == "table" then
-      for _, key in ipairs(valid_migration_kwargs) do
-        if migration_kwargs[key] then
-          opts[key] = migration_kwargs[key]
-        end
+  if type(migration_kwargs) == "table" then
+    for _, key in ipairs(valid_migration_kwargs) do
+      if migration_kwargs[key] then
+        opts[key] = migration_kwargs[key]
       end
     end
   end


### PR DESCRIPTION
… devices"

This reverts commit 2533e079be45a5b4996fbc310f89d5863c2bddd4.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Reverts the change to fix the error in the migration path. Fixing this error allows the migration path to progress to the point where the driver is killed. These devices were already non-functional but killing the driver causes other devices that might have been functional to not work as well. 

# Summary of Completed Tests

I tested with the migration emulator script and deleted my _entire_ hue datastore. This caused by driver to get stuck in the crash loop and then when applying these changes to the driver, it caused the devices to fail their init handlers but the driver did not crash.
