### PR TITLE
Add the fanSpeedPercent capability to specific devices

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-modular.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-modular.yml
@@ -9,6 +9,9 @@ components:
       - id: fanMode
         version: 1
         optional: true
+      - id: fanSpeedPercent
+        version: 1
+        optional: true
       - id: thermostatFanMode
         version: 1
         optional: true

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -81,6 +81,11 @@ local THERMOSTAT_OPERATING_MODE_MAP = {
   [6] = capabilities.thermostatOperatingState.thermostatOperatingState.fan_only,
 }
 
+-- Thermostat:devices that support PercentSetting and PercentCurrent
+local THERMOSTAT_SUPPORTED_PERCENT_PRODUCTS = {
+  {0x1575, 0x0001} -- Xizhen, 81MtAc01
+}
+
 local WIND_MODE_MAP = {
   [0] = capabilities.windMode.windMode.sleepWind,
   [1] = capabilities.windMode.windMode.naturalWind
@@ -1012,6 +1017,11 @@ local function match_modular_profile_thermostat(driver, device)
 
   if #fan_eps > 0 then
     table.insert(main_component_capabilities, capabilities.fanMode.ID)
+    for _, p in ipairs(THERMOSTAT_SUPPORTED_PERCENT_PRODUCTS) do
+      if device.manufacturer_info.vendor_id == p[1] and device.manufacturer_info.product_id == p[2] then
+        table.insert(main_component_capabilities, capabilities.fanSpeedPercent.ID)
+      end
+    end
   end
   if #rock_eps > 0 then
     table.insert(main_component_capabilities, capabilities.fanOscillationMode.ID)


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [√] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [√] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [√] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
We have a thermostat device that needs to add the ”fanSpeedPercent“ capability, so we made special modifications for it.

# Summary of Completed Tests
We added Unit Test and tested with real device.

