### PR TITLE
sonos: Add persistent token refresher task

### DIFF
--- a/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
+++ b/drivers/SmartThings/sonos/src/api/cmd_handlers.lua
@@ -24,9 +24,9 @@ local function _do_send_to_group(driver, device, payload)
   local household_id, group_id = driver.sonos:get_group_for_device(device)
   payload[1].householdId = household_id
   payload[1].groupId = group_id
-  local maybe_token, err = driver:get_oauth_token()
+  local maybe_token, err = driver:wait_for_oauth_token(30)
   if err then
-    log.warn(string.format("notice: get_oauth_token -> %s", err))
+    log.warn(string.format("notice: wait_for_oauth_token -> %s", err))
   end
 
   if maybe_token then
@@ -40,9 +40,9 @@ local function _do_send_to_self(driver, device, payload)
   local household_id, player_id = driver.sonos:get_player_for_device(device)
   payload[1].householdId = household_id
   payload[1].playerId = player_id
-  local maybe_token, err = driver:get_oauth_token()
+  local maybe_token, err = driver:wait_for_oauth_token(30)
   if err then
-    log.warn(string.format("notice: get_oauth_token -> %s", err))
+    log.warn(string.format("notice: wait_for_oauth_token -> %s", err))
   end
 
   if maybe_token then

--- a/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
+++ b/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
@@ -82,16 +82,9 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
                   local token, token_recv_err
                   -- max 30 mins
                   local backoff_builder = utils.backoff_builder(60 * 30, 30, 2)
-                  if not driver:is_waiting_for_oauth_token() then
-                    local _, request_token_err = driver:request_oauth_token()
-                    if request_token_err then
-                      log.warn(string.format("Error sending token request: %s", request_token_err))
-                    end
-                  end
 
                   local backoff_timer = nil
                   while not token do
-                    local send_request = false
                     -- we use the backoff to create a timer and utilize a select loop here, instead of
                     -- utilizing a sleep, so that we can create a long delay on our polling of the cloud
                     -- without putting ourselves in a situation where we're sleeping for an extended period
@@ -117,7 +110,6 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
                         --
                         -- This is just in case both receivers are ready, so that we can prioritize
                         -- handling the token instead of putting another request in flight.
-                        send_request = true
                         backoff_timer:handled()
                         backoff_timer = nil
                       end
@@ -136,17 +128,6 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
                           token_recv_err
                         )
                       )
-                    end
-
-                    if send_request then
-                      if not driver:is_waiting_for_oauth_token() then
-                        local _, request_token_err = driver:request_oauth_token()
-                        if request_token_err then
-                          log.warn(
-                            string.format("Error sending token request: %s", request_token_err)
-                          )
-                        end
-                      end
                     end
                   end
                 else

--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -222,6 +222,10 @@ end
 function SonosDriver:handle_startup_state_received()
   self:start_ssdp_event_task()
   self:notify_augmented_data_changed "snapshot"
+  if api_version >= 14 and security ~= nil then
+    local token_refresher = require "token_refresher"
+    token_refresher.spawn_token_refresher(self)
+  end
   self.startup_state_received = true
   for _, device in pairs(self.devices_waiting_for_startup_state) do
     SonosDriverLifecycleHandlers.initialize_device(self, device)

--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -25,8 +25,6 @@ if not security_load_success then
   security = nil
 end
 
-local ONE_HOUR_IN_SECONDS = 3600
-
 ---@class SonosDriver: Driver
 ---
 ---@field public datastore table<string, any> driver persistent store
@@ -384,13 +382,6 @@ function SonosDriver:get_oauth_token()
     local now = os.time()
     -- token has not expired yet
     if now < expiration then
-      -- token is expiring soon, so we pre-emptively refresh
-      if math.abs(expiration - now) < ONE_HOUR_IN_SECONDS then
-        local result, err = security.get_sonos_oauth()
-        if not result then
-          log.warn(string.format("Error requesting OAuth token via Security API: %s", err))
-        end
-      end
       return self.oauth.token
     else
       return nil, "token expired"

--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -189,9 +189,7 @@ end
 ---@param update_key "endpointAppInfo"|"sonosOAuthToken"
 ---@param update_value string
 function SonosDriver:notify_augmented_data_changed(update_kind, update_key, update_value)
-  local already_connected = self.oauth
-    and self.oauth.endpoint_app_info
-    and self.oauth.endpoint_app_info.state == "connected"
+  local already_connected = self:oauth_is_connected()
   log.info(string.format("Already connected? %s", already_connected))
   if update_kind == "snapshot" then
     self:update_after_startup_state_received()
@@ -251,12 +249,7 @@ end
 function SonosDriver:check_auth(info_or_device)
   local maybe_token, _ = self:get_oauth_token()
 
-  local token_valid = (api_version >= 14 and security ~= nil)
-    and self.oauth
-    and self.oauth.endpoint_app_info
-    and self.oauth.endpoint_app_info.state == "connected"
-    and maybe_token ~= nil
-  if token_valid then
+  if maybe_token then
     return true, SonosApi.api_keys.oauth_key
   elseif self.oauth.force_oauth then
     return false
@@ -369,23 +362,14 @@ function SonosDriver:request_oauth_token()
 end
 
 ---@return { accessToken: string, expiresAt: number }? the token if a currently valid token is available, nil if not
----@return "token expired"|"no token"|"not supported"|nil reason the reason a token was not provided, nil if there is a valid token available
+---@return "token expired"|"no token"|"not supported"|"not connected"|nil reason the reason a token was not provided, nil if there is a valid token available
 function SonosDriver:get_oauth_token()
   if api_version < 14 or security == nil then
     return nil, "not supported"
   end
-  self.hub_augmented_driver_data = self.hub_augmented_driver_data or {}
-  local decode_success, maybe_token =
-    pcall(json.decode, self.hub_augmented_driver_data.sonosOAuthToken)
-  if
-    decode_success
-    and type(maybe_token) == "table"
-    and type(maybe_token.accessToken) == "string"
-    and type(maybe_token.expiresAt) == "number"
-  then
-    self.oauth.token = maybe_token
-  elseif self.hub_augmented_driver_data.sonosOAuthToken ~= nil then
-    log.warn(string.format("Unable to JSON decode token from hub augmented data: %s", maybe_token))
+
+  if not self:oauth_is_connected() then
+    return nil, "not connected"
   end
 
   if self.oauth.token then
@@ -400,6 +384,13 @@ function SonosDriver:get_oauth_token()
   end
 
   return nil, "no token"
+end
+
+function SonosDriver:oauth_is_connected()
+  return (api_version >= 14 and security ~= nil)
+    and self.oauth
+    and self.oauth.endpoint_app_info
+    and self.oauth.endpoint_app_info.state == "connected"
 end
 
 ---Create a cosock task that handles events from the persistent SSDP task.

--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -184,7 +184,7 @@ end
 ---@param update_key "endpointAppInfo"|"sonosOAuthToken"
 ---@param update_value string
 function SonosDriver:notify_augmented_data_changed(update_kind, update_key, update_value)
-  local already_connected = self:oauth_is_connected()
+  local already_connected = self:oauth_app_connected()
   log.info(string.format("Already connected? %s", already_connected))
   if update_kind == "snapshot" then
     self:update_after_startup_state_received()
@@ -335,7 +335,7 @@ function SonosDriver:get_oauth_token()
     return nil, "not supported"
   end
 
-  if not self:oauth_is_connected() then
+  if not self:oauth_app_connected() then
     return nil, "not connected"
   end
 
@@ -358,7 +358,7 @@ function SonosDriver:wait_for_oauth_token(timeout)
     return nil, "not supported"
   end
 
-  if not self:oauth_is_connected() then
+  if not self:oauth_app_connected() then
     return nil, "not connected"
   end
 
@@ -381,7 +381,7 @@ function SonosDriver:wait_for_oauth_token(timeout)
   return nil, err
 end
 
-function SonosDriver:oauth_is_connected()
+function SonosDriver:oauth_app_connected()
   return (api_version >= 14 and security ~= nil)
     and self.oauth
     and self.oauth.endpoint_app_info

--- a/drivers/SmartThings/sonos/src/sonos_driver.lua
+++ b/drivers/SmartThings/sonos/src/sonos_driver.lua
@@ -114,11 +114,6 @@ function SonosDriver:handle_augmented_data_change(update_key, decoded)
   end
 end
 
----@return boolean
-function SonosDriver:is_waiting_for_oauth_token()
-  return (api_version >= 14 and security ~= nil) and self.waiting_for_oauth_token
-end
-
 ---@return (cosock.Bus.Subscription)? receiver the subscription receiver if the bus hasn't been closed, nil if closed
 ---@return nil|"not supported"|"closed" err_msg "not supported" on old API versions, "closed" if the bus is closed, nil on success
 function SonosDriver:oauth_token_event_subscribe()
@@ -205,17 +200,6 @@ function SonosDriver:notify_augmented_data_changed(update_kind, update_key, upda
         true
       )
     )
-  end
-
-  if
-    self.oauth.endpoint_app_info
-    and self.oauth.endpoint_app_info.state == "connected"
-    and not already_connected
-  then
-    local _, err = self:request_oauth_token()
-    if err then
-      log.error(string.format("Request OAuth token error: %s", err))
-    end
   end
 end
 
@@ -342,27 +326,6 @@ function SonosDriver:check_auth(info_or_device)
       "Unable to determine Authentication Status for %s",
       st_utils.stringify_table(info_or_device)
     )
-end
-
----@return any? ret nil on permissions violation
----@return string? error nil on success
-function SonosDriver:request_oauth_token()
-  if api_version < 14 or security == nil then
-    return nil, "not supported"
-  end
-  local maybe_token, maybe_err = self:get_oauth_token()
-  if maybe_err then
-    log.warn(string.format("get oauth token error: %s", maybe_err))
-  end
-  if type(maybe_token) == "table" and type(maybe_token.accessToken) == "string" then
-    self.oauth_token_bus:send(maybe_token)
-  end
-  local result, err = security.get_sonos_oauth()
-  if not result then
-    return nil, string.format("Error requesting OAuth token via Security API: %s", err)
-  end
-  self.waiting_for_oauth_token = true
-  return result, err
 end
 
 ---@return { accessToken: string, expiresAt: number }? the token if a currently valid token is available, nil if not
@@ -653,7 +616,6 @@ function SonosDriver.new_driver_template()
     oauth_token_bus = oauth_token_bus,
     oauth_info_bus = oauth_info_bus,
     oauth = {},
-    waiting_for_oauth_token = false,
     startup_state_received = false,
     devices_waiting_for_startup_state = {},
     bonded_devices = utils.new_mac_address_keyed_table(),

--- a/drivers/SmartThings/sonos/src/token_refresher.lua
+++ b/drivers/SmartThings/sonos/src/token_refresher.lua
@@ -1,0 +1,152 @@
+local cosock = require "cosock"
+local utils = require "utils"
+local security = require "st.security"
+local log = require "log"
+
+local module = {}
+
+local ACTIONS = {
+  -- This action waits for an event via the oauth endpoint app info bus in order to determine
+  -- when the driver goes from a disconnected to connected state.
+  WAIT_FOR_CONNECTED = 1,
+  -- This action will wait for the current valid token to expire. It will also handle a new token
+  -- event to redetermine the current action. New tokens that come in during this action will likely
+  -- be from debug testing.
+  WAIT_FOR_EXPIRE = 2,
+  -- This action requests a new token and waits for it to come in.
+  REQUEST_TOKEN = 3,
+}
+
+local ACTION_STRINGIFY = {
+  [ACTIONS.WAIT_FOR_CONNECTED] = "wait for connected",
+  [ACTIONS.WAIT_FOR_EXPIRE] = "wait for expire",
+  [ACTIONS.REQUEST_TOKEN] = "request token",
+}
+
+local Refresher = {}
+Refresher.__index = Refresher
+
+--- Determine which action the refresher should take.
+--- This just depends on:
+--- - Is Oauth connected?
+--- - Do we have a valid token?
+function Refresher:determine_action()
+  if not self.driver:oauth_is_connected() then
+    -- Oauth is disconnected so no point in trying to request a token until we are connected.
+    return ACTIONS.WAIT_FOR_CONNECTED
+  end
+  local token, _ = self.driver:get_oauth_token()
+  if token then
+    local now = os.time()
+    local expiration = math.floor(token.expiresAt / 1000)
+    if (expiration - now) > 60 then
+      -- Token is valid and not expiring in the next 60 seconds.
+      return ACTIONS.WAIT_FOR_EXPIRE
+    end
+  end
+  -- We don't have a valid token or it is about to expire soon.
+  return ACTIONS.REQUEST_TOKEN
+end
+
+--- Waits for a token event with a timeout.
+--- @param timeout number How long the function will wait for a new token
+function Refresher:try_wait_for_token_event(timeout)
+  local token_bus, err = self.driver:oauth_token_event_subscribe()
+  if err == "closed" then
+    self.token_bus_closed = true
+  end
+  if token_bus then
+    token_bus:settimeout(timeout)
+    token_bus:receive()
+  end
+end
+
+--- Waits for the current token to expire or a new token event.
+---
+--- The likely outcome of this function is to wait the entire expiration timeout. It will
+--- also listen for token events just in case a new token with a new expiration is sent to the driver.
+--- A new token would most likely come from developer testing, but since the new token requests are
+--- not synchronous one could come from an earlier request.
+function Refresher:wait_for_expire_or_token_event()
+  local maybe_token, err = self.driver:get_oauth_token()
+  if not maybe_token then
+    -- Something got funky in the state machine, return and re-determine our next action
+    log.warn(string.format("Tried to wait for expiration of non-existent token: %s", err))
+    return
+  end
+  -- The token will be refreshed if requested within 1 minute of expiration
+  local expiration = math.floor(maybe_token.expiresAt / 1000) - 60
+  local now = os.time()
+  local timeout = math.max(expiration - now, 0)
+
+  log.debug(string.format("Token will refresh in %d seconds", timeout))
+  -- Wait while trying to receive a token event in case it gets updated for some reason.
+  self:try_wait_for_token_event(timeout)
+end
+
+--- Waits for an oauth endpoint app info event indefinitely.
+---
+--- A new info event indicates that `Refresher:determine_action` should be called to check if oauth
+--- is now connected.
+function Refresher:wait_for_info_event()
+  local info_sub, err = self.driver:oauth_info_event_subscribe()
+  if err == "closed" then
+    self.info_bus_closed = true
+  end
+  if info_sub then
+    info_sub:receive()
+  end
+end
+
+--- Requests a token then waits for a new token event.
+function Refresher:request_token()
+  local result, err = security.get_sonos_oauth()
+  if not result then
+    log.warn(string.format("Failed to request oauth token: %s", err))
+  end
+  -- Try to receive token even if the request failed.
+  self:try_wait_for_token_event(10)
+  local maybe_token, _ = self.driver:get_oauth_token()
+  if maybe_token then
+    -- token is valid, reset backoff
+    self.token_backoff = utils.backoff_builder(30 * 60, 5, 0.1)
+  else
+    -- We either didn't receive a token or it is not valid.
+    -- Backoff and maybe we will receive it in that time, or we retry.
+    cosock.socket.sleep(self.token_backoff())
+  end
+end
+
+function module.spawn_token_refresher(driver)
+  local refresher = setmetatable({ driver = driver,
+                                   token_backoff = utils.backoff_builder(30 * 60, 5, 0.1),
+                                  },
+                                  Refresher)
+  cosock.spawn(function ()
+    while true do
+      -- We can always determine what we should be doing based off the information we have,
+      -- any action can proceed action depending on what needs to be done.
+      local action = refresher:determine_action()
+      log.info(string.format("Token refresher action: %s", ACTION_STRINGIFY[action]))
+      if action == ACTIONS.WAIT_FOR_CONNECTED then
+        refresher:wait_for_info_event()
+      elseif action == ACTIONS.WAIT_FOR_EXPIRE then
+        refresher:wait_for_expire_or_token_event()
+      elseif action == ACTIONS.REQUEST_TOKEN then
+        refresher:request_token()
+      else
+        log.error(string.format("Token refresher task exiting due to bad token refresher action: %s", action))
+        return
+      end
+      if refresher.token_bus_closed or refresher.info_bus_closed then
+        log.error(string.format("Token refresher task exiting. Token bus closed: %s Info bus close: %s",
+          refresher.token_bus_closed, refresher.info_bus_closed))
+        return
+      end
+    end
+  end, "token refresher task")
+end
+
+return module
+
+

--- a/drivers/SmartThings/sonos/src/token_refresher.lua
+++ b/drivers/SmartThings/sonos/src/token_refresher.lua
@@ -31,7 +31,7 @@ Refresher.__index = Refresher
 --- - Is Oauth connected?
 --- - Do we have a valid token?
 function Refresher:determine_action()
-  if not self.driver:oauth_is_connected() then
+  if not self.driver:oauth_app_connected() then
     -- Oauth is disconnected so no point in trying to request a token until we are connected.
     return ACTIONS.WAIT_FOR_CONNECTED
   end


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change fixes a potential issue where the driver's oauth token is expired and a capability command comes in before the hourly auth check (via SSDP event handler) happens. The command would not be handled because the driver doesn't have a valid token and there is no retry mechanism.

The crux of this change is adding a persistent token refresher task that tracks when the token expires and refreshes the token when it will expire in under a minute (Same value Viper uses when determining to refresh a token). 

The token refresher task has 3 actions that it can take based off the current state of the driver:
- If oauth is not connected, then the refresher will wait until it is connected. We cannot request tokens if this is not in a connected state.
- If oauth is connected and we have a valid token that is not set to expire within the next minute, then wait for the token to expire.
- If oauth is connected and we don't have a valid token, then request a new token and wait for it to arrive.

Commit by commit this change:
- Removes the previous preemptive token refreshing. This was not valid and would only refresh the token if the time to expire was within 1 minute.
- Add a new oauth endpoint app info bus to alert subscribers of new endpoint app info. This is used to alert the refresher when we go from a disconnected -> connected state.
- Add checks to the oauth token getter such that we only return a token if we are in a connected state. This avoids situation where we might be using an invalid token. Also adds the oauth_is_connected check to be used elsewhere.
- Add the token refresher task.
- Remove token requests from everywhere else in the driver. We don't want to be spamming this elsewhere if we are already on top of it.
- Add a wait for token function for the command handlers to use where it will wait for a token if it it should. It should be very rare where we actually need to wait.


# Summary of Completed Tests

I have tested some basic functionality but will come up with a test plan for thinktank and myself to run through.
