### PR TITLE
add InitialPress to Ikea Scroll subscription

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/fields.lua
@@ -11,9 +11,9 @@ IkeaScrollFields.ENDPOINT_POWER_SOURCE = 0
 -- Switch Endpoints used for basic press functionality
 IkeaScrollFields.ENDPOINTS_PRESS = {3, 6, 9}
 
--- Required Events for the ENDPOINTS_PRESS. Remove the default subscription to
--- InitialPress since this is a MultiPress device and InitialPress will be ignored.
+-- Required Events for the ENDPOINTS_PRESS.
 IkeaScrollFields.switch_press_subscribed_events = {
+  clusters.Switch.events.InitialPress.ID,
   clusters.Switch.events.MultiPressComplete.ID,
   clusters.Switch.events.LongPress.ID,
 }

--- a/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
@@ -127,6 +127,7 @@ local ENDPOINTS_PRESS = { 3, 6, 9 }
 -- the ikea scroll subdriver has overriden subscribe behavior
 local function ikea_scroll_subscribe()
   local CLUSTER_SUBSCRIBE_LIST ={
+  clusters.Switch.events.InitialPress,
     clusters.Switch.server.events.LongPress,
     clusters.Switch.server.events.MultiPressComplete,
   }


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
In response to this report: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/issues/2633, I am re-adding the InitialPress back into the device subscription for the press endpoints.

# Summary of Completed Tests
Tested on device and the identified bug was fixed by this change with an already onbaorded device. Unit test updated

