### PR TITLE
Update leviton-zw6hd.yml to expand range 99->100

### DIFF
--- a/drivers/SmartThings/zwave-switch/profiles/leviton-zw6hd.yml
+++ b/drivers/SmartThings/zwave-switch/profiles/leviton-zw6hd.yml
@@ -10,7 +10,7 @@ components:
     config:
       values:
         - key: "level.value"
-          range: [1, 99]
+          range: [1, 100]
   - id: refresh
     version: 1
   categories:


### PR DESCRIPTION
We are seeing issues when the zwave range is report is 99, the ST app claims it is out of range.   All other drivers go to 100 range, so I believe this is the source of the issue, so changing our driver to match

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- X Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- X I have performed a self-review of my code
- X I have commented my code in hard-to-understand areas
- X I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Change the max range of z-wave dimmer from 99 to 100

# Summary of Completed Tests


