### PR TITLE
CHAD-17093: zwave-siren lazy loading of sub-drivers

### DIFF
--- a/drivers/SmartThings/zwave-siren/src/aeon-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeon-siren/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeon_siren(opts, driver, device, ...)
+  local AEON_MFR = 0x0086
+  local AEON_SIREN_PRODUCT_ID = 0x0050
+
+  if device.zwave_manufacturer_id == AEON_MFR and device.zwave_product_id == AEON_SIREN_PRODUCT_ID then
+    return true, require("aeon-siren")
+  end
+  return false
+end
+
+return can_handle_aeon_siren

--- a/drivers/SmartThings/zwave-siren/src/aeon-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeon-siren/init.lua
@@ -1,22 +1,9 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local Basic = (require "st.zwave.CommandClass.Basic")({ version=1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=1 })
-
-local AEON_MFR = 0x0086
-local AEON_SIREN_PRODUCT_ID = 0x0050
 
 local SOUND_TYPE_AND_VOLUME_PARAMETER_NUMBER = 37
 local CONFIGURE_SOUND_TYPE = "type"
@@ -24,9 +11,6 @@ local SOUND_TYPE_DEFAULT = 1
 local CONFIGURE_VOLUME = "volume"
 local VOLUME_DEFAULT = 3
 
-local function can_handle_aeon_siren(opts, driver, device, ...)
-  return device.zwave_manufacturer_id == AEON_MFR and device.zwave_product_id == AEON_SIREN_PRODUCT_ID
-end
 
 local function configure_sound(device, sound_type, volume)
   if sound_type == nil then sound_type = SOUND_TYPE_DEFAULT end
@@ -64,7 +48,7 @@ end
 
 local aeon_siren = {
   NAME = "aeon-siren",
-  can_handle = can_handle_aeon_siren,
+  can_handle = require("aeon-siren.can_handle"),
   lifecycle_handlers = {
     doConfigure = do_configure,
     infoChanged = info_changed

--- a/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeotec_doorbell_siren(opts, driver, device, ...)
+  local FINGERPRINTS = require("aeotec-doorbell-siren.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("aeotec-doorbell-siren")
+    end
+  end
+  return false
+end
+
+return can_handle_aeotec_doorbell_siren

--- a/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/fingerprints.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/fingerprints.lua
@@ -1,0 +1,13 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local AEOTEC_DOORBELL_SIREN_FINGERPRINTS = {
+  { manufacturerId = 0x0371, productType = 0x0003, productId = 0x00A2}, -- Aeotec Doorbell 6 (EU)
+  { manufacturerId = 0x0371, productType = 0x0103, productId = 0x00A2}, -- Aeotec Doorbell 6 (US)
+  { manufacturerId = 0x0371, productType = 0x0203, productId = 0x00A2}, -- Aeotec Doorbell 6 (AU)
+  { manufacturerId = 0x0371, productType = 0x0003, productId = 0x00A4}, -- Aeotec Siren 6 (EU)
+  { manufacturerId = 0x0371, productType = 0x0103, productId = 0x00A4}, -- Aeotec Siren 6 (US)
+  { manufacturerId = 0x0371, productType = 0x0203, productId = 0x00A4}, -- Aeotec Siren 6 (AU)
+}
+
+return AEOTEC_DOORBELL_SIREN_FINGERPRINTS

--- a/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/aeotec-doorbell-siren/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
@@ -20,14 +10,6 @@ local Notification = (require "st.zwave.CommandClass.Notification")({version=3})
 local SoundSwitch = (require "st.zwave.CommandClass.SoundSwitch")({version=1})
 local preferencesMap = require "preferences"
 
-local AEOTEC_DOORBELL_SIREN_FINGERPRINTS = {
-  { manufacturerId = 0x0371, productType = 0x0003, productId = 0x00A2}, -- Aeotec Doorbell 6 (EU)
-  { manufacturerId = 0x0371, productType = 0x0103, productId = 0x00A2}, -- Aeotec Doorbell 6 (US)
-  { manufacturerId = 0x0371, productType = 0x0203, productId = 0x00A2}, -- Aeotec Doorbell 6 (AU)
-  { manufacturerId = 0x0371, productType = 0x0003, productId = 0x00A4}, -- Aeotec Siren 6 (EU)
-  { manufacturerId = 0x0371, productType = 0x0103, productId = 0x00A4}, -- Aeotec Siren 6 (US)
-  { manufacturerId = 0x0371, productType = 0x0203, productId = 0x00A4}, -- Aeotec Siren 6 (AU)
-}
 
 local COMPONENT_NAME = "componentName"
 local TONE = "tone"
@@ -51,14 +33,6 @@ local BUTTON_BATTERY_NORMAL = 99
 local DEVICE_PROFILE_CHANGE_IN_PROGRESS = "device_profile_change_in_progress"
 local NEXT_BUTTON_BATTERY_EVENT_DETAILS = "next_button_battery_event_details"
 
-local function can_handle_aeotec_doorbell_siren(opts, driver, device, ...)
-  for _, fingerprint in ipairs(AEOTEC_DOORBELL_SIREN_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function querySoundStatus(device)
   for endpoint = 2, NUMBER_OF_SOUND_COMPONENTS do
@@ -316,7 +290,7 @@ end
 
 local aeotec_doorbell_siren = {
   NAME = "aeotec-doorbell-siren",
-  can_handle = can_handle_aeotec_doorbell_siren,
+  can_handle = require("aeotec-doorbell-siren.can_handle"),
 
   lifecycle_handlers = {
     added = device_added,

--- a/drivers/SmartThings/zwave-siren/src/apiv6_bugfix/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/apiv6_bugfix/can_handle.lua
@@ -1,0 +1,17 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local cc = require "st.zwave.CommandClass"
+  local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+  local version = require "version"
+  if version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION
+    then
+      return true, require("apiv6_bugfix")
+  end
+  return false
+end
+
+return can_handle

--- a/drivers/SmartThings/zwave-siren/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/apiv6_bugfix/init.lua
@@ -1,13 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local cc = require "st.zwave.CommandClass"
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 
-local function can_handle(opts, driver, device, cmd, ...)
-  local version = require "version"
-  return version.api == 6 and
-    cmd.cmd_class == cc.WAKE_UP and
-    cmd.cmd_id == WakeUp.NOTIFICATION
-end
 
 local function wakeup_notification(driver, device, cmd)
   device:refresh()
@@ -20,7 +17,7 @@ local apiv6_bugfix = {
     }
   },
   NAME = "apiv6_bugfix",
-  can_handle = can_handle
+  can_handle = require("apiv6_bugfix.can_handle"),
 }
 
 return apiv6_bugfix

--- a/drivers/SmartThings/zwave-siren/src/configurations.lua
+++ b/drivers/SmartThings/zwave-siren/src/configurations.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local devices = {
   YALE_SIREN = {

--- a/drivers/SmartThings/zwave-siren/src/ecolink-wireless-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/ecolink-wireless-siren/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_ecolink_wireless_siren(opts, driver, device, ...)
+  local FINGERPRINTS = require("ecolink-wireless-siren.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("ecolink-wireless-siren")
+    end
+  end
+  return false
+end
+
+return can_handle_ecolink_wireless_siren

--- a/drivers/SmartThings/zwave-siren/src/ecolink-wireless-siren/fingerprints.lua
+++ b/drivers/SmartThings/zwave-siren/src/ecolink-wireless-siren/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ECOLINK_WIRELESS_SIREN_FINGERPRINTS = {
+  { manufacturerId = 0x014A, productType = 0x0005, productId = 0x000A }, -- Ecolink Siren
+}
+
+return ECOLINK_WIRELESS_SIREN_FINGERPRINTS

--- a/drivers/SmartThings/zwave-siren/src/ecolink-wireless-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/ecolink-wireless-siren/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -20,18 +10,7 @@ local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
 --- @type st.zwave.CommandClass.SwitchBinary
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({ version = 2 })
 
-local ECOLINK_WIRELESS_SIREN_FINGERPRINTS = {
-  { manufacturerId = 0x014A, productType = 0x0005, productId = 0x000A }, -- Ecolink Siren
-}
 
-local function can_handle_ecolink_wireless_siren(opts, driver, device, ...)
-  for _, fingerprint in ipairs(ECOLINK_WIRELESS_SIREN_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function basic_set_handler(driver, device, cmd)
   local value = cmd.args.target_value and cmd.args.target_value or cmd.args.value
@@ -103,7 +82,7 @@ local ecolink_wireless_siren = {
   lifecycle_handlers = {
     init = device_init
   },
-  can_handle = can_handle_ecolink_wireless_siren,
+  can_handle = require("ecolink-wireless-siren.can_handle"),
 }
 
 return ecolink_wireless_siren

--- a/drivers/SmartThings/zwave-siren/src/fortrezz/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/fortrezz/can_handle.lua
@@ -1,0 +1,13 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fortrezz_siren(opts, self, device, ...)
+  if device.zwave_manufacturer_id == 0x0084 and
+    device.zwave_product_type == 0x0313 and
+    device.zwave_product_id == 0x010B then
+      return true, require("fortrezz")
+    end
+    return false
+end
+
+return can_handle_fortrezz_siren

--- a/drivers/SmartThings/zwave-siren/src/fortrezz/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/fortrezz/init.lua
@@ -1,26 +1,11 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local cc = require "st.zwave.CommandClass"
 local capabilities = require "st.capabilities"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 
-local function can_handle_fortrezz_siren(opts, self, device, ...)
-  return device.zwave_manufacturer_id == 0x0084 and
-    device.zwave_product_type == 0x0313 and
-    device.zwave_product_id == 0x010B
-end
 
 local function set_and_get(value)
   return function (self, device, command)
@@ -47,7 +32,7 @@ end
 
 local fortrezz_siren = {
   NAME = "fortrezz-siren",
-  can_handle = can_handle_fortrezz_siren,
+  can_handle = require("fortrezz.can_handle"),
   capability_handlers = {
     [capabilities.alarm.ID] = {
       [capabilities.alarm.commands.siren.NAME] = set_and_get(0x42),

--- a/drivers/SmartThings/zwave-siren/src/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cap_defaults = require "st.capabilities.defaults"
@@ -92,19 +82,7 @@ local driver_template = {
     capabilities.relativeHumidityMeasurement,
     capabilities.chime
   },
-  sub_drivers = {
-    require("multifunctional-siren"),
-    require("zwave-sound-sensor"),
-    require("ecolink-wireless-siren"),
-    require("philio-sound-siren"),
-    require("aeotec-doorbell-siren"),
-    require("aeon-siren"),
-    require("yale-siren"),
-    require("zipato-siren"),
-    require("utilitech-siren"),
-    require("fortrezz"),
-    require("apiv6_bugfix"),
-  },
+  sub_drivers = require("sub_drivers"),
   lifecycle_handlers = {
     infoChanged = info_changed,
     doConfigure = do_configure,

--- a/drivers/SmartThings/zwave-siren/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-siren/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-siren/src/multifunctional-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/multifunctional-siren/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_multifunctional_siren(opts, driver, device, ...)
+  local FINGERPRINTS = require("multifunctional-siren.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("multifunctional-siren")
+    end
+  end
+  return false
+end
+
+return can_handle_multifunctional_siren

--- a/drivers/SmartThings/zwave-siren/src/multifunctional-siren/fingerprints.lua
+++ b/drivers/SmartThings/zwave-siren/src/multifunctional-siren/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local MULTIFUNCTIONAL_SIREN_FINGERPRINTS = {
+  { manufacturerId = 0x027A, productType = 0x000C, productId = 0x0003 }, -- Zooz S2 Multisiren ZSE19
+  { manufacturerId = 0x0060, productType = 0x000C, productId = 0x0003 } -- Everspring Indoor Voice Siren
+}
+
+return MULTIFUNCTIONAL_SIREN_FINGERPRINTS

--- a/drivers/SmartThings/zwave-siren/src/multifunctional-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/multifunctional-siren/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -20,24 +10,12 @@ local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 --- @type st.zwave.CommandClass.Battery
 local Notification = (require "st.zwave.CommandClass.Notification")({version=3})
 
-local MULTIFUNCTIONAL_SIREN_FINGERPRINTS = {
-  { manufacturerId = 0x027A, productType = 0x000C, productId = 0x0003 }, -- Zooz S2 Multisiren ZSE19
-  { manufacturerId = 0x0060, productType = 0x000C, productId = 0x0003 } -- Everspring Indoor Voice Siren
-}
 
 --- Determine whether the passed device is multifunctional siren
 ---
 --- @param driver Driver driver instance
 --- @param device Device device isntance
 --- @return boolean true if the device proper, else false
-local function can_handle_multifunctional_siren(opts, driver, device, ...)
-  for _, fingerprint in ipairs(MULTIFUNCTIONAL_SIREN_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 --- Default handler for notification command class reports
 ---
@@ -74,7 +52,7 @@ local multifunctional_siren = {
     doConfigure = do_configure
   },
   NAME = "multifunctional siren",
-  can_handle = can_handle_multifunctional_siren,
+  can_handle = require("multifunctional-siren.can_handle"),
 }
 
 return multifunctional_siren

--- a/drivers/SmartThings/zwave-siren/src/philio-sound-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/philio-sound-siren/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_philio_sound_siren(opts, driver, device, ...)
+  local FINGERPRINTS = require("philio-sound-siren.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("philio-sound-siren")
+    end
+  end
+  return false
+end
+
+return can_handle_philio_sound_siren

--- a/drivers/SmartThings/zwave-siren/src/philio-sound-siren/fingerprints.lua
+++ b/drivers/SmartThings/zwave-siren/src/philio-sound-siren/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local PHILIO_SOUND_SIREN = {
+  { manufacturerId = 0x013C, productType = 0x0004, productId = 0x000A }
+}
+
+return PHILIO_SOUND_SIREN

--- a/drivers/SmartThings/zwave-siren/src/philio-sound-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/philio-sound-siren/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local cc = require "st.zwave.CommandClass"
 local capabilities = require "st.capabilities"
@@ -19,9 +9,6 @@ local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({version=2})
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
 local preferencesMap = require "preferences"
 
-local PHILIO_SOUND_SIREN = {
-  { manufacturerId = 0x013C, productType = 0x0004, productId = 0x000A }
-}
 
 local PARAMETER_SOUND = "sound"
 local SMOKE = 0
@@ -43,14 +30,6 @@ local sounds = {
   [SMOKE]     = {notificationType = Notification.notification_type.SMOKE,          event = Notification.event.smoke.DETECTED_LOCATION_PROVIDED}
 }
 
-local function can_handle_philio_sound_siren(opts, driver, device, ...)
-  for _, fingerprint in ipairs(PHILIO_SOUND_SIREN) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function device_added(self, device)
   device:refresh()
@@ -157,7 +136,7 @@ end
 
 local philio_sound_siren = {
   NAME = "Philio sound siren",
-  can_handle = can_handle_philio_sound_siren,
+  can_handle = require("philio-sound-siren.can_handle"),
   lifecycle_handlers = {
     added = device_added
   },

--- a/drivers/SmartThings/zwave-siren/src/preferences.lua
+++ b/drivers/SmartThings/zwave-siren/src/preferences.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local devices = {
   PHILIO_SOUND_SIREN = {

--- a/drivers/SmartThings/zwave-siren/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-siren/src/sub_drivers.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("multifunctional-siren"),
+   lazy_load_if_possible("zwave-sound-sensor"),
+   lazy_load_if_possible("ecolink-wireless-siren"),
+   lazy_load_if_possible("philio-sound-siren"),
+   lazy_load_if_possible("aeotec-doorbell-siren"),
+   lazy_load_if_possible("aeon-siren"),
+   lazy_load_if_possible("yale-siren"),
+   lazy_load_if_possible("zipato-siren"),
+   lazy_load_if_possible("utilitech-siren"),
+   lazy_load_if_possible("fortrezz"),
+   lazy_load_if_possible("apiv6_bugfix"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-siren/src/test/test_aeon_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_aeon_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-siren/src/test/test_aeotec_doorbell_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_aeotec_doorbell_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zwave-siren/src/test/test_ecolink_wireless_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_ecolink_wireless_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-siren/src/test/test_fortrezz_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_fortrezz_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-siren/src/test/test_philio_sound_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_philio_sound_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/zwave-siren/src/test/test_utilitech_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_utilitech_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-siren/src/test/test_yale_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_yale_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-siren/src/test/test_zipato_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zipato_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_multifunctional-siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_multifunctional-siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_notification_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_notification_siren.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_siren.lua
@@ -1,4 +1,4 @@
----@diagnostic disable: param-type-mismatch, undefined-field
+-- Copyright 2022 SmartThings, Inc.
 -- Copyright 2022 SmartThings
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_sound_sensor.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_sound_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-siren/src/utilitech-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/utilitech-siren/can_handle.lua
@@ -1,0 +1,13 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_utilitech_siren(opts, driver, device, ...)
+  local UTILITECH_MFR = 0x0060
+  local UTILITECH_SIREN_PRODUCT_ID = 0x0001
+  if device.zwave_manufacturer_id == UTILITECH_MFR and device.zwave_product_id == UTILITECH_SIREN_PRODUCT_ID then
+    return true, require("utilitech-siren")
+  end
+  return false
+end
+
+return can_handle_utilitech_siren

--- a/drivers/SmartThings/zwave-siren/src/utilitech-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/utilitech-siren/init.lua
@@ -1,28 +1,11 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local cc = require "st.zwave.CommandClass"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1,strict=true})
 local Battery = (require "st.zwave.CommandClass.Battery")({version=1})
 local BatteryDefaults = require "st.zwave.defaults.battery"
-
-local UTILITECH_MFR = 0x0060
-local UTILITECH_SIREN_PRODUCT_ID = 0x0001
-
-local function can_handle_utilitech_siren(opts, driver, device, ...)
-  return device.zwave_manufacturer_id == UTILITECH_MFR and device.zwave_product_id == UTILITECH_SIREN_PRODUCT_ID
-end
 
 local function device_added(self, device)
   device:send(Basic:Get({}))
@@ -39,7 +22,7 @@ end
 
 local utilitech_siren = {
   NAME = "utilitech-siren",
-  can_handle = can_handle_utilitech_siren,
+  can_handle = require("utilitech-siren.can_handle"),
   zwave_handlers = {
     [cc.BATTERY] = {
       [Battery.REPORT] = battery_report_handler

--- a/drivers/SmartThings/zwave-siren/src/yale-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/yale-siren/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_yale_siren(opts, self, device, ...)
+  local YALE_MFR = 0x0129
+  if device.zwave_manufacturer_id == YALE_MFR then
+    return true, require("yale-siren")
+  end
+  return false
+end
+
+return can_handle_yale_siren

--- a/drivers/SmartThings/zwave-siren/src/yale-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/yale-siren/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local cc = require "st.zwave.CommandClass"
 local capabilities = require "st.capabilities"
@@ -19,12 +9,6 @@ local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local Configuration = (require "st.zwave.CommandClass.Configuration")({version=1})
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({version=1})
 local preferencesMap = require "preferences"
-
-local YALE_MFR = 0x0129
-
-local function can_handle_yale_siren(opts, self, device, ...)
-  return device.zwave_manufacturer_id == YALE_MFR
-end
 
 local function siren_set_helper(device, value)
   device:send(Basic:Set({value = value}))
@@ -98,7 +82,7 @@ end
 
 local yale_siren = {
   NAME = "yale-siren",
-  can_handle = can_handle_yale_siren,
+  can_handle = require("yale-siren.can_handle"),
   capability_handlers = {
     [capabilities.alarm.ID] = {
       [capabilities.alarm.commands.both.NAME] = siren_on,

--- a/drivers/SmartThings/zwave-siren/src/zipato-siren/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/zipato-siren/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_zipato_siren(opts, driver, device, ...)
+  local ZIPATO_MFR = 0x0131
+  if device.zwave_manufacturer_id == ZIPATO_MFR then
+    return true, require("zipato-siren")
+  end
+  return false
+end
+
+return can_handle_zipato_siren

--- a/drivers/SmartThings/zwave-siren/src/zipato-siren/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/zipato-siren/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 local cc  = require "st.zwave.CommandClass"
@@ -18,13 +8,9 @@ local AlarmDefaults = require "st.zwave.defaults.alarm"
 local Basic = (require "st.zwave.CommandClass.Basic")({version=1})
 local Battery = (require "st.zwave.CommandClass.Battery")({version=1})
 
-local ZIPATO_MFR = 0x0131
 local BASIC_AND_SWITCH_BINARY_REPORT_STROBE_LIMIT = 33
 local BASIC_AND_SWITCH_BINARY_REPORT_SIREN_LIMIT = 66
 
-local function can_handle_zipato_siren(opts, driver, device, ...)
-  return device.zwave_manufacturer_id == ZIPATO_MFR
-end
 
 local function basic_report_handler(driver, device, cmd)
   local value = cmd.args.value
@@ -64,7 +50,7 @@ end
 
 local zipato_siren = {
   NAME = "zipato-siren",
-  can_handle = can_handle_zipato_siren,
+  can_handle = require("zipato-siren.can_handle"),
   capability_handlers = {
     [capabilities.alarm.ID] = {
       [capabilities.alarm.commands.both.NAME] = siren_on,

--- a/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_zwave_sound_sensor(opts, driver, device, ...)
+  local FINGERPRINTS = require("zwave-sound-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("zwave-sound-sensor")
+    end
+  end
+  return false
+end
+
+return can_handle_zwave_sound_sensor

--- a/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZWAVE_SOUND_SENSOR_FINGERPRINTS = {
+  { manufacturerId = 0x014A, productType = 0x0005, productId = 0x000F } --Ecolink Firefighter
+}
+
+return ZWAVE_SOUND_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/init.lua
+++ b/drivers/SmartThings/zwave-siren/src/zwave-sound-sensor/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -18,23 +8,12 @@ local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Alarm
 local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 2 })
 
-local ZWAVE_SOUND_SENSOR_FINGERPRINTS = {
-  { manufacturerId = 0x014A, productType = 0x0005, productId = 0x000F } --Ecolink Firefighter
-}
 
 --- Determine whether the passed device is zwave-sound-sensor
 ---
 --- @param driver Driver driver instance
 --- @param device Device device isntance
 --- @return boolean true if the device proper, else false
-local function can_handle_zwave_sound_sensor(opts, driver, device, ...)
-  for _, fingerprint in ipairs(ZWAVE_SOUND_SENSOR_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 --- Default handler for alarm command class reports
 ---
@@ -73,7 +52,7 @@ local zwave_sound_sensor = {
     added = added_handler,
   },
   NAME = "zwave sound sensor",
-  can_handle = can_handle_zwave_sound_sensor,
+  can_handle = require("zwave-sound-sensor.can_handle"),
 }
 
 return zwave_sound_sensor


### PR DESCRIPTION
`zwave-siren` lazy loading of sub-drivers and copyright updates