### PR TITLE
preventing unnecessary emitting in edge driver

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
@@ -59,7 +59,9 @@ end
 
 local device_added = function(self, device)
   lock_utils.populate_state_from_data(device)
-  device:emit_event(capabilities.lock.lock.unlocked())
+  if device:get_latest_state("main", capabilities.lock.ID, capabilities.lock.lock.NAME) == nil and device:supports_capability(capabilities.lock) then
+    device:emit_event(capabilities.lock.lock.unlocked())
+  end
   device:emit_event(capabilities.battery.battery(100))
 end
 

--- a/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/arrival-sensor-v1/init.lua
@@ -101,7 +101,9 @@ local function beep_handler(self, device, command)
 end
 
 local function added_handler(self, device)
-  device:emit_event(PresenceSensor.presence("present"))
+  if device:get_latest_state("main", PresenceSensor.ID, PresenceSensor.presence.NAME) == nil and device:supports_capability(PresenceSensor) then
+    device:emit_event(PresenceSensor.presence("present"))
+  end
 end
 
 local function init_handler(self, device, event, args)

--- a/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
@@ -140,7 +140,9 @@ local function beep_handler(self, device, command)
 end
 
 local function added_handler(self, device)
-  device:emit_event(PresenceSensor.presence("present"))
+  if device:get_latest_state("main", PresenceSensor.ID, PresenceSensor.presence.NAME) == nil and device:supports_capability(PresenceSensor) then
+    device:emit_event(PresenceSensor.presence("present"))
+  end
   device:set_field(IS_PRESENCE_BASED_ON_BATTERY_REPORTS, false, {persist = true})
   device:send(PowerConfiguration.attributes.BatteryVoltage:read(device))
 end

--- a/drivers/SmartThings/zigbee-thermostat/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/aqara/init.lua
@@ -116,11 +116,13 @@ local function device_added(driver, device)
   device:emit_event(capabilities.temperatureMeasurement.temperature({value = 27.0, unit = "C"}))
   device:emit_event(capabilities.thermostatMode.thermostatMode.manual())
   device:emit_event(capabilities.valve.valve.open())
-  device:emit_component_event(device.profile.components.ChildLock, capabilities.lock.lock.unlocked())
   device:emit_event(capabilities.hardwareFault.hardwareFault.clear())
   device:emit_event(valveCalibration.calibrationState.calibrationPending())
   device:emit_event(invisibleCapabilities.invisibleCapabilities({""}))
   device:emit_event(capabilities.battery.battery(100))
+  if device:get_latest_state("main", capabilities.lock.ID, capabilities.lock.lock.NAME) == nil and device:supports_capability(capabilities.lock) then
+    device:emit_component_event(device.profile.components.ChildLock, capabilities.lock.lock.unlocked())
+  end
 end
 
 local function thermostat_alarm_status_handler(driver, device, value, zb_rx)

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
@@ -68,10 +68,13 @@ end
 
 local function device_added(driver, device)
   do_refresh(driver, device)
-  device:emit_event(capabilities.tamperAlert.tamper.clear())
-  device:emit_event(capabilities.contactSensor.contact.open())
+  if device:get_latest_state("main", capabilities.contactSensor.ID, capabilities.contactSensor.contact.NAME) == nil and device:supports_capability(capabilities.contactSensor) then
+    device:emit_event(capabilities.contactSensor.contact.open())
+  end
+  if device:get_latest_state("main", capabilities.tamperAlert.ID, capabilities.tamperAlert.tamper.NAME) == nil and device:supports_capability(capabilities.tamperAlert) then
+    device:emit_event(capabilities.tamperAlert.tamper.clear())
+  end
 end
-
 
 local fibaro_door_window_sensor_1 = {
   NAME = "fibaro door window sensor 1",

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
@@ -34,9 +34,15 @@ local function can_handle_fibaro_door_window_sensor_2(opts, driver, device, cmd,
 end
 
 local function device_added(self, device)
-  device:emit_event(capabilities.tamperAlert.tamper.clear())
-  device:emit_event(capabilities.contactSensor.contact.open())
-  device:emit_event(capabilities.temperatureAlarm.temperatureAlarm.cleared())
+  if device:get_latest_state("main", capabilities.tamperAlert.ID, capabilities.tamperAlert.tamper.NAME) == nil and device:supports_capability(capabilities.tamperAlert) then
+    device:emit_event(capabilities.tamperAlert.tamper.clear())
+  end
+  if device:get_latest_state("main", capabilities.contactSensor.ID, capabilities.contactSensor.contact.NAME) == nil and device:supports_capability(capabilities.contactSensor) then
+    device:emit_event(capabilities.contactSensor.contact.open())
+  end
+  if device:get_latest_state("main", capabilities.temperatureAlarm.ID, capabilities.temperatureAlarm.temperatureAlarm.NAME) == nil and device:supports_capability(capabilities.temperatureAlarm) then
+    device:emit_event(capabilities.temperatureAlarm.temperatureAlarm.cleared())
+  end
 end
 
 local function alarm_report_handler(self, device, cmd)


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [X] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code in hard-to-understand areas
- [X] I have verified my changes by testing with a device or have communicated a plan for testing
- [X] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
There’re VoCs about ZigBee Things reported from Korean Market while user is doing switchover, a device event emitting may be called to initialize device state from edge driver to cloud, so an unexpected routine could be triggered and make user confused.
we change the driver code to avoid emitting unnecessary event during the hub switch-over by checking the latest state, only focus on the important(security related) events, 'open', 'present', 'unlocked'.
# Summary of Completed Tests


