### PR TITLE
Enable the pin feature of Deasino door lock devices

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -53,6 +53,8 @@ local NEW_MATTER_LOCK_PRODUCTS = {
   {0x135D, 0x00C1}, -- Nuki, Smart Lock
   {0x135D, 0x00A1}, -- Nuki, Smart Lock
   {0x135D, 0x00B0}, -- Nuki, Smart Lock
+  {0x15F2, 0x0001}, -- Viomi, AiSafety Smart Lock E100
+  {0x158B, 0x0001}, -- Deasino, DS-MT01
   {0x10E1, 0x2002}  -- VDA
 }
 


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Add the corresponding vid & pid to the NEW_MATTER_LOCK_PRODUCTS table to enable the Deasino devices (One of these was transferred to another manufacturer, Viomi) to support PIN feature.

# Summary of Completed Tests
After the modification, the pin feature of these two devices is enabled normally without exception. Please refer to the link below for details: 
https://smartthings.atlassian.net/wiki/spaces/CS/pages/4236215029/Function+test+after+pin+feature+of+Deasino+devices+is+enabled

