### PR TITLE
Add Linxura Aura smart button support 12 Matter buttons.

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -1,4 +1,12 @@
 matterManufacturer:
+#Linxura
+  - id: "Aura Smart Button"
+    deviceLabel: Aura Smart Button
+    vendorId: 0xFFF1
+    productId: 0x8004
+    deviceProfileName: 12-buttons-without-main-button
+    # deviceProfileName: 8-buttons-without-main-button
+    # deviceProfileName: four-buttons-without-main-button
 #Aqara
   - id: "4447/6145"
     deviceLabel: Aqara LED Bulb T2 RGB CCT

--- a/drivers/SmartThings/matter-switch/profiles/12-buttons-without-main-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/12-buttons-without-main-button.yml
@@ -1,0 +1,80 @@
+name: 12-buttons-without-main-button
+components:
+  - id: main
+    capabilities:
+      - id: refresh
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button1
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button2
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button3
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button4
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController 
+  - id: button5
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController 
+  - id: button6
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController 
+  - id: button7
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button8
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController  
+  - id: button9
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController  
+  - id: button10
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController  
+  - id: button11
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController
+  - id: button12
+    capabilities:
+      - id: button
+        version: 1
+    categories:
+      - name: RemoteController


### PR DESCRIPTION
1.Add Linxura Aura smart button support 12 Matter buttons. 2.Each button support click, double click, held.
3.12 buttons mapped in Smartthings app as button 1-12. Does not show main button.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Add Linxura Aura smart button support 12 Matter buttons.
Each button support click, double click, held.
12 buttons mapped in Smartthings app as button 1-12. Does not show main button.

# Summary of Completed Tests
Test has been processed on Smartthings developers test suite.

