### PR TITLE
Matter Switch: remove ENERGY_MANAGEMENT_ENDPOINT field

### DIFF
--- a/drivers/SmartThings/matter-switch/src/generic_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/generic_handlers/attribute_handlers.lua
@@ -250,8 +250,6 @@ function AttributeHandlers.active_power_handler(driver, device, ib, response)
   if ib.data.value then
     local watt_value = ib.data.value / fields.CONVERSION_CONST_MILLIWATT_TO_WATT
     device:emit_component_event(component, capabilities.powerMeter.power({ value = watt_value, unit = "W"}))
-  else
-    device:emit_component_event(component, capabilities.powerMeter.power({ value = 0, unit = "W"}))
   end
   if type(device.register_native_capability_attr_handler) == "function" then
     device:register_native_capability_attr_handler("powerMeter","power")

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -24,7 +24,6 @@ local fields = require "utils.switch_fields"
 local switch_utils = require "utils.switch_utils"
 local cfg = require "utils.device_configuration"
 local device_cfg = cfg.DeviceCfg
-local switch_cfg = cfg.SwitchCfg
 local button_cfg = cfg.ButtonCfg
 
 local attribute_handlers = require "generic_handlers.attribute_handlers"
@@ -87,15 +86,8 @@ function SwitchLifecycleHandlers.device_init(driver, device)
     end
     local main_endpoint = switch_utils.find_default_endpoint(device)
     -- ensure subscription to all endpoint attributes- including those mapped to child devices
-    for idx, ep in ipairs(device.endpoints) do
+    for _, ep in ipairs(device.endpoints) do
       if ep.endpoint_id ~= main_endpoint then
-        if device:supports_server_cluster(clusters.OnOff.ID, ep) then
-          local child_profile = switch_cfg.assign_child_profile(device, ep)
-          if idx == 1 and string.find(child_profile, "energy") then
-            -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
-            device:set_field(fields.ENERGY_MANAGEMENT_ENDPOINT, ep, {persist = true})
-          end
-        end
         local id = 0
         for _, dt in ipairs(ep.device_types) do
           id = math.max(id, dt.device_type_id)

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -271,10 +271,8 @@ test.register_coroutine_test(
     function()
       test.socket.matter:__queue_receive(
         {
-          -- don't use "aqara_mock_children[aqara_child1_ep].id,"
-          -- because energy management is at the root endpoint.
-          aqara_mock_device.id,
-          clusters.ElectricalPowerMeasurement.attributes.ActivePower:build_test_report_data(aqara_mock_device, 1, 17000)
+          aqara_mock_children[aqara_child1_ep].id,
+          clusters.ElectricalPowerMeasurement.attributes.ActivePower:build_test_report_data(aqara_mock_children[aqara_child1_ep], 1, 17000)
         }
       )
 
@@ -283,12 +281,14 @@ test.register_coroutine_test(
         aqara_mock_children[aqara_child1_ep]:generate_test_message("main", capabilities.powerMeter.power({value = 17.0, unit="W"}))
       )
 
+      aqara_mock_children[aqara_child1_ep]:expect_native_attr_handler_registration("powerMeter", "power")
+
       test.mock_time.advance_time(901) -- move time 15 minutes past 0 (this can be assumed to be true in practice in all cases)
 
       test.socket.matter:__queue_receive(
         {
-          aqara_mock_device.id,
-          clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_device, 1, cumulative_report_val_19)
+          aqara_mock_children[aqara_child1_ep].id,
+          clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_children[aqara_child1_ep], 1, cumulative_report_val_19)
         }
       )
 
@@ -307,8 +307,8 @@ test.register_coroutine_test(
 
       test.socket.matter:__queue_receive(
         {
-          aqara_mock_device.id,
-          clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_device, 1, cumulative_report_val_29)
+          aqara_mock_children[aqara_child1_ep].id,
+          clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(aqara_mock_children[aqara_child1_ep], 1, cumulative_report_val_29)
         }
       )
 
@@ -323,9 +323,9 @@ test.register_coroutine_test(
 
       test.socket.matter:__queue_receive(
         {
-          aqara_mock_device.id,
+          aqara_mock_children[aqara_child1_ep].id,
           clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(
-            aqara_mock_device, 1, cumulative_report_val_39
+            aqara_mock_children[aqara_child1_ep], 1, cumulative_report_val_39
           )
         }
       )
@@ -338,7 +338,7 @@ test.register_coroutine_test(
         aqara_mock_children[aqara_child1_ep]:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
           start = "1970-01-01T00:15:01Z",
           ["end"] = "1970-01-01T00:40:00Z",
-          deltaEnergy = 0.0,
+          deltaEnergy = 20.0,
           energy = 39.0
         }))
       )

--- a/drivers/SmartThings/matter-switch/src/utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/utils/device_configuration.lua
@@ -59,7 +59,7 @@ function SwitchDeviceConfiguration.assign_child_profile(device, child_ep)
   --      child_device_profile_overrides
   for id, vendor in pairs(fields.child_device_profile_overrides_per_vendor_id) do
     for _, fingerprint in ipairs(vendor) do
-      if device.manufacturer_info.product_id == fingerprint.product_id and
+      if device.manufacturer_info and device.manufacturer_info.product_id == fingerprint.product_id and
          ((device.manufacturer_info.vendor_id == fields.AQARA_MANUFACTURER_ID and child_ep == 1) or profile == fingerprint.initial_profile) then
          return fingerprint.target_profile
       end
@@ -75,7 +75,7 @@ function SwitchDeviceConfiguration.create_child_switch_devices(driver, device, m
   local parent_child_device = false
   local switch_eps = device:get_endpoints(clusters.OnOff.ID)
   table.sort(switch_eps)
-  for idx, ep in ipairs(switch_eps) do
+  for _, ep in ipairs(switch_eps) do
     if device:supports_server_cluster(clusters.OnOff.ID, ep) then
       num_switch_server_eps = num_switch_server_eps + 1
       if ep ~= main_endpoint then -- don't create a child device that maps to the main endpoint
@@ -92,10 +92,6 @@ function SwitchDeviceConfiguration.create_child_switch_devices(driver, device, m
           }
         )
         parent_child_device = true
-        if idx == 1 and string.find(child_profile, "energy") then
-          -- when energy management is defined in the root endpoint(0), replace it with the first switch endpoint and process it.
-          device:set_field(fields.ENERGY_MANAGEMENT_ENDPOINT, ep, {persist = true})
-        end
       end
     end
   end

--- a/drivers/SmartThings/matter-switch/src/utils/switch_fields.lua
+++ b/drivers/SmartThings/matter-switch/src/utils/switch_fields.lua
@@ -86,7 +86,6 @@ SwitchFields.CONVERSION_CONST_MILLIWATT_TO_WATT = 1000 -- A milliwatt is 1/1000t
 -- table for devices that joined prior to this transition, and is also used for
 -- button devices that require component mapping.
 SwitchFields.COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
-SwitchFields.ENERGY_MANAGEMENT_ENDPOINT = "__energy_management_endpoint"
 SwitchFields.IS_PARENT_CHILD_DEVICE = "__is_parent_child_device"
 SwitchFields.COLOR_TEMP_BOUND_RECEIVED_KELVIN = "__colorTemp_bound_received_kelvin"
 SwitchFields.COLOR_TEMP_BOUND_RECEIVED_MIRED = "__colorTemp_bound_received_mired"
@@ -99,7 +98,8 @@ SwitchFields.COLOR_MODE = "__color_mode"
 
 SwitchFields.updated_fields = {
   { current_field_name = "__component_to_endpoint_map_button", updated_field_name = SwitchFields.COMPONENT_TO_ENDPOINT_MAP },
-  { current_field_name = "__switch_intialized", updated_field_name = nil }
+  { current_field_name = "__switch_intialized", updated_field_name = nil },
+  { current_field_name = "__energy_management_endpoint", updated_field_name = nil }
 }
 
 SwitchFields.HUE_SAT_COLOR_MODE = clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION


### PR DESCRIPTION
# Description of Change
This field is a workaround for the fact that in the Aqara Switch H2 device (and possibly others), the ElectricalEnergyMeasurement cluster is stored on the root endpoint, which is not associated with the main component in out current logic. Therefore, the current handling directly circumvents this issue by writing the event on ep 1 instead of ep 0  by means of this field. 

However, there is a cleaner solution here which circumvents the entire `emit_event_for_endpoint` logic, which I have implemented here, specifically by using the `emit_component_event`, which is what `emit_event_for_endpoint` breaks down into anyway on the backend.

For now, `main` can be directly written here as the component of choice (all devices currently have `powerConsumptionReport` and `energyMeter` on main) but if we expand this logic to become more inclusive of different configurations, this is still a more robust and more clear solution.

# Summary of Completed Tests
All unit tests pass.

Tested with Aqara H2 Switch (the only known device that functions like this) and `energyMeter` and `powerConsumptionReport` events are emitted as expected. Tested with Meross plug and similarly functionality is retained.
