### PR TITLE
Update Level Lock fingerprint to use batteryLevel

### DIFF
--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -61,12 +61,12 @@ matterManufacturer:
     deviceLabel: Level Lock Pro
     vendorId: 0x129F
     productId: 0x0004
-    deviceProfileName: lock-nocodes-notamper
+    deviceProfileName: lock-nocodes-notamper-batteryLevel
   - id: "4767/5"
     deviceLabel: Level Lock (Matter)
     vendorId: 0x129F
     productId: 0x0005
-    deviceProfileName: lock-nocodes-notamper
+    deviceProfileName: lock-nocodes-notamper-batteryLevel
   #Nuki
   - id: "4957/161"
     deviceLabel: Nuki Smart Lock Ultra


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
We were notified that Level Lock did support the Matter attribute that we use as a mapping to the batteryLevel capability, and that this was a small miss in their initial WWST request. Therefore, they have requested we update the fingerprint to allow this support. Further, it has been communicated that these should be safe to change from a WWST perspective since "these should have been "certified by similarity" based on one of the locks that used the correct profile."

# Summary of Completed Tests

