### PR TITLE
CHAD-17042: zb-motion: Lazy loading of can handle and scripting testing ground

### DIFF
--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/aqara_utils.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/aqara_utils.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 
 local aqara_utils = {}

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_aqara_products = function(opts, driver, device)
+  local FINGERPRINTS = require("aqara.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("aqara")
+    end
+  end
+  return false
+end
+
+return is_aqara_products

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FINGERPRINTS = {
+  { mfr = "LUMI", model = "lumi.motion.ac02" },
+  { mfr = "LUMI", model = "lumi.motion.agl02" },
+  { mfr = "LUMI", model = "lumi.motion.agl04" }
+}
+
+return FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/can_handle.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(opts, driver, device, ...)
+    if device:get_model() == "lumi.motion.agl04" then
+        return true, require("aqara.high-precision-motion")
+    end
+    return false
+end

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/high-precision-motion/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"
@@ -118,9 +121,7 @@ local aqara_high_precision_motion_handler = {
       }
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_model() == "lumi.motion.agl04"
-  end
+  can_handle = require("aqara.high-precision-motion.can_handle")
 }
 
 return aqara_high_precision_motion_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/init.lua
@@ -1,3 +1,6 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 local zcl_commands = require "st.zigbee.zcl.global_commands"
 local clusters = require "st.zigbee.zcl.clusters"
@@ -16,11 +19,6 @@ local FREQUENCY_ATTRIBUTE_ID = 0x0102
 
 local MOTION_DETECTED_UINT32 = 65536
 
-local FINGERPRINTS = {
-  { mfr = "LUMI", model = "lumi.motion.ac02" },
-  { mfr = "LUMI", model = "lumi.motion.agl02" },
-  { mfr = "LUMI", model = "lumi.motion.agl04" }
-}
 
 local CONFIGURATIONS = {
   {
@@ -33,14 +31,6 @@ local CONFIGURATIONS = {
   }
 }
 
-local is_aqara_products = function(opts, driver, device)
-  for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function motion_illuminance_attr_handler(driver, device, value, zb_rx)
   -- The low 16 bits for Illuminance
@@ -123,10 +113,8 @@ local aqara_motion_handler = {
       }
     }
   },
-  sub_drivers = {
-    require("aqara.high-precision-motion")
-  },
-  can_handle = is_aqara_products
+  sub_drivers = require("aqara.sub_drivers"),
+  can_handle = require("aqara.can_handle"),
 }
 
 return aqara_motion_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aqara/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aqara/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load = require "lazy_load_subdriver"
+
+return {
+    lazy_load("aqara.high-precision-motion")
+}

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aurora/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aurora/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function aurora_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "Aurora" and device:get_model() == "MotionSensor51AU" then
+    return true, require("aurora")
+  end
+  return false
+end
+
+return aurora_can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/aurora/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/aurora/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local capabilities = require "st.capabilities"
 
 local function added_handler(self, device)
@@ -24,9 +14,7 @@ local aurora_motion_driver = {
   lifecycle_handlers = {
     added = added_handler,
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "Aurora" and device:get_model() == "MotionSensor51AU"
-  end
+  can_handle = require("aurora.can_handle"),
 }
 
 return aurora_motion_driver

--- a/drivers/SmartThings/zigbee-motion-sensor/src/battery-voltage/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/battery-voltage/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local can_handle_battery_voltage = function(opts, driver, device, ...)
+  local FINGERPRINTS = require("battery-voltage.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("battery-voltage")
+    end
+  end
+  return false
+end
+
+return can_handle_battery_voltage

--- a/drivers/SmartThings/zigbee-motion-sensor/src/battery-voltage/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/battery-voltage/fingerprints.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local DEVICES_REPORTING_BATTERY_VOLTAGE = {
+  { mfr = "Bosch", model = "RFPR-ZB" },
+  { mfr = "Bosch", model = "RFDL-ZB-MS" },
+  { mfr = "Ecolink", model = "PIRZB1-ECO" },
+  { mfr = "ADUROLIGHT", model = "VMS_ADUROLIGHT" },
+  { mfr = "AduroSmart Eria", model = "VMS_ADUROLIGHT" }
+}
+
+return DEVICES_REPORTING_BATTERY_VOLTAGE

--- a/drivers/SmartThings/zigbee-motion-sensor/src/battery-voltage/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/battery-voltage/init.lua
@@ -1,35 +1,8 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
-
-local DEVICES_REPORTING_BATTERY_VOLTAGE = {
-  { mfr = "Bosch", model = "RFPR-ZB" },
-  { mfr = "Bosch", model = "RFDL-ZB-MS" },
-  { mfr = "Ecolink", model = "PIRZB1-ECO" },
-  { mfr = "ADUROLIGHT", model = "VMS_ADUROLIGHT" },
-  { mfr = "AduroSmart Eria", model = "VMS_ADUROLIGHT" }
-}
-
-local can_handle_battery_voltage = function(opts, driver, device, ...)
-  for _, fingerprint in ipairs(DEVICES_REPORTING_BATTERY_VOLTAGE) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 
 local battery_voltage_motion = {
@@ -37,7 +10,7 @@ local battery_voltage_motion = {
   lifecycle_handlers = {
     init = battery_defaults.build_linear_voltage_init(2.1, 3.0)
   },
-  can_handle = can_handle_battery_voltage
+  can_handle = require("battery-voltage.can_handle"),
 }
 
 return battery_voltage_motion

--- a/drivers/SmartThings/zigbee-motion-sensor/src/centralite/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/centralite/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function centralite_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "CentraLite" then
+    return true, require("centralite")
+  end
+  return false
+end
+
+return centralite_can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/centralite/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/centralite/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -46,9 +36,7 @@ local centralite_handler = {
   lifecycle_handlers = {
     init = init_handler
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "CentraLite"
-  end
+  can_handle = require("centralite.can_handle"),
 }
 
 return centralite_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/compacta/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/compacta/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function compacta_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "Compacta" then
+    return true, require("compacta")
+  end
+  return false
+end
+
+return compacta_can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/compacta/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/compacta/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- ZCL
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -43,9 +33,7 @@ local compacta_driver = {
     added = added_handler,
     doConfigure = do_configure
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "Compacta"
-  end
+  can_handle = require("compacta.can_handle"),
 }
 
 return compacta_driver

--- a/drivers/SmartThings/zigbee-motion-sensor/src/frient/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/frient/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_frient_motion_sensor(opts, driver, device)
+  local FINGERPRINTS = require("frient.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("frient")
+    end
+  end
+  return false
+end
+
+return can_handle_frient_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/frient/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/frient/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FRIENT_DEVICE_FINGERPRINTS = {
+  { mfr = "frient A/S", model = "MOSZB-140"},
+  { mfr = "frient A/S", model = "MOSZB-141"},
+  { mfr = "frient A/S", model = "MOSZB-153"}
+}
+
+return FRIENT_DEVICE_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/frient/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 local capabilities = require "st.capabilities"
@@ -35,20 +24,7 @@ local POWER_CONFIGURATION_ENDPOINT = 0x23
 local TEMPERATURE_ENDPOINT = 0x26
 local ILLUMINANCE_ENDPOINT = 0x27
 
-local FRIENT_DEVICE_FINGERPRINTS = {
-  { mfr = "frient A/S", model = "MOSZB-140"},
-  { mfr = "frient A/S", model = "MOSZB-141"},
-  { mfr = "frient A/S", model = "MOSZB-153"}
-}
 
-local function can_handle_frient_motion_sensor(opts, driver, device)
-  for _, fingerprint in ipairs(FRIENT_DEVICE_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function occupancy_attr_handler(driver, device, occupancy, zb_rx)
   device:emit_event(occupancy.value == 0x01 and capabilities.motionSensor.motion.active() or capabilities.motionSensor.motion.inactive())
@@ -214,6 +190,6 @@ local frient_motion_driver = {
       [capabilities.refresh.commands.refresh.NAME] = do_refresh
     }
   },
-  can_handle = can_handle_frient_motion_sensor
+  can_handle = require("frient.can_handle"),
 }
 return frient_motion_driver

--- a/drivers/SmartThings/zigbee-motion-sensor/src/gatorsystem/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/gatorsystem/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function gatorsystem_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "GatorSystem" and device:get_model() == "GSHW01" then
+    return true, require("gatorsystem")
+  end
+  return false
+end
+
+return gatorsystem_can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/gatorsystem/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/gatorsystem/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -84,9 +74,7 @@ local gator_handler = {
     added = device_added,
     doConfigure = do_configure
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "GatorSystem" and device:get_model() == "GSHW01"
-  end
+  can_handle = require("gatorsystem.can_handle"),
 }
 
 return gator_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/ikea/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/ikea/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_ikea_motion = function(opts, driver, device)
+  local FINGERPRINTS = require("ikea.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("ikea")
+    end
+  end
+  return false
+end
+
+return is_ikea_motion

--- a/drivers/SmartThings/zigbee-motion-sensor/src/ikea/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/ikea/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local IKEA_MOTION_SENSOR_FINGERPRINTS = {
+    { mfr = "IKEA of Sweden", model = "TRADFRI motion sensor" }
+}
+
+return IKEA_MOTION_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/ikea/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local constants = require "st.zigbee.constants"
 local clusters = require "st.zigbee.zcl.clusters"
@@ -26,9 +16,6 @@ local OnOff = clusters.OnOff
 local PowerConfiguration = clusters.PowerConfiguration
 local Groups = clusters.Groups
 
-local IKEA_MOTION_SENSOR_FINGERPRINTS = {
-    { mfr = "IKEA of Sweden", model = "TRADFRI motion sensor" }
-}
 
 local MOTION_RESET_TIMER = "motionResetTimer"
 local ENTRIES_READ = "ENTRIES_READ"
@@ -48,14 +35,6 @@ local function on_with_timed_off_command_handler(driver, device, zb_rx)
   device:set_field(MOTION_RESET_TIMER, motion_reset_timer)
 end
 
-local is_ikea_motion = function(opts, driver, device)
-  for _, fingerprint in ipairs(IKEA_MOTION_SENSOR_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function zdo_binding_table_handler(driver, device, zb_rx)
   for _, binding_table in pairs(zb_rx.body.zdo_body.binding_table_entries) do
@@ -141,7 +120,7 @@ local ikea_motion_sensor = {
     added = device_added,
     doConfigure = do_configure
   },
-  can_handle = is_ikea_motion
+  can_handle = require("ikea.can_handle"),
 }
 
 return ikea_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/init.lua
@@ -1,22 +1,13 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
 local constants = require "st.zigbee.constants"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
+local lazy_load_if_possible = require "lazy_load_subdriver"
 
 local temperature_measurement_defaults = {
   MIN_TEMP = "MIN_TEMP",
@@ -110,23 +101,23 @@ local zigbee_motion_driver = {
     added = added_handler
   },
   sub_drivers = {
-    require("aqara"),
-    require("aurora"),
-    require("ikea"),
-    require("iris"),
-    require("gatorsystem"),
-    require("motion_timeout"),
-    require("nyce"),
-    require("zigbee-plugin-motion-sensor"),
-    require("compacta"),
-    require("frient"),
-    require("samjin"),
-    require("battery-voltage"),
-    require("centralite"),
-    require("smartthings"),
-    require("smartsense"),
-    require("thirdreality"),
-    require("sengled")
+    lazy_load_if_possible("aqara"),
+    lazy_load_if_possible("aurora"),
+    lazy_load_if_possible("ikea"),
+    lazy_load_if_possible("iris"),
+    lazy_load_if_possible("gatorsystem"),
+    lazy_load_if_possible("motion_timeout"),
+    lazy_load_if_possible("nyce"),
+    lazy_load_if_possible("zigbee-plugin-motion-sensor"),
+    lazy_load_if_possible("compacta"),
+    lazy_load_if_possible("frient"),
+    lazy_load_if_possible("samjin"),
+    lazy_load_if_possible("battery-voltage"),
+    lazy_load_if_possible("centralite"),
+    lazy_load_if_possible("smartthings"),
+    lazy_load_if_possible("smartsense"),
+    lazy_load_if_possible("thirdreality"),
+    lazy_load_if_possible("sengled"),
   },
   additional_zcl_profiles = {
     [0xFC01] = true

--- a/drivers/SmartThings/zigbee-motion-sensor/src/iris/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/iris/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_zigbee_iris_motion_sensor = function(opts, driver, device)
+  local FINGERPRINTS = require("iris.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("iris")
+    end
+  end
+  return false
+end
+
+return is_zigbee_iris_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/iris/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/iris/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_IRIS_MOTION_SENSOR_FINGERPRINTS = {
+  { mfr = "iMagic by GreatStar", model = "1117-S" }
+}
+
+return ZIGBEE_IRIS_MOTION_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/iris/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/iris/init.lua
@@ -1,23 +1,10 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 
-local ZIGBEE_IRIS_MOTION_SENSOR_FINGERPRINTS = {
-  { mfr = "iMagic by GreatStar", model = "1117-S" }
-}
 
 -- TODO: the IAS Zone changes should be replaced after supporting functions are included in the lua libs
 local do_init = function(driver, device)
@@ -26,21 +13,13 @@ local do_init = function(driver, device)
   device:remove_configured_attribute(zcl_clusters.IASZone.ID, zcl_clusters.IASZone.attributes.ZoneStatus.ID)
 end
 
-local is_zigbee_iris_motion_sensor = function(opts, driver, device)
-  for _, fingerprint in ipairs(ZIGBEE_IRIS_MOTION_SENSOR_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local iris_motion_handler = {
   NAME = "Iris Motion Handler",
   lifecycle_handlers = {
     init = do_init
   },
-  can_handle = is_zigbee_iris_motion_sensor
+  can_handle = require("iris.can_handle"),
 }
 
 return iris_motion_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-motion-sensor/src/motion_timeout/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/motion_timeout/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_zigbee_motion_sensor = function(opts, driver, device)
+  local FINGERPRINTS = require("motion_timeout.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("motion_timeout")
+    end
+  end
+  return false
+end
+
+return is_zigbee_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/motion_timeout/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/motion_timeout/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_MOTION_SENSOR_FINGERPRINTS = {
+  { mfr = "ORVIBO", model = "895a2d80097f4ae2b2d40500d5e03dcc", timeout = 20 },
+  { mfr = "Megaman", model = "PS601/z1", timeout = 20 },
+  { mfr = "HEIMAN", model = "PIRSensor-N", timeout = 20 }
+}
+
+return ZIGBEE_MOTION_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/motion_timeout/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/motion_timeout/init.lua
@@ -1,40 +1,18 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local IASZone = zcl_clusters.IASZone
 
-local ZIGBEE_MOTION_SENSOR_FINGERPRINTS = {
-  { mfr = "ORVIBO", model = "895a2d80097f4ae2b2d40500d5e03dcc", timeout = 20 },
-  { mfr = "Megaman", model = "PS601/z1", timeout = 20 },
-  { mfr = "HEIMAN", model = "PIRSensor-N", timeout = 20 }
-}
 
-local is_zigbee_motion_sensor = function(opts, driver, device)
-  for _, fingerprint in ipairs(ZIGBEE_MOTION_SENSOR_FINGERPRINTS) do
-      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-          return true
-      end
-  end
-  return false
-end
 
 local generate_event_from_zone_status = function(driver, device, zone_status, zigbee_message)
+  local FINGERPRINTS = require("motion_timeout.fingerprints")
   device:emit_event(
       (zone_status:is_alarm1_set() or zone_status:is_alarm2_set()) and capabilities.motionSensor.motion.active() or capabilities.motionSensor.motion.inactive())
-  for _, fingerprint in ipairs(ZIGBEE_MOTION_SENSOR_FINGERPRINTS) do
+  for _, fingerprint in ipairs(FINGERPRINTS) do
     if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
       device.thread:call_with_delay(fingerprint.timeout, function(d)
           device:emit_event(capabilities.motionSensor.motion.inactive())
@@ -66,7 +44,7 @@ local motion_timeout_handler = {
       }
     }
   },
-  can_handle = is_zigbee_motion_sensor
+  can_handle = require("motion_timeout.can_handle"),
 }
 
 return motion_timeout_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/nyce/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/nyce/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_zigbee_nyce_motion_sensor = function(opts, driver, device)
+  local FINGERPRINTS = require("nyce.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+          return true, require("nyce")
+      end
+  end
+  return false
+end
+
+return is_zigbee_nyce_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/nyce/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/nyce/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_NYCE_MOTION_SENSOR_FINGERPRINTS = {
+  { mfr = "NYCE", model = "3041" },
+  { mfr = "NYCE", model = "3043" },
+  { mfr = "NYCE", model = "3045" }
+}
+
+return ZIGBEE_NYCE_MOTION_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/nyce/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/nyce/init.lua
@@ -1,36 +1,13 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 local OccupancySensing = zcl_clusters.OccupancySensing
 
-local ZIGBEE_NYCE_MOTION_SENSOR_FINGERPRINTS = {
-  { mfr = "NYCE", model = "3041" },
-  { mfr = "NYCE", model = "3043" },
-  { mfr = "NYCE", model = "3045" }
-}
 
-local is_zigbee_nyce_motion_sensor = function(opts, driver, device)
-  for _, fingerprint in ipairs(ZIGBEE_NYCE_MOTION_SENSOR_FINGERPRINTS) do
-      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-          return true
-      end
-  end
-  return false
-end
 
 local function occupancy_attr_handler(driver, device, occupancy, zb_rx)
   device:emit_event(
@@ -49,7 +26,7 @@ local nyce_motion_handler = {
       }
     }
   },
-  can_handle = is_zigbee_nyce_motion_sensor
+  can_handle = require("nyce.can_handle"),
 }
 
 return nyce_motion_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/samjin/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/samjin/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function samjin_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "Samjin" then
+    return true, require("samjin")
+  end
+  return false
+end
+
+return samjin_can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/samjin/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/samjin/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- ZCL
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -44,9 +34,7 @@ local samjin_driver = {
       }
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "Samjin"
-  end
+  can_handle = require("samjin.can_handle"),
 }
 
 return samjin_driver

--- a/drivers/SmartThings/zigbee-motion-sensor/src/sengled/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/sengled/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_sengled_products = function(opts, driver, device, ...)
+  local FINGERPRINTS = require("sengled.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("sengled")
+    end
+  end
+  return false
+end
+
+return is_sengled_products

--- a/drivers/SmartThings/zigbee-motion-sensor/src/sengled/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/sengled/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FINGERPRINTS = {
+  { mfr = "sengled", model = "E1M-G7H" }
+}
+
+return FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/sengled/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/sengled/init.lua
@@ -1,12 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local clusters = require "st.zigbee.zcl.clusters"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 
 local IASZone = clusters.IASZone
 local PowerConfiguration = clusters.PowerConfiguration
 
-local FINGERPRINTS = {
-  { mfr = "sengled", model = "E1M-G7H" }
-}
 
 local CONFIGURATIONS = {
   {
@@ -27,14 +27,6 @@ local CONFIGURATIONS = {
   }
 }
 
-local is_sengled_products = function(opts, driver, device, ...)
-  for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function device_init(driver, device)
   battery_defaults.build_linear_voltage_init(2.6, 3.0)(driver, device)
@@ -49,7 +41,7 @@ local sengled_motion_sensor_handler = {
   lifecycle_handlers = {
     init = device_init
   },
-  can_handle = is_sengled_products
+  can_handle = require("sengled.can_handle"),
 }
 
 return sengled_motion_sensor_handler

--- a/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/can_handle.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle(opts, driver, device, ...)
+
+  local SMARTSENSE_MFR = "SmartThings"
+  local SMARTSENSE_MODEL = "PGC314"
+  local SMARTSENSE_PROFILE_ID = 0xFC01
+
+  local endpoint = device.zigbee_endpoints[1] or device.zigbee_endpoints["1"]
+  if (device:get_manufacturer() == SMARTSENSE_MFR and device:get_model() == SMARTSENSE_MODEL) or
+    endpoint.profile_id == SMARTSENSE_PROFILE_ID then
+    return true, require("smartsense")
+  end
+  return false
+end
+
+return can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/smartsense/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local utils = require "st.utils"
@@ -18,9 +8,6 @@ local utils = require "st.utils"
 local motion = capabilities.motionSensor.motion
 local signalStrength = capabilities.signalStrength
 
-local SMARTSENSE_MFR = "SmartThings"
-local SMARTSENSE_MODEL = "PGC314"
-local SMARTSENSE_PROFILE_ID = 0xFC01
 local SMARTSENSE_MOTION_CLUSTER = 0xFC04
 local SMARTSENSE_MOTION_STATUS_CMD = 0x00
 local MOTION_MASK = 0x02
@@ -43,14 +30,6 @@ local battery_table = {
   [0] = 0
 }
 
-local function can_handle(opts, driver, device, ...)
-  local endpoint = device.zigbee_endpoints[1] or device.zigbee_endpoints["1"]
-  if (device:get_manufacturer() == SMARTSENSE_MFR and device:get_model() == SMARTSENSE_MODEL) or
-    endpoint.profile_id == SMARTSENSE_PROFILE_ID then
-    return true
-  end
-  return false
-end
 
 local function device_added(driver, device)
   device:emit_event(motion.inactive())
@@ -96,7 +75,7 @@ local smartsense_motion = {
   lifecycle_handlers = {
     added = device_added
   },
-  can_handle = can_handle
+  can_handle = require("smartsense.can_handle"),
 }
 
 return smartsense_motion

--- a/drivers/SmartThings/zigbee-motion-sensor/src/smartthings/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/smartthings/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function smartthings_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "SmartThings" then
+    return true, require("smartthings")
+  end
+  return false
+  end
+
+return smartthings_can_handle

--- a/drivers/SmartThings/zigbee-motion-sensor/src/smartthings/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/smartthings/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
@@ -44,9 +34,7 @@ local smartthings_motion = {
   lifecycle_handlers = {
     init = init_handler
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "SmartThings"
-  end
+  can_handle = require("smartthings.can_handle"),
 }
 
 return smartthings_motion

--- a/drivers/SmartThings/zigbee-motion-sensor/src/st/zigbee/zdo/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/st/zigbee/zdo/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2021 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2021 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local data_types = require "st.zigbee.data_types"
 local utils = require "st.zigbee.utils"
 local zdo_commands = require "st.zigbee.zdo.commands"
@@ -101,7 +91,7 @@ function ZdoMessageBody.deserialize(parent, buf)
     -- binding table entry endpoint_id
     local version = require "version"
     if version.rpc == 8 then
-      buf.buf = buf.buf .. "\01"
+      buf.buf = buf.buf .. ""
       buf:seek(1)
     end
     s.zdo_body = zdo_commands.parse_zdo_command(parent.address_header.cluster.value, buf)

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aurora_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aurora_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_battery_voltage_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_battery_voltage_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_centralite_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_centralite_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_compacta_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_compacta_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local base64 = require "base64"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor2_pet.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor2_pet.lua
@@ -1,16 +1,6 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local base64 = require "base64"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor_pro.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor_pro.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local base64 = require "base64"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_gator_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_gator_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_ikea_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_ikea_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"
@@ -133,7 +123,7 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "ZDO Message handler and adding hub to group",
   function()
-    local binding_table = mgmt_bind_response.BindingTableListRecord("\x6A\x9D\xC0\xFE\xFF\x5E\xCF\xD0", 0x01, 0x0006, 0x01, 0xB9F2)
+    local binding_table = mgmt_bind_response.BindingTableListRecord("jù¿˛ˇ^œ–", 0x01, 0x0006, 0x01, 0xB9F2)
     local response = mgmt_bind_response.MgmtBindResponse({
       status = 0x00,
       total_binding_table_entry_count = 0x01,
@@ -154,7 +144,7 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Request all binding table entries and fall back to group 0x0000",
   function()
-    local binding_table_long = mgmt_bind_response.BindingTableListRecord("\x6A\x9D\xC0\xFE\xFF\x5E\xCF\xD0", 0x01, 0x0006, 0x03, "DEADBEEF", 0x01)
+    local binding_table_long = mgmt_bind_response.BindingTableListRecord("jù¿˛ˇ^œ–", 0x01, 0x0006, 0x03, "DEADBEEF", 0x01)
     local response = mgmt_bind_response.MgmtBindResponse({
       status = 0x00,
       total_binding_table_entry_count = 0x02,

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_samjin_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_samjin_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_sengled_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_sengled_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
@@ -71,7 +61,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\x7C")
+      build_motion_status_message(mock_device, "|")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
@@ -85,7 +75,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\x7E")
+      build_motion_status_message(mock_device, "~")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.active()))
@@ -99,7 +89,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\x58")
+      build_motion_status_message(mock_device, "X")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(70)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
@@ -113,7 +103,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\x5A")
+      build_motion_status_message(mock_device, "Z")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(70)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.active()))
@@ -127,7 +117,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\xBD")
+      build_motion_status_message(mock_device, "½")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.lqi(50)))
@@ -140,7 +130,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\xBF")
+      build_motion_status_message(mock_device, "¿")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.active()))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.lqi(50)))
@@ -153,7 +143,7 @@ test.register_coroutine_test(
   function()
     test.socket.zigbee:__queue_receive({
       mock_device.id,
-      build_motion_status_message(mock_device, "\x30")
+      build_motion_status_message(mock_device, "0")
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(0)))
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartthings_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartthings_motion.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_thirdreality_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_thirdreality_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_iris.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_iris.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_nyce.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_nyce.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_orvibo.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_orvibo.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_plugin_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_plugin_motion_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-motion-sensor/src/thirdreality/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/thirdreality/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_third_reality_motion_sensor = function(opts, driver, device)
+  local FINGERPRINTS = require("thirdreality.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("thirdreality")
+    end
+  end
+  return false
+end
+
+return is_third_reality_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/thirdreality/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/thirdreality/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_MOTION_SENSOR_FINGERPRINTS = {
+  { mfr = "Third Reality, Inc", model = "3RMS16BZ"},
+  { mfr = "THIRDREALITY", model = "3RMS16BZ"}
+}
+
+return ZIGBEE_MOTION_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/thirdreality/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/thirdreality/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -20,19 +10,7 @@ local utils = require "st.utils"
 
 local APPLICATION_VERSION = "application_version"
 
-local ZIGBEE_MOTION_SENSOR_FINGERPRINTS = {
-  { mfr = "Third Reality, Inc", model = "3RMS16BZ"},
-  { mfr = "THIRDREALITY", model = "3RMS16BZ"}
-}
 
-local is_third_reality_motion_sensor = function(opts, driver, device)
-  for _, fingerprint in ipairs(ZIGBEE_MOTION_SENSOR_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local device_added = function(self, device)
   device:set_field(APPLICATION_VERSION, 0)
@@ -73,7 +51,7 @@ local third_reality_motion_sensor = {
   lifecycle_handlers = {
     added = device_added,
   },
-  can_handle = is_third_reality_motion_sensor
+  can_handle = require("thirdreality.can_handle"),
 }
 
 return third_reality_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/zigbee-plugin-motion-sensor/can_handle.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/zigbee-plugin-motion-sensor/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_zigbee_plugin_motion_sensor = function(opts, driver, device)
+  local FINGERPRINTS = require("zigbee-plugin-motion-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_model() == fingerprint.model then
+      return true, require("zigbee-plugin-motion-sensor")
+    end
+  end
+  return false
+end
+
+return is_zigbee_plugin_motion_sensor

--- a/drivers/SmartThings/zigbee-motion-sensor/src/zigbee-plugin-motion-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/zigbee-plugin-motion-sensor/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_PLUGIN_MOTION_SENSOR_FINGERPRINTS = {
+  { model = "E280-KR0A0Z0-HA" }
+}
+
+return ZIGBEE_PLUGIN_MOTION_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-motion-sensor/src/zigbee-plugin-motion-sensor/init.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/zigbee-plugin-motion-sensor/init.lua
@@ -1,34 +1,13 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local device_management = require "st.zigbee.device_management"
 local OccupancySensing = zcl_clusters.OccupancySensing
 
-local ZIGBEE_PLUGIN_MOTION_SENSOR_FINGERPRINTS = {
-  { model = "E280-KR0A0Z0-HA" }
-}
 
-local is_zigbee_plugin_motion_sensor = function(opts, driver, device)
-  for _, fingerprint in ipairs(ZIGBEE_PLUGIN_MOTION_SENSOR_FINGERPRINTS) do
-    if device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function occupancy_attr_handler(driver, device, occupancy, zb_rx)
   device:emit_event(occupancy.value == 0x01 and capabilities.motionSensor.motion.active() or capabilities.motionSensor.motion.inactive())
@@ -59,7 +38,7 @@ local zigbee_plugin_motion_sensor = {
       [capabilities.refresh.commands.refresh.NAME] = do_refresh,
     }
   },
-  can_handle = is_zigbee_plugin_motion_sensor
+  can_handle = require("zigbee-plugin-motion-sensor.can_handle"),
 }
 
 return zigbee_plugin_motion_sensor


### PR DESCRIPTION
Lazy loading of the `zigbee-motion-sensor` sub drivers with the `can_handle` lazy loading.

This driver was modified heavily by the use of a script I've been developing to automate this process for the rest of the zigbee, zwave and matter drivers. This is the first PR & driver refactored with the assistance of the script (though still massaged to pass all driver tests by me).