### PR TITLE
Enhance code coverate for zigbee-temperature driver

### DIFF
--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_aqara_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_aqara_thermostat.lua
@@ -113,6 +113,16 @@ test.register_coroutine_test(
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
     capabilities.hardwareFault.hardwareFault.detected()))
+
+    local attr_report_data_1 = {
+      { PRIVATE_THERMOSTAT_ALARM_INFORMATION_ID, data_types.Uint32.ID, 0x00000000 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_1, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+    capabilities.hardwareFault.hardwareFault.clear()))
   end
 )
 
@@ -128,6 +138,26 @@ test.register_coroutine_test(
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       valveCalibration.calibrationState.calibrationSuccess()))
+
+    local attr_report_data_1 = {
+      { PRIVATE_VALVE_RESULT_CALIBRATION_ID, data_types.Uint8.ID, 0x00 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_1, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      valveCalibration.calibrationState.calibrationPending()))
+
+    local attr_report_data_2 = {
+      { PRIVATE_VALVE_RESULT_CALIBRATION_ID, data_types.Uint8.ID, 0x02 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_2, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      valveCalibration.calibrationState.calibrationFailure()))
   end
 )
 
@@ -145,6 +175,18 @@ test.register_coroutine_test(
       capabilities.thermostatMode.thermostatMode.manual()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       invisibleCapabilities.invisibleCapabilities({""})))
+
+    local attr_report_data_1 = {
+      { PRIVATE_THERMOSTAT_OPERATING_MODE_ATTRIBUTE_ID, data_types.Uint8.ID, 0x02 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_1, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.thermostatMode.thermostatMode.antifreezing()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      invisibleCapabilities.invisibleCapabilities({"thermostatHeatingSetpoint"})))
   end
 )
 
@@ -162,6 +204,54 @@ test.register_coroutine_test(
       capabilities.valve.valve.closed()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",
       invisibleCapabilities.invisibleCapabilities({"thermostatHeatingSetpoint","stse.valveCalibration","thermostatMode","lock"})))
+
+    local attr_report_data_1 = {
+      { PRIVATE_THERMOSTAT_OPERATING_MODE_ATTRIBUTE_ID, data_types.Uint8.ID, 0x00 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_1, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.thermostatMode.thermostatMode.manual()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      invisibleCapabilities.invisibleCapabilities({""})))
+
+    local attr_report_data_2 = {
+      { PRIVATE_VALVE_SWITCH_ATTRIBUTE_ID, data_types.Uint8.ID, 0x01 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_2, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.valve.valve.open()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      invisibleCapabilities.invisibleCapabilities({""})))
+
+    local attr_report_data_3 = {
+      { PRIVATE_THERMOSTAT_OPERATING_MODE_ATTRIBUTE_ID, data_types.Uint8.ID, 0x02 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_3, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.thermostatMode.thermostatMode.antifreezing()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      invisibleCapabilities.invisibleCapabilities({"thermostatHeatingSetpoint"})))
+
+    local attr_report_data_4 = {
+      { PRIVATE_VALVE_SWITCH_ATTRIBUTE_ID, data_types.Uint8.ID, 0x01 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_4, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      capabilities.valve.valve.open()))
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+      invisibleCapabilities.invisibleCapabilities({"thermostatHeatingSetpoint"})))
   end
 )
 
@@ -177,6 +267,16 @@ test.register_coroutine_test(
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("ChildLock",
       capabilities.lock.lock.unlocked()))
+
+    local attr_report_data_1 = {
+      { PRIVATE_CHILD_LOCK_ID, data_types.Uint8.ID, 0x01 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, PRIVATE_CLUSTER_ID, attr_report_data_1, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("ChildLock",
+      capabilities.lock.lock.locked()))
   end
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_leviton_rc.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_leviton_rc.lua
@@ -192,4 +192,36 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Handle added lifecycle",
+  function()
+    -- The initial valve and lock event should be send during the device's first time onboarding
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main",
+      capabilities.thermostatMode.supportedThermostatModes({
+        capabilities.thermostatMode.thermostatMode.auto.NAME,
+        capabilities.thermostatMode.thermostatMode.cool.NAME,
+        capabilities.thermostatMode.thermostatMode.heat.NAME,
+        capabilities.thermostatMode.thermostatMode.emergency_heat.NAME
+      }, { visibility = { displayed = false } }))
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main",
+      capabilities.thermostatFanMode.supportedThermostatFanModes({
+        capabilities.thermostatFanMode.thermostatFanMode.auto.NAME,
+        capabilities.thermostatFanMode.thermostatFanMode.on.NAME,
+        capabilities.thermostatFanMode.thermostatFanMode.circulate.NAME
+      }, { visibility = { displayed = false } }))
+    )
+    test.socket.zigbee:__expect_send( { mock_device.id, FanControl.attributes.FanMode:read(mock_device):to_endpoint(ENDPOINT) })
+    test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.SystemMode:read(mock_device):to_endpoint(ENDPOINT) })
+    test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.ControlSequenceOfOperation:read(mock_device):to_endpoint(ENDPOINT) })
+    test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.OccupiedCoolingSetpoint:read(mock_device):to_endpoint(ENDPOINT) })
+    test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.OccupiedHeatingSetpoint:read(mock_device):to_endpoint(ENDPOINT) })
+    test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.LocalTemperature:read(mock_device):to_endpoint(ENDPOINT) })
+  end
+)
+
+
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_popp_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_popp_thermostat.lua
@@ -361,5 +361,95 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Setting the thermostat mode should generate the appropriate messages",
+  function ()
+    test.socket.capability:__queue_receive({ mock_device.id, { component = "main", capability = capabilities.thermostatMode.ID, command = "setThermostatMode", args = {"eco"} } })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        cluster_base.build_manufacturer_specific_command(mock_device, Thermostat.ID, THERMOSTAT_SETPOINT_CMD_ID, MFG_CODE, string.char(0x00, (math.floor(21.0 * 100) & 0xFF), (math.floor(21.0 * 100) >> 8)))
+      }
+    )
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.eco()))
+  end
+)
+
+test.register_coroutine_test(
+  "init and doConfigure lifecycles should be handled properly",
+  function()
+      test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+      test.mock_time.advance_time(2)
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.eco()))
+      test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.on()))
+      test.socket.zigbee:__expect_send(
+        {
+          mock_device.id,
+          Thermostat.attributes.OccupiedHeatingSetpoint:read(mock_device)
+        }
+      )
+      test.socket.zigbee:__expect_send(
+        {
+          mock_device.id,
+          ThermostatUIConfig.attributes.KeypadLockout:read(mock_device)
+        }
+      )
+      test.socket.zigbee:__expect_send(
+        {
+          mock_device.id,
+          PowerConfiguration.attributes.BatteryVoltage:read(mock_device)
+        }
+      )
+      test.socket.zigbee:__expect_send(
+        {
+          mock_device.id,
+          Thermostat.attributes.LocalTemperature:read(mock_device)
+        }
+      )
+      test.socket.zigbee:__expect_send({mock_device.id, cluster_base.read_manufacturer_specific_attribute(
+        mock_device,
+        Thermostat.ID,
+        ETRV_WINDOW_OPEN_DETECTION_ATTR_ID,
+        MFG_CODE
+      )})
+      test.socket.zigbee:__expect_send({mock_device.id, cluster_base.read_manufacturer_specific_attribute(
+        mock_device,
+        Thermostat.ID,
+        EXTERNAL_WINDOW_OPEN_DETECTION,
+        MFG_CODE
+      )})
+  end
+)
+
+test.register_coroutine_test(
+  "Device reported Thermostat WINDOW_OPEN_DETECTION_ATTR_ID attribute",
+  function()
+    local attr_report_data = {
+      { ETRV_WINDOW_OPEN_DETECTION_ATTR_ID, data_types.Uint8.ID, 1 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, Thermostat.ID, attr_report_data, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureAlarm.temperatureAlarm.cleared()))
+  end
+)
+
+test.register_coroutine_test(
+  "Device reported Thermostat WINDOW_OPEN_DETECTION_ATTR_ID attribute",
+  function()
+    local attr_report_data = {
+      { EXTERNAL_WINDOW_OPEN_DETECTION, data_types.Uint8.ID, 1 }
+    }
+    test.socket.zigbee:__queue_receive({
+      mock_device.id,
+      zigbee_test_utils.build_attribute_report(mock_device, Thermostat.ID, attr_report_data, MFG_CODE)
+    })
+    test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.off()))
+  end
+)
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_resideo_dt300st_m000.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_resideo_dt300st_m000.lua
@@ -713,5 +713,19 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end)
 
+test.register_coroutine_test("ThermostatRunningState reporting shoulb create the appropriate events", function()
+  test.socket.zigbee:__queue_receive({mock_device.id,
+                                      Thermostat.attributes.ThermostatRunningState:build_test_attr_report(mock_device, 0x0001)})
+  test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+    capabilities.thermostatOperatingState.thermostatOperatingState({value="heating"})))
+  test.socket.zigbee:__queue_receive({mock_device.id,
+                                      Thermostat.attributes.ThermostatRunningState:build_test_attr_report(mock_device, 0x0002)})
+  test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+    capabilities.thermostatOperatingState.thermostatOperatingState({value="cooling"})))
+  test.socket.zigbee:__queue_receive({mock_device.id,
+                                      Thermostat.attributes.ThermostatRunningState:build_test_attr_report(mock_device, 0x0004)})
+  test.socket.capability:__expect_send(mock_device:generate_test_message("main",
+    capabilities.thermostatOperatingState.thermostatOperatingState({value="fan only"})))
+end)
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_thermostat.lua
@@ -474,4 +474,39 @@ test.register_coroutine_test(
   end
 )
 
+test.register_coroutine_test(
+  "Handle added lifecycle",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.temperatureAlarm.temperatureAlarm.cleared())
+    )
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      Thermostat.attributes.LocalTemperature:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      Thermostat.attributes.PIHeatingDemand:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      Thermostat.attributes.OccupiedHeatingSetpoint:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      ThermostatUserInterfaceConfiguration.attributes.TemperatureDisplayMode:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      ThermostatUserInterfaceConfiguration.attributes.KeypadLockout:read(mock_device)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      RelativeHumidity.attributes.MeasuredValue:read(mock_device)
+    })
+  end
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [x] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Enhance code coverate for zigbee-temperature driver

aqara/init.lua 86.74% -> 95.03
leviton/init.lua 89.91% 100.0%
popp/init.lua 78.33% ->95.1%
resideo_korea/init.lua 81.55% -> 90.29%
stelpro-ki-zigbee-thermostat/init.lua 89.44% -> 94.44%
stelpro/init.lua 88.61% -> 95.03% -> 94.79%
Total 89.77% -> 95.04%

# Summary of Completed Tests


