### PR TITLE
Matter Lock: Deprecate old Matter Lock profiles

### DIFF
--- a/drivers/SmartThings/matter-lock/profiles/base-lock-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock-batteryLevel.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: base-lock-batteryLevel
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/base-lock-nobattery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock-nobattery.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: base-lock-nobattery
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/base-lock.yml
+++ b/drivers/SmartThings/matter-lock/profiles/base-lock.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: base-lock
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-lockalarm-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-lockalarm-batteryLevel.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-lockalarm-batteryLevel
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-lockalarm-nobattery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-lockalarm-nobattery.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-lockalarm-nobattery
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-lockalarm.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-lockalarm.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-lockalarm
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-nocodes-notamper-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-nocodes-notamper-batteryLevel.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-nocodes-notamper-batteryLevel
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-nocodes-notamper.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-nocodes-notamper.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-nocodes-notamper
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-without-codes-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-without-codes-batteryLevel.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-without-codes-batteryLevel
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-without-codes-nobattery.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-without-codes-nobattery.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-without-codes-nobattery
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/lock-without-codes.yml
+++ b/drivers/SmartThings/matter-lock/profiles/lock-without-codes.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: lock-without-codes
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/nonfunctional-lock-batteryLevel.yml
+++ b/drivers/SmartThings/matter-lock/profiles/nonfunctional-lock-batteryLevel.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: nonfunctional-lock-batteryLevel
 components:
 - id: main

--- a/drivers/SmartThings/matter-lock/profiles/nonfunctional-lock.yml
+++ b/drivers/SmartThings/matter-lock/profiles/nonfunctional-lock.yml
@@ -1,3 +1,4 @@
+# Deprecated: do not use this profile for device fingerprinting.
 name: nonfunctional-lock
 components:
 - id: main


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Deprecate the suite of old Matter Lock profiles being used before the new sub-driver was put in place

# Summary of Completed Tests


