### PR TITLE
CHAD-17075: zigbee-smoke-detector lazy load subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/can_handle.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function is_aqara_products(opts, driver, device)
+  local FINGERPRINTS = require("aqara-gas.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("aqara-gas")
+    end
+  end
+  return false
+end
+
+return is_aqara_products

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FINGERPRINTS = {
+    { mfr = "LUMI", model = "lumi.sensor_gas.acn02" }
+}
+
+return FINGERPRINTS

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara-gas/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local data_types = require "st.zigbee.data_types"
 local cluster_base = require "st.zigbee.cluster_base"
 local capabilities = require "st.capabilities"
@@ -31,9 +21,6 @@ local PRIVATE_LIFE_TIME_ATTRIBUTE_ID = 0x0128
 local PRIVATE_GAS_ZONE_STATUS_ATTRIBUTE_ID = 0x013A
 
 
-local FINGERPRINTS = {
-    { mfr = "LUMI", model = "lumi.sensor_gas.acn02" }
-}
 
 
 local CONFIGURATIONS = {
@@ -125,14 +112,6 @@ local function self_check_attr_handler(self, device, zone_status, zb_rx)
     PRIVATE_CLUSTER_ID, PRIVATE_SELF_CHECK_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true))
 end
 
-local function is_aqara_products(opts, driver, device)
-  for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function device_init(driver, device)
   if CONFIGURATIONS ~= nil then
@@ -186,8 +165,7 @@ local aqara_gas_detector_handler = {
       [startSelfCheckCommandName] = self_check_attr_handler
     },
   },
-  can_handle = is_aqara_products
+  can_handle = require("aqara-gas.can_handle"),
 }
 
 return aqara_gas_detector_handler
-

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara/can_handle.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function is_aqara_products(opts, driver, device)
+  local FINGERPRINTS = require("aqara.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
+      return true, require("aqara")
+    end
+  end
+  return false
+end
+
+return is_aqara_products

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara/fingerprints.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FINGERPRINTS = {
+    { mfr = "LUMI", model = "lumi.sensor_smoke.acn03" }
+}
+
+return FINGERPRINTS

--- a/drivers/SmartThings/zigbee-smoke-detector/src/aqara/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/aqara/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local data_types = require "st.zigbee.data_types"
 local clusters = require "st.zigbee.zcl.clusters"
 local cluster_base = require "st.zigbee.cluster_base"
@@ -30,9 +20,6 @@ local PRIVATE_SMOKE_ZONE_STATUS_ATTRIBUTE_ID = 0x013A
 local PowerConfiguration = clusters.PowerConfiguration
 
 
-local FINGERPRINTS = {
-    { mfr = "LUMI", model = "lumi.sensor_smoke.acn03" }
-}
 
 
 local CONFIGURATIONS = {
@@ -98,14 +85,6 @@ local function self_check_attr_handler(self, device, zone_status, zb_rx)
     PRIVATE_CLUSTER_ID, PRIVATE_SELF_CHECK_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true))
 end
 
-local function is_aqara_products(opts, driver, device)
-  for _, fingerprint in ipairs(FINGERPRINTS) do
-    if device:get_manufacturer() == fingerprint.mfr and device:get_model() == fingerprint.model then
-      return true
-    end
-  end
-  return false
-end
 
 local function device_init(driver, device)
   battery_defaults.build_linear_voltage_init(2.6, 3.0)(driver, device)
@@ -154,8 +133,7 @@ local aqara_gas_detector_handler = {
       [startSelfCheckCommandName] = self_check_attr_handler
     },
   },
-  can_handle = is_aqara_products
+  can_handle = require("aqara.can_handle"),
 }
 
 return aqara_gas_detector_handler
-

--- a/drivers/SmartThings/zigbee-smoke-detector/src/frient/can_handle.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/frient/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function frient_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "frient A/S" and (device:get_model() == "SMSZB-120" or device:get_model() == "HESZB-120") then
+    return true, require("frient")
+  end
+  return false
+end
+
+return frient_can_handle

--- a/drivers/SmartThings/zigbee-smoke-detector/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/frient/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 local capabilities = require "st.capabilities"
@@ -270,8 +260,6 @@ local frient_smoke_sensor = {
       }
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "frient A/S" and (device:get_model() == "SMSZB-120" or device:get_model() == "HESZB-120")
-  end
+  can_handle = require("frient.can_handle"),
 }
 return frient_smoke_sensor

--- a/drivers/SmartThings/zigbee-smoke-detector/src/init.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local ZigbeeDriver = require "st.zigbee"
@@ -25,11 +15,7 @@ local zigbee_smoke_driver_template = {
     capabilities.temperatureMeasurement,
     capabilities.temperatureAlarm
   },
-  sub_drivers = {
-    require("frient"),
-    require("aqara-gas"),
-    require("aqara")
-  },
+  sub_drivers = require("sub_drivers"),
   ias_zone_configuration_method = constants.IAS_ZONE_CONFIGURE_TYPE.AUTO_ENROLL_RESPONSE,
   health_check = false,
 }

--- a/drivers/SmartThings/zigbee-smoke-detector/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-smoke-detector/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/sub_drivers.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("frient"),
+   lazy_load_if_possible("aqara-gas"),
+   lazy_load_if_possible("aqara"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_gas_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_gas_detector.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_smoke_detector.lua
@@ -1,16 +1,5 @@
--- Copyright 2024 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2024 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_heat_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_heat_detector.lua
@@ -1,16 +1,5 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_smoke_detector.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_zigbee_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_zigbee_smoke_detector.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 -- Mock out globals
 local test = require "integration_test"


### PR DESCRIPTION
Lazy loading of `zigbee-smoke-detector` sub-drivers and copyright updates.