### PR TITLE
Matter Sensor: Allow modular profile updates in infoChanged

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/air_quality_sensor_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/air_quality_sensor_utils/device_configuration.lua
@@ -71,6 +71,7 @@ function DeviceConfiguration.match_profile(device)
   end
 
   device:try_update_metadata({profile = profile_name, optional_component_capabilities = optional_supported_component_capabilities})
+  device:set_field(fields.MODULAR_PROFILE_UPDATED, true)
 
   -- earlier modular profile gating (min api v14, rpc 8) ensures we are running >= 0.57 FW.
   -- This gating specifies a workaround required only for 0.57 FW, which is not needed for 0.58 and higher.

--- a/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/air_quality_sensor_utils/fields.lua
+++ b/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/air_quality_sensor_utils/fields.lua
@@ -26,6 +26,8 @@ local AirQualitySensorFields = {}
 
 AirQualitySensorFields.AIR_QUALITY_SENSOR_DEVICE_TYPE_ID = 0x002C
 
+AirQualitySensorFields.MODULAR_PROFILE_UPDATED = "__modular_profile_updated"
+
 AirQualitySensorFields.SUPPORTED_COMPONENT_CAPABILITIES = "__supported_component_capabilities"
 
 AirQualitySensorFields.units_required = {

--- a/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/init.lua
+++ b/drivers/SmartThings/matter-sensor/src/sub_drivers/air_quality_sensor/init.lua
@@ -66,11 +66,12 @@ function AirQualitySensorLifecycleHandlers.device_init(driver, device)
 end
 
 function AirQualitySensorLifecycleHandlers.info_changed(driver, device, event, args)
-  if device.profile.id ~= args.old_st_store.profile.id then
+  if device.profile.id ~= args.old_st_store.profile.id or device:get_field(fields.MODULAR_PROFILE_UPDATED) then
     if device:get_field(fields.SUPPORTED_COMPONENT_CAPABILITIES) then
       --re-up subscription with new capabilities using the modular supports_capability override
        device:extend_device("supports_capability_by_id", aqs_utils.supports_capability_by_id_modular)
     end
+    device:set_field(fields.MODULAR_PROFILE_UPDATED, nil)
     aqs_utils.set_supported_health_concern_values(device)
     device:subscribe()
   end


### PR DESCRIPTION
# Description of Change
When an updated on a modular profile changed event occurs, allow the infoChanged logic to run though the profile id has not changed. 

# Summary of Completed Tests


