### PR TITLE
CHAD-17084: zwave-bulb lazy loading of sub-drivers

### DIFF
--- a/drivers/SmartThings/zwave-bulb/src/aeon-multiwhite-bulb/can_handle.lua
+++ b/drivers/SmartThings/zwave-bulb/src/aeon-multiwhite-bulb/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeon_multiwhite_bulb(opts, driver, device, ...)
+  local FINGERPRINTS = require("aeon-multiwhite-bulb.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+      return true, require("aeon-multiwhite-bulb")
+    end
+  end
+  return false
+end
+
+return can_handle_aeon_multiwhite_bulb

--- a/drivers/SmartThings/zwave-bulb/src/aeon-multiwhite-bulb/fingerprints.lua
+++ b/drivers/SmartThings/zwave-bulb/src/aeon-multiwhite-bulb/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local AEON_MULTIWHITE_BULB_FINGERPRINTS = {
+  {mfr = 0x0371, prod = 0x0103, model = 0x0001}, -- Aeon LED Bulb 6 Multi-White US
+  {mfr = 0x0371, prod = 0x0003, model = 0x0001}, -- Aeon LED Bulb 6 Multi-White EU
+  {mfr = 0x0300, prod = 0x0003, model = 0x0004}  -- ilumin Tunable White
+}
+
+return AEON_MULTIWHITE_BULB_FINGERPRINTS

--- a/drivers/SmartThings/zwave-bulb/src/aeon-multiwhite-bulb/init.lua
+++ b/drivers/SmartThings/zwave-bulb/src/aeon-multiwhite-bulb/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.utils
@@ -26,25 +16,12 @@ local SwitchColor = (require "st.zwave.CommandClass.SwitchColor")({ version = 3 
 --- @type st.zwave.CommandClass.SwitchMultilevel
 local SwitchMultilevel = (require "st.zwave.CommandClass.SwitchMultilevel")({ version = 4 })
 
-local AEON_MULTIWHITE_BULB_FINGERPRINTS = {
-  {mfr = 0x0371, prod = 0x0103, model = 0x0001}, -- Aeon LED Bulb 6 Multi-White US
-  {mfr = 0x0371, prod = 0x0003, model = 0x0001}, -- Aeon LED Bulb 6 Multi-White EU
-  {mfr = 0x0300, prod = 0x0003, model = 0x0004}  -- ilumin Tunable White
-}
 
 local WARM_WHITE_CONFIG = 0x51
 local COLD_WHITE_CONFIG = 0x52
 local SWITCH_COLOR_QUERY_DELAY = 2
 local DEFAULT_COLOR_TEMPERATURE = 2700
 
-local function can_handle_aeon_multiwhite_bulb(opts, driver, device, ...)
-  for _, fingerprint in ipairs(AEON_MULTIWHITE_BULB_FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
-    end
-  end
-  return false
-end
 
 local function onoff_level_report_handler(self, device, cmd)
   local value = cmd.args.target_value and cmd.args.target_value or cmd.args.value
@@ -126,7 +103,7 @@ local aeon_multiwhite_bulb = {
       [capabilities.colorTemperature.commands.setColorTemperature.NAME] = set_color_temperature
     }
   },
-  can_handle = can_handle_aeon_multiwhite_bulb,
+  can_handle = require("aeon-multiwhite-bulb.can_handle"),
   lifecycle_handlers = {
     added = device_added
   }

--- a/drivers/SmartThings/zwave-bulb/src/aeotec-led-bulb-6/can_handle.lua
+++ b/drivers/SmartThings/zwave-bulb/src/aeotec-led-bulb-6/can_handle.lua
@@ -1,0 +1,23 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+--- Determine whether the passed device is an Aeotec LED Bulb 6.
+---
+--- @param driver Driver driver instance
+--- @param device Device device isntance
+--- @return boolean true if the device is an Aeotec LED Bulb 6, else false
+local function is_aeotec_led_bulb_6(opts, driver, device, ...)
+    local AEOTEC_MFR_ID = 0x0371
+    local AEOTEC_LED_BULB_6_PRODUCT_TYPE_US = 0x0103
+    local AEOTEC_LED_BULB_6_PRODUCT_TYPE_EU = 0x0003
+    local AEOTEC_LED_BULB_6_PRODUCT_ID = 0x0002
+    if device:id_match(
+        AEOTEC_MFR_ID,
+        { AEOTEC_LED_BULB_6_PRODUCT_TYPE_US, AEOTEC_LED_BULB_6_PRODUCT_TYPE_EU },
+        AEOTEC_LED_BULB_6_PRODUCT_ID) then
+        return true, require("aeotec-led-bulb-6")
+    end
+    return false
+end
+
+return is_aeotec_led_bulb_6

--- a/drivers/SmartThings/zwave-bulb/src/aeotec-led-bulb-6/init.lua
+++ b/drivers/SmartThings/zwave-bulb/src/aeotec-led-bulb-6/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.utils
@@ -26,10 +16,6 @@ local SwitchColor = (require "st.zwave.CommandClass.SwitchColor")({ version=3 })
 --- @type st.zwave.CommandClass.SwitchMultilevel
 local SwitchMultilevel = (require "st.zwave.CommandClass.SwitchMultilevel")({ version=4 })
 
-local AEOTEC_MFR_ID = 0x0371
-local AEOTEC_LED_BULB_6_PRODUCT_TYPE_US = 0x0103
-local AEOTEC_LED_BULB_6_PRODUCT_TYPE_EU = 0x0003
-local AEOTEC_LED_BULB_6_PRODUCT_ID = 0x0002
 local WARM_WHITE_CONFIG = 0x51
 local COLD_WHITE_CONFIG = 0x52
 
@@ -102,18 +88,6 @@ function capability_handlers.refresh(driver, device)
   device:send(Configuration:Get({ parameter_number=COLD_WHITE_CONFIG }))
 end
 
---- Determine whether the passed device is an Aeotec LED Bulb 6.
----
---- @param driver Driver driver instance
---- @param device Device device isntance
---- @return boolean true if the device is an Aeotec LED Bulb 6, else false
-local function is_aeotec_led_bulb_6(opts, driver, device, ...)
-  return device:id_match(
-    AEOTEC_MFR_ID,
-    { AEOTEC_LED_BULB_6_PRODUCT_TYPE_US, AEOTEC_LED_BULB_6_PRODUCT_TYPE_EU },
-    AEOTEC_LED_BULB_6_PRODUCT_ID)
-end
-
 local aeotec_led_bulb_6 = {
   NAME = "Aeotec LED Bulb 6",
   zwave_handlers = {
@@ -129,7 +103,7 @@ local aeotec_led_bulb_6 = {
       [capabilities.refresh.commands.refresh.NAME] = capability_handlers.refresh
     }
   },
-  can_handle = is_aeotec_led_bulb_6,
+  can_handle = require("aeotec-led-bulb-6.can_handle"),
 }
 
 return aeotec_led_bulb_6

--- a/drivers/SmartThings/zwave-bulb/src/fibaro-rgbw-controller/can_handle.lua
+++ b/drivers/SmartThings/zwave-bulb/src/fibaro-rgbw-controller/can_handle.lua
@@ -1,0 +1,20 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function is_fibaro_rgbw_controller(opts, driver, device, ...)
+  local FIBARO_MFR_ID = 0x010F
+  local FIBARO_RGBW_CONTROLLER_PROD_TYPE = 0x0900
+  local FIBARO_RGBW_CONTROLLER_PROD_ID_US = 0x2000
+  local FIBARO_RGBW_CONTROLLER_PROD_ID_EU = 0x1000
+
+  if device:id_match(
+    FIBARO_MFR_ID,
+    FIBARO_RGBW_CONTROLLER_PROD_TYPE,
+    {FIBARO_RGBW_CONTROLLER_PROD_ID_US, FIBARO_RGBW_CONTROLLER_PROD_ID_EU}
+  ) then
+    return true, require("fibaro-rgbw-controller")
+  end
+  return false
+end
+
+return is_fibaro_rgbw_controller

--- a/drivers/SmartThings/zwave-bulb/src/fibaro-rgbw-controller/init.lua
+++ b/drivers/SmartThings/zwave-bulb/src/fibaro-rgbw-controller/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass.Association
@@ -32,19 +22,6 @@ local SwitchLevelDefaults = require "st.zwave.defaults.switchLevel"
 local CAP_CACHE_KEY = "st.capabilities." .. capabilities.colorControl.ID
 local LAST_COLOR_SWITCH_CMD_FIELD = "lastColorSwitchCmd"
 local FAKE_RGB_ENDPOINT = 10
-
-local FIBARO_MFR_ID = 0x010F
-local FIBARO_RGBW_CONTROLLER_PROD_TYPE = 0x0900
-local FIBARO_RGBW_CONTROLLER_PROD_ID_US = 0x2000
-local FIBARO_RGBW_CONTROLLER_PROD_ID_EU = 0x1000
-
-local function is_fibaro_rgbw_controller(opts, driver, device, ...)
-  return device:id_match(
-    FIBARO_MFR_ID,
-    FIBARO_RGBW_CONTROLLER_PROD_TYPE,
-    {FIBARO_RGBW_CONTROLLER_PROD_ID_US, FIBARO_RGBW_CONTROLLER_PROD_ID_EU}
-  )
-end
 
 -- This handler is copied from defaults with scraped of sets for both WHITE channels
 local function set_color(driver, device, command)
@@ -201,7 +178,7 @@ local fibaro_rgbw_controller = {
     added = device_added,
     init = device_init
   },
-  can_handle = is_fibaro_rgbw_controller,
+  can_handle = require("fibaro-rgbw-controller.can_handle"),
 }
 
 return fibaro_rgbw_controller

--- a/drivers/SmartThings/zwave-bulb/src/init.lua
+++ b/drivers/SmartThings/zwave-bulb/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.Driver
@@ -30,11 +20,7 @@ local driver_template = {
     capabilities.colorTemperature,
     capabilities.powerMeter
   },
-  sub_drivers = {
-    require("aeotec-led-bulb-6"),
-    require("aeon-multiwhite-bulb"),
-    require("fibaro-rgbw-controller")
-  },
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities, {native_capability_cmds_enabled = true})

--- a/drivers/SmartThings/zwave-bulb/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-bulb/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-bulb/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-bulb/src/sub_drivers.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("aeotec-led-bulb-6"),
+   lazy_load_if_possible("aeon-multiwhite-bulb"),
+   lazy_load_if_possible("fibaro-rgbw-controller"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-bulb/src/test/test_aeon_multiwhite_bulb.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_aeon_multiwhite_bulb.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-bulb/src/test/test_aeotec_led_bulb_6.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_aeotec_led_bulb_6.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-bulb/src/test/test_fibaro_rgbw_controller.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_fibaro_rgbw_controller.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-bulb/src/test/test_zwave_bulb.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_zwave_bulb.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"


### PR DESCRIPTION
`zigbee-bulb` lazy loading of sub-drivers and copyright updates