### PR TITLE
CHAD-17086: zwave-electric-meter lazy loading of sub-drivers

### DIFF
--- a/drivers/SmartThings/zwave-electric-meter/src/aeon-meter/can_handle.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/aeon-meter/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeon_meter(opts, driver, device, ...)
+  local FINGERPRINTS = require("aeon-meter.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+      return true, require("aeon-meter")
+    end
+  end
+  return false
+end
+
+return can_handle_aeon_meter

--- a/drivers/SmartThings/zwave-electric-meter/src/aeon-meter/fingerprints.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/aeon-meter/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local AEON_FINGERPRINTS = {
+  {mfr = 0x0086, prod = 0x0002, model = 0x0009},  -- DSB09xxx-ZWUS
+  {mfr = 0x0086, prod = 0x0002, model = 0x0001},  -- DSB28-ZWEU
+}
+
+return AEON_FINGERPRINTS

--- a/drivers/SmartThings/zwave-electric-meter/src/aeon-meter/init.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/aeon-meter/init.lua
@@ -1,33 +1,8 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 --- @type st.zwave.CommandClass.Configuration
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
-
-local AEON_FINGERPRINTS = {
-  {mfr = 0x0086, prod = 0x0002, model = 0x0009},  -- DSB09xxx-ZWUS
-  {mfr = 0x0086, prod = 0x0002, model = 0x0001},  -- DSB28-ZWEU
-}
-
-local function can_handle_aeon_meter(opts, driver, device, ...)
-  for _, fingerprint in ipairs(AEON_FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
-    end
-  end
-  return false
-end
 
 local do_configure = function (self, device)
   device:send(Configuration:Set({parameter_number = 101, size = 4, configuration_value = 4}))   -- combined power in watts...
@@ -42,7 +17,7 @@ local aeon_meter = {
     doConfigure = do_configure
   },
   NAME = "aeon meter",
-  can_handle = can_handle_aeon_meter
+  can_handle = require("aeon-meter.can_handle"),
 }
 
 return aeon_meter

--- a/drivers/SmartThings/zwave-electric-meter/src/aeotec-gen5-meter/can_handle.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/aeotec-gen5-meter/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeotec_gen5_meter(opts, driver, device, ...)
+  local FINGERPRINTS = require("aeotec-gen5-meter.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+      return true, require("aeotec-gen5-meter")
+    end
+  end
+  return false
+end
+
+return can_handle_aeotec_gen5_meter

--- a/drivers/SmartThings/zwave-electric-meter/src/aeotec-gen5-meter/fingerprints.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/aeotec-gen5-meter/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local AEOTEC_GEN5_FINGERPRINTS = {
+  {mfr = 0x0086, prod = 0x0102, model = 0x005F},  -- Aeotec Home Energy Meter (Gen5) US
+  {mfr = 0x0086, prod = 0x0002, model = 0x005F},  -- Aeotec Home Energy Meter (Gen5) EU
+}
+
+return AEOTEC_GEN5_FINGERPRINTS

--- a/drivers/SmartThings/zwave-electric-meter/src/aeotec-gen5-meter/init.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/aeotec-gen5-meter/init.lua
@@ -1,33 +1,8 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 --- @type st.zwave.CommandClass.Configuration
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
-
-local AEOTEC_GEN5_FINGERPRINTS = {
-  {mfr = 0x0086, prod = 0x0102, model = 0x005F},  -- Aeotec Home Energy Meter (Gen5) US
-  {mfr = 0x0086, prod = 0x0002, model = 0x005F},  -- Aeotec Home Energy Meter (Gen5) EU
-}
-
-local function can_handle_aeotec_gen5_meter(opts, driver, device, ...)
-  for _, fingerprint in ipairs(AEOTEC_GEN5_FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
-    end
-  end
-  return false
-end
 
 local do_configure = function (self, device)
   device:send(Configuration:Set({parameter_number = 101, size = 4, configuration_value = 3}))   -- report total power in Watts and total energy in kWh...
@@ -43,7 +18,7 @@ local aeotec_gen5_meter = {
     doConfigure = do_configure
   },
   NAME = "aeotec gen5 meter",
-  can_handle = can_handle_aeotec_gen5_meter
+  can_handle = require("aeotec-gen5-meter.can_handle"),
 }
 
 return aeotec_gen5_meter

--- a/drivers/SmartThings/zwave-electric-meter/src/init.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.defaults
@@ -31,11 +21,7 @@ local driver_template = {
   lifecycle_handlers = {
     added = device_added
   },
-  sub_drivers = {
-    require("qubino-meter"),
-    require("aeotec-gen5-meter"),
-    require("aeon-meter")
-  }
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)

--- a/drivers/SmartThings/zwave-electric-meter/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-electric-meter/src/qubino-meter/can_handle.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/qubino-meter/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_qubino_meter(opts, driver, device, ...)
+  local FINGERPRINTS = require("qubino-meter.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+      return true, require("qubino-meter")
+    end
+  end
+  return false
+end
+
+return can_handle_qubino_meter

--- a/drivers/SmartThings/zwave-electric-meter/src/qubino-meter/fingerprints.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/qubino-meter/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local QUBINO_FINGERPRINTS = {
+  {mfr = 0x0159, prod = 0x0007, model = 0x0054},  -- Qubino 3 Phase Meter
+  {mfr = 0x0159, prod = 0x0007, model = 0x0052}   -- Qubino Smart Meter
+}
+
+return QUBINO_FINGERPRINTS

--- a/drivers/SmartThings/zwave-electric-meter/src/qubino-meter/init.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/qubino-meter/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass.Configuration
@@ -20,22 +10,10 @@ local Meter = (require "st.zwave.CommandClass.Meter")({ version=3 })
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
 
-local QUBINO_FINGERPRINTS = {
-  {mfr = 0x0159, prod = 0x0007, model = 0x0054},  -- Qubino 3 Phase Meter
-  {mfr = 0x0159, prod = 0x0007, model = 0x0052}   -- Qubino Smart Meter
-}
 
 local POWER_UNIT_WATT = "W"
 local ENERGY_UNIT_KWH = "kWh"
 
-local function can_handle_qubino_meter(opts, driver, device, ...)
-  for _, fingerprint in ipairs(QUBINO_FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      return true
-    end
-  end
-  return false
-end
 
 local function meter_report_handler(self, device, cmd)
 
@@ -101,7 +79,7 @@ local qubino_meter = {
     init = device_init
   },
   NAME = "qubino meter",
-  can_handle = can_handle_qubino_meter
+  can_handle = require("qubino-meter.can_handle"),
 }
 
 return qubino_meter

--- a/drivers/SmartThings/zwave-electric-meter/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/sub_drivers.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("qubino-meter"),
+   lazy_load_if_possible("aeotec-gen5-meter"),
+   lazy_load_if_possible("aeon-meter"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeon_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeon_meter.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_gen5_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_gen5_meter.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_3_phase_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_3_phase_meter.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_smart_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_smart_meter.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_zwave_electric_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_zwave_electric_meter.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"


### PR DESCRIPTION
`zwave-electric-meter` lazy loading of sub-drivers and copyright updates