### PR TITLE
Matter Switch: subscribe to PowerSource AttributeList

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -111,6 +111,12 @@ function SwitchLifecycleHandlers.device_init(driver, device)
         end
       end
     end
+    -- For devices supporting BATTERY, add the PowerSource AttributeList to the list of subscribed
+    -- attributes in order to determine whether to use the battery or batteryLevel capability.
+    local battery_supported = #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY}) > 0
+    if battery_supported then
+      device:add_subscribed_attribute(clusters.PowerSource.attributes.AttributeList)
+    end
     device:subscribe()
 
     -- device energy reporting must be handled cumulatively, periodically, or by both simulatanously.

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
@@ -123,6 +123,7 @@ local function test_init()
   test.disable_startup_messages()
   test.mock_device.add_test_device(aqara_mock_device)
   local cluster_subscribe_list = {
+    clusters.PowerSource.server.attributes.AttributeList,
     clusters.PowerSource.server.attributes.BatPercentRemaining,
     clusters.TemperatureMeasurement.attributes.MeasuredValue,
     clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
@@ -148,8 +149,6 @@ local function test_init()
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "doConfigure" })
-  local read_attribute_list = clusters.PowerSource.attributes.AttributeList:read()
-  test.socket.matter:__expect_send({aqara_mock_device.id, read_attribute_list})
   configure_buttons()
   aqara_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
@@ -92,6 +92,7 @@ local mock_device = test.mock_device.build_test_matter_device(
 
 -- add device for each mock device
 local CLUSTER_SUBSCRIBE_LIST ={
+  clusters.PowerSource.server.attributes.AttributeList,
   clusters.PowerSource.server.attributes.BatPercentRemaining,
   clusters.Switch.server.events.InitialPress,
   clusters.Switch.server.events.LongPress,
@@ -136,7 +137,6 @@ local function test_init()
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
 
   --doConfigure sets the provisioning state to provisioned
-  test.socket.matter:__expect_send({mock_device.id, clusters.PowerSource.attributes.AttributeList:read()})
   mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   expect_configure_buttons()
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })

--- a/drivers/SmartThings/matter-switch/src/utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/utils/device_configuration.lua
@@ -94,9 +94,7 @@ function ButtonDeviceConfiguration.update_button_profile(device, default_endpoin
     profile_name = profile_name .. "-motion"
   end
   local battery_supported = #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY}) > 0
-  if battery_supported then -- battery profiles are configured later, in power_source_attribute_list_handler
-    device:send(clusters.PowerSource.attributes.AttributeList:read(device))
-  else
+  if not battery_supported then -- battery profiles are configured later, in power_source_attribute_list_handler
     device:try_update_metadata({profile = profile_name})
   end
 end

--- a/drivers/SmartThings/matter-switch/src/utils/switch_fields.lua
+++ b/drivers/SmartThings/matter-switch/src/utils/switch_fields.lua
@@ -176,6 +176,8 @@ SwitchFields.EMULATE_HELD = "__emulate_held" -- for non-MSR (MomentarySwitchRele
 SwitchFields.SUPPORTS_MULTI_PRESS = "__multi_button" -- for MSM devices (MomentarySwitchMultiPress), create an event on receipt of MultiPressComplete
 SwitchFields.INITIAL_PRESS_ONLY = "__initial_press_only" -- for devices that support MS (MomentarySwitch), but not MSR (MomentarySwitchRelease)
 
+SwitchFields.BUTTON_PROFILE_NAME = "__button_profile_name"
+
 SwitchFields.TEMP_BOUND_RECEIVED = "__temp_bound_received"
 SwitchFields.TEMP_MIN = "__temp_min"
 SwitchFields.TEMP_MAX = "__temp_max"


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Change the read of PowerSource AttributeList to a subscription, in order to prevent failed reads leading to misconfigured devices.

# Summary of Completed Tests


