### PR TITLE
CHAD-17043: Created pre-commit script to check for newline and copyright on all staged lua files

### DIFF
--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -6,13 +6,17 @@
 # pre-commit
 #
 # - Soft link into .git/hooks/pre-commit
-#   - $ ln -s tools/pre-commit .git/hooks/pre-commit
+#   - $ ln -s ../../tools/pre-commit .git/hooks/pre-commit
 # - Ensure executable
 
 set -e
 
 # Get changed files that are Added or Modified
-files=$(git diff --staged --name-only --diff-filter=AM)
+if [[ "$1" ]]; then
+    files=$(find $1 -type f -follow -print)
+else
+    files=$(git diff --staged --name-only --diff-filter=AM)
+fi
 
 fail=0
 for file in $files; do
@@ -23,7 +27,7 @@ for file in $files; do
             [ -f "$file" ] || continue
 
             # Check if file is not empty, is a SmartThings driver and has the copyright header
-            if [ -s "$file" ] && [[ "$file" =~ "drivers/SmartThings" ]] 
+            if [ -s "$file" ] && [[ "$file" =~ "drivers/SmartThings" ]] \
                 && [[ ! $(grep $file -P -e "-{2,} Copyright \d{4}(?:-\d{4})? SmartThings") ]]; then
                 echo "$file: SmartThings Copyright missing from file"
                 fail=1


### PR DESCRIPTION
# Description of Change

Created a script to check all staged lua files that they end with a newline character and begin with the current year's copyright header. This file should be made executable and copied to `.git/hooks/pre-commit`.

# Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor