### PR TITLE
CHAD-17088: zwave-garage-door-opener lazy load subdrivers

### DIFF
--- a/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/can_handle.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_ecolink_garage_door(opts, driver, device, ...)
+  local FINGERPRINTS = require("ecolink-zw-gdo.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("ecolink-zw-gdo")
+    end
+  end
+  return false
+end
+
+return can_handle_ecolink_garage_door

--- a/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/fingerprints.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+-- Ecolink garage door operator
+local ECOLINK_GARAGE_DOOR_FINGERPRINTS = {
+    {manufacturerId = 0x014A, productType = 0x0007, productId = 0x4731},
+}
+
+return ECOLINK_GARAGE_DOOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/init.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 --- @type st.capabilities
 local capabilities = require "st.capabilities"
@@ -27,11 +16,6 @@ local Configuration = (require "st.zwave.CommandClass.Configuration")({ version 
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version = 11 })
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 8 })
-
--- Ecolink garage door operator
-local ECOLINK_GARAGE_DOOR_FINGERPRINTS = {
-  manufacturerId = 0x014A, productType = 0x0007, productId = 0x4731
-}
 
 local GDO_ENDPOINT_NAME = "main"
 local CONTACTSENSOR_ENDPOINT_NAME = "sensor"
@@ -55,11 +39,6 @@ local GDO_CONFIG_PARAMS = {
 --- @param driver Driver driver instance
 --- @param device Device device isntance
 --- @return boolean true if the device proper, else false
-local function can_handle_ecolink_garage_door(opts, driver, device, ...)
-  return device:id_match(ECOLINK_GARAGE_DOOR_FINGERPRINTS.manufacturerId,
-                          ECOLINK_GARAGE_DOOR_FINGERPRINTS.productType,
-                          ECOLINK_GARAGE_DOOR_FINGERPRINTS.productId)
-end
 
 local function component_to_endpoint(device, component_id)
   if (CONTACTSENSOR_ENDPOINT_NAME == component_id)  then
@@ -282,7 +261,7 @@ local ecolink_garage_door_operator = {
     doConfigure = configure_device_with_updated_config,
     infoChanged = configure_device_with_updated_config
   },
-  can_handle = can_handle_ecolink_garage_door
+  can_handle = require("ecolink-zw-gdo.can_handle"),
 }
 
 return ecolink_garage_door_operator

--- a/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/init.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/ecolink-zw-gdo/init.lua
@@ -262,6 +262,7 @@ local ecolink_garage_door_operator = {
     infoChanged = configure_device_with_updated_config
   },
   can_handle = require("ecolink-zw-gdo.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return ecolink_garage_door_operator

--- a/drivers/SmartThings/zwave-garage-door-opener/src/init.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.Driver
@@ -24,10 +14,7 @@ local driver_template = {
     capabilities.doorControl,
     capabilities.contactSensor,
   },
-  sub_drivers = {
-    require("mimolite-garage-door"),
-    require("ecolink-zw-gdo")
-  }
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)

--- a/drivers/SmartThings/zwave-garage-door-opener/src/init.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/init.lua
@@ -15,6 +15,7 @@ local driver_template = {
     capabilities.contactSensor,
   },
   sub_drivers = require("sub_drivers"),
+  shared_device_thread_enabled = true,
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)

--- a/drivers/SmartThings/zwave-garage-door-opener/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/can_handle.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_mimolite_garage_door(opts, driver, device, ...)
+  local FINGERPRINTS = require("mimolite-garage-door.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("mimolite-garage-door")
+    end
+  end
+  return false
+end
+
+return can_handle_mimolite_garage_door

--- a/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/fingerprints.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local MIMOLITE_GARAGE_DOOR_FINGERPRINTS = {
+  { manufacturerId = 0x0084, productType = 0x0453, productId = 0x0111 } -- mimolite garage door
+}
+
+return MIMOLITE_GARAGE_DOOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/init.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -28,23 +18,12 @@ local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 
 --- @type st.zwave.CommandClass.SwitchBinary
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({ version = 2 })
 
-local MIMOLITE_GARAGE_DOOR_FINGERPRINTS = {
-  { manufacturerId = 0x0084, productType = 0x0453, productId = 0x0111 } -- mimolite garage door
-}
 
 --- Determine whether the passed device is mimolite garage door
 ---
 --- @param driver Driver driver instance
 --- @param device Device device isntance
 --- @return boolean true if the device proper, else false
-local function can_handle_mimolite_garage_door(opts, driver, device, ...)
-  for _, fingerprint in ipairs(MIMOLITE_GARAGE_DOOR_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function door_event_helper(device, value)
   device:emit_event(value == 0x00 and capabilities.doorControl.door.closed() or capabilities.doorControl.door.open())
@@ -118,7 +97,7 @@ local mimolite_garage_door = {
     doConfigure = do_configure
   },
   NAME = "mimolite garage door",
-  can_handle = can_handle_mimolite_garage_door
+  can_handle = require("mimolite-garage-door.can_handle"),
 }
 
 return mimolite_garage_door

--- a/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/init.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/mimolite-garage-door/init.lua
@@ -98,6 +98,7 @@ local mimolite_garage_door = {
   },
   NAME = "mimolite garage door",
   can_handle = require("mimolite-garage-door.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return mimolite_garage_door

--- a/drivers/SmartThings/zwave-garage-door-opener/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/sub_drivers.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("mimolite-garage-door"),
+   lazy_load_if_possible("ecolink-zw-gdo"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-garage-door-opener/src/test/test_ecolink_garage_door_operator.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/test/test_ecolink_garage_door_operator.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-garage-door-opener/src/test/test_mimolite_garage_door.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/test/test_mimolite_garage_door.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-garage-door-opener/src/test/test_zwave_garage_door_opener.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/test/test_zwave_garage_door_opener.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"


### PR DESCRIPTION
`zwave-garage-door-opener` lazy loading of sub-drivers and copyright updates