### PR TITLE
Lazy loading test for zigbee switch

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/aqara-light/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara-light/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local FINGERPRINTS = {
     { mfr = "LUMI", model = "lumi.light.acn004" },

--- a/drivers/SmartThings/zigbee-switch/src/aqara-light/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara-light/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"
 local data_types = require "st.zigbee.data_types"

--- a/drivers/SmartThings/zigbee-switch/src/aqara/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local FINGERPRINTS = require("aqara.fingerprints")
   for _, fingerprint in ipairs(FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/aqara/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
     { mfr = "LUMI", model = "lumi.plug.maeu01" },
     { mfr = "LUMI", model = "lumi.plug.macn01" },

--- a/drivers/SmartThings/zigbee-switch/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local FINGERPRINTS = require("aqara.multi-switch.fingerprints")
   for _, fingerprint in ipairs(FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   { mfr = "LUMI", model = "lumi.switch.n1acn1",   children = 1, child_profile = "" },
   { mfr = "LUMI", model = "lumi.switch.n2acn1",   children = 2, child_profile = "aqara-switch-child" },

--- a/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/multi-switch/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local device_lib = require "st.device"
 local capabilities = require "st.capabilities"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/aqara/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/sub_drivers.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local lazy_load = require "lazy_load_subdriver"
 
 return {

--- a/drivers/SmartThings/zigbee-switch/src/aqara/version/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/version/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function (opts, driver, device)
   local PRIVATE_MODE = "PRIVATE_MODE"
   local private_mode = device:get_field(PRIVATE_MODE) or 0

--- a/drivers/SmartThings/zigbee-switch/src/aqara/version/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/aqara/version/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local constants = require "st.zigbee.constants"

--- a/drivers/SmartThings/zigbee-switch/src/bad_on_off_data_type/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/bad_on_off_data_type/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- There are reports of at least one device (SONOFF 01MINIZB) which occasionally
 -- reports this value as an Int8, rather than a Boolean, as per the spec

--- a/drivers/SmartThings/zigbee-switch/src/bad_on_off_data_type/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/bad_on_off_data_type/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/configurations/devices.lua
+++ b/drivers/SmartThings/zigbee-switch/src/configurations/devices.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local ColorControl = clusters.ColorControl

--- a/drivers/SmartThings/zigbee-switch/src/configurations/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/configurations/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 
 local CONFIGURATION_VERSION_KEY = "_configuration_version"

--- a/drivers/SmartThings/zigbee-switch/src/ezex/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ezex/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local ZIGBEE_METERING_SWITCH_FINGERPRINTS = {
     { model = "E240-KR116Z-HA" }

--- a/drivers/SmartThings/zigbee-switch/src/ezex/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ezex/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local zigbee_constants = require "st.zigbee.constants"
 local configurations = require "configurations"

--- a/drivers/SmartThings/zigbee-switch/src/frient/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/frient/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 -- Function to determine if the driver can handle this device
 return function(opts, driver, device, ...)
   local FRIENT_SMART_PLUG_FINGERPRINTS = require("frient.fingerprints")

--- a/drivers/SmartThings/zigbee-switch/src/frient/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/frient/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   { mfr = "frient A/S", model = "SPLZB-131" },
   { mfr = "frient A/S", model = "SPLZB-132" },

--- a/drivers/SmartThings/zigbee-switch/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/frient/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/ge-link-bulb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ge-link-bulb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
     local GE_LINK_BULB_FINGERPRINTS = {
   ["GE_Appliances"] = {

--- a/drivers/SmartThings/zigbee-switch/src/ge-link-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ge-link-bulb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/hanssem/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/hanssem/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
   local FINGERPRINTS = require "hanssem.fingerprints"
   for _, fingerprint in ipairs(FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/hanssem/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/hanssem/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   { mfr = "Winners", model = "LSS1-101", children = 0 },
   { mfr = "Winners", model = "LSS1-102", children = 1 },

--- a/drivers/SmartThings/zigbee-switch/src/hanssem/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/hanssem/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local stDevice = require "st.device"
 local configurations = require "configurations"

--- a/drivers/SmartThings/zigbee-switch/src/ikea-xy-color-bulb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ikea-xy-color-bulb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 return function(opts, driver, device)
   local IKEA_XY_COLOR_BULB_FINGERPRINTS = {

--- a/drivers/SmartThings/zigbee-switch/src/ikea-xy-color-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/ikea-xy-color-bulb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- The only reason we need this is because of supported_capabilities on the driver template
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/inovelli/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 return function(opts, driver, device)
   local INOVELLI_FINGERPRINTS = {

--- a/drivers/SmartThings/zigbee-switch/src/inovelli/common.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli/common.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local device_management = require "st.zigbee.device_management"

--- a/drivers/SmartThings/zigbee-switch/src/inovelli/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/inovelli/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli/sub_drivers.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local lazy_load = require "lazy_load_subdriver"
 
 return {

--- a/drivers/SmartThings/zigbee-switch/src/inovelli/vzm32-sn/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli/vzm32-sn/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 return function(opts, driver, device)
   local INOVELLI_VZM32_SN_FINGERPRINTS = {

--- a/drivers/SmartThings/zigbee-switch/src/inovelli/vzm32-sn/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/inovelli/vzm32-sn/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/jasco/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/jasco/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
     local JASCO_SWTICH_FINGERPRINTS = {
   { mfr = "Jasco Products", model = "43095" },

--- a/drivers/SmartThings/zigbee-switch/src/jasco/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/jasco/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/laisiao/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/laisiao/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
 local FINGERPRINTS = {
   { mfr = "LAISIAO", model = "yuba" },

--- a/drivers/SmartThings/zigbee-switch/src/laisiao/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/laisiao/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lazy_load_subdriver.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(sub_driver_name)
   -- gets the current lua libs api version
   local version = require "version"

--- a/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/device_added.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/device_added.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local find_child = require "lifecycle_handlers.find_child"
 

--- a/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/do_configure.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/do_configure.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 return function(self, device)

--- a/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/find_child.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/find_child.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 return function(parent, ep_id)
   return parent:get_child_by_parent_assigned_key(string.format("%02X", ep_id))

--- a/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/info_changed.lua
+++ b/drivers/SmartThings/zigbee-switch/src/lifecycle_handlers/info_changed.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 return function(self, device, event, args)
   local preferences = require "preferences"

--- a/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local FINGERPRINTS = require "multi-switch-no-master.fingerprints"
   for _, fingerprint in ipairs(FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   { mfr = "DAWON_DNS", model = "PM-S240-ZB", children = 1 },
   { mfr = "DAWON_DNS", model = "PM-S240R-ZB", children = 1 },

--- a/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/multi-switch-no-master/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 local st_device = require "st.device"
 local utils = require "st.utils"
 local configurations = require "configurations"

--- a/drivers/SmartThings/zigbee-switch/src/non_zigbee_devices/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/non_zigbee_devices/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local st_device = require "st.device"
 

--- a/drivers/SmartThings/zigbee-switch/src/non_zigbee_devices/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/non_zigbee_devices/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- This is a patch for the zigbee-switch driver to fix https://smartthings.atlassian.net/browse/CHAD-16558
 -- Several hubs were found that had zigbee switch drivers hosting zwave devices.

--- a/drivers/SmartThings/zigbee-switch/src/preferences.lua
+++ b/drivers/SmartThings/zigbee-switch/src/preferences.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/rexense/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rexense/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
 local ZIGBEE_METERING_PLUG_FINGERPRINTS = {
   { mfr = "REXENSE", model = "HY0105" }          -- HONYAR Outlet"

--- a/drivers/SmartThings/zigbee-switch/src/rexense/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rexense/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/rgb-bulb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rgb-bulb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
 local RGB_BULB_FINGERPRINTS = {
   ["OSRAM"] = {

--- a/drivers/SmartThings/zigbee-switch/src/rgb-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rgb-bulb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local RGBW_BULB_FINGERPRINTS = require "rgbw-bulb.fingerprints"
   local can_handle = (RGBW_BULB_FINGERPRINTS[device:get_manufacturer()] or {})[device:get_model()]

--- a/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   ["Samsung Electronics"] = {
     ["SAMSUNG-ITM-Z-002"] = true

--- a/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/rgbw-bulb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/robb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/robb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
 local ROBB_DIMMER_FINGERPRINTS = {
   { mfr = "ROBB smarrt", model = "ROB_200-011-0" },

--- a/drivers/SmartThings/zigbee-switch/src/robb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/robb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local constants = require "st.zigbee.constants"
 local zcl_clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/sinope-dimmer/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/sinope-dimmer/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
     local can_handle = device:get_manufacturer() == "Sinope Technologies" and device:get_model() == "DM2500ZB"
     if can_handle then

--- a/drivers/SmartThings/zigbee-switch/src/sinope-dimmer/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/sinope-dimmer/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/sinope/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/sinope/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
     local can_handle = device:get_manufacturer() == "Sinope Technologies" and device:get_model() == "SW2500ZB"
     if can_handle then

--- a/drivers/SmartThings/zigbee-switch/src/sinope/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/sinope/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local cluster_base = require "st.zigbee.cluster_base"
 local data_types = require "st.zigbee.data_types"

--- a/drivers/SmartThings/zigbee-switch/src/switch_utils.lua
+++ b/drivers/SmartThings/zigbee-switch/src/switch_utils.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local switch_utils = {}
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module_no_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module_no_power.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_no_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_no_power.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_power.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_bad_data_type.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_bad_data_type.lua
@@ -1,17 +1,5 @@
-
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_bad_device_kind.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_bad_device_kind.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_cree_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_cree_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_frient_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_frient_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_ge_link_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_ge_link_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_child.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_child.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_preferences.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_preferences.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_child.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_child.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_preferences.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_preferences.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_laisiao_bath_heather.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_laisiao_bath_heather.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_osram_iqbr30_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_osram_iqbr30_light.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_osram_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_osram_light.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgb_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sengled_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sengled_color_temp_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sengled_dimmer_bulb_with_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sengled_dimmer_bulb_with_motion_sensor.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sinope_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sinope_dimmer.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local base64 = require "st.base64"
 local cluster_base = require "st.zigbee.cluster_base"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sinope_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sinope_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local base64 = require "st.base64"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_power_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_power_consumption_report.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_rexense.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_rexense.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/tuya-multi/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/tuya-multi/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local function is_multi_endpoint(device)
   local main_endpoint = device:get_endpoint(0x0006)
   for _, ep in ipairs(device.zigbee_endpoints) do

--- a/drivers/SmartThings/zigbee-switch/src/tuya-multi/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/tuya-multi/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local data_types = require "st.zigbee.data_types"

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
   local FINGERPRINTS = require "wallhero.fingerprints"
   for _, fingerprint in ipairs(FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   { mfr = "WALL HERO", model = "ACL-401S4I", switches = 4, buttons = 0 },
   { mfr = "WALL HERO", model = "ACL-401S8I", switches = 4, buttons = 4 },

--- a/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/wallhero/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local log = require "log"

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local WHITE_COLOR_TEMP_BULB_FINGERPRINTS = require "white-color-temp-bulb.fingerprints"
   local can_handle = (WHITE_COLOR_TEMP_BULB_FINGERPRINTS[device:get_manufacturer()] or {})[device:get_model()]

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/duragreen/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/duragreen/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local DURAGREEN_BULB_FINGERPRINTS = {
     ["DURAGREEN"] = {

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/duragreen/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/duragreen/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   ["DURAGREEN"] = {
     ["DG-CW-02"] = true,

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-switch/src/white-color-temp-bulb/sub_drivers.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local lazy_load = require "lazy_load_subdriver"
 return {
   lazy_load("white-color-temp-bulb.duragreen"),

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimmer-power-energy/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimmer-power-energy/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local ZIGBEE_DIMMER_POWER_ENERGY_FINGERPRINTS = {
   { mfr = "Jasco Products", model = "43082" }
 }

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimmer-power-energy/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimmer-power-energy/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local DIMMING_LIGHT_FINGERPRINTS = require "zigbee-dimming-light.fingerprints"
   for _, fingerprint in ipairs(DIMMING_LIGHT_FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   {mfr = "Vimar", model = "DimmerSwitch_v1.0"},               -- Vimar Smart Dimmer Switch
   {mfr = "OSRAM", model = "LIGHTIFY A19 ON/OFF/DIM"},         -- SYLVANIA Smart A19 Soft White

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/osram-iqbr30/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/osram-iqbr30/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
   local res = device:get_manufacturer() == "OSRAM SYLVANIA" and device:get_model() == "iQBR30"
   if res then

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/osram-iqbr30/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/osram-iqbr30/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/sub_drivers.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local lazy_load = require "lazy_load_subdriver"
 
 return {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/zll-dimmer/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/zll-dimmer/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local ZLL_DIMMER_FINGERPRINTS = require("zigbee-dimming-light.zll-dimmer.fingerprints")
   for _, fingerprint in ipairs(ZLL_DIMMER_FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/zll-dimmer/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/zll-dimmer/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   {mfr = "Leviton", model = "DL6HD"},   -- Leviton Dimmer Switch
   {mfr = "Leviton", model = "DL3HL"},   -- Leviton Lumina RF Plug-In Dimmer

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/zll-dimmer/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dimming-light/zll-dimmer/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local ZIGBEE_DUAL_METERING_SWITCH_FINGERPRINT = {
   {mfr = "Aurora", model = "DoubleSocket50AU"}
 }

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-dual-metering-switch/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 local capabilities = require "st.capabilities"
 local st_device = require "st.device"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, ...)
   local can_handle = device:get_manufacturer() == "DAWON_DNS"
   if can_handle then

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/aurora-relay/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/aurora-relay/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 return function(opts, driver, device)
   local AURORA_RELAY_FINGERPRINTS = {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/aurora-relay/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/aurora-relay/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local constants = require "st.zigbee.constants"
 

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local SWITCH_POWER_FINGERPRINTS = require "zigbee-switch-power.fingerprints"
   for _, fingerprint in ipairs(SWITCH_POWER_FINGERPRINTS) do

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   { mfr = "Vimar", model = "Mains_Power_Outlet_v1.0" },
   { model = "PAN18-v1.0.7" },

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/sub_drivers.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local lazy_load = require "lazy_load_subdriver"
 
 return {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 return function(opts, driver, device)
   local VIMAR_FINGERPRINTS = {

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-switch-power/vimar/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local constants = require "st.zigbee.constants"
 local device_management = require "st.zigbee.device_management"

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device)
   local ZLL_DIMMER_BULB_FINGERPRINTS = require "zll-dimmer-bulb.fingerprints"
   local can_handle = (ZLL_DIMMER_BULB_FINGERPRINTS[device:get_manufacturer()] or {})[device:get_model()]

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/fingerprints.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return {
   ["AduroSmart Eria"] = {
     ["ZLL-DimmableLight"] = true,

--- a/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-dimmer-bulb/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-switch/src/zll-polling/can_handle.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-polling/can_handle.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 return function(opts, driver, device, zb_rx, ...)
   local constants = require "st.zigbee.constants"
 

--- a/drivers/SmartThings/zigbee-switch/src/zll-polling/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zll-polling/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local device_lib = require "st.device"
 local clusters = require "st.zigbee.zcl.clusters"


### PR DESCRIPTION
We are considering adding a new way to lazy load subdrivers in 0.59.x, and this is what we would want to do to our zigbee switch driver to have it work with that functionality. The improvement is that we avoid requiring the base subdriver entirely to get access to the can handle and any nested subdrivers. So to convert our drivers subdrivers will all need to have a `can_handle.lua` file and any base driver or subdriver that has subdrivers will need a `sub_drivers.lua` file.

- [x] Undo name update from testing