### PR TITLE
CHAD-17090: zwave-mouse-trap lazy loading of sub-drivers

### DIFF
--- a/drivers/SmartThings/zwave-mouse-trap/src/init.lua
+++ b/drivers/SmartThings/zwave-mouse-trap/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.defaults

--- a/drivers/SmartThings/zwave-mouse-trap/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-mouse-trap/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-mouse-trap/src/test/test_zwave_mouse_trap.lua
+++ b/drivers/SmartThings/zwave-mouse-trap/src/test/test_zwave_mouse_trap.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"


### PR DESCRIPTION
`zwave-mouse-trap` lazy loading of sub-drivers and copyright updates