### PR TITLE
sonos: Retry ssdp task creation to fix log spam and spinning

### DIFF
--- a/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
+++ b/drivers/SmartThings/sonos/src/lifecycle_handlers.lua
@@ -165,6 +165,7 @@ function SonosDriverLifecycleHandlers.initialize_device(driver, device)
             { hub_logs = true },
             string.format("Driver wasn't able to spin up SSDP task, cannot initialize devices.")
           )
+          cosock.socket.sleep(30)
         end
       end
     end,


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

We would try to create the SSDP task a single time and if the UDP socket creation failed then we would spin in the init lifecycle loop. This has us retry the task creation if it fails and adds a sleep in the loop so we don't spin anymore.

# Summary of Completed Tests

I made it so the UDP socket creation returns nil for the first 5 attempts and reproduced the behavior, then with this change we eventually recover.

