### PR TITLE
CHAD-17040: Zwave thermostat lazy load subdrivers

### DIFF
--- a/drivers/SmartThings/zwave-thermostat/src/aeotec-radiator-thermostat/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/aeotec-radiator-thermostat/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeotec_radiator_thermostat(opts, driver, device, ...)
+    local AEOTEC_THERMOSTAT_FINGERPRINT = {mfr = 0x0371, prod = 0x0002, model = 0x0015}
+
+    if device:id_match(AEOTEC_THERMOSTAT_FINGERPRINT.mfr, AEOTEC_THERMOSTAT_FINGERPRINT.prod, AEOTEC_THERMOSTAT_FINGERPRINT.model) then
+        return true, require "aeotec-radiator-thermostat"
+    else
+        return false
+    end
+end
+
+return can_handle_aeotec_radiator_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/aeotec-radiator-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/aeotec-radiator-thermostat/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -23,12 +13,6 @@ local Battery = (require "st.zwave.CommandClass.Battery")({version=1})
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({version=2})
 --- @type st.zwave.CommandClass.ThermostatSetpoint
 local ThermostatSetpoint = (require "st.zwave.CommandClass.ThermostatSetpoint")({version=1})
-
-local AEOTEC_THERMOSTAT_FINGERPRINT = {mfr = 0x0371, prod = 0x0002, model = 0x0015}
-
-local function can_handle_aeotec_radiator_thermostat(opts, driver, device, ...)
-  return device:id_match(AEOTEC_THERMOSTAT_FINGERPRINT.mfr, AEOTEC_THERMOSTAT_FINGERPRINT.prod, AEOTEC_THERMOSTAT_FINGERPRINT.model)
-end
 
 local function thermostat_mode_report_handler(self, device, cmd)
   local event = nil
@@ -114,7 +98,7 @@ local aeotec_radiator_thermostat = {
     }
   },
   lifecycle_handlers = {added = device_added},
-  can_handle = can_handle_aeotec_radiator_thermostat
+  can_handle = require("aeotec-radiator-thermostat.can_handle"),
 }
 
 return aeotec_radiator_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/can_handle.lua
@@ -1,0 +1,25 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  local cc = require "st.zwave.CommandClass"
+  local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+  local DANFOSS_LC13_THERMOSTAT_FPS = require "apiv6_bugfix.fingerprints"
+
+  if version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION and not
+    (device:id_match(DANFOSS_LC13_THERMOSTAT_FPS[1].manufacturerId,
+      DANFOSS_LC13_THERMOSTAT_FPS[1].productType,
+      DANFOSS_LC13_THERMOSTAT_FPS[1].productId) or
+    device:id_match(DANFOSS_LC13_THERMOSTAT_FPS[2].manufacturerId,
+      DANFOSS_LC13_THERMOSTAT_FPS[2].productType,
+      DANFOSS_LC13_THERMOSTAT_FPS[2].productId)) then
+    return true, require "apiv6_bugfix"
+      else
+    return false
+  end
+end
+
+return can_handle

--- a/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/fingerprints.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local DANFOSS_LC13_THERMOSTAT_FPS = {
+    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0003 }, -- Danfoss LC13 Thermostat
+    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0004 } -- Danfoss LC13 Thermostat
+}
+
+return DANFOSS_LC13_THERMOSTAT_FPS

--- a/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/apiv6_bugfix/init.lua
@@ -1,23 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local cc = require "st.zwave.CommandClass"
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
-local DANFOSS_LC13_THERMOSTAT_FPS = {
-    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0003 }, -- Danfoss LC13 Thermostat
-    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0004 } -- Danfoss LC13 Thermostat
-}
-
-local function can_handle(opts, driver, device, cmd, ...)
-  local version = require "version"
-  return version.api == 6 and
-    cmd.cmd_class == cc.WAKE_UP and
-    cmd.cmd_id == WakeUp.NOTIFICATION and not
-    (device:id_match(DANFOSS_LC13_THERMOSTAT_FPS[1].manufacturerId,
-      DANFOSS_LC13_THERMOSTAT_FPS[1].productType,
-      DANFOSS_LC13_THERMOSTAT_FPS[1].productId) or
-    device:id_match(DANFOSS_LC13_THERMOSTAT_FPS[2].manufacturerId,
-      DANFOSS_LC13_THERMOSTAT_FPS[2].productType,
-      DANFOSS_LC13_THERMOSTAT_FPS[2].productId))
-end
 
 local function wakeup_notification(driver, device, cmd)
   device:refresh()
@@ -30,7 +16,7 @@ local apiv6_bugfix = {
     }
   },
   NAME = "apiv6_bugfix",
-  can_handle = can_handle
+  can_handle = require("apiv6_bugfix.can_handle"),
 }
 
 return apiv6_bugfix

--- a/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_ct100_thermostat(opts, driver, device)
+    local CT100_THERMOSTAT_FINGERPRINTS = require "ct100-thermostat.fingerprints"
+    for _, fingerprint in ipairs(CT100_THERMOSTAT_FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require "ct100-thermostat"
+    end
+  end
+
+  return false
+end
+
+return can_handle_ct100_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/fingerprints.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local CT100_THERMOSTAT_FINGERPRINTS = {
+  { manufacturerId = 0x0098, productType = 0x6401, productId = 0x0107 }, -- 2Gig CT100 Programmable Thermostat
+  { manufacturerId = 0x0098, productType = 0x6501, productId = 0x000C }, -- Iris Thermostat
+}
+
+return CT100_THERMOSTAT_FINGERPRINTS

--- a/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/ct100-thermostat/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
@@ -32,11 +22,6 @@ local heating_setpoint_defaults = require "st.zwave.defaults.thermostatHeatingSe
 local cooling_setpoint_defaults = require "st.zwave.defaults.thermostatCoolingSetpoint"
 local constants = require "st.zwave.constants"
 local utils = require "st.utils"
-
-local CT100_THERMOSTAT_FINGERPRINTS = {
-  { manufacturerId = 0x0098, productType = 0x6401, productId = 0x0107 }, -- 2Gig CT100 Programmable Thermostat
-  { manufacturerId = 0x0098, productType = 0x6501, productId = 0x000C }, -- Iris Thermostat
-}
 
 -- This old device uses separate endpoints to get values of temp and humidity
 -- DTH actually uses the old mutliInstance encap, but multichannel should be back-compat
@@ -73,16 +58,6 @@ local function set_setpoint_factory(setpoint_type)
       device:send(ThermostatOperatingState:Get({}))
     end)
   end
-end
-
-local function can_handle_ct100_thermostat(opts, driver, device)
-  for _, fingerprint in ipairs(CT100_THERMOSTAT_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-
-  return false
 end
 
 local function thermostat_mode_report_handler(self, device, cmd)
@@ -210,7 +185,7 @@ local ct100_thermostat = {
       [capabilities.refresh.commands.refresh.NAME] = do_refresh
     }
   },
-  can_handle = can_handle_ct100_thermostat,
+  can_handle = require("ct100-thermostat.can_handle"),
 }
 
 return ct100_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_heat_controller(opts, driver, device, ...)
+  local FINGERPRINTS = require("fibaro-heat-controller.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+      if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+          return true, require("fibaro-heat-controller")
+      end
+  end
+
+  return false
+end
+
+return can_handle_fibaro_heat_controller

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/fingerprints.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FIBARO_HEAT_FINGERPRINTS = {
+    {mfr = 0x010F, prod = 0x1301, model = 0x1000}, -- Fibaro Heat Controller
+    {mfr = 0x010F, prod = 0x1301, model = 0x1001} -- Fibaro Heat Controller
+}
+
+return FIBARO_HEAT_FINGERPRINTS

--- a/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/fibaro-heat-controller/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -30,22 +20,9 @@ local ApplicationStatus = (require "st.zwave.CommandClass.ApplicationStatus")({v
 
 local utils = require "st.utils"
 
-local FIBARO_HEAT_FINGERPRINTS = {
-    {mfr = 0x010F, prod = 0x1301, model = 0x1000}, -- Fibaro Heat Controller
-    {mfr = 0x010F, prod = 0x1301, model = 0x1001} -- Fibaro Heat Controller
-}
 
 local FORCED_REFRESH_THREAD = "forcedRefreshThread"
 
-local function can_handle_fibaro_heat_controller(opts, driver, device, ...)
-  for _, fingerprint in ipairs(FIBARO_HEAT_FINGERPRINTS) do
-      if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-          return true
-      end
-  end
-
-  return false
-end
 
 local function thermostat_mode_report_handler(self, device, cmd)
   local event = nil
@@ -189,7 +166,7 @@ local fibaro_heat_controller = {
     added = device_added,
     init = map_components
   },
-  can_handle = can_handle_fibaro_heat_controller
+  can_handle = require("fibaro-heat-controller.can_handle"),
 }
 
 return fibaro_heat_controller

--- a/drivers/SmartThings/zwave-thermostat/src/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.Driver
@@ -115,16 +105,7 @@ local driver_template = {
   lifecycle_handlers = {
     added = device_added
   },
-  sub_drivers = {
-    require("aeotec-radiator-thermostat"),
-    require("popp-radiator-thermostat"),
-    require("ct100-thermostat"),
-    require("fibaro-heat-controller"),
-    require("stelpro-ki-thermostat"),
-    require("qubino-flush-thermostat"),
-    require("thermostat-heating-battery"),
-    require("apiv6_bugfix"),
-  }
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities, {native_capability_attrs_enabled = true})

--- a/drivers/SmartThings/zwave-thermostat/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_popp_radiator_thermostat(opts, driver, device, ...)
+  local POPP_THERMOSTAT_FINGERPRINT = {mfr = 0x0002, prod = 0x0115, model = 0xA010}
+
+  if device:id_match(POPP_THERMOSTAT_FINGERPRINT.mfr, POPP_THERMOSTAT_FINGERPRINT.prod, POPP_THERMOSTAT_FINGERPRINT.model) then
+    return true, require "popp-radiator-thermostat"
+  else
+    return false
+  end
+end
+
+return can_handle_popp_radiator_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/popp-radiator-thermostat/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local utils = require "st.utils"
@@ -29,8 +19,6 @@ local LATEST_WAKEUP = "latest_wakeup"
 local CACHED_SETPOINT = "cached_setpoint"
 local POPP_WAKEUP_INTERVAL = 600 --seconds
 
-local POPP_THERMOSTAT_FINGERPRINT = {mfr = 0x0002, prod = 0x0115, model = 0xA010}
-
 local function get_latest_wakeup_timestamp(device)
   return device:get_field(LATEST_WAKEUP)
 end
@@ -46,10 +34,6 @@ local function seconds_since_latest_wakeup(device)
   else
     return 0
   end
-end
-
-local function can_handle_popp_radiator_thermostat(opts, driver, device, ...)
-  return device:id_match(POPP_THERMOSTAT_FINGERPRINT.mfr, POPP_THERMOSTAT_FINGERPRINT.prod, POPP_THERMOSTAT_FINGERPRINT.model)
 end
 
 -- POPP is a sleepy device, therefore it won't accept setpoint commands rightaway.
@@ -116,7 +100,7 @@ local popp_radiator_thermostat = {
   lifecycle_handlers = {
     added = added_handler
   },
-  can_handle = can_handle_popp_radiator_thermostat
+  can_handle = require("popp-radiator-thermostat.can_handle"),
 }
 
 return popp_radiator_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_qubino_thermostat(opts, driver, device, ...)
+  local FINGERPRINTS = require("qubino-flush-thermostat.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+      return true, require("qubino-flush-thermostat")
+    end
+  end
+  return false
+end
+
+return can_handle_qubino_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/fingerprints.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local QUBINO_FINGERPRINTS = {
+  {mfr = 0x0159, prod = 0x0005, model = 0x0054},  -- Qubino Flush On/Off Thermostat 2
+}
+
+return QUBINO_FINGERPRINTS

--- a/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/qubino-flush-thermostat/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 --- @type st.zwave.defaults.switch
 local TemperatureMeasurementDefaults = require "st.zwave.defaults.temperatureMeasurement"
@@ -31,9 +21,6 @@ local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ ve
 --- @type st.zwave.CommandClass.ThermostatOperatingState
 local ThermostatOperatingState = (require "st.zwave.CommandClass.ThermostatOperatingState")({version=1})
 
-local QUBINO_FINGERPRINTS = {
-  {mfr = 0x0159, prod = 0x0005, model = 0x0054},  -- Qubino Flush On/Off Thermostat 2
-}
 
 -- parameter which tells whether device is configured heat or cool thermostat mode
 local DEVICE_MODE_PARAMETER = 59
@@ -47,14 +34,6 @@ local CONFIGURED_MODE = "configured_mode"
 local COOL_MODE = "cool"
 local HEAT_MODE = "heat"
 
-local function can_handle_qubino_thermostat(opts, driver, device, ...)
-  for _, fingerprint in ipairs(QUBINO_FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
-    end
-  end
-  return false
-end
 
 local function info_changed(self, device, event, args)
   local new_parameter_value
@@ -137,7 +116,7 @@ local qubino_thermostat = {
     infoChanged = info_changed
   },
   NAME = "qubino thermostat",
-  can_handle = can_handle_qubino_thermostat
+  can_handle = require("qubino-flush-thermostat.can_handle"),
 }
 
 return qubino_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/stelpro-ki-thermostat/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/stelpro-ki-thermostat/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_stelpro_ki_thermostat(opts, driver, device, cmd, ...)
+  local FINGERPRINTS = require("stelpro-ki-thermostat.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("stelpro-ki-thermostat")
+    end
+  end
+
+  return false
+end
+
+return can_handle_stelpro_ki_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/stelpro-ki-thermostat/fingerprints.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/stelpro-ki-thermostat/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local STELPRO_KI_THERMOSTAT_FINGERPRINTS = {
+  { manufacturerId = 0x0239, productType = 0x0001, productId = 0x0001 } -- Stelpro Ki Thermostat
+}
+
+return STELPRO_KI_THERMOSTAT_FINGERPRINTS

--- a/drivers/SmartThings/zwave-thermostat/src/stelpro-ki-thermostat/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/stelpro-ki-thermostat/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local log = require "log"
 local capabilities = require "st.capabilities"
@@ -21,19 +11,7 @@ local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ ve
 --- @type st.zwave.CommandClass.ThermostatMode
 local ThermostatMode = (require "st.zwave.CommandClass.ThermostatMode")({ version = 2 })
 
-local STELPRO_KI_THERMOSTAT_FINGERPRINTS = {
-  { manufacturerId = 0x0239, productType = 0x0001, productId = 0x0001 } -- Stelpro Ki Thermostat
-}
 
-local function can_handle_stelpro_ki_thermostat(opts, driver, device, cmd, ...)
-  for _, fingerprint in ipairs(STELPRO_KI_THERMOSTAT_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-
-  return false
-end
 
 local function sensor_multilevel_report_handler(self, device, cmd)
   if (cmd.args.sensor_type == SensorMultilevel.sensor_type.TEMPERATURE) then
@@ -138,7 +116,7 @@ local stelpro_ki_thermostat = {
   lifecycle_handlers = {
     added = device_added
   },
-  can_handle = can_handle_stelpro_ki_thermostat,
+  can_handle = require("stelpro-ki-thermostat.can_handle"),
 }
 
 return stelpro_ki_thermostat

--- a/drivers/SmartThings/zwave-thermostat/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/sub_drivers.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("aeotec-radiator-thermostat"),
+   lazy_load_if_possible("popp-radiator-thermostat"),
+   lazy_load_if_possible("ct100-thermostat"),
+   lazy_load_if_possible("fibaro-heat-controller"),
+   lazy_load_if_possible("stelpro-ki-thermostat"),
+   lazy_load_if_possible("qubino-flush-thermostat"),
+   lazy_load_if_possible("thermostat-heating-battery"),
+   lazy_load_if_possible("apiv6_bugfix"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/can_handle.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_thermostat_heating_battery(opts, driver, device, cmd, ...)
+    local DANFOSS_LC13_THERMOSTAT_FINGERPRINTS = require "thermostat-heating-battery.fingerprints"
+    for _, fingerprint in ipairs(DANFOSS_LC13_THERMOSTAT_FINGERPRINTS) do
+        if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+            return true, require "thermostat-heating-battery"
+        end
+    end
+
+    return false
+end
+
+return can_handle_thermostat_heating_battery

--- a/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/fingerprints.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local DANFOSS_LC13_THERMOSTAT_FINGERPRINTS = {
+    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0003 }, -- Danfoss LC13 Thermostat
+    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0004 } -- Danfoss LC13 Thermostat
+}
+
+return DANFOSS_LC13_THERMOSTAT_FINGERPRINTS

--- a/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/init.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/thermostat-heating-battery/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local utils = require "st.utils"
@@ -42,11 +32,6 @@ local CLAMP = {
     CELSIUS_MAX = 28
 }
 
-local DANFOSS_LC13_THERMOSTAT_FINGERPRINTS = {
-    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0003 }, -- Danfoss LC13 Thermostat
-    { manufacturerId = 0x0002, productType = 0x0005, productId = 0x0004 } -- Danfoss LC13 Thermostat
-}
-
 local WEEK = {6, 0, 1, 2, 3, 4, 5}
 
 --[[ Danfoss LC13 (Living Connect)
@@ -61,16 +46,6 @@ Note: https://idency.com/products/idencyhome/smarthome/sensors/danfoss-z-wave-li
     Note: The Danfoss Z-Wave Living Connect Thermostat cannot report its local temperature
     to the Z-Wave network, it only allows a one-way communication to change its setpoint.
 --]]
-
-local function can_handle_thermostat_heating_battery(opts, driver, device, cmd, ...)
-    for _, fingerprint in ipairs(DANFOSS_LC13_THERMOSTAT_FINGERPRINTS) do
-        if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-            return true
-        end
-    end
-
-    return false
-end
 
 local function adjust_temperature_if_exceeded_min_max_limit (degree, scale)
     if scale == ThermostatSetpoint.scale.CELSIUS then
@@ -283,7 +258,7 @@ local thermostat_heating_battery = {
         init = device_init,
         added = added_handler,
     },
-    can_handle = can_handle_thermostat_heating_battery
+    can_handle = require("thermostat-heating-battery.can_handle"),
 }
 
 return thermostat_heating_battery


### PR DESCRIPTION
Lazy loading of sub-drivers for zwave thermostat. Required some manual intervention to fix some subdrivers. Passing all unit tests now.