### PR TITLE
CHAD-17072: zigbee-range-extender lazy load subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-range-extender/src/frient/can_handle.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/frient/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function frient_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "frient A/S" and (device:get_model() == "REXZB-111") then
+    return true, require("frient")
+  end
+  return false
+end
+
+return frient_can_handle

--- a/drivers/SmartThings/zigbee-range-extender/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/frient/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local clusters = require "st.zigbee.zcl.clusters"
@@ -70,9 +60,7 @@ local frient_range_extender = {
       }
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "frient A/S" and (device:get_model() == "REXZB-111")
-  end
+  can_handle = require("frient.can_handle"),
 }
 
 return frient_range_extender

--- a/drivers/SmartThings/zigbee-range-extender/src/init.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local defaults = require "st.zigbee.defaults"
@@ -32,9 +22,7 @@ local zigbee_range_driver_template = {
     }
   },
   health_check = false,
-  sub_drivers = {
-    require("frient")
-  }
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(zigbee_range_driver_template, zigbee_range_driver_template.supported_capabilities)

--- a/drivers/SmartThings/zigbee-range-extender/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-range-extender/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("frient"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zigbee-range-extender/src/test/test_frient_zigbee_range_extender.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/test/test_frient_zigbee_range_extender.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-range-extender/src/test/test_zigbee_extend.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/test/test_zigbee_extend.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"


### PR DESCRIPTION
Lazy loading of `zigbee-range-extender` sub-drivers and copyright updates.