### PR TITLE
philips-hue: Split mapping of hue resource IDs by bridge

### DIFF
--- a/drivers/SmartThings/philips-hue/src/disco/init.lua
+++ b/drivers/SmartThings/philips-hue/src/disco/init.lua
@@ -334,8 +334,13 @@ function HueDiscovery.handle_discovered_child_device(driver, bridge_network_id, 
   end
 
   for _, svc_info in ipairs(primary_services[primary_service_type]) do
+    if driver:get_device_by_dni(v1_dni) then
+      return
+    end
     local v2_resource_id = svc_info.rid or ""
-    if driver:get_device_by_dni(v1_dni) or driver.hue_identifier_to_device_record[v2_resource_id] then return end
+    if (driver.hue_identifier_to_device_record_by_bridge[bridge_network_id] or {})[v2_resource_id] then
+      return
+    end
   end
 
   local api_instance =

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/button.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/button.lua
@@ -52,8 +52,9 @@ function ButtonLifecycleHandlers.added(driver, device, parent_device_id, resourc
   end
 
   local button_rid_to_index_map = {}
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
   if button_info.button then
-    driver.hue_identifier_to_device_record[button_info.id] = device
+    hue_id_to_device[button_info.id] = device
     button_rid_to_index_map[button_info.id] = 1
   end
 
@@ -65,7 +66,7 @@ function ButtonLifecycleHandlers.added(driver, device, parent_device_id, resourc
       local button_id = button_info[button_id_key]
 
       if button and button_id then
-        driver.hue_identifier_to_device_record[button_id] = device
+        hue_id_to_device[button_id] = device
         button_rid_to_index_map[button_id] = var
 
         local supported_button_values = utils.get_supported_button_values(button.event_values)
@@ -86,7 +87,7 @@ function ButtonLifecycleHandlers.added(driver, device, parent_device_id, resourc
   end
 
   if button_info.power_id then
-    driver.hue_identifier_to_device_record[button_info.power_id] = device
+    hue_id_to_device[button_info.power_id] = device
   end
 
   log.debug(st_utils.stringify_table(button_rid_to_index_map, "button index map", true))
@@ -98,7 +99,7 @@ function ButtonLifecycleHandlers.added(driver, device, parent_device_id, resourc
   device:set_field(Fields._ADDED, true, { persist = true })
   device:set_field(Fields._REFRESH_AFTER_INIT, true, { persist = true })
 
-  driver.hue_identifier_to_device_record[device_button_resource_id] = device
+  hue_id_to_device[device_button_resource_id] = device
 end
 
 ---@param driver HueDriver
@@ -114,8 +115,9 @@ function ButtonLifecycleHandlers.init(driver, device)
   log.debug("resource id " .. tostring(device_button_resource_id))
 
   local hue_device_id = device:get_field(Fields.HUE_DEVICE_ID)
-  if not driver.hue_identifier_to_device_record[device_button_resource_id] then
-    driver.hue_identifier_to_device_record[device_button_resource_id] = device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
+  if not hue_id_to_device[device_button_resource_id] then
+    hue_id_to_device[device_button_resource_id] = device
   end
   local button_info, err
   button_info = Discovery.device_state_disco_cache[device_button_resource_id]

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/contact.lua
@@ -51,8 +51,9 @@ function ContactLifecycleHandlers.added(driver, device, parent_device_id, resour
     return
   end
 
-  driver.hue_identifier_to_device_record[sensor_info.power_id] = device
-  driver.hue_identifier_to_device_record[sensor_info.tamper_id] = device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
+  hue_id_to_device[sensor_info.power_id] = device
+  hue_id_to_device[sensor_info.tamper_id] = device
 
   device:set_field(Fields.DEVICE_TYPE, HueDeviceTypes.CONTACT, { persist = true })
   device:set_field(Fields.HUE_DEVICE_ID, sensor_info.hue_device_id, { persist = true })
@@ -61,7 +62,7 @@ function ContactLifecycleHandlers.added(driver, device, parent_device_id, resour
   device:set_field(Fields._ADDED, true, { persist = true })
   device:set_field(Fields._REFRESH_AFTER_INIT, true, { persist = true })
 
-  driver.hue_identifier_to_device_record[device_sensor_resource_id] = device
+  hue_id_to_device[device_sensor_resource_id] = device
 end
 
 ---@param driver HueDriver
@@ -77,8 +78,9 @@ function ContactLifecycleHandlers.init(driver, device)
   log.debug("resource id " .. tostring(device_sensor_resource_id))
 
   local hue_device_id = device:get_field(Fields.HUE_DEVICE_ID)
-  if not driver.hue_identifier_to_device_record[device_sensor_resource_id] then
-    driver.hue_identifier_to_device_record[device_sensor_resource_id] = device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
+  if not hue_id_to_device[device_sensor_resource_id] then
+    hue_id_to_device[device_sensor_resource_id] = device
   end
   local sensor_info, err
   sensor_info = Discovery.device_state_disco_cache[device_sensor_resource_id]

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/init.lua
@@ -93,8 +93,9 @@ function LifecycleHandlers.device_added(driver, device, ...)
     if device_type ~= HueDeviceTypes.BRIDGE then
       ---@cast device HueChildDevice
       local resource_id = utils.get_hue_rid(device)
+      local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
       if resource_id then
-        driver.hue_identifier_to_device_record[resource_id] = device
+        hue_id_to_device[resource_id] = device
       end
 
       local resource_state_known = (Discovery.device_state_disco_cache[resource_id] ~= nil)

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/light.lua
@@ -190,7 +190,8 @@ function LightLifecycleHandlers.added(driver, device, parent_device_id, resource
   device:set_field(Fields._ADDED, true, { persist = true })
   device:set_field(Fields._REFRESH_AFTER_INIT, true, { persist = true })
 
-  driver.hue_identifier_to_device_record[device_light_resource_id] = device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
+  hue_id_to_device[device_light_resource_id] = device
 
   -- the refresh handler adds lights that don't have a fully initialized bridge to a queue.
   driver:inject_capability_command(device, {
@@ -218,8 +219,9 @@ function LightLifecycleHandlers.init(driver, device)
       device.device_network_id
 
   local hue_device_id = device:get_field(Fields.HUE_DEVICE_ID)
-  if not driver.hue_identifier_to_device_record[device_light_resource_id] then
-    driver.hue_identifier_to_device_record[device_light_resource_id] = device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
+  if not hue_id_to_device[device_light_resource_id] then
+    hue_id_to_device[device_light_resource_id] = device
   end
   local svc_rids_for_device = driver.services_for_device_rid[hue_device_id] or {}
   if not svc_rids_for_device[device_light_resource_id] then

--- a/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/lifecycle_handlers/motion.lua
@@ -50,10 +50,11 @@ function MotionLifecycleHandlers.added(driver, device, parent_device_id, resourc
     })
     return
   end
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
 
-  driver.hue_identifier_to_device_record[sensor_info.power_id] = device
-  driver.hue_identifier_to_device_record[sensor_info.temperature_id] = device
-  driver.hue_identifier_to_device_record[sensor_info.light_level_id] = device
+  hue_id_to_device[sensor_info.power_id] = device
+  hue_id_to_device[sensor_info.temperature_id] = device
+  hue_id_to_device[sensor_info.light_level_id] = device
 
   device:set_field(Fields.DEVICE_TYPE, HueDeviceTypes.MOTION, { persist = true })
   device:set_field(Fields.HUE_DEVICE_ID, sensor_info.hue_device_id, { persist = true })
@@ -62,7 +63,7 @@ function MotionLifecycleHandlers.added(driver, device, parent_device_id, resourc
   device:set_field(Fields._ADDED, true, { persist = true })
   device:set_field(Fields._REFRESH_AFTER_INIT, true, { persist = true })
 
-  driver.hue_identifier_to_device_record[device_sensor_resource_id] = device
+  hue_id_to_device[device_sensor_resource_id] = device
 end
 
 ---@param driver HueDriver
@@ -78,8 +79,9 @@ function MotionLifecycleHandlers.init(driver, device)
   log.debug("resource id " .. tostring(device_sensor_resource_id))
 
   local hue_device_id = device:get_field(Fields.HUE_DEVICE_ID)
-  if not driver.hue_identifier_to_device_record[device_sensor_resource_id] then
-    driver.hue_identifier_to_device_record[device_sensor_resource_id] = device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device) or {}
+  if not hue_id_to_device[device_sensor_resource_id] then
+    hue_id_to_device[device_sensor_resource_id] = device
   end
   local sensor_info, err
   sensor_info = Discovery.device_state_disco_cache[device_sensor_resource_id]

--- a/drivers/SmartThings/philips-hue/src/hue_driver_template.lua
+++ b/drivers/SmartThings/philips-hue/src/hue_driver_template.lua
@@ -70,7 +70,7 @@ local set_color_temp_handler = utils.safe_wrap_handler(command_handlers.set_colo
 --- @class HueDriver:Driver
 --- @field public ignored_bridges table<string,boolean>
 --- @field public joined_bridges table<string,boolean>
---- @field public hue_identifier_to_device_record table<string,HueChildDevice>
+--- @field public hue_identifier_to_device_record_by_bridge table<string, table<string,HueChildDevice>>
 --- @field public services_for_device_rid table<string,table<string,string>> Map the device resource ID to another map that goes from service rid to service rtype
 --- @field public waiting_grandchildren table<string,{ waiting_resource_info: HueResourceInfo, join_callback: fun(driver: HueDriver, waiting_resource_info: HueResourceInfo, parent_device: HueChildDevice)}[]>?
 --- @field public stray_device_tx table cosock channel
@@ -113,7 +113,7 @@ function HueDriver.new_driver_template(dbg_config)
 
     ignored_bridges = {},
     joined_bridges = {},
-    hue_identifier_to_device_record = {},
+    hue_identifier_to_device_record_by_bridge = {},
     services_for_device_rid = {},
     -- the only real way we have to know which bridge a bulb wants to use at migration time
     -- is by looking at the stored api key so we will make a map to look up bridge IDs with

--- a/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_bridge_utils.lua
@@ -40,6 +40,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
       { [HueApi.APPLICATION_KEY_HEADER] = api_key },
       nil
     )
+    local hue_identifier_to_device_record = utils.get_hue_id_to_device_table_by_bridge(driver, bridge_device) or {}
 
     eventsource.onopen = function(msg)
       log.info_with({ hub_logs = true },
@@ -171,7 +172,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
               local resource_ids = {}
               if update_data.type == "zigbee_connectivity" and update_data.owner ~= nil then
                 for rid, rtype in pairs(driver.services_for_device_rid[update_data.owner.rid] or {}) do
-                  if driver.hue_identifier_to_device_record[rid] then
+                  if hue_identifier_to_device_record[rid] then
                     log.debug(string.format("Adding RID %s to resource_ids", rid))
                     table.insert(resource_ids, rid)
                   end
@@ -186,7 +187,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
               end
               for _, resource_id in ipairs(resource_ids) do
                 log.debug(string.format("Looking for device record for %s", resource_id))
-                local child_device = driver.hue_identifier_to_device_record[resource_id]
+                local child_device = hue_identifier_to_device_record[resource_id]
                 if child_device ~= nil and child_device.id ~= nil then
                   if update_data.type == "zigbee_connectivity" then
                     log.debug("emitting event for zigbee connectivity")
@@ -203,7 +204,7 @@ function hue_bridge_utils.do_bridge_network_init(driver, bridge_device, bridge_u
             for _, delete_data in ipairs(event.data) do
               if HueDeviceTypes.can_join_device_for_service(delete_data.type) then
                 local resource_id = delete_data.id
-                local child_device = driver.hue_identifier_to_device_record[resource_id]
+                local child_device = hue_identifier_to_device_record[resource_id]
                 if child_device ~= nil and child_device.id ~= nil then
                   log.info(
                     string.format(

--- a/drivers/SmartThings/philips-hue/src/utils/hue_multi_service_device_utils/sensor.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/hue_multi_service_device_utils/sensor.lua
@@ -1,3 +1,5 @@
+local utils = require "utils"
+
 local SensorMultiServiceHelper = {}
 function SensorMultiServiceHelper.update_multi_service_device_maps(driver, device, hue_device_id, sensor_info)
   local svc_rids_for_device = driver.services_for_device_rid[hue_device_id] or {}
@@ -15,8 +17,9 @@ function SensorMultiServiceHelper.update_multi_service_device_maps(driver, devic
   end
 
   driver.services_for_device_rid[hue_device_id] = svc_rids_for_device
+  local hue_id_to_device = utils.get_hue_id_to_device_table_by_bridge(driver, device)
   for rid, _ in pairs(driver.services_for_device_rid[hue_device_id]) do
-    driver.hue_identifier_to_device_record[rid] = device
+    hue_id_to_device[rid] = device
   end
 end
 

--- a/drivers/SmartThings/philips-hue/src/utils/init.lua
+++ b/drivers/SmartThings/philips-hue/src/utils/init.lua
@@ -345,6 +345,7 @@ end
 ---@param driver HueDriver
 ---@param device HueDevice
 ---@param parent_device_id string?
+---@param quiet boolean?
 ---@return HueBridgeDevice? bridge_device
 function utils.get_hue_bridge_for_device(driver, device, parent_device_id, quiet)
   local _ = quiet or
@@ -369,6 +370,27 @@ function utils.get_hue_bridge_for_device(driver, device, parent_device_id, quiet
   end
 
   return utils.get_hue_bridge_for_device(driver, parent_device, nil, quiet)
+end
+
+--- Get the mapping of hue id to device table by associated bridge. The mapping is separated by bridge to account
+--- for devices migrated to a new hue bridge.
+---@param driver HueDriver
+---@param bridge_or_device HueDevice
+---@return table<string,HueChildDevice>? hue_id_to_device
+function utils.get_hue_id_to_device_table_by_bridge(driver, bridge_or_device)
+  -- If bridge_or_device is a bridge this will just return itself
+  local bridge = utils.get_hue_bridge_for_device(driver, bridge_or_device)
+  if not bridge then
+    log.warn(string.format("Failed to lookup bridge for device %s", bridge_or_device.label))
+    return nil
+  end
+  local bridge_id = bridge:get_field(Fields.BRIDGE_ID)
+  if not bridge_id then
+    log.warn(string.format("Failed to get bridge id for %s", bridge.label))
+    return nil
+  end
+  driver.hue_identifier_to_device_record_by_bridge[bridge_id] = driver.hue_identifier_to_device_record_by_bridge[bridge_id] or {}
+  return driver.hue_identifier_to_device_record_by_bridge[bridge_id]
 end
 
 --- build a exponential backoff time value generator


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This change is to help facilitate the migration of an old hue bridge to the pro hue bridge. Currently, the driver holds a mapping of hue resource IDs to smartthings devices records. This becomes a problem when adding the new pro to smartthings because the children of the pro will have the same resource ids as they did when on the old bridge. Child creation is gated by if we already have a record of that hue resource ID. The driver also makes assumptions throughout that the hue resource ID is unique.

By splitting up the mapping by hue bridge, we shouldn't run into any issues with collusions and should be able to re-create the devices on the new pro bridge.


# Summary of Completed Tests

By hue setup is currently offline so I haven't had a chance to test this yet. 
