### PR TITLE
CHAD-17046: zigbee-carbon-monoxide-detector subdriver lazy loading

### DIFF
--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/ClimaxTechnology/can_handle.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/ClimaxTechnology/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_climax_technology_carbon_monoxide = function(opts, driver, device)
+  local FINGERPRINTS = require("ClimaxTechnology.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("ClimaxTechnology")
+    end
+  end
+
+  return false
+end
+
+return is_climax_technology_carbon_monoxide

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/ClimaxTechnology/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/ClimaxTechnology/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local CLIMAX_TECHNOLOGY_CARBON_MONOXIDE_FINGERPRINTS = {
+    { mfr = "ClimaxTechnology", model = "CO_00.00.00.22TC" },
+    { mfr = "ClimaxTechnology", model = "CO_00.00.00.15TC" }
+}
+
+return CLIMAX_TECHNOLOGY_CARBON_MONOXIDE_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/ClimaxTechnology/init.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/ClimaxTechnology/init.lua
@@ -1,33 +1,10 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 
-local CLIMAX_TECHNOLOGY_CARBON_MONOXIDE_FINGERPRINTS = {
-    { mfr = "ClimaxTechnology", model = "CO_00.00.00.22TC" },
-    { mfr = "ClimaxTechnology", model = "CO_00.00.00.15TC" }
-}
 
-local is_climax_technology_carbon_monoxide = function(opts, driver, device)
-  for _, fingerprint in ipairs(CLIMAX_TECHNOLOGY_CARBON_MONOXIDE_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-
-  return false
-end
 
 local device_added = function(self, device)
   device:emit_event(capabilities.battery.battery(100))
@@ -38,7 +15,7 @@ local climax_technology_carbon_monoxide = {
   lifecycle_handlers = {
     added = device_added
   },
-  can_handle = is_climax_technology_carbon_monoxide
+  can_handle = require("ClimaxTechnology.can_handle"),
 }
 
 return climax_technology_carbon_monoxide

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/init.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local ZigbeeDriver = require "st.zigbee"
 local capabilities = require "st.capabilities"
@@ -24,8 +14,8 @@ local zigbee_carbon_monoxide_driver_template = {
         capabilities.battery,
     },
     ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE,
-    sub_drivers = { require("ClimaxTechnology") },
     health_check = false,
+    sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(zigbee_carbon_monoxide_driver_template,

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/sub_drivers.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+
+local sub_drivers = {
+    lazy_load_if_possible("ClimaxTechnology")
+}
+
+return sub_drivers

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_climax_technology_carbon_monoxide.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_climax_technology_carbon_monoxide.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_zigbee_carbon_monoxide.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_zigbee_carbon_monoxide.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"


### PR DESCRIPTION
Lazy loading of `zigbee-carbon-monoxide-detector` sub-drivers and copyright updates.