### PR TITLE
CHAD-17070: zigbee-lock lazy loading of subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-lock/src/configurations.lua
+++ b/drivers/SmartThings/zigbee-lock/src/configurations.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local clusters = require "st.zigbee.zcl.clusters"
 

--- a/drivers/SmartThings/zigbee-lock/src/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Zigbee Driver utilities
 local defaults          = require "st.zigbee.defaults"
@@ -445,12 +435,7 @@ local zigbee_lock_driver = {
       [capabilities.refresh.commands.refresh.NAME] = refresh
     }
   },
-  sub_drivers = {
-    require("samsungsds"),
-    require("yale"),
-    require("yale-fingerprint-lock"),
-    require("lock-without-codes")
-  },
+  sub_drivers = require("sub_drivers"),
   lifecycle_handlers = {
     doConfigure = do_configure,
     added = device_added,

--- a/drivers/SmartThings/zigbee-lock/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-lock/src/lock-without-codes/can_handle.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock-without-codes/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_lock_without_codes(opts, driver, device)
+  local FINGERPRINTS = require("lock-without-codes.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("lock-without-codes")
+    end
+  end
+  return false
+end
+
+return can_handle_lock_without_codes

--- a/drivers/SmartThings/zigbee-lock/src/lock-without-codes/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock-without-codes/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local LOCK_WITHOUT_CODES_FINGERPRINTS = {
+  { model = "E261-KR0B0Z0-HA" },
+  { mfr = "Danalock", model = "V3-BTZB" }
+}
+
+return LOCK_WITHOUT_CODES_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-lock/src/lock-without-codes/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock-without-codes/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local configurationMap = require "configurations"
 local clusters = require "st.zigbee.zcl.clusters"
@@ -19,19 +9,7 @@ local capabilities = require "st.capabilities"
 local DoorLock = clusters.DoorLock
 local PowerConfiguration = clusters.PowerConfiguration
 
-local LOCK_WITHOUT_CODES_FINGERPRINTS = {
-  { model = "E261-KR0B0Z0-HA" },
-  { mfr = "Danalock", model = "V3-BTZB" }
-}
 
-local function can_handle_lock_without_codes(opts, driver, device)
-  for _, fingerprint in ipairs(LOCK_WITHOUT_CODES_FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function device_init(driver, device)
   local configuration = configurationMap.get_device_configuration(device)
@@ -95,7 +73,7 @@ local lock_without_codes = {
       }
     }
   },
-  can_handle = can_handle_lock_without_codes
+  can_handle = require("lock-without-codes.can_handle"),
 }
 
 return lock_without_codes

--- a/drivers/SmartThings/zigbee-lock/src/lock_utils.lua
+++ b/drivers/SmartThings/zigbee-lock/src/lock_utils.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 local utils = require "st.utils"
 local capabilities = require "st.capabilities"
 local json = require "st.json"

--- a/drivers/SmartThings/zigbee-lock/src/samsungsds/can_handle.lua
+++ b/drivers/SmartThings/zigbee-lock/src/samsungsds/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function samsungsds_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "SAMSUNG SDS" then
+    return true, require("samsungsds")
+  end
+  return false
+end
+
+return samsungsds_can_handle

--- a/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/samsungsds/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local device_management = require "st.zigbee.device_management"
 local clusters = require "st.zigbee.zcl.clusters"
@@ -112,9 +102,7 @@ local samsung_sds_driver = {
     added = device_added,
     init = device_init
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "SAMSUNG SDS"
-  end
+  can_handle = require("samsungsds.can_handle"),
 }
 
 return samsung_sds_driver

--- a/drivers/SmartThings/zigbee-lock/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-lock/src/sub_drivers.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("samsungsds"),
+   lazy_load_if_possible("yale"),
+   lazy_load_if_possible("yale-fingerprint-lock"),
+   lazy_load_if_possible("lock-without-codes"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zigbee-lock/src/test/test_c2o_lock.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_c2o_lock.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_generic_lock_migration.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_generic_lock_migration.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_yale_fingerprint_bad_battery_reporter.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_yale_fingerprint_bad_battery_reporter.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_code_migration.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_code_migration.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale-bad-battery-reporter.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale-bad-battery-reporter.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale-fingerprint-lock.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale-fingerprint-lock.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-lock/src/yale-fingerprint-lock/can_handle.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale-fingerprint-lock/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local yale_fingerprint_lock_models = function(opts, driver, device)
+  local FINGERPRINTS = require("yale-fingerprint-lock.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+          return true, require("yale-fingerprint-lock")
+      end
+  end
+  return false
+end
+
+return yale_fingerprint_lock_models

--- a/drivers/SmartThings/zigbee-lock/src/yale-fingerprint-lock/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale-fingerprint-lock/fingerprints.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local YALE_FINGERPRINT_LOCK = {
+  { mfr = "ASSA ABLOY iRevo", model = "iZBModule01" },
+  { mfr = "ASSA ABLOY iRevo", model = "c700000202" },
+  { mfr = "ASSA ABLOY iRevo", model = "0700000001" },
+  { mfr = "ASSA ABLOY iRevo", model = "06ffff2027" }
+}
+
+return YALE_FINGERPRINT_LOCK

--- a/drivers/SmartThings/zigbee-lock/src/yale-fingerprint-lock/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale-fingerprint-lock/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
@@ -19,21 +9,7 @@ local LockCodes = capabilities.lockCodes
 
 local YALE_FINGERPRINT_MAX_CODES = 0x1E
 
-local YALE_FINGERPRINT_LOCK = {
-  { mfr = "ASSA ABLOY iRevo", model = "iZBModule01" },
-  { mfr = "ASSA ABLOY iRevo", model = "c700000202" },
-  { mfr = "ASSA ABLOY iRevo", model = "0700000001" },
-  { mfr = "ASSA ABLOY iRevo", model = "06ffff2027" }
-}
 
-local yale_fingerprint_lock_models = function(opts, driver, device)
-  for _, fingerprint in ipairs(YALE_FINGERPRINT_LOCK) do
-      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-          return true
-      end
-  end
-  return false
-end
 
 local handle_max_codes = function(driver, device, value)
   device:emit_event(LockCodes.maxCodes(YALE_FINGERPRINT_MAX_CODES), { visibility = { displayed = false } })
@@ -48,7 +24,7 @@ local yale_fingerprint_lock_driver = {
       }
     }
   },
-  can_handle =  yale_fingerprint_lock_models
+  can_handle = require("yale-fingerprint-lock.can_handle"),
 }
 
 return yale_fingerprint_lock_driver

--- a/drivers/SmartThings/zigbee-lock/src/yale/can_handle.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function yale_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "ASSA ABLOY iRevo" or device:get_manufacturer() == "Yale" then
+    return true, require("yale")
+  end
+  return false
+end
+
+return yale_can_handle

--- a/drivers/SmartThings/zigbee-lock/src/yale/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 -- Zigbee Spec Utils
 local clusters                = require "st.zigbee.zcl.clusters"
@@ -151,11 +142,7 @@ local yale_door_lock_driver = {
       [LockCodes.commands.setCode.NAME] = set_code
     }
   },
-
-  sub_drivers = { require("yale.yale-bad-battery-reporter") },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "ASSA ABLOY iRevo" or device:get_manufacturer() == "Yale"
-  end
+  sub_drivers = require("yale.sub_drivers"),
 }
 
 return yale_door_lock_driver

--- a/drivers/SmartThings/zigbee-lock/src/yale/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("yale.yale-bad-battery-reporter"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zigbee-lock/src/yale/yale-bad-battery-reporter/can_handle.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/yale-bad-battery-reporter/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local is_bad_yale_lock_models = function(opts, driver, device)
+  local FINGERPRINTS = require("yale.yale-bad-battery-reporter.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+          return true, require("yale.yale-bad-battery-reporter")
+      end
+  end
+  return false
+end
+
+return is_bad_yale_lock_models

--- a/drivers/SmartThings/zigbee-lock/src/yale/yale-bad-battery-reporter/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/yale-bad-battery-reporter/fingerprints.lua
@@ -1,0 +1,13 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local BAD_YALE_LOCK_FINGERPRINTS = {
+  { mfr = "Yale", model = "YRD220/240 TSDB" },
+  { mfr = "Yale", model = "YRL220 TS LL" },
+  { mfr = "Yale", model = "YRD210 PB DB" },
+  { mfr = "Yale", model = "YRL210 PB LL" },
+  { mfr = "ASSA ABLOY iRevo", model = "c700000202" },
+  { mfr = "ASSA ABLOY iRevo", model = "06ffff2027" }
+}
+
+return BAD_YALE_LOCK_FINGERPRINTS

--- a/drivers/SmartThings/zigbee-lock/src/yale/yale-bad-battery-reporter/init.lua
+++ b/drivers/SmartThings/zigbee-lock/src/yale/yale-bad-battery-reporter/init.lua
@@ -1,37 +1,11 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
 
-local BAD_YALE_LOCK_FINGERPRINTS = {
-  { mfr = "Yale", model = "YRD220/240 TSDB" },
-  { mfr = "Yale", model = "YRL220 TS LL" },
-  { mfr = "Yale", model = "YRD210 PB DB" },
-  { mfr = "Yale", model = "YRL210 PB LL" },
-  { mfr = "ASSA ABLOY iRevo", model = "c700000202" },
-  { mfr = "ASSA ABLOY iRevo", model = "06ffff2027" }
-}
 
-local is_bad_yale_lock_models = function(opts, driver, device)
-  for _, fingerprint in ipairs(BAD_YALE_LOCK_FINGERPRINTS) do
-      if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-          return true
-      end
-  end
-  return false
-end
 
 local battery_report_handler = function(driver, device, value)
    device:emit_event(capabilities.battery.battery(value.value))
@@ -46,7 +20,7 @@ local bad_yale_driver = {
       }
     }
   },
-  can_handle =  is_bad_yale_lock_models
+  can_handle = require("yale.yale-bad-battery-reporter.can_handle"),
 }
 
 return bad_yale_driver


### PR DESCRIPTION
Lazy loading of `zigbee-lock` sub-drivers and copyright updates.