### PR TITLE
matter sensor: Add base rain, leak, and freeze profiles

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/freeze.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/freeze.yml
@@ -1,0 +1,18 @@
+name: freeze
+components:
+- id: main
+  capabilities:
+  - id: temperatureAlarm
+    version: 1
+    config:
+      values:
+        - key: "temperatureAlarm.value"
+          enabledValues:
+            - cleared
+            - freeze
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: WaterFreezeDetector

--- a/drivers/SmartThings/matter-sensor/profiles/leak.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/leak.yml
@@ -1,0 +1,12 @@
+name: leak
+components:
+- id: main
+  capabilities:
+  - id: waterSensor
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: LeakSensor

--- a/drivers/SmartThings/matter-sensor/profiles/rain.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/rain.yml
@@ -1,0 +1,12 @@
+name: rain
+components:
+- id: main
+  capabilities:
+  - id: rainSensor
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: RainSensor


### PR DESCRIPTION
# Description of Change
From a community post: https://community.smartthings.com/t/matter-smart-home-connectivity-standard-formerly-project-chip/180934/1475

and a comment mentioned here: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/issues/2376#issuecomment-3257478374

it has been identified that we are missing a couple of base profiles for the following Matter 1.3 device types.

# Summary of Completed Tests


