### PR TITLE
CHAD-17094: zwave-smoke-alarm lazy loading of sub-drivers

### DIFF
--- a/drivers/SmartThings/zwave-smoke-alarm/src/apiv6_bugfix/can_handle.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/apiv6_bugfix/can_handle.lua
@@ -1,0 +1,16 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local cc = require "st.zwave.CommandClass"
+  local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+  local version = require "version"
+  if version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION then
+      return true, require("apiv6_bugfix")
+  end
+  return false
+end
+
+return can_handle

--- a/drivers/SmartThings/zwave-smoke-alarm/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/apiv6_bugfix/init.lua
@@ -1,13 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local cc = require "st.zwave.CommandClass"
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
-
-
-local function can_handle(opts, driver, device, cmd, ...)
-  local version = require "version"
-  return version.api == 6 and
-    cmd.cmd_class == cc.WAKE_UP and
-    cmd.cmd_id == WakeUp.NOTIFICATION
-end
 
 local function wakeup_notification(driver, device, cmd)
   device:refresh()
@@ -20,7 +15,7 @@ local apiv6_bugfix = {
     }
   },
   NAME = "apiv6_bugfix",
-  can_handle = can_handle
+  can_handle = require("apiv6_bugfix.can_handle"),
 }
 
 return apiv6_bugfix

--- a/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_smoke_sensor(opts, driver, device, cmd, ...)
+  local FINGERPRINTS = require("fibaro-smoke-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("fibaro-smoke-sensor")
+    end
+  end
+  return false
+end
+
+return can_handle_fibaro_smoke_sensor

--- a/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/fingerprints.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FIBARO_SMOKE_SENSOR_FINGERPRINTS = {
+  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x1002 }, -- Fibaro Smoke Sensor
+  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x1003 }, -- Fibaro Smoke Sensor
+  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x3002 }, -- Fibaro Smoke Sensor
+  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x4002 } -- Fibaro Smoke Sensor
+}
+
+return FIBARO_SMOKE_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/fibaro-smoke-sensor/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -24,26 +14,12 @@ local WakeUp = (require "st.zwave.CommandClass.WakeUp")({version=1})
 
 local FIBARO_SMOKE_SENSOR_WAKEUP_INTERVAL = 21600 --seconds
 
-local FIBARO_SMOKE_SENSOR_FINGERPRINTS = {
-  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x1002 }, -- Fibaro Smoke Sensor
-  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x1003 }, -- Fibaro Smoke Sensor
-  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x3002 }, -- Fibaro Smoke Sensor
-  { manufacturerId = 0x010F, productType = 0x0C02, productId = 0x4002 } -- Fibaro Smoke Sensor
-}
 
 --- Determine whether the passed device is fibaro smoke sensro
 ---
 --- @param driver st.zwave.Driver
 --- @param device st.zwave.Device
 --- @return boolean true if the device is fibaro smoke sensor
-local function can_handle_fibaro_smoke_sensor(opts, driver, device, cmd, ...)
-  for _, fingerprint in ipairs(FIBARO_SMOKE_SENSOR_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function device_added(self, device)
   device:send(WakeUp:IntervalSet({node_id = self.environment_info.hub_zwave_id, seconds = FIBARO_SMOKE_SENSOR_WAKEUP_INTERVAL}))
@@ -76,7 +52,7 @@ local fibaro_smoke_sensor = {
     added = device_added
   },
   NAME = "fibaro smoke sensor",
-  can_handle = can_handle_fibaro_smoke_sensor,
+  can_handle = require("fibaro-smoke-sensor.can_handle"),
   health_check = false,
 }
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -83,12 +73,7 @@ local driver_template = {
     capabilities.temperatureAlarm,
     capabilities.temperatureMeasurement
   },
-  sub_drivers = {
-    require("zwave-smoke-co-alarm-v1"),
-    require("zwave-smoke-co-alarm-v2"),
-    require("fibaro-smoke-sensor"),
-    require("apiv6_bugfix"),
-  },
+  sub_drivers = require("sub_drivers"),
   lifecycle_handlers = {
     init = device_init,
     infoChanged = info_changed,

--- a/drivers/SmartThings/zwave-smoke-alarm/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-smoke-alarm/src/preferences.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/preferences.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local devices = {
     FIBARO = {

--- a/drivers/SmartThings/zwave-smoke-alarm/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/sub_drivers.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("zwave-smoke-co-alarm-v1"),
+   lazy_load_if_possible("zwave-smoke-co-alarm-v2"),
+   lazy_load_if_possible("fibaro-smoke-sensor"),
+   lazy_load_if_possible("apiv6_bugfix"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_co_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_co_sensor_zw5.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_alarm_v1.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_alarm_v1.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_co_detector.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_co_detector.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v1/can_handle.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v1/can_handle.lua
@@ -1,0 +1,13 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_v1_alarm(opts, driver, device, cmd, ...)
+  -- The default handlers for the Alarm/Notification command class(es) for the
+  -- Smoke Detector and Carbon Monoxide Detector only handles V3 and up.
+  if opts.dispatcher_class == "ZwaveDispatcher" and cmd ~= nil and cmd.version ~= nil and cmd.version < 3 then
+    return true, require("zwave-smoke-co-alarm-v1")
+  end
+  return false
+end
+
+return can_handle_v1_alarm

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v1/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v1/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -22,17 +11,6 @@ local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 1 })
 --   manufacturerId = 0x0138, productType = 0x0001, productId = 0x0001 -- First Alert Smoke Detector
 --   manufacturerId = 0x0138, productType = 0x0001, productId = 0x0002 -- First Alert Smoke & CO Detector
 --   manufacturerId = 0x0138, productType = 0x0001, productId = 0x0003 -- First Alert Smoke & CO Detector
-
---- Determine whether the passed device only supports V1 or V2 of the Alarm command class
----
---- @param driver st.zwave.Driver
---- @param device st.zwave.Device
---- @return boolean true if the device is smoke co alarm
-local function can_handle_v1_alarm(opts, driver, device, cmd, ...)
-  -- The default handlers for the Alarm/Notification command class(es) for the
-  -- Smoke Detector and Carbon Monoxide Detector only handles V3 and up.
-  return opts.dispatcher_class == "ZwaveDispatcher" and cmd ~= nil and cmd.version ~= nil and cmd.version < 3
-end
 
 --- Default handler for alarm command class reports
 ---
@@ -75,7 +53,7 @@ local zwave_alarm = {
     }
   },
   NAME = "Z-Wave smoke and CO alarm V1",
-  can_handle = can_handle_v1_alarm,
+  can_handle = require("zwave-smoke-co-alarm-v1.can_handle"),
 }
 
 return zwave_alarm

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/can_handle.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_v2_alarm(opts, driver, device, cmd, ...)
+  local FINGERPRINTS = require("zwave-smoke-co-alarm-v2.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("zwave-smoke-co-alarm-v2")
+    end
+  end
+  return false
+end
+
+return can_handle_v2_alarm

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5/can_handle.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_co_sensor(opts, driver, device, cmd, ...)
+  local FINGERPRINTS = require("zwave-smoke-co-alarm-v2.fibaro-co-sensor-zw5.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("zwave-smoke-co-alarm-v2.fibaro-co-sensor-zw5")
+    end
+  end
+  return false
+end
+
+return can_handle_fibaro_co_sensor

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5/fingerprints.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FIBARO_CO_SENSORS_FINGERPRINTS = {
+  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1000 }, -- Fibaro CO Sensor
+  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1001 }  -- Fibaro CO Sensor
+}
+
+return FIBARO_CO_SENSORS_FINGERPRINTS

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local cc = require "st.zwave.CommandClass"
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 2 })
@@ -21,10 +11,6 @@ local TAMPERING_AND_EXCEEDING_THE_TEMPERATURE = 3
 local ACOUSTIC_SIGNALS = 4
 local EXCEEDING_THE_TEMPERATURE = 2
 
-local FIBARO_CO_SENSORS_FINGERPRINTS = {
-  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1000 }, -- Fibaro CO Sensor
-  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1001 }  -- Fibaro CO Sensor
-}
 
 local function parameterNumberToParameterName(preferences,parameterNumber)
   for id, parameter in pairs(preferences) do
@@ -40,14 +26,6 @@ end
 --- @param driver st.zwave.Driver
 --- @param device st.zwave.Device
 --- @return boolean true if the device is smoke co alarm
-local function can_handle_fibaro_co_sensor(opts, driver, device, cmd, ...)
-  for _, fingerprint in ipairs(FIBARO_CO_SENSORS_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function update_preferences(self, device, args)
   local preferences = preferencesMap.get_device_parameters(device)
@@ -108,7 +86,7 @@ local fibaro_co_sensor = {
     init = device_init,
     infoChanged = info_changed
   },
-  can_handle = can_handle_fibaro_co_sensor
+  can_handle = require("zwave-smoke-co-alarm-v2.fibaro-co-sensor-zw5.can_handle"),
 }
 
 return fibaro_co_sensor

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fingerprints.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local SMOKE_CO_ALARM_V2_FINGERPRINTS = {
+  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1000 }, -- Fibaro CO Sensor
+  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1001 }  -- Fibaro CO Sensor
+}
+
+return SMOKE_CO_ALARM_V2_FINGERPRINTS

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/init.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -20,24 +11,12 @@ local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 2 })
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({version=3})
 
-local SMOKE_CO_ALARM_V2_FINGERPRINTS = {
-  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1000 }, -- Fibaro CO Sensor
-  { manufacturerId = 0x010F, productType = 0x1201, productId = 0x1001 }  -- Fibaro CO Sensor
-}
 
 --- Determine whether the passed device is Smoke Alarm
 ---
 --- @param driver st.zwave.Driver
 --- @param device st.zwave.Device
 --- @return boolean true if the device is smoke co alarm
-local function can_handle_v2_alarm(opts, driver, device, cmd, ...)
-  for _, fingerprint in ipairs(SMOKE_CO_ALARM_V2_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local device_added = function(self, device)
   device:emit_event(capabilities.carbonMonoxideDetector.carbonMonoxide.clear())
@@ -94,13 +73,11 @@ local zwave_alarm = {
     }
   },
   NAME = "Z-Wave smoke and CO alarm V2",
-  can_handle = can_handle_v2_alarm,
+  can_handle = require("zwave-smoke-co-alarm-v2.can_handle"),
   lifecycle_handlers = {
     added = device_added
   },
-  sub_drivers = {
-    require("zwave-smoke-co-alarm-v2/fibaro-co-sensor-zw5")
-  }
+  sub_drivers = require("zwave-smoke-co-alarm-v2.sub_drivers"),
 }
 
 return zwave_alarm

--- a/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/zwave-smoke-co-alarm-v2/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("zwave-smoke-co-alarm-v2.fibaro-co-sensor-zw5"),
+}
+return sub_drivers


### PR DESCRIPTION
`zwave-smoke-alarm` lazy loading of sub-drivers and copyright updates