### PR TITLE
CHAD-17089: zwave-lock lazy loading of subdrivers

### DIFF
--- a/drivers/SmartThings/zwave-lock/src/apiv6_bugfix/can_handle.lua
+++ b/drivers/SmartThings/zwave-lock/src/apiv6_bugfix/can_handle.lua
@@ -1,0 +1,16 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local cc = require "st.zwave.CommandClass"
+  local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+  local version = require "version"
+  if version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION then
+      return true, require("apiv6_bugfix")
+  end
+  return false
+end
+
+return can_handle

--- a/drivers/SmartThings/zwave-lock/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/apiv6_bugfix/init.lua
@@ -1,13 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local cc = require "st.zwave.CommandClass"
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
-
-
-local function can_handle(opts, driver, device, cmd, ...)
-  local version = require "version"
-  return version.api == 6 and
-    cmd.cmd_class == cc.WAKE_UP and
-    cmd.cmd_id == WakeUp.NOTIFICATION
-end
 
 local function wakeup_notification(driver, device, cmd)
   device:refresh()
@@ -20,7 +15,7 @@ local apiv6_bugfix = {
     }
   },
   NAME = "apiv6_bugfix",
-  can_handle = can_handle
+  can_handle = require("apiv6_bugfix.can_handle"),
 }
 
 return apiv6_bugfix

--- a/drivers/SmartThings/zwave-lock/src/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -182,13 +171,7 @@ local driver_template = {
       [Time.GET] = time_get_handler -- used by DanaLock
     }
   },
-  sub_drivers = {
-    require("zwave-alarm-v1-lock"),
-    require("schlage-lock"),
-    require("samsung-lock"),
-    require("keywe-lock"),
-    require("apiv6_bugfix"),
-  }
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)

--- a/drivers/SmartThings/zwave-lock/src/keywe-lock/can_handle.lua
+++ b/drivers/SmartThings/zwave-lock/src/keywe-lock/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_keywe_lock(opts, self, device, cmd, ...)
+  local KEYWE_MFR = 0x037B
+  if device.zwave_manufacturer_id == KEYWE_MFR then
+    return true, require("keywe-lock")
+  end
+  return false
+end
+
+return can_handle_keywe_lock

--- a/drivers/SmartThings/zwave-lock/src/keywe-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/keywe-lock/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
@@ -23,12 +13,7 @@ local LockDefaults = require "st.zwave.defaults.lock"
 local LockCodesDefaults = require "st.zwave.defaults.lockCodes"
 local TamperDefaults = require "st.zwave.defaults.tamperAlert"
 
-local KEYWE_MFR = 0x037B
 local TAMPER_CLEAR_DELAY = 10
-
-local function can_handle_keywe_lock(opts, self, device, cmd, ...)
-  return device.zwave_manufacturer_id == KEYWE_MFR
-end
 
 local function clear_tamper_if_needed(device)
   local current_tamper_state = device:get_latest_state("main", capabilities.tamperAlert.ID, capabilities.tamperAlert.tamper.NAME)
@@ -80,7 +65,7 @@ local keywe_lock = {
     doConfigure = do_configure
   },
   NAME = "Keywe Lock",
-  can_handle = can_handle_keywe_lock,
+  can_handle = require("keywe-lock.can_handle"),
 }
 
 return keywe_lock

--- a/drivers/SmartThings/zwave-lock/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-lock/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-lock/src/samsung-lock/can_handle.lua
+++ b/drivers/SmartThings/zwave-lock/src/samsung-lock/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_samsung_lock(opts, self, device, cmd, ...)
+  local SAMSUNG_MFR = 0x022E
+  if device.zwave_manufacturer_id == SAMSUNG_MFR then
+    return true, require("samsung-lock")
+  end
+  return false
+end
+
+return can_handle_samsung_lock

--- a/drivers/SmartThings/zwave-lock/src/samsung-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/samsung-lock/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
@@ -28,11 +18,6 @@ local get_lock_codes = LockCodesDefaults.get_lock_codes
 local clear_code_state = LockCodesDefaults.clear_code_state
 local code_deleted = LockCodesDefaults.code_deleted
 
-local SAMSUNG_MFR = 0x022E
-
-local function can_handle_samsung_lock(opts, self, device, cmd, ...)
-  return device.zwave_manufacturer_id == SAMSUNG_MFR
-end
 
 local function get_ongoing_code_set(device)
   local code_id
@@ -105,7 +90,7 @@ local samsung_lock = {
     doConfigure = do_configure
   },
   NAME = "Samsung Lock",
-  can_handle = can_handle_samsung_lock,
+  can_handle = require("samsung-lock.can_handle"),
 }
 
 return samsung_lock

--- a/drivers/SmartThings/zwave-lock/src/schlage-lock/can_handle.lua
+++ b/drivers/SmartThings/zwave-lock/src/schlage-lock/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_schlage_lock(opts, self, device, cmd, ...)
+  local SCHLAGE_MFR = 0x003B
+  if device.zwave_manufacturer_id == SCHLAGE_MFR then
+    return true, require("schlage-lock")
+  end
+  return false
+end
+
+return can_handle_schlage_lock

--- a/drivers/SmartThings/zwave-lock/src/schlage-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/schlage-lock/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
@@ -27,14 +17,9 @@ local Association = (require "st.zwave.CommandClass.Association")({version=1})
 
 local LockCodesDefaults = require "st.zwave.defaults.lockCodes"
 
-local SCHLAGE_MFR = 0x003B
 local SCHLAGE_LOCK_CODE_LENGTH_PARAM = {number = 16, size = 1}
 
 local DEFAULT_COMMANDS_DELAY = 4.2 -- seconds
-
-local function can_handle_schlage_lock(opts, self, device, cmd, ...)
-  return device.zwave_manufacturer_id == SCHLAGE_MFR
-end
 
 local function set_code_length(self, device, cmd)
   local length = cmd.args.length
@@ -187,7 +172,7 @@ local schlage_lock = {
     doConfigure = do_configure,
   },
   NAME = "Schlage Lock",
-  can_handle = can_handle_schlage_lock,
+  can_handle = require("schlage-lock.can_handle"),
 }
 
 return schlage_lock

--- a/drivers/SmartThings/zwave-lock/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-lock/src/sub_drivers.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("zwave-alarm-v1-lock"),
+   lazy_load_if_possible("schlage-lock"),
+   lazy_load_if_possible("samsung-lock"),
+   lazy_load_if_possible("keywe-lock"),
+   lazy_load_if_possible("apiv6_bugfix"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-lock/src/test/test_keywe_lock.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_keywe_lock.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-lock/src/test/test_lock_battery.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_lock_battery.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-lock/src/test/test_samsung_lock.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_samsung_lock.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-lock/src/test/test_schlage_lock.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_schlage_lock.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_code_migration.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 -- Mock out globals
 local test = require "integration_test"

--- a/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/can_handle.lua
+++ b/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_v1_alarm(opts, driver, device, cmd, ...)
+  if opts.dispatcher_class == "ZwaveDispatcher" and cmd ~= nil and cmd.version ~= nil and cmd.version == 1 then
+    return true, require("zwave-alarm-v1-lock")
+  end
+  return false
+end
+
+return can_handle_v1_alarm

--- a/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/zwave-alarm-v1-lock/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -35,9 +25,6 @@ local METHOD = {
 --- @param driver st.zwave.Driver
 --- @param device st.zwave.Device
 --- @return boolean true if the device is smoke co alarm
-local function can_handle_v1_alarm(opts, driver, device, cmd, ...)
-  return opts.dispatcher_class == "ZwaveDispatcher" and cmd ~= nil and cmd.version ~= nil and cmd.version == 1
-end
 
 --- Default handler for alarm command class reports, these were largely OEM-defined
 ---
@@ -159,7 +146,7 @@ local zwave_lock = {
     }
   },
   NAME = "Z-Wave lock alarm V1",
-  can_handle = can_handle_v1_alarm,
+  can_handle = require("zwave-alarm-v1-lock.can_handle"),
 }
 
 return zwave_lock


### PR DESCRIPTION
`zwave-lock` lazy loading of sub-drivers and copyright updates