### PR TITLE
CHAD-17096: zwave-valve lazy loading of sub-drivers

### DIFF
--- a/drivers/SmartThings/zwave-valve/src/init.lua
+++ b/drivers/SmartThings/zwave-valve/src/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.defaults
@@ -26,10 +16,7 @@ local driver_template = {
   supported_capabilities = {
     capabilities.valve,
   },
-  sub_drivers = {
-    -- Fortrezz and Zooz valves treat open as "off" and close as "on"
-    require("inverse_valve")
-  },
+  sub_drivers = require("sub_drivers"),
 }
 
 defaults.register_for_default_handlers(driver_template, driver_template.supported_capabilities)

--- a/drivers/SmartThings/zwave-valve/src/inverse_valve/can_handle.lua
+++ b/drivers/SmartThings/zwave-valve/src/inverse_valve/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function inverse_valve_can_handle(opts, driver, device, ...)
+  if device.zwave_manufacturer_id == 0x0084 or device.zwave_manufacturer_id == 0x027A then
+    return true, require("inverse_valve")
+  end
+  return false
+end
+
+return inverse_valve_can_handle

--- a/drivers/SmartThings/zwave-valve/src/inverse_valve/init.lua
+++ b/drivers/SmartThings/zwave-valve/src/inverse_valve/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -55,9 +45,7 @@ local inverse_valve = {
       [capabilities.valve.commands.close.NAME] = close_handler
     }
   },
-  can_handle = function(opts, driver, device, ...)
-    return device.zwave_manufacturer_id == 0x0084 or device.zwave_manufacturer_id == 0x027A
-  end
+  can_handle = require("inverse_valve.can_handle"),
 }
 
 return inverse_valve

--- a/drivers/SmartThings/zwave-valve/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-valve/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-valve/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-valve/src/sub_drivers.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("inverse_valve"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-valve/src/test/test_inverse.valve.lua
+++ b/drivers/SmartThings/zwave-valve/src/test/test_inverse.valve.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-valve/src/test/test_zwave_valve.lua
+++ b/drivers/SmartThings/zwave-valve/src/test/test_zwave_valve.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"


### PR DESCRIPTION
`zwave-valve` lazy loading of sub-drivers and copyright updates