### PR TITLE
Add missed optional capabilities to thermostat modular profile

### DIFF
--- a/drivers/SmartThings/matter-thermostat/profiles/thermostat-modular.yml
+++ b/drivers/SmartThings/matter-thermostat/profiles/thermostat-modular.yml
@@ -9,6 +9,12 @@ components:
       - id: fanMode
         version: 1
         optional: true
+      - id: fanOscillationMode
+        version: 1
+        optional: true
+      - id: windMode
+        version: 1
+        optional: true
       - id: thermostatFanMode
         version: 1
         optional: true


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
These capabilities (fanOscillationMode, windMode) are optionally addable per the thermostat device type configuration logic, but were never actually added to the thermostat modular profile definition.

# Summary of Completed Tests


