### PR TITLE
Modular Profiles: Gate HubCore 0.57 Release Required Logic

### DIFF
--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -492,9 +492,14 @@ end
 
 local function device_init(driver, device)
   if device:get_field(SUPPORTED_COMPONENT_CAPABILITIES) then
-    -- assume that device is using a modular profile, override supports_capability_by_id
-    -- library function to utilize optional capabilities
-    device:extend_device("supports_capability_by_id", supports_capability_by_id_modular)
+    if version.api >= 15 and version.rpc >= 9 then
+      -- the device used this modular profile workaround on 0.57 FW but no longer requires this table with >=0.58 FW
+      device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, nil)
+    else
+      -- assume that device is using a modular profile on 0.57 FW, override supports_capability_by_id
+      -- library function to utilize optional capabilities
+      device:extend_device("supports_capability_by_id", supports_capability_by_id_modular)
+    end
   end
   device:subscribe()
   device:set_component_to_endpoint_fn(component_to_endpoint)
@@ -985,14 +990,18 @@ local function match_modular_profile_air_purifer(driver, device)
 
   device:try_update_metadata({profile = profile_name, optional_component_capabilities = optional_supported_component_capabilities})
 
-  -- add mandatory capabilities for subscription
-  local total_supported_capabilities = optional_supported_component_capabilities
-  table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.airPurifierFanMode.ID)
-  table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.fanSpeedPercent.ID)
-  table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.refresh.ID)
-  table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.firmwareUpdate.ID)
+  -- earlier modular profile gating (min api v14, rpc 8) ensures we are running >= 0.57 FW.
+  -- This gating specifies a workaround required only for 0.57 FW, which is not needed for 0.58 and higher.
+  if version.api < 15 or version.rpc < 9 then
+    -- add mandatory capabilities for subscription
+    local total_supported_capabilities = optional_supported_component_capabilities
+    table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.airPurifierFanMode.ID)
+    table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.fanSpeedPercent.ID)
+    table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.refresh.ID)
+    table.insert(total_supported_capabilities[MAIN_COMPONENT_IDX][CAPABILITIES_LIST_IDX], capabilities.firmwareUpdate.ID)
 
-  device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, total_supported_capabilities, { persist = true })
+    device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, total_supported_capabilities, { persist = true })
+  end
 end
 
 local function match_modular_profile_thermostat(driver, device)
@@ -1035,14 +1044,18 @@ local function match_modular_profile_thermostat(driver, device)
   table.insert(optional_supported_component_capabilities, {"main", main_component_capabilities})
   device:try_update_metadata({profile = profile_name, optional_component_capabilities = optional_supported_component_capabilities})
 
-  -- add mandatory capabilities for subscription
-  local total_supported_capabilities = optional_supported_component_capabilities
-  table.insert(main_component_capabilities, capabilities.thermostatMode.ID)
-  table.insert(main_component_capabilities, capabilities.temperatureMeasurement.ID)
-  table.insert(main_component_capabilities, capabilities.refresh.ID)
-  table.insert(main_component_capabilities, capabilities.firmwareUpdate.ID)
+  -- earlier modular profile gating (min api v14, rpc 8) ensures we are running >= 0.57 FW.
+  -- This gating specifies a workaround required only for 0.57 FW, which is not needed for 0.58 and higher.
+  if version.api < 15 or version.rpc < 9 then
+    -- add mandatory capabilities for subscription
+    local total_supported_capabilities = optional_supported_component_capabilities
+    table.insert(main_component_capabilities, capabilities.thermostatMode.ID)
+    table.insert(main_component_capabilities, capabilities.temperatureMeasurement.ID)
+    table.insert(main_component_capabilities, capabilities.refresh.ID)
+    table.insert(main_component_capabilities, capabilities.firmwareUpdate.ID)
 
-  device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, total_supported_capabilities, { persist = true })
+    device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, total_supported_capabilities, { persist = true })
+  end
 end
 
 local function match_modular_profile_room_ac(driver, device)
@@ -1086,15 +1099,19 @@ local function match_modular_profile_room_ac(driver, device)
   table.insert(optional_supported_component_capabilities, {"main", main_component_capabilities})
   device:try_update_metadata({profile = profile_name, optional_component_capabilities = optional_supported_component_capabilities})
 
-  -- add mandatory capabilities for subscription
-  local total_supported_capabilities = optional_supported_component_capabilities
-  table.insert(main_component_capabilities, capabilities.switch.ID)
-  table.insert(main_component_capabilities, capabilities.temperatureMeasurement.ID)
-  table.insert(main_component_capabilities, capabilities.thermostatMode.ID)
-  table.insert(main_component_capabilities, capabilities.refresh.ID)
-  table.insert(main_component_capabilities, capabilities.firmwareUpdate.ID)
+  -- earlier modular profile gating (min api v14, rpc 8) ensures we are running >= 0.57 FW.
+  -- This gating specifies a workaround required only for 0.57 FW, which is not needed for 0.58 and higher.
+  if version.api < 15 or version.rpc < 9 then
+    -- add mandatory capabilities for subscription
+    local total_supported_capabilities = optional_supported_component_capabilities
+    table.insert(main_component_capabilities, capabilities.switch.ID)
+    table.insert(main_component_capabilities, capabilities.temperatureMeasurement.ID)
+    table.insert(main_component_capabilities, capabilities.thermostatMode.ID)
+    table.insert(main_component_capabilities, capabilities.refresh.ID)
+    table.insert(main_component_capabilities, capabilities.firmwareUpdate.ID)
 
-  device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, total_supported_capabilities, { persist = true })
+    device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, total_supported_capabilities, { persist = true })
+  end
 end
 
 local function match_modular_profile(driver, device, device_type)

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier_modular.lua
@@ -15,8 +15,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
-local dkjson = require "dkjson"
 local clusters = require "st.matter.clusters"
 local im = require "st.matter.interaction_model"
 local uint32 = require "st.matter.data_types.Uint32"
@@ -326,10 +324,10 @@ test.register_coroutine_test(
 
     test.wait_for_events()
 
-    local device_info_copy = utils.deep_copy(mock_device_basic.raw_st_data)
-    device_info_copy.profile.id = "air-purifier-modular"
-    local device_info_json = dkjson.encode(device_info_copy)
-    test.socket.device_lifecycle:__queue_receive({ mock_device_basic.id, "infoChanged", device_info_json })
+    local updated_device_profile = t_utils.get_profile_definition("air-purifier-modular.yml",
+      {enabled_optional_capabilities = expected_update_metadata.optional_component_capabilities}
+    )
+    test.socket.device_lifecycle:__queue_receive(mock_device_basic:generate_info_changed({ profile = updated_device_profile }))
     test.socket.matter:__expect_send({mock_device_basic.id, subscribe_request})
   end,
   { test_init = test_init_basic }
@@ -400,10 +398,10 @@ test.register_coroutine_test(
 
     test.wait_for_events()
 
-    local device_info_copy = utils.deep_copy(mock_device_ap_thermo_aqs.raw_st_data)
-    device_info_copy.profile.id = "air-purifier-modular"
-    local device_info_json = dkjson.encode(device_info_copy)
-    test.socket.device_lifecycle:__queue_receive({ mock_device_ap_thermo_aqs.id, "infoChanged", device_info_json })
+    local updated_device_profile = t_utils.get_profile_definition("air-purifier-modular.yml",
+      {enabled_optional_capabilities = expected_update_metadata.optional_component_capabilities}
+    )
+    test.socket.device_lifecycle:__queue_receive(mock_device_ap_thermo_aqs:generate_info_changed({ profile = updated_device_profile }))
     test.socket.matter:__expect_send({mock_device_ap_thermo_aqs.id, subscribe_request})
   end,
   { test_init = test_init_ap_thermo_aqs_preconfigured }

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac_modular.lua
@@ -14,8 +14,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
-local dkjson = require "dkjson"
 local clusters = require "st.matter.clusters"
 local im = require "st.matter.interaction_model"
 local uint32 = require "st.matter.data_types.Uint32"
@@ -291,11 +289,10 @@ local function test_room_ac_device_type_update_modular_profile(generic_mock_devi
     clusters.Thermostat.attributes.AttributeList:build_test_report_data(generic_mock_device, 1, {thermostat_attr_list_value})
   })
   generic_mock_device:expect_metadata_update(expected_metadata)
-
-  local device_info_copy = utils.deep_copy(generic_mock_device.raw_st_data)
-  device_info_copy.profile.id = "room-air-conditioner-modular"
-  local device_info_json = dkjson.encode(device_info_copy)
-  test.socket.device_lifecycle:__queue_receive({ generic_mock_device.id, "infoChanged", device_info_json })
+  local updated_device_profile = t_utils.get_profile_definition("air-purifier-modular.yml",
+    {enabled_optional_capabilities = expected_metadata.optional_component_capabilities}
+  )
+  test.socket.device_lifecycle:__queue_receive(generic_mock_device:generate_info_changed({ profile = updated_device_profile }))
   test.socket.matter:__expect_send({generic_mock_device.id, subscribe_request})
 end
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
@@ -15,9 +15,7 @@
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"
-local dkjson = require "dkjson"
 local uint32 = require "st.matter.data_types.Uint32"
-local utils = require "st.utils"
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("thermostat-humidity-fan.yml"),
@@ -196,10 +194,10 @@ local function test_thermostat_device_type_update_modular_profile(generic_mock_d
 
   test.wait_for_events()
 
-  local device_info_copy = utils.deep_copy(generic_mock_device.raw_st_data)
-  device_info_copy.profile.id = "thermostat-modular"
-  local device_info_json = dkjson.encode(device_info_copy)
-  test.socket.device_lifecycle:__queue_receive({ generic_mock_device.id, "infoChanged", device_info_json })
+  local updated_device_profile = t_utils.get_profile_definition("thermostat-modular.yml",
+    {enabled_optional_capabilities = expected_metadata.optional_component_capabilities}
+  )
+  test.socket.device_lifecycle:__queue_receive(generic_mock_device:generate_info_changed({ profile = updated_device_profile }))
   test.socket.matter:__expect_send({generic_mock_device.id, subscribe_request})
 end
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_modular.lua
@@ -15,10 +15,8 @@
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"
-local dkjson = require "dkjson"
 local im = require "st.matter.interaction_model"
 local uint32 = require "st.matter.data_types.Uint32"
-local utils = require "st.utils"
 
 test.disable_startup_messages()
 
@@ -122,10 +120,10 @@ local function test_thermostat_device_type_update_modular_profile(generic_mock_d
   })
   generic_mock_device:expect_metadata_update(expected_metadata)
 
-  local device_info_copy = utils.deep_copy(generic_mock_device.raw_st_data)
-  device_info_copy.profile.id = "thermostat-modular"
-  local device_info_json = dkjson.encode(device_info_copy)
-  test.socket.device_lifecycle:__queue_receive({ generic_mock_device.id, "infoChanged", device_info_json })
+  local updated_device_profile = t_utils.get_profile_definition("thermostat-modular.yml",
+    {enabled_optional_capabilities = expected_metadata.optional_component_capabilities}
+  )
+  test.socket.device_lifecycle:__queue_receive(mock_device_basic:generate_info_changed({ profile = updated_device_profile }))
   test.socket.matter:__expect_send({generic_mock_device.id, subscribe_request})
 end
 


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Gate pre-0.58 logic for modular profiling. It is confirmed that these versions have been bumped in 0.58.

# Summary of Completed Tests
Test Devices Used: VDA versions of all affected device types (Air Quality Sensor, Air Purifier, Thermostat, and Room Air Conditioner)

Tests Completed:
1. For each of the above device types, when run on the 0.58.x Hub firmware it was confirmed through logs that the proper subscriptions were handled for each device's particular capability-attribute mapping. Further, extra debug logic was included to ensure the proper profile was directly being serialized into lua.
2. Testing with the AP and AQS VDA, when run on the released 0.57 Hub firmware, it was confirmed through subscription logs that when moving from the previous production driver to this change, the correct subscription continues to hold.
3. Testing with the AP and AQS VDA. when run on the 0.58 Hub firmware, it was confirmed through subscription logs that when moving from the previous production driver to this change, the correct subscription continues to hold.