### PR TITLE
CHAD-17066: zigbee-dimmer-remote lazy loading subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-dimmer-remote/src/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local ZigbeeDriver = require "st.zigbee"
@@ -18,12 +8,12 @@ local defaults = require "st.zigbee.defaults"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 
 local battery_attribute_configuration = {
-  cluster = zcl_clusters.PowerConfiguration.ID,
-  attribute = zcl_clusters.PowerConfiguration.attributes.BatteryPercentageRemaining.ID,
-  minimum_interval = 30,
-  maximum_interval = 14300, -- ~4hrs
-  data_type = zcl_clusters.PowerConfiguration.attributes.BatteryPercentageRemaining.base_type,
-  reportable_change = 1
+    cluster = zcl_clusters.PowerConfiguration.ID,
+    attribute = zcl_clusters.PowerConfiguration.attributes.BatteryPercentageRemaining.ID,
+    minimum_interval = 30,
+    maximum_interval = 14300, -- ~4hrs
+    data_type = zcl_clusters.PowerConfiguration.attributes.BatteryPercentageRemaining.base_type,
+    reportable_change = 1
 }
 
 local function device_init(driver, device)
@@ -38,9 +28,9 @@ local zigbee_dimmer_remote_driver_template = {
         capabilities.switchLevel
     },
     lifecycle_handlers = {
-      init = device_init,
+        init = device_init,
     },
-    sub_drivers = { require("zigbee-accessory-dimmer"), require("zigbee-battery-accessory-dimmer")},
+    sub_drivers = require("sub_drivers"),
     health_check = false,
 }
 

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/sub_drivers.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+
+local sub_drivers = {
+    lazy_load_if_possible("zigbee-accessory-dimmer"),
+    lazy_load_if_possible("zigbee-battery-accessory-dimmer"),
+}
+
+return sub_drivers

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/test/test_zigbee_accessory_dimmer.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/test/test_zigbee_accessory_dimmer.lua
@@ -1,4 +1,4 @@
--- Copyright 2022 SmartThings
+-- Copyright 2022 SmartThings, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/can_handle.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_zigbee_accessory_dimmer = function(opts, driver, device)
+    local FINGERPRINTS = require("zigbee-accessory-dimmer.fingerprints")
+    for _, fingerprint in ipairs(FINGERPRINTS) do
+        if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+            return true, require("zigbee-accessory-dimmer")
+        end
+    end
+    return false
+end
+
+return is_zigbee_accessory_dimmer

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_ACCESSORY_DIMMER_FINGERPRINTS = {
+    { mfr = "Aurora", model = "Remote50AU" },
+    { mfr = "LDS", model = "ZBT-DIMController-D0800" }
+}
+
+return ZIGBEE_ACCESSORY_DIMMER_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-accessory-dimmer/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local device_management = require "st.zigbee.device_management"
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -29,10 +19,6 @@ local CURRENT_LEVEL = "current_level"
 local CURRENT_STATUS = "current_status"
 local STEP = 10
 
-local ZIGBEE_ACCESSORY_DIMMER_FINGERPRINTS = {
-    { mfr = "Aurora", model = "Remote50AU" },
-    { mfr = "LDS", model = "ZBT-DIMController-D0800" }
-}
 
 local generate_switch_onoff_event = function(device, value)
   if value == "on" then
@@ -142,14 +128,6 @@ local do_configure = function(self, device)
 end
 
 
-local is_zigbee_accessory_dimmer = function(opts, driver, device)
-    for _, fingerprint in ipairs(ZIGBEE_ACCESSORY_DIMMER_FINGERPRINTS) do
-        if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-            return true
-        end
-    end
-    return false
-end
 
 local zigbee_accessory_dimmer = {
   NAME = "zigbee accessory dimmer",
@@ -182,7 +160,7 @@ local zigbee_accessory_dimmer = {
     added = device_added,
     doConfigure = do_configure
   },
-  can_handle = is_zigbee_accessory_dimmer
+  can_handle = require("zigbee-accessory-dimmer.can_handle"),
 }
 
 return zigbee_accessory_dimmer

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/can_handle.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_centralite_systems = function(opts, driver, device)
+  local FINGERPRINTS = require("zigbee-battery-accessory-dimmer.CentraliteSystems.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+        return true, require("zigbee-battery-accessory-dimmer.CentraliteSystems")
+    end
+  end
+
+  return false
+end
+
+return is_centralite_systems

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local CENTRALITE_SYSTEMS_FINGERPRINTS = {
+  { mfr = "Centralite Systems", model = "3131-G" }
+}
+
+return CENTRALITE_SYSTEMS_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/CentraliteSystems/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local device_management = require "st.zigbee.device_management"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
@@ -24,9 +14,6 @@ local capabilities = require "st.capabilities"
 local DEFAULT_LEVEL = 100
 local DOUBLE_STEP = 10
 
-local CENTRALITE_SYSTEMS_FINGERPRINTS = {
-  { mfr = "Centralite Systems", model = "3131-G" }
-}
 
 local generate_switch_level_event = function(device, value)
   device:emit_event(capabilities.switchLevel.level(value))
@@ -77,15 +64,6 @@ local do_configure = function(self, device)
   device:send(device_management.build_bind_request(device, Level.ID, self.environment_info.hub_zigbee_eui))
 end
 
-local is_centralite_systems = function(opts, driver, device)
-  for _, fingerprint in ipairs(CENTRALITE_SYSTEMS_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-        return true
-    end
-  end
-
-  return false
-end
 
 local voltage_configuration = {
   cluster = zcl_clusters.PowerConfiguration.ID,
@@ -118,7 +96,7 @@ local centralite_systems = {
     init = device_init,
     doConfigure = do_configure
   },
-  can_handle = is_centralite_systems
+  can_handle = require("zigbee-battery-accessory-dimmer.CentraliteSystems.can_handle"),
 }
 
 return centralite_systems

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/IKEAofSweden/can_handle.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/IKEAofSweden/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_ikea_of_sweden = function(opts, driver, device)
+  local FINGERPRINTS = require("zigbee-battery-accessory-dimmer.IKEAofSweden.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("zigbee-battery-accessory-dimmer.IKEAofSweden")
+    end
+  end
+
+  return false
+end
+
+return is_ikea_of_sweden

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/IKEAofSweden/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/IKEAofSweden/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local IKEA_OF_SWEDEN_FINGERPRINTS = {
+  { mfr = "IKEA of Sweden", model = "TRADFRI wireless dimmer" }
+}
+
+return IKEA_OF_SWEDEN_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/IKEAofSweden/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/IKEAofSweden/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local utils = require 'st.utils'
 local zcl_clusters = require "st.zigbee.zcl.clusters"
@@ -23,9 +13,6 @@ local capabilities = require "st.capabilities"
 local DEFAULT_LEVEL = 100
 local DOUBLE_STEP = 10
 
-local IKEA_OF_SWEDEN_FINGERPRINTS = {
-  { mfr = "IKEA of Sweden", model = "TRADFRI wireless dimmer" }
-}
 
 local generate_switch_level_event = function(device, value)
   device:emit_event(capabilities.switchLevel.level(value))
@@ -99,15 +86,6 @@ local battery_perc_attr_handler = function(driver, device, value, zb_rx)
   device:emit_event(capabilities.battery.battery(utils.clamp_value(value.value, 0, 100)))
 end
 
-local is_ikea_of_sweden = function(opts, driver, device)
-  for _, fingerprint in ipairs(IKEA_OF_SWEDEN_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-
-  return false
-end
 
 local ikea_of_sweden = {
   NAME = "IKEA of Sweden",
@@ -126,7 +104,7 @@ local ikea_of_sweden = {
       }
     }
   },
-  can_handle = is_ikea_of_sweden
+  can_handle = require("zigbee-battery-accessory-dimmer.IKEAofSweden.can_handle"),
 }
 
 return ikea_of_sweden

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/can_handle.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_zigbee_battery_accessory_dimmer = function(opts, driver, device)
+  local FINGERPRINTS = require("zigbee-battery-accessory-dimmer.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("zigbee-battery-accessory-dimmer")
+    end
+  end
+
+  return false
+end
+
+return is_zigbee_battery_accessory_dimmer

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZIGBEE_BATTERY_ACCESSORY_DIMMER_FINGERPRINTS = {
+  { mfr = "sengled", model = "E1E-G7F" },
+  { mfr = "IKEA of Sweden", model = "TRADFRI wireless dimmer" },
+  { mfr = "Centralite Systems", model = "3131-G" }
+}
+
+return ZIGBEE_BATTERY_ACCESSORY_DIMMER_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local zcl_clusters = require "st.zigbee.zcl.clusters"
 local OnOff = zcl_clusters.OnOff
@@ -22,11 +13,6 @@ local SwitchLevel = capabilities.switchLevel
 local DEFAULT_LEVEL = 100
 local DOUBLE_STEP = 10
 
-local ZIGBEE_BATTERY_ACCESSORY_DIMMER_FINGERPRINTS = {
-  { mfr = "sengled", model = "E1E-G7F" },
-  { mfr = "IKEA of Sweden", model = "TRADFRI wireless dimmer" },
-  { mfr = "Centralite Systems", model = "3131-G" }
-}
 
 local generate_switch_level_event = function(device, value)
   device:emit_event(capabilities.switchLevel.level(value))
@@ -89,15 +75,6 @@ local device_added = function(self, device)
   end
 end
 
-local is_zigbee_battery_accessory_dimmer = function(opts, driver, device)
-  for _, fingerprint in ipairs(ZIGBEE_BATTERY_ACCESSORY_DIMMER_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-
-  return false
-end
 
 local zigbee_battery_accessory_dimmer = {
   NAME = "zigbee battery accessory dimmer",
@@ -121,8 +98,7 @@ local zigbee_battery_accessory_dimmer = {
   lifecycle_handlers = {
     added = device_added
   },
-  sub_drivers = { require("zigbee-battery-accessory-dimmer/CentraliteSystems"), require("zigbee-battery-accessory-dimmer/IKEAofSweden"), require("zigbee-battery-accessory-dimmer/sengled") },
-  can_handle = is_zigbee_battery_accessory_dimmer
+  sub_drivers = require("zigbee-battery-accessory-dimmer.sub_drivers"),
 }
 
 return zigbee_battery_accessory_dimmer

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sengled/can_handle.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sengled/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_sengled = function(opts, driver, device)
+  local FINGERPRINTS = require("zigbee-battery-accessory-dimmer.sengled.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("zigbee-battery-accessory-dimmer.sengled")
+    end
+  end
+
+  return false
+end
+
+return is_sengled

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sengled/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sengled/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local SENGLED_FINGERPRINTS = {
+  { mfr = "sengled", model = "E1E-G7F" }
+}
+
+return SENGLED_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sengled/init.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sengled/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 
@@ -20,9 +10,6 @@ local DOUBLE_STEP = 10
 local SENGLED_MFR_SPECIFIC_CLUSTER = 0xFC10
 local SENGLED_MFR_SPECIFIC_COMMAND = 0x00
 
-local SENGLED_FINGERPRINTS = {
-  { mfr = "sengled", model = "E1E-G7F" }
-}
 
 local generate_switch_level_event = function(device, value)
   device:emit_event(capabilities.switchLevel.level(value))
@@ -84,15 +71,6 @@ local sengled_mfr_specific_command_handler = function(driver, device, zb_rx)
   end
 end
 
-local is_sengled = function(opts, driver, device)
-  for _, fingerprint in ipairs(SENGLED_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-
-  return false
-end
 
 local sengled = {
   NAME = "sengled",
@@ -103,7 +81,7 @@ local sengled = {
       }
     }
   },
-  can_handle = is_sengled
+  can_handle = require("zigbee-battery-accessory-dimmer.sengled.can_handle"),
 }
 
 return sengled

--- a/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-dimmer-remote/src/zigbee-battery-accessory-dimmer/sub_drivers.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+
+local sub_drivers = {
+    lazy_load_if_possible("zigbee-battery-accessory-dimmer.CentraliteSystems"),
+    lazy_load_if_possible("zigbee-battery-accessory-dimmer.IKEAofSweden"),
+    lazy_load_if_possible("zigbee-battery-accessory-dimmer.sengled"),
+}
+
+return sub_drivers


### PR DESCRIPTION
Lazy loading of `zigbee-dimmer-remote` sub-drivers and copyright updates.