### PR TITLE
Remove the adding of monitored attributes in Zigbee drivers

### DIFF
--- a/drivers/SmartThings/zigbee-button/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/aqara/init.lua
@@ -76,7 +76,6 @@ local function device_init(driver, device)
     if configuration ~= nil then
       for _, attribute in ipairs(configuration) do
         device:add_configured_attribute(attribute)
-        device:add_monitored_attribute(attribute)
       end
     end
 end

--- a/drivers/SmartThings/zigbee-button/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/frient/init.lua
@@ -156,7 +156,6 @@ end
 local function init_handler(self, device)
   for _,attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
   battery_defaults.enable_battery_voltage_table(device, battery_table)
 end

--- a/drivers/SmartThings/zigbee-button/src/samjin/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/samjin/init.lua
@@ -21,7 +21,6 @@ battery_config.data_type = zcl_clusters.PowerConfiguration.attributes.BatteryVol
 
 local function init_handler(self, device)
   device:add_configured_attribute(battery_config)
-  device:add_monitored_attribute(battery_config)
 end
 
 local samjin_button = {

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/linxura/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/linxura/init.lua
@@ -67,7 +67,6 @@ end
 local function device_init(driver, device)
   for _, attribute in ipairs(configuration) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/zunzunbee/init.lua
+++ b/drivers/SmartThings/zigbee-button/src/zigbee-multi-button/zunzunbee/init.lua
@@ -38,7 +38,6 @@ local ZUNZUNBEE_BUTTON_FINGERPRINTS = {
 -- Initialize device attributes
 local function init_handler(self, device)
   device:add_configured_attribute(battery_config)
-  device:add_monitored_attribute(battery_config)
 end
 
 -- Check if a given device matches the supported fingerprints

--- a/drivers/SmartThings/zigbee-contact/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/aqara/init.lua
@@ -53,7 +53,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-contact/src/aurora-contact-sensor/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/aurora-contact-sensor/init.lua
@@ -47,7 +47,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(AURORA_CONTACT_CONFIGURATION) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-contact/src/contact-temperature-sensor/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/contact-temperature-sensor/init.lua
@@ -52,7 +52,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-contact/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/frient/init.lua
@@ -44,7 +44,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-contact/src/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/init.lua
@@ -65,7 +65,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-contact/src/sengled/init.lua
+++ b/drivers/SmartThings/zigbee-contact/src/sengled/init.lua
@@ -41,7 +41,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/init.lua
@@ -98,7 +98,6 @@ local voltage_configuration = {
 
 local function device_init(driver, device)
   device:add_configured_attribute(voltage_configuration)
-  device:add_monitored_attribute(voltage_configuration)
   device:remove_monitored_attribute(zcl_clusters.PowerConfiguration.ID, zcl_clusters.PowerConfiguration.attributes.BatteryPercentageRemaining.ID)
   device:remove_configured_attribute(zcl_clusters.PowerConfiguration.ID, zcl_clusters.PowerConfiguration.attributes.BatteryPercentageRemaining.ID)
   device:set_field(battery_defaults.DEVICE_MIN_VOLTAGE_KEY, 2.3)

--- a/drivers/SmartThings/zigbee-fan/src/init.lua
+++ b/drivers/SmartThings/zigbee-fan/src/init.lua
@@ -22,7 +22,6 @@ local device_init = function(self, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/aqara/init.lua
@@ -67,7 +67,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/frient-sensor/init.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/frient-sensor/init.lua
@@ -38,7 +38,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/init.lua
@@ -51,7 +51,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/aqara/init.lua
@@ -69,7 +69,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-lock/src/lock-without-codes/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock-without-codes/init.lua
@@ -38,7 +38,6 @@ local function device_init(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
@@ -96,7 +96,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/frient/init.lua
@@ -109,24 +109,17 @@ local function device_init(driver, device)
   battery_defaults.build_linear_voltage_init(BATTERY_MIN_VOLTAGE, BATTERY_MAX_VOLTAGE)(driver, device)
 
   local attribute
-  attribute = CONFIGURATIONS[OCCUPANCY_ENDPOINT]
-  -- binding is directly triggered for specific endpoint in do_configure
-  device:add_monitored_attribute(attribute)
-
   if device:supports_capability_by_id(capabilities.temperatureMeasurement.ID) then
     attribute = CONFIGURATIONS[TEMPERATURE_ENDPOINT]
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
   if device:supports_capability_by_id(capabilities.illuminanceMeasurement.ID) then
     attribute = CONFIGURATIONS[ILLUMINANCE_ENDPOINT]
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
   if device:supports_capability_by_id(capabilities.tamperAlert.ID) then
     attribute = CONFIGURATIONS[TAMPER_ENDPOINT]
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/sengled/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/sengled/init.lua
@@ -41,7 +41,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-power-meter/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/ezex/init.lua
@@ -49,8 +49,6 @@ end
 local device_init = function(self, device)
   device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1000000, {persist = true})
   device:set_field(constants.ELECTRICAL_MEASUREMENT_DIVISOR_KEY, 10, {persist = true})
-
-  device:add_monitored_attribute(instantaneous_demand_configuration)
   device:add_configured_attribute(instantaneous_demand_configuration)
 end
 

--- a/drivers/SmartThings/zigbee-power-meter/src/shinasystems/init.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/shinasystems/init.lua
@@ -111,7 +111,6 @@ local device_init = function(self, device)
   device:set_field(constants.SIMPLE_METERING_DIVISOR_KEY, 1000, {persist = true})
   for _, attribute in ipairs(POWERMETER_CONFIGURATION_V2) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/init.lua
@@ -111,7 +111,6 @@ end
 local function init_handler(self, device, event, args)
   device:set_field(battery_defaults.DEVICE_VOLTAGE_TABLE_KEY, battery_table)
   device:add_configured_attribute(battery_voltage_attr_configuration)
-  device:add_monitored_attribute(battery_voltage_attr_configuration)
   device:remove_monitored_attribute(PowerConfiguration.ID, PowerConfiguration.attributes.BatteryPercentageRemaining.ID)
   device:remove_configured_attribute(PowerConfiguration.ID, PowerConfiguration.attributes.BatteryPercentageRemaining.ID)
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/init.lua
@@ -138,7 +138,6 @@ local function device_init(driver, device)
   if CONFIGURATIONS ~= nil then
     for _, attribute in ipairs(CONFIGURATIONS) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara/init.lua
@@ -112,7 +112,6 @@ local function device_init(driver, device)
   if CONFIGURATIONS ~= nil then
     for _, attribute in ipairs(CONFIGURATIONS) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-smoke-detector/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/frient/init.lua
@@ -81,7 +81,6 @@ local function device_init(driver, device)
   if CONFIGURATIONS ~= nil then
     for _, attribute in ipairs(CONFIGURATIONS) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-switch/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/frient/init.lua
@@ -139,7 +139,6 @@ local function do_configure(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
   device:configure()

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -78,7 +78,6 @@ local device_init = function(driver, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
@@ -87,7 +87,6 @@ end
 local function device_init(driver, device)
   for _,attribute in ipairs(DIMMING_LIGHT_CONFIGURATION) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/ikea-xy-color-bulb/init.lua
@@ -48,7 +48,6 @@ local device_init = function(self, device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
       device:add_configured_attribute(attribute)
-      device:add_monitored_attribute(attribute)
     end
   end
 end

--- a/drivers/SmartThings/zigbee-thermostat/src/popp/init.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/popp/init.lua
@@ -325,7 +325,6 @@ local function device_init(driver, device)
     -- Add the manufacturer-specific attributes to generate their configure reporting and bind requests
     for _, config in pairs(cluster_configurations) do
       device:add_configured_attribute(config)
-      device:add_monitored_attribute(config)
     end
     -- initial set of heating mode
     local stored_heat_mode = device:get_field(STORED_HEAT_MODE) or 'eco'

--- a/drivers/SmartThings/zigbee-valve/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-valve/src/ezex/init.lua
@@ -56,7 +56,6 @@ end
 local function device_init(driver, device)
   for _, attribute in ipairs(configuration) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/aqara/init.lua
@@ -47,7 +47,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/frient/init.lua
@@ -26,7 +26,6 @@ local function device_init(driver, device)
         battery_defaults.build_linear_voltage_init(config.minV, config.maxV)(driver, device)
       elseif (config.cluster) then
         device:add_configured_attribute(config)
-        device:add_monitored_attribute(config)
       end
     end
   end

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/init.lua
@@ -59,7 +59,6 @@ local function device_init(driver, device)
         battery_defaults.enable_battery_voltage_table(device, config.battery_voltage_table)
       elseif (config.cluster) then
         device:add_configured_attribute(config)
-        device:add_monitored_attribute(config)
       end
     end
   end

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/sengled/init.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/sengled/init.lua
@@ -41,7 +41,6 @@ local function device_init(driver, device)
 
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/aqara/curtain-driver-e1/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/aqara/curtain-driver-e1/init.lua
@@ -76,7 +76,6 @@ local CONFIGURATIONS = {
 local function device_init(driver, device)
   for _, attribute in ipairs(CONFIGURATIONS) do
     device:add_configured_attribute(attribute)
-    device:add_monitored_attribute(attribute)
   end
 end
 


### PR DESCRIPTION
This feature is already disabled on these drivers and is moving toward deprecation.  We will remove the unnecessary adding



