### PR TITLE
Fix test cases using EnergyMeasurementStruct

### DIFF
--- a/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
@@ -196,7 +196,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyImported:build_test_report_data(mock_device,
       BATTERY_STORAGE_EP,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) --100Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) --100Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("importedEnergy",
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyExported:build_test_report_data(mock_device,
       BATTERY_STORAGE_EP,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 400000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) --400Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 400000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) --400Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("exportedEnergy",
@@ -245,7 +245,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyImported:build_test_report_data(mock_device,
       BATTERY_STORAGE_EP,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 200000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) --200Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 200000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) --200Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("importedEnergy",
@@ -266,7 +266,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyExported:build_test_report_data(mock_device,
       BATTERY_STORAGE_EP,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 400000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) --400Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 400000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) --400Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("exportedEnergy",

--- a/drivers/SmartThings/matter-energy/src/test/test_solar_power.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_solar_power.lua
@@ -133,7 +133,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyExported:build_test_report_data(mock_device,
       SOLAR_POWER_EP_ONE,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) })             --100Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) })             --100Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -156,7 +156,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyExported:build_test_report_data(mock_device,
       SOLAR_POWER_EP_TWO,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 150000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) })             --150Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 150000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) })             --150Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -178,7 +178,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
       .CumulativeEnergyExported:build_test_report_data(mock_device,
       SOLAR_POWER_EP_ONE,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) })             --100Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) })             --100Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -190,7 +190,7 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
       .CumulativeEnergyImported:build_test_report_data(mock_device,
       SOLAR_POWER_EP_ONE,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) })             --100Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) })             --100Wh
   end
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -123,6 +123,8 @@ local cumulative_report_val_19 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local cumulative_report_val_29 = {
@@ -131,6 +133,8 @@ local cumulative_report_val_29 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local cumulative_report_val_39 = {
@@ -139,6 +143,8 @@ local cumulative_report_val_39 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local function configure_buttons()

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor.lua
@@ -111,6 +111,8 @@ local cumulative_report_val_19 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local cumulative_report_val_29 = {
@@ -119,6 +121,8 @@ local cumulative_report_val_29 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local cumulative_report_val_39 = {
@@ -127,6 +131,8 @@ local cumulative_report_val_39 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local periodic_report_val_23 = {
@@ -135,6 +141,8 @@ local periodic_report_val_23 = {
   end_timestamp = 0,
   start_systime = 0,
   end_systime = 0,
+  apparent_energy = 0,
+  reactive_energy = 0
 }
 
 local function test_init()

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
@@ -633,7 +633,7 @@ test.register_message_test(
         clusters.ElectricalEnergyMeasurement.attributes
             .CumulativeEnergyImported:build_test_report_data(mock_device,
           HEAT_PUMP_EP,
-          clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 15000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 }))
+          clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 15000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 }))
       }
     },
     {
@@ -651,7 +651,7 @@ test.register_coroutine_test(
 
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     HEAT_PUMP_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 20Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 20Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -675,7 +675,7 @@ test.register_coroutine_test(
 
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     HEAT_PUMP_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 30000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 30Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 30000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 30Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -698,7 +698,7 @@ test.register_coroutine_test(
 
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     HEAT_PUMP_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 20Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 20Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -722,12 +722,12 @@ test.register_coroutine_test(
     -- do not expect energyMeter event for this report.
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported:build_test_report_data(mock_device,
     HEAT_PUMP_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 800, start_systime = 0, end_systime = 0 })) }) -- 20Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 800, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 20Wh
 
     -- do not expect a powerConsumptionReport to be emitted
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     HEAT_PUMP_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 50000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 50Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 50000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 50Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_water_heater.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_water_heater.lua
@@ -249,7 +249,7 @@ test.register_message_test(
         clusters.ElectricalEnergyMeasurement.attributes
             .CumulativeEnergyImported:build_test_report_data(mock_device,
           ELECTRICAL_SENSOR_EP,
-          clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 15000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 }))
+          clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 15000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 }))
       }
     },
     {
@@ -267,7 +267,7 @@ test.register_coroutine_test(
 
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     ELECTRICAL_SENSOR_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 20Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 20000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 20Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -288,7 +288,7 @@ test.register_coroutine_test(
 
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     ELECTRICAL_SENSOR_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 30000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 30Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 30000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 30Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",
@@ -303,7 +303,7 @@ test.register_coroutine_test(
 
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported:build_test_report_data(mock_device,
     ELECTRICAL_SENSOR_EP,
-    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 50000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0 })) }) -- 30Wh
+    clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 50000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) -- 30Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main",


### PR DESCRIPTION
Two fields were added to the type definition for EnergyMeasurementStruct and must be added to tests using this struct to fix test case failures.

Marked `do not merge` until the LuaLibs artifact is updated in the repo.