### PR TITLE
Matter Switch: Add ResetEnergyMeter command support

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -274,6 +274,9 @@ local matter_driver_template = {
     [capabilities.colorTemperature.ID] = {
       [capabilities.colorTemperature.commands.setColorTemperature.NAME] = capability_handlers.handle_set_color_temperature,
     },
+    [capabilities.energyMeter.ID] = {
+      [capabilities.energyMeter.commands.resetEnergyMeter.NAME] = capability_handlers.handle_reset_energy_meter,
+    },
     [capabilities.fanMode.ID] = {
       [capabilities.fanMode.commands.setFanMode.NAME] = capability_handlers.handle_set_fan_mode
     },

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -284,6 +284,11 @@ function AttributeHandlers.energy_imported_factory(is_periodic_report)
           device, ib, capabilities.energyMeter.ID, capabilities.energyMeter.energy.NAME
         ) or 0
         energy_imported_wh = energy_imported_wh + energy_meter_latest_state
+      else
+        -- the field containing the offset may be associated with a child device
+        local field_device = switch_utils.find_child(device, ib.endpoint_id) or device
+        local energy_meter_offset = field_device:get_field(fields.ENERGY_METER_OFFSET) or 0.0
+        energy_imported_wh = energy_imported_wh - energy_meter_offset
       end
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.energyMeter.energy({ value = energy_imported_wh, unit = "Wh" }))
       switch_utils.report_power_consumption_to_st_energy(device, ib.endpoint_id, energy_imported_wh)

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -155,6 +155,7 @@ SwitchFields.profiling_data = {
   POWER_TOPOLOGY = "__power_topology",
 }
 
+SwitchFields.ENERGY_METER_OFFSET = "__energy_meter_offset"
 SwitchFields.CUMULATIVE_REPORTS_SUPPORTED = "__cumulative_reports_supported"
 SwitchFields.LAST_IMPORTED_REPORT_TIMESTAMP = "__last_imported_report_timestamp"
 SwitchFields.MINIMUM_ST_ENERGY_REPORT_INTERVAL = (15 * 60) -- 15 minutes, reported in seconds

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -76,7 +76,8 @@ function utils.mired_to_kelvin(value, minOrMax)
 end
 
 function utils.get_product_override_field(device, override_key)
-  if fields.vendor_overrides[device.manufacturer_info.vendor_id]
+  if device.manufacturer_info
+  and fields.vendor_overrides[device.manufacturer_info.vendor_id]
   and fields.vendor_overrides[device.manufacturer_info.vendor_id][device.manufacturer_info.product_id]
   then
     return fields.vendor_overrides[device.manufacturer_info.vendor_id][device.manufacturer_info.product_id][override_key]


### PR DESCRIPTION
# Description of Change
Add support for the ResetEnergyMeter command from the energyMeter capability.

This looks generally similar to the current Zigbee implementation, though it is slightly re-worked for the Periodic energy case (the extra field is irrelevant in that case), and requires some slight adjustments to account for parent/child devices

# Summary of Completed Tests
Unit tests added, tested on-device with single and multi-plug device.

