### PR TITLE
sonos: Fix oauth account linking notifications

### DIFF
--- a/drivers/SmartThings/sonos/src/api/sonos_connection.lua
+++ b/drivers/SmartThings/sonos/src/api/sonos_connection.lua
@@ -258,6 +258,7 @@ local function _oauth_reconnect_task(sonos_conn)
       local unauthorized = (check_auth == false)
 
       if unauthorized then
+        sonos_conn.driver:alert_unauthorized()
         local token, channel_error = token_receive_handle:receive()
         if not token then
           log.warn(string.format("Error requesting token: %s", channel_error))
@@ -347,6 +348,7 @@ function SonosConnection.new(driver, device)
             else
               Router.close_socket_for_player(unique_key)
             end
+            self.driver:alert_unauthorized()
           end
         end
       elseif header.type == "groups" then

--- a/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
+++ b/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
@@ -82,6 +82,7 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
                   local token, token_recv_err
                   -- max 30 mins
                   local backoff_builder = utils.backoff_builder(60 * 30, 30, 2)
+                  driver:alert_unauthorized()
 
                   local backoff_timer = nil
                   while not token do


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This was a miss by me that I thought I had tested in the token refresher PR that was found when during regression testing. When we request a token, if the call returns a 404, then we will make another api call which will trigger a notification to the user guiding them to link their sonos account.

This change adds a function `SonosDriver:alert_unauthorized()` that will go through the token request flow and trigger a notification to the user. This is called when the websocket closes due to being unauthorized, when we determine we are unauthorized in the websocket reconnect task, and in the device init lifecycle handler task when we determine we are unauthorized.

This is done outside of the token refresher task because instead of calling `security.get_sonos_oauth()` with the intent to get a new token, the intent is strictly to notify the user why their device is offline.

`SonosDriver:alert_unauthorized()` will call `security.get_sonos_oauth()` regardless of the oauth connection state because there is a possibility that there is stale data in the augmented driver data table. That flow would look something like this, user onboards sonos speaker with linked sonos account, user unlinks sonos account and device is deleted from smartthings, user re-onboards device via scan nearby, oauth information is still in augmented data so we can connect to the device correctly until the token expires. This may lead to an extra call to `security.get_sonos_oauth()` but doing that outweighs the possibility of the notification not appearing. I can create a ticket to look at clearing out the driver augmented data when a driver has no more devices.

# Summary of Completed Tests

I have tested that the notification now appears when we get disconnected from the device due to auth and on driver startup when we determine we are not authorized.

