### PR TITLE
CHAD-17062: zigbee-bed lazy loading subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-bed/src/init.lua
+++ b/drivers/SmartThings/zigbee-bed/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local ZigbeeDriver = require "st.zigbee"
@@ -20,9 +10,7 @@ local zigbee_bed_template = {
   supported_capabilities = {
     capabilities.refresh,
   },
-  sub_drivers = {
-    require("shus-mattress"),
-  },
+  sub_drivers = require("sub_drivers"),
   health_check = false,
 }
 

--- a/drivers/SmartThings/zigbee-bed/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-bed/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-bed/src/shus-mattress/can_handle.lua
+++ b/drivers/SmartThings/zigbee-bed/src/shus-mattress/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function is_shus_products(opts, driver, device)
+  local FINGERPRINTS = require("shus-mattress.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("shus-mattress")
+    end
+  end
+  return false
+end
+
+return is_shus_products

--- a/drivers/SmartThings/zigbee-bed/src/shus-mattress/custom_capabilities.lua
+++ b/drivers/SmartThings/zigbee-bed/src/shus-mattress/custom_capabilities.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 

--- a/drivers/SmartThings/zigbee-bed/src/shus-mattress/custom_clusters.lua
+++ b/drivers/SmartThings/zigbee-bed/src/shus-mattress/custom_clusters.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local data_types = require "st.zigbee.data_types"
 

--- a/drivers/SmartThings/zigbee-bed/src/shus-mattress/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-bed/src/shus-mattress/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FINGERPRINTS = {
+  { mfr = "SHUS", model = "SX-1" }
+}
+
+return FINGERPRINTS

--- a/drivers/SmartThings/zigbee-bed/src/shus-mattress/init.lua
+++ b/drivers/SmartThings/zigbee-bed/src/shus-mattress/init.lua
@@ -1,25 +1,12 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cluster_base = require "st.zigbee.cluster_base"
 local custom_clusters = require "shus-mattress/custom_clusters"
 local custom_capabilities = require "shus-mattress/custom_capabilities"
 
-local FINGERPRINTS = {
-  { mfr = "SHUS", model = "SX-1" }
-}
 
 -- #############################
 -- # Attribute handlers define #
@@ -155,14 +142,6 @@ end
 local function do_configure(driver, device)
 end
 
-local function is_shus_products(opts, driver, device)
-  for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 -- #################
 -- # Handlers bind #
@@ -229,7 +208,7 @@ local shus_smart_mattress = {
       ["stateControl"] = process_capabilities_factory("stateControl","yoga")
     }
   },
-  can_handle = is_shus_products
+  can_handle = require("shus-mattress.can_handle"),
 }
 
 return shus_smart_mattress

--- a/drivers/SmartThings/zigbee-bed/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-bed/src/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("shus-mattress"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zigbee-bed/src/test/test_shus_mattress.lua
+++ b/drivers/SmartThings/zigbee-bed/src/test/test_shus_mattress.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"


### PR DESCRIPTION
Lazy loading of `zigbee-bed` sub-drivers and copyright updates.