### PR TITLE
Lazy load camera subdriver only for LuaLibs 16 and greater

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -297,7 +297,7 @@ local matter_driver_template = {
   supported_capabilities = fields.supported_capabilities,
   sub_drivers = {
     require("sub_drivers.aqara_cube"),
-    switch_utils.lazy_load_if_possible("sub_drivers.camera"),
+    switch_utils.lazy_load("sub_drivers.camera"),
     require("sub_drivers.eve_energy"),
     require("sub_drivers.third_reality_mk1")
   }

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -344,13 +344,9 @@ function utils.report_power_consumption_to_st_energy(device, latest_total_import
   end
 end
 
-function utils.lazy_load_if_possible(sub_driver_name)
+function utils.lazy_load(sub_driver_name)
   if version.api >= 16 then
     return MatterDriver.lazy_load_sub_driver_v2(sub_driver_name)
-  elseif version.api >= 9 then
-    return MatterDriver.lazy_load_sub_driver(require(sub_driver_name))
-  else
-    return require(sub_driver_name)
   end
 end
 


### PR DESCRIPTION
The camera subdriver is only supported on LuaLibs version >= 16, and causes issues if it's loaded on previous versions, so this commit changes `lazy_load_if_possible` to `lazy_load`, which only attempts to pull in the subdriver if the api version if 16 or greater.

Note that `lazy_load_if_possible` will be reintroduced by #2525 to allow for lazy loading other subdrivers, which do support lower lua libs versions.