### PR TITLE
Matter Window Covering: Remove default tilt preset

### DIFF
--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -789,9 +789,6 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send(
       {mock_device.id, WindowCovering.server.commands.GoToLiftPercentage(mock_device, 10, (100 - PRESET_LEVEL) * 100)}
     )
-    test.socket.matter:__expect_send(
-      {mock_device.id, WindowCovering.server.commands.GoToTiltPercentage(mock_device, 10, 5000)}
-    )
   end
 )
 


### PR DESCRIPTION
Remove the `GoToTiltPercentage` command sent when the `presetPosition` capability command is received, which previously would set the tilt preset level to a default level of 50%. A new capability will be introduced later to support setting the tilt preset level.