### PR TITLE
Matter AQS Subdriver: Improve unit conversion handling

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/air_quality_sensor_utils/utils.lua
+++ b/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/air_quality_sensor_utils/utils.lua
@@ -40,20 +40,6 @@ function AirQualitySensorUtils.supports_capability_by_id_modular(device, capabil
   return false
 end
 
-function AirQualitySensorUtils.unit_conversion(device, value, from_unit, to_unit)
-  local conversion_function = fields.conversion_tables[from_unit][to_unit]
-  if conversion_function == nil then
-    device.log.info_with( {hub_logs = true} , string.format("Unsupported unit conversion from %s to %s", fields.unit_strings[from_unit], fields.unit_strings[to_unit]))
-    return 1
-  end
-
-  if value == nil then
-    device.log.info_with( {hub_logs = true} , "unit conversion value is nil")
-    return 1
-  end
-  return conversion_function(value)
-end
-
 local function get_supported_health_concern_values_for_air_quality(device)
   local health_concern_datatype = capabilities.airQualityHealthConcern.airQualityHealthConcern
   local supported_values = {health_concern_datatype.unknown.NAME, health_concern_datatype.good.NAME, health_concern_datatype.unhealthy.NAME}


### PR DESCRIPTION
# Description of Change
- Re-work logic to more closely follow the usual nil value handler checking.
- return nil instead of 1 if unit conversion function does not exist.

# Summary of Completed Tests


