### PR TITLE
Matter Switch: Lazy load subdrivers if possible

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -297,11 +297,11 @@ local matter_driver_template = {
   },
   supported_capabilities = fields.supported_capabilities,
   sub_drivers = {
-    require("sub_drivers.aqara_cube"),
+    switch_utils.lazy_load_if_possible("sub_drivers.aqara_cube"),
     switch_utils.lazy_load("sub_drivers.camera"),
-    require("sub_drivers.eve_energy"),
-    require("sub_drivers.ikea_scroll"),
-    require("sub_drivers.third_reality_mk1")
+    switch_utils.lazy_load_if_possible("sub_drivers.eve_energy"),
+    switch_utils.lazy_load_if_possible("sub_drivers.ikea_scroll"),
+    switch_utils.lazy_load_if_possible("sub_drivers.third_reality_mk1")
   }
 }
 

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/aqara_cube/can_handle.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/aqara_cube/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local device_lib = require "st.device"
+
+return function(opts, driver, device)
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
+    local name = string.format("%s", device.manufacturer_info.product_name)
+    if string.find(name, "Aqara Cube T1 Pro") then
+      return true, require("sub_drivers.aqara_cube")
+    end
+  end
+  return false
+end

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/aqara_cube/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/aqara_cube/init.lua
@@ -21,16 +21,6 @@ local INITIAL_PRESS_ONLY = "__initial_press_only" -- for devices that support MS
 local CUBEACTION_TIMER = "__cubeAction_timer"
 local CUBEACTION_TIME = 3
 
-local function is_aqara_cube(opts, driver, device)
-  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
-    local name = string.format("%s", device.manufacturer_info.product_name)
-    if string.find(name, "Aqara Cube T1 Pro") then
-      return true
-    end
-  end
-  return false
-end
-
 local callback_timer = function(device)
   return function()
     device:emit_event(cubeAction.cubeAction("noAction"))
@@ -240,7 +230,7 @@ local aqara_cube_handler = {
       }
     },
   },
-  can_handle = is_aqara_cube
+  can_handle = require("sub_drivers.aqara_cube.can_handle")
 }
 
 return aqara_cube_handler

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/eve_energy/can_handle.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/eve_energy/can_handle.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local device_lib = require "st.device"
+local fields = require "switch_utils.fields"
+local switch_utils = require "switch_utils.utils"
+
+return function(opts, driver, device)
+  local EVE_MANUFACTURER_ID = 0x130A
+  -- this sub driver does NOT support child devices, and ONLY supports Eve devices
+  -- that do NOT support the Electrical Sensor device type
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
+    device.manufacturer_info.vendor_id == EVE_MANUFACTURER_ID and
+    #switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.ELECTRICAL_SENSOR) == 0 then
+    return true, require("sub_drivers.eve_energy")
+  end
+  return false
+end

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/eve_energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/eve_energy/init.lua
@@ -11,14 +11,11 @@ local cluster_base = require "st.matter.cluster_base"
 local st_utils = require "st.utils"
 local data_types = require "st.matter.data_types"
 local device_lib = require "st.device"
-local switch_utils = require "switch_utils.utils"
-local fields = require "switch_utils.fields"
 
 local SWITCH_INITIALIZED = "__switch_intialized"
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
 local ON_OFF_STATES = "ON_OFF_STATES"
 
-local EVE_MANUFACTURER_ID = 0x130A
 local PRIVATE_CLUSTER_ID = 0x130AFC01
 
 local PRIVATE_ATTR_ID_WATT = 0x130A000A
@@ -37,18 +34,6 @@ local MINIMUM_ST_ENERGY_REPORT_INTERVAL = (15 * 60) -- 15 minutes, reported in s
 -------------------------------------------------------------------------------------
 -- Eve specifics
 -------------------------------------------------------------------------------------
-
-local function is_eve_energy_products(opts, driver, device)
-  -- this sub driver does NOT support child devices, and ONLY supports Eve devices
-  -- that do NOT support the Electrical Sensor device type
-  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
-      device.manufacturer_info.vendor_id == EVE_MANUFACTURER_ID and
-      #switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.ELECTRICAL_SENSOR) == 0 then
-    return true
-  end
-
-  return false
-end
 
 -- Return a ISO 8061 formatted timestamp in UTC (Z)
 -- @return e.g. 2022-02-02T08:00:00Z
@@ -370,7 +355,7 @@ local eve_energy_handler = {
     capabilities.energyMeter,
     capabilities.powerConsumptionReport
   },
-  can_handle = is_eve_energy_products
+  can_handle = require("sub_drivers.eve_energy.can_handle")
 }
 
 return eve_energy_handler

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/can_handle.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local switch_utils = require "switch_utils.utils"
+
+return function(opts, driver, device)
+  if switch_utils.get_product_override_field(device, "is_ikea_scroll") then
+    return true, require("sub_drivers.ikea_scroll")
+  end
+  return false
+end

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/init.lua
@@ -44,7 +44,7 @@ local ikea_scroll_handler = {
     infoChanged = IkeaScrollLifecycleHandlers.info_changed,
     init = IkeaScrollLifecycleHandlers.device_init,
   },
-  can_handle = scroll_utils.is_ikea_scroll
+  can_handle = require("sub_drivers.ikea_scroll.can_handle")
 }
 
 return ikea_scroll_handler

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/utils.lua
@@ -3,14 +3,9 @@
 
 local im = require "st.matter.interaction_model"
 local clusters = require "st.matter.clusters"
-local switch_utils = require "switch_utils.utils"
 local scroll_fields = require "sub_drivers.ikea_scroll.scroll_utils.fields"
 
 local IkeaScrollUtils = {}
-
-function IkeaScrollUtils.is_ikea_scroll(opts, driver, device)
-  return switch_utils.get_product_override_field(device, "is_ikea_scroll")
-end
 
 -- override subscribe function to prevent subscribing to additional events from the main driver
 function IkeaScrollUtils.subscribe(device)

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/third_reality_mk1/can_handle.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/third_reality_mk1/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local device_lib = require "st.device"
+
+return function(opts, driver, device)
+  local THIRD_REALITY_MK1_FINGERPRINT = { vendor_id = 0x1407, product_id = 0x1388 }
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
+    device.manufacturer_info.vendor_id == THIRD_REALITY_MK1_FINGERPRINT.vendor_id and
+    device.manufacturer_info.product_id == THIRD_REALITY_MK1_FINGERPRINT.product_id then
+    return true, require("sub_drivers.third_reality_mk1")
+  end
+  return false
+end

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/third_reality_mk1/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/third_reality_mk1/init.lua
@@ -3,27 +3,13 @@
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
-local device_lib = require "st.device"
 local im = require "st.matter.interaction_model"
-local log = require "log"
 
 local COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
 
 -------------------------------------------------------------------------------------
 -- Third Reality MK1 specifics
 -------------------------------------------------------------------------------------
-
-local THIRD_REALITY_MK1_FINGERPRINT = { vendor_id = 0x1407, product_id = 0x1388 }
-
-local function is_third_reality_mk1(opts, driver, device)
-  if device.network_type == device_lib.NETWORK_TYPE_MATTER and
-     device.manufacturer_info.vendor_id == THIRD_REALITY_MK1_FINGERPRINT.vendor_id and
-     device.manufacturer_info.product_id == THIRD_REALITY_MK1_FINGERPRINT.product_id then
-    log.info("Using Third Reality MK1 sub driver")
-    return true
-  end
-  return false
-end
 
 local function endpoint_to_component(device, ep)
   local map = device:get_field(COMPONENT_TO_ENDPOINT_MAP) or {}
@@ -121,7 +107,7 @@ local third_reality_mk1_handler = {
   supported_capabilities = {
     capabilities.button
   },
-  can_handle = is_third_reality_mk1
+  can_handle = require("sub_drivers.third_reality_mk1.can_handle")
 }
 
 return third_reality_mk1_handler

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -416,4 +416,14 @@ function utils.lazy_load(sub_driver_name)
   end
 end
 
+function utils.lazy_load_if_possible(sub_driver_name)
+  if version.api >= 16 then
+    return MatterDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return MatterDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end
+
 return utils


### PR DESCRIPTION
This change utilizes the new `lazy_load_sub_driver_v2` api to lazy load subdrivers in the matter switch driver.