### PR TITLE
ZLL: Use Native / Default handlers

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/ikea-xy-color-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ikea-xy-color-bulb/init.lua
@@ -35,7 +35,13 @@ local IKEA_XY_COLOR_BULB_FINGERPRINTS = {
 }
 
 local function can_handle_ikea_xy_color_bulb(opts, driver, device)
-  return (IKEA_XY_COLOR_BULB_FINGERPRINTS[device:get_manufacturer()] or {})[device:get_model()] or false
+  local can_handle = (IKEA_XY_COLOR_BULB_FINGERPRINTS[device:get_manufacturer()] or {})[device:get_model()]
+  if can_handle then
+    local subdriver = require("ikea-xy-color-bulb")
+    return true, subdriver
+  else
+    return false
+  end
 end
 
 local device_init = function(self, device)

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -31,7 +31,6 @@ end
 
 local function lazy_load_if_possible(sub_driver_name)
   -- gets the current lua libs api version
-
   -- version 9 will include the lazy loading functions
   if version.api >= 9 then
     return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
@@ -105,7 +104,8 @@ local zigbee_switch_driver_template = {
     lazy_load_if_possible("zigbee-dimming-light"),
     lazy_load_if_possible("white-color-temp-bulb"),
     lazy_load_if_possible("rgbw-bulb"),
-    lazy_load_if_possible("zll-dimmer-bulb"),
+    (version.api < 16) and lazy_load_if_possible("zll-dimmer-bulb") or nil,
+    lazy_load_if_possible("ikea-xy-color-bulb"),
     lazy_load_if_possible("zll-polling"),
     lazy_load_if_possible("zigbee-switch-power"),
     lazy_load_if_possible("ge-link-bulb"),

--- a/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/device_added.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/device_added.lua
@@ -27,7 +27,9 @@ end
 
 return function(driver, device, event)
   local clusters = require "st.zigbee.zcl.clusters"
+  local ZLL_PROFILE_ID = 0xC05E
   local device_lib = require "st.device"
+  local version = require "version"
 
   local main_endpoint = device:get_endpoint(clusters.OnOff.ID)
   if is_mcd_device(device) == false and device.network_type == device_lib.NETWORK_TYPE_ZIGBEE then
@@ -52,5 +54,8 @@ return function(driver, device, event)
         end
       end
     end
+  end
+  if version.api > 15 and device:get_profile_id() == ZLL_PROFILE_ID then
+    device:refresh()
   end
 end

--- a/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/do_configure.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/do_configure.lua
@@ -14,7 +14,11 @@
 
 local capabilities = require "st.capabilities"
 return function(self, device)
-  device:refresh()
+  local ZLL_PROFILE_ID = 0xC05E
+  local version = require "version"
+  if version.api < 16 or (version.api > 15 and device:get_profile_id() ~= ZLL_PROFILE_ID) then
+    device:refresh()
+  end
   device:configure()
 
   -- Additional one time configuration

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
@@ -15,6 +15,7 @@
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
+local version = require "version"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 
 local OnOff = clusters.OnOff
@@ -83,6 +84,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "on") end
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device)})
     test.wait_for_events()
     test.mock_time.advance_time(2)
@@ -98,6 +100,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "off") end
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.Off(mock_device)})
     test.wait_for_events()
     test.mock_time.advance_time(2)
@@ -113,6 +116,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = {50} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel") end
     test.socket.zigbee:__expect_send({ mock_device.id, Level.commands.MoveToLevelWithOnOff(mock_device, math.floor(50 / 100.0 * 254), 0xFFFF)})
     test.wait_for_events()
     test.mock_time.advance_time(2)
@@ -128,6 +132,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {200} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature") end
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device)})
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.commands.MoveToColorTemperature(mock_device, 5000, 0x0000)})
     test.wait_for_events()

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
@@ -15,6 +15,7 @@
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
+local version = require "version"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 
 local OnOff = clusters.OnOff
@@ -121,6 +122,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "on") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
@@ -138,6 +140,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "off") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.Off(mock_device) })
 
@@ -155,6 +158,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57 } } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, Level.server.commands.MoveToLevelWithOnOff(mock_device, 144, 0xFFFF) })
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
@@ -16,6 +16,7 @@ local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
+local version = require "version"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 
 local OnOff = clusters.OnOff
@@ -149,6 +150,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "on") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
@@ -168,6 +170,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "off") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.Off(mock_device) })
 
@@ -187,6 +190,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57 } } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, Level.server.commands.MoveToLevelWithOnOff(mock_device, 144, 0xFFFF) })
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
@@ -15,6 +15,7 @@
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"
 local t_utils = require "integration_test.utils"
+local version = require "version"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 
 local OnOff = clusters.OnOff
@@ -140,6 +141,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "on") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
 
@@ -160,6 +162,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "off") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.Off(mock_device) })
 
@@ -180,6 +183,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57 } } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, Level.server.commands.MoveToLevelWithOnOff(mock_device, 144, 0xFFFF) })
 
@@ -200,6 +204,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__set_channel_ordering("relaxed")
     test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
     test.socket.capability:__queue_receive({ mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {200} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature") end
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device)})
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.commands.MoveToColorTemperature(mock_device, 5000, 0x0000)})

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
@@ -85,6 +85,11 @@ local function can_handle_zigbee_dimming_light(opts, driver, device)
   return false
 end
 
+local function do_configure(driver, device)
+  device:refresh()
+  device:configure()
+end
+
 local function device_init(driver, device)
   for _,attribute in ipairs(DIMMING_LIGHT_CONFIGURATION) do
     device:add_configured_attribute(attribute)
@@ -99,7 +104,8 @@ local zigbee_dimming_light = {
   NAME = "Zigbee Dimming Light",
   lifecycle_handlers = {
     init = configurations.power_reconfig_wrapper(device_init),
-    added = device_added
+    added = device_added,
+    doConfigure = do_configure
   },
   sub_drivers = {
     require("zigbee-dimming-light/osram-iqbr30"),

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/init.lua
@@ -204,9 +204,6 @@ local zll_dimmer_bulb = {
       [capabilities.colorTemperature.commands.setColorTemperature.NAME] = handle_set_color_temperature
     }
   },
-  sub_drivers = {
-    require("zll-dimmer-bulb/ikea-xy-color-bulb")
-  },
   can_handle = can_handle_zll_dimmer_bulb
 }
 

--- a/drivers/SmartThings/zigbee-switch/src/zll-polling/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-polling/init.lua
@@ -13,12 +13,12 @@
 -- limitations under the License.
 
 local device_lib = require "st.device"
-local constants = require "st.zigbee.constants"
 local clusters = require "st.zigbee.zcl.clusters"
+local ZLL_PROFILE_ID = 0xC05E
 
 local function zll_profile(opts, driver, device, zb_rx, ...)
   local endpoint = device.zigbee_endpoints[device.fingerprinted_endpoint_id] or device.zigbee_endpoints[tostring(device.fingerprinted_endpoint_id)]
-  if (endpoint ~= nil and endpoint.profile_id == constants.ZLL_PROFILE_ID) then
+  if (endpoint ~= nil and endpoint.profile_id == ZLL_PROFILE_ID) then
     local subdriver = require("zll-polling")
     return true, subdriver
   else


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [x] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

This pull request defaults handing for `on`, `off`, `set_level`, and `set_color_temperature` in the ZLL sub-driver back to the main `zigbee-switch` driver. 

# Summary of Completed Tests


