### PR TITLE
Matter Thermostat: edit generic fingerprints to more minimal lists of capabilities

### DIFF
--- a/drivers/SmartThings/matter-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/matter-thermostat/fingerprints.yml
@@ -66,55 +66,55 @@ matterGeneric:
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0300 # HVAC Heating/Cooling Unit
-    deviceProfileName: thermostat
+    deviceProfileName: thermostat-nostate-nobattery
   - id: "matter/hvac/thermostat"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0301 # Thermostat
-    deviceProfileName: thermostat
+    deviceProfileName: thermostat-nostate-nobattery
   - id: "matter/hvac/heatcool/humidity"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0300 # HVAC Heating/Cooling Unit
       - id: 0x0307 # Humidity Sensor
-    deviceProfileName: thermostat-humidity
+    deviceProfileName: thermostat-humidity-nostate-nobattery
   - id: "matter/hvac/thermostat/humidity"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0301 # Thermostat
       - id: 0x0307 # Humidity Sensor
-    deviceProfileName: thermostat-humidity
+    deviceProfileName: thermostat-humidity-nostate-nobattery
   - id: "matter/hvac/heatcool/fan"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0300 # HVAC Heating/Cooling Unit
       - id: 0x002B # Fan
-    deviceProfileName: thermostat-fan
+    deviceProfileName: thermostat-fan-nostate-nobattery
   - id: "matter/hvac/thermostat/fan"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0301 # Thermostat
       - id: 0x002B # Fan
-    deviceProfileName: thermostat-fan
+    deviceProfileName: thermostat-fan-nostate-nobattery
   - id: "matter/hvac/heatcool/humidity/fan"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0300 # HVAC Heating/Cooling Unit
       - id: 0x0307 # Humidity Sensor
       - id: 0x002B # Fan
-    deviceProfileName: thermostat-humidity-fan
+    deviceProfileName: thermostat-humidity-fan-nostate-nobattery
   - id: "matter/hvac/thermostat/humidity/fan"
     deviceLabel: Matter Thermostat
     deviceTypes:
       - id: 0x0301 # Thermostat
       - id: 0x0307 # Humidity Sensor
       - id: 0x002B # Fan
-    deviceProfileName: thermostat-humidity-fan
+    deviceProfileName: thermostat-humidity-fan-nostate-nobattery
   - id: "matter/room-air-conditioner"
     deviceLabel: Matter Room Air Conditioner
     deviceTypes:
       - id: 0x0072
-    deviceProfileName: room-air-conditioner
+    deviceProfileName: room-air-conditioner-fan-heating-cooling-nostate
   - id: "matter/fan"
     deviceLabel: Matter Fan
     deviceTypes:
@@ -124,7 +124,7 @@ matterGeneric:
     deviceLabel: Matter Air Purifier
     deviceTypes:
       - id: 0x002D # Air Purifier
-    deviceProfileName: air-purifier-hepa-ac-wind
+    deviceProfileName: air-purifier
   - id: "matter/air-purifier/quality-sensor"
     deviceLabel: Matter Air Purifier & Quality Sensor
     deviceTypes:


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
The Matter subscribe logic will automatically subscribe a device to all attributes associated with a capability in a chosen profile, and this is not reset when a new profile is chosen. Therefore, using these larger lists of capabilities in the "generic" profiles is: 
1. leaving it more feasible that a device will not update for whatever reason and have unusable capabilities
2. adding unnecessary attributes to an initial list of subscribed attributes which are never removed after the fact.

# Summary of Completed Tests


