### PR TITLE
Matter Switch: remove double init on device added

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -1325,8 +1325,12 @@ local function device_added(driver, device)
     device:send(req)
   end
 
-  -- call device init in case init is not called after added due to device caching
-  device_init(driver, device)
+
+  -- The device init event is guaranteed in FW versions 58+, so this is only needed for older hubs
+  if version.rpc < 10 then
+    -- call device init in case init is not called after added due to device caching
+    device_init(driver, device)
+  end
 end
 
 local function temperature_attr_handler(driver, device, ib, response)


### PR DESCRIPTION
The device_added handler was calling device_init in order to account for situations where device_init was not called due to a race condition with the device cache. Since lifecycle events are now guaranteed and ordered with FW 58, we no longer need to depend on this extra init.

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


