### PR TITLE
Matter Camera: Check for server cluster type

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_utils/device_configuration.lua
@@ -55,10 +55,6 @@ function CameraDeviceConfiguration.match_profile(device, status_light_enabled_pr
 
   local camera_endpoints = switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.CAMERA)
   if #camera_endpoints > 0 then
-    if #device:get_endpoints(clusters.WebRTCTransportProvider.ID) > 0 and
-      #device:get_endpoints(clusters.WebRTCTransportRequestor.ID, {cluster_type = "CLIENT"}) > 0 then
-      table.insert(main_component_capabilities, capabilities.webrtc.ID)
-    end
     local camera_ep = switch_utils.get_endpoint_info(device, camera_endpoints[1])
     for _, ep_cluster in pairs(camera_ep.clusters or {}) do
       if ep_cluster.cluster_id == clusters.CameraAvStreamManagement.ID and has_server_cluster_type(ep_cluster) then
@@ -110,6 +106,9 @@ function CameraDeviceConfiguration.match_profile(device, status_light_enabled_pr
         table.insert(main_component_capabilities, capabilities.zoneManagement.ID)
       elseif ep_cluster.cluster_id == clusters.OccupancySensing.ID and has_server_cluster_type(ep_cluster) then
         table.insert(main_component_capabilities, capabilities.motionSensor.ID)
+      elseif ep_cluster.cluster_id == clusters.WebRTCTransportProvider.ID and has_server_cluster_type(ep_cluster) and
+        #device:get_endpoints(clusters.WebRTCTransportRequestor.ID, {cluster_type = "CLIENT"}) > 0 then
+        table.insert(main_component_capabilities, capabilities.webrtc.ID)
       end
     end
   end

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -156,7 +156,6 @@ local function update_device_profile()
       {
         "main",
         {
-          "webrtc",
           "videoCapture2",
           "cameraViewportSettings",
           "localMediaStorage",
@@ -168,6 +167,7 @@ local function update_device_profile()
           "mechanicalPanTiltZoom",
           "videoStreamSettings",
           "zoneManagement",
+          "webrtc",
           "motionSensor",
           "sounds",
         }


### PR DESCRIPTION
Check for cluster_type = SERVER or BOTH when adding optional capabilities. When using get_endpoints, omit the check for SERVER because it is already implied in that api.

Tested with matter SDK camera example app.