### PR TITLE
Keep SUPPORTED_COMPONENT_CAPABILITIES table on driver

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/air-quality-sensor/init.lua
@@ -439,15 +439,10 @@ local function driver_switched(driver, device)
 end
 
 local function device_init(driver, device)
-  if device:get_field(SUPPORTED_COMPONENT_CAPABILITIES) then
-    if version.api >= 15 and version.rpc >= 9 then
-      -- the device used this modular profile workaround on 0.57 FW but no longer requires this table with >=0.58 FW
-      device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, nil)
-    else
-      -- assume that device is using a modular profile on 0.57 FW, override supports_capability_by_id
-      -- library function to utilize optional capabilities
-      device:extend_device("supports_capability_by_id", supports_capability_by_id_modular)
-    end
+  if device:get_field(SUPPORTED_COMPONENT_CAPABILITIES) and (version.api < 15 or version.rpc < 9) then
+    -- assume that device is using a modular profile on 0.57 FW, override supports_capability_by_id
+    -- library function to utilize optional capabilities
+    device:extend_device("supports_capability_by_id", supports_capability_by_id_modular)
   end
   device:subscribe()
 end

--- a/drivers/SmartThings/matter-thermostat/src/init.lua
+++ b/drivers/SmartThings/matter-thermostat/src/init.lua
@@ -431,15 +431,10 @@ local endpoint_to_component = function (device, endpoint_id)
 end
 
 local function device_init(driver, device)
-  if device:get_field(SUPPORTED_COMPONENT_CAPABILITIES) then
-    if version.api >= 15 and version.rpc >= 9 then
-      -- the device used this modular profile workaround on 0.57 FW but no longer requires this table with >=0.58 FW
-      device:set_field(SUPPORTED_COMPONENT_CAPABILITIES, nil)
-    else
-      -- assume that device is using a modular profile on 0.57 FW, override supports_capability_by_id
-      -- library function to utilize optional capabilities
-      device:extend_device("supports_capability_by_id", supports_capability_by_id_modular)
-    end
+  if device:get_field(SUPPORTED_COMPONENT_CAPABILITIES) and (version.api < 15 or version.rpc < 9) then
+    -- assume that device is using a modular profile on 0.57 FW, override supports_capability_by_id
+    -- library function to utilize optional capabilities
+    device:extend_device("supports_capability_by_id", supports_capability_by_id_modular)
   end
   device:subscribe()
   device:set_component_to_endpoint_fn(component_to_endpoint)


### PR DESCRIPTION
# Description of Change
In the case a hub on 58 FW fails over to a hub on 57 FW, this table being removed will lead to incorrect handling.

# Summary of Completed Tests


