### PR TITLE
CHAD-17074: zigbee-siren lazy load subdrivers

### DIFF
--- a/drivers/SmartThings/zigbee-siren/src/frient/can_handle.lua
+++ b/drivers/SmartThings/zigbee-siren/src/frient/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function frient_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "frient A/S" and
+    (device:get_model() == "SIRZB-110" or
+    device:get_model() == "SIRZB-111" or
+    device:get_model() == "SIRZB-112")
+    then
+    return true, require("frient")
+  end
+  return false
+end
+
+return frient_can_handle

--- a/drivers/SmartThings/zigbee-siren/src/frient/init.lua
+++ b/drivers/SmartThings/zigbee-siren/src/frient/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 local data_types = require "st.zigbee.data_types"
 local battery_defaults = require "st.zigbee.defaults.battery_defaults"
 --ZCL
@@ -419,9 +410,7 @@ local frient_siren_driver = {
       }
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "frient A/S" and (device:get_model() == "SIRZB-110" or device:get_model() == "SIRZB-111" or device:get_model() == "SIRZB-112")
-  end
+  can_handle = require("frient.can_handle"),
 }
 
 return frient_siren_driver

--- a/drivers/SmartThings/zigbee-siren/src/init.lua
+++ b/drivers/SmartThings/zigbee-siren/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
@@ -194,7 +184,7 @@ local zigbee_siren_driver_template = {
     added = device_added,
     doConfigure = do_configure
   },
-  sub_drivers = { require("ozom"), require("frient") },
+  sub_drivers = require("sub_drivers"),
   cluster_configurations = {
     [alarm.ID] = {
       {

--- a/drivers/SmartThings/zigbee-siren/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zigbee-siren/src/lazy_load_subdriver.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local version = require "version"
+  local ZigbeeDriver = require "st.zigbee"
+  if version.api >= 16 then
+    return ZigbeeDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZigbeeDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+end

--- a/drivers/SmartThings/zigbee-siren/src/ozom/can_handle.lua
+++ b/drivers/SmartThings/zigbee-siren/src/ozom/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function ozom_can_handle(opts, driver, device, ...)
+  if device:get_manufacturer() == "ClimaxTechnology" then
+    return true, require("ozom")
+  end
+  return false
+end
+
+return ozom_can_handle

--- a/drivers/SmartThings/zigbee-siren/src/ozom/init.lua
+++ b/drivers/SmartThings/zigbee-siren/src/ozom/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local data_types = require "st.zigbee.data_types"
 --ZCL
@@ -75,9 +65,7 @@ local ozom_siren_driver = {
       [switch.commands.on.NAME] = siren_switch_on_handler
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device:get_manufacturer() == "ClimaxTechnology"
-  end
+  can_handle = require("ozom.can_handle"),
 }
 
 return ozom_siren_driver

--- a/drivers/SmartThings/zigbee-siren/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-siren/src/sub_drivers.lua
@@ -1,0 +1,9 @@
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+
+return {
+    lazy_load_if_possible("frient"),
+    lazy_load_if_possible("ozom"),
+}

--- a/drivers/SmartThings/zigbee-siren/src/test/test_frient_siren.lua
+++ b/drivers/SmartThings/zigbee-siren/src/test/test_frient_siren.lua
@@ -1,4 +1,4 @@
--- Copyright 2022 SmartThings
+-- Copyright 2022 SmartThings, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.

--- a/drivers/SmartThings/zigbee-siren/src/test/test_ozom_siren.lua
+++ b/drivers/SmartThings/zigbee-siren/src/test/test_ozom_siren.lua
@@ -1,4 +1,4 @@
--- Copyright 2022 SmartThings
+-- Copyright 2022 SmartThings, Inc.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.


### PR DESCRIPTION
Lazy loading of `zigbee-siren` sub-drivers and copyright updates