### PR TITLE
Matter Lock: Use Door Lock Device type in Lock Modular logic

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -217,6 +217,7 @@ local function match_profile_modular(driver, device)
   for _, ep_data in ipairs(device.endpoints) do
     if ep_data.device_types[1].device_type_id == DEVICE_TYPE_ID.DOOR_LOCK then
       door_lock_ep_data = ep_data
+      break
     end
   end
   for _, cluster in pairs(door_lock_ep_data.clusters) do


### PR DESCRIPTION
# Description of Change
Slightly reduces number of checks in the lock modular logic by using the device type as a first check, before searching for the door lock cluster to map a profile to.

# Summary of Completed Tests
Unit tests continue to pass, and VDA onboarding indicated a correct modular profile was selected.

