### PR TITLE
Matter Smoke Co Alarm: Remove smokeSensitivity preference from profile

### DIFF
--- a/drivers/SmartThings/matter-sensor/profiles/smoke-temp-humidity-battery.yml
+++ b/drivers/SmartThings/matter-sensor/profiles/smoke-temp-humidity-battery.yml
@@ -19,8 +19,6 @@ components:
   categories:
   - name: SmokeDetector
 preferences:
-  - preferenceId: certifiedpreferences.smokeSensorSensitivity
-    explicit: true
   - preferenceId: tempOffset
     explicit: true
   - preferenceId: humidityOffset


### PR DESCRIPTION
# Description of Change
The partner has requested this preference be removed. Per the spec, support for this preference as we map it is optional anyway, so I think this is reasonable, especially since we don't know of other devices that will be mapping to this.

# Summary of Completed Tests


