### PR TITLE
Matter Switch: Fix Fingerprint

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -552,7 +552,7 @@ matterManufacturer:
     deviceLabel: IM Pushbutton Module
     vendorId: 0x1372
     productId: 0x0002
-    deviceProfileName: switch-binary
+    deviceProfileName: 4-button
 #JUNG
   - id: "5161/1"
     deviceLabel: Matter Push button 2-gang


### PR DESCRIPTION
# Description of Change

The switch-4 profile is not currently supported by the Matter Switch driver, and so any devices being onboarded with this profile will not work as expected. The current expected handling for this device should be 4-button, since it supports 4 generic switches. 

# Summary of Completed Tests


