### PR TITLE
CHAD-17067: zigbee-fan lazy load subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-fan/src/configurations.lua
+++ b/drivers/SmartThings/zigbee-fan/src/configurations.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 

--- a/drivers/SmartThings/zigbee-fan/src/fan-light/can_handle.lua
+++ b/drivers/SmartThings/zigbee-fan/src/fan-light/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_itm_fanlight(opts, driver, device)
+  local FINGERPRINTS = require("fan-light.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("fan-light")
+    end
+  end
+  return false
+end
+
+return can_handle_itm_fanlight

--- a/drivers/SmartThings/zigbee-fan/src/fan-light/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-fan/src/fan-light/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FINGERPRINTS = {
+  { mfr = "Samsung Electronics", model = "SAMSUNG-ITM-Z-003" },
+}
+
+return FINGERPRINTS

--- a/drivers/SmartThings/zigbee-fan/src/fan-light/init.lua
+++ b/drivers/SmartThings/zigbee-fan/src/fan-light/init.lua
@@ -1,34 +1,13 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
 local FanControl = clusters.FanControl
 local Level = clusters.Level
 local OnOff = clusters.OnOff
 
-local FINGERPRINTS = {
-  { mfr = "Samsung Electronics", model = "SAMSUNG-ITM-Z-003" },
-}
 
-local function can_handle_itm_fanlight(opts, driver, device)
-  for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 -- CAPABILITY HANDLERS
 
@@ -111,9 +90,7 @@ local itm_fan_light = {
       [capabilities.fanSpeed.commands.setFanSpeed.NAME] = fan_speed_handler
     }
   },
-  can_handle = can_handle_itm_fanlight
+  can_handle = require("fan-light.can_handle"),
 }
 
 return itm_fan_light
-
-

--- a/drivers/SmartThings/zigbee-fan/src/init.lua
+++ b/drivers/SmartThings/zigbee-fan/src/init.lua
@@ -1,23 +1,13 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
-local configurationMap = require "configurations"
 
 local device_init = function(self, device)
+  local configurationMap = require "configurations"
   local configuration = configurationMap.get_device_configuration(device)
   if configuration ~= nil then
     for _, attribute in ipairs(configuration) do
@@ -32,9 +22,7 @@ local zigbee_fan_driver = {
     capabilities.switchLevel,
     capabilities.fanspeed
   },
-  sub_drivers = {
-    require("fan-light")
-  },
+  sub_drivers = require("sub_drivers"),
   lifecycle_handlers = {
     init = device_init
   },
@@ -44,4 +32,3 @@ local zigbee_fan_driver = {
 defaults.register_for_default_handlers(zigbee_fan_driver,zigbee_fan_driver.supported_capabilities)
 local fan = ZigbeeDriver("zigbee-fan", zigbee_fan_driver)
 fan:run()
-

--- a/drivers/SmartThings/zigbee-fan/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-fan/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-fan/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-fan/src/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("fan-light"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zigbee-fan/src/test/test_fan_light.lua
+++ b/drivers/SmartThings/zigbee-fan/src/test/test_fan_light.lua
@@ -1,16 +1,6 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 local clusters = require "st.zigbee.zcl.clusters"


### PR DESCRIPTION
Lazy loading of `zigbee-fan` sub-drivers and copyright updates. 