### PR TITLE
CHAD-17017: Add the ReadAttrbitue or refresh code for the initial state

### DIFF
--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/init.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/init.lua
@@ -16,6 +16,11 @@ local capabilities = require "st.capabilities"
 local ZigbeeDriver = require "st.zigbee"
 local defaults = require "st.zigbee.defaults"
 
+local do_configure = function(self, device)
+  device:configure()
+  device:refresh()
+end
+
 local zigbee_illuminance_driver = {
   supported_capabilities = {
     capabilities.illuminanceMeasurement,
@@ -23,6 +28,9 @@ local zigbee_illuminance_driver = {
   },
   sub_drivers = {
     require("aqara")
+  },
+  lifecycle_handlers = {
+    doConfigure = do_configure,
   },
   health_check = false,
 }

--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor.lua
@@ -107,6 +107,8 @@ test.register_coroutine_test(
           zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, PowerConfiguration.ID)
         }
     )
+    test.socket.zigbee:__expect_send({ mock_device.id, IlluminanceMeasurement.attributes.MeasuredValue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
@@ -469,6 +469,9 @@ test.register_coroutine_test(
                                             3
                                           ):to_endpoint(3)
     })
+    test.socket.zigbee:__expect_send({ mock_base_device.id, OnOff.attributes.OnOff:read(mock_base_device) })
+    test.socket.zigbee:__expect_send({ mock_base_device.id, OnOff.attributes.OnOff:read(mock_base_device):to_endpoint(2) })
+    test.socket.zigbee:__expect_send({ mock_base_device.id, OnOff.attributes.OnOff:read(mock_base_device):to_endpoint(3) })
     mock_base_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_power_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_power_consumption_report.lua
@@ -6,6 +6,8 @@ local test = require "integration_test"
 local clusters = require "st.zigbee.zcl.clusters"
 local capabilities = require "st.capabilities"
 local SimpleMetering = clusters.SimpleMetering
+local ElectricalMeasurement = clusters.ElectricalMeasurement
+local OnOff = clusters.OnOff
 local zigbee_test_utils = require "integration_test.zigbee_test_utils"
 local t_utils = require "integration_test.utils"
 
@@ -17,7 +19,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
           id = 1,
           manufacturer = "DAWON_DNS",
           model = "PM-B430-ZB",
-          server_clusters = {}
+          server_clusters = { 0x0000, 0x0002, 0x0003, 0x0006, 0x0702, 0x0B04 }
         }
       }
     }
@@ -79,6 +81,71 @@ test.register_message_test(
         message = mock_device:generate_test_message("main", capabilities.powerMeter.power({ value = 32.0, unit = "W" }))
       }
     }
+)
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ElectricalMeasurement.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, SimpleMetering.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ElectricalMeasurement.attributes.ACPowerMultiplier:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ElectricalMeasurement.attributes.ACPowerDivisor:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 3600, 5)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 3600, 5)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        SimpleMetering.attributes.CurrentSummationDelivered:configure_reporting(mock_device, 5, 3600, 1)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ElectricalMeasurement.attributes.ActivePower:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ElectricalMeasurement.attributes.ACPowerDivisor:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ElectricalMeasurement.attributes.ACPowerMultiplier:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, SimpleMetering.attributes.InstantaneousDemand:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, SimpleMetering.attributes.CurrentSummationDelivered:read(mock_device) })
+
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/zigbee-metering-plug-power-consumption-report/init.lua
@@ -24,6 +24,7 @@ end
 
 local do_configure = function(self, device)
   device:configure()
+  device:refresh()
 end
 
 local device_init = function(self, device)

--- a/drivers/SmartThings/zigbee-window-treatment/src/axis/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/axis/init.lua
@@ -110,6 +110,7 @@ local do_configure = function(self, device)
   device:send(WindowCovering.attributes.CurrentPositionLiftPercentage:configure_reporting(device, 1, 3600, 1))
   device:send(device_management.build_bind_request(device, PowerConfiguration.ID, self.environment_info.hub_zigbee_eui))
   device:send(PowerConfiguration.attributes.BatteryPercentageRemaining:configure_reporting(device, 1, 3600, 1))
+  device:refresh()
 end
 
 local device_added = function(self, device)

--- a/drivers/SmartThings/zigbee-window-treatment/src/feibit/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/feibit/init.lua
@@ -61,6 +61,7 @@ end
 local do_configure = function(self, device)
   device:send(device_management.build_bind_request(device, Level.ID, self.environment_info.hub_zigbee_eui))
   device:send(Level.attributes.CurrentLevel:configure_reporting(device, 1, 3600, 1))
+  device:refresh()
 end
 
 local feibit_handler = {

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_axis.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_axis.lua
@@ -637,6 +637,8 @@ test.register_coroutine_test(
                                               zigbee_test_utils.mock_hub_eui,
                                               PowerConfiguration.ID)
       })
+      test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, WindowCovering.attributes.CurrentPositionLiftPercentage:read(mock_device) })
     end
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_feibit.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_feibit.lua
@@ -20,6 +20,7 @@ local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 
 local Level = clusters.Level
+local WindowCovering = clusters.WindowCovering
 
 local mock_device = test.mock_device.build_test_zigbee_device(
     { profile = t_utils.get_profile_definition("window-treatment-profile.yml"),
@@ -396,6 +397,7 @@ test.register_coroutine_test(
                                               zigbee_test_utils.mock_hub_eui,
                                               Level.ID)
       })
+      test.socket.zigbee:__expect_send({ mock_device.id, WindowCovering.attributes.CurrentPositionLiftPercentage:read(mock_device) })
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end
 )


### PR DESCRIPTION
https://smartthings.atlassian.net/browse/CHAD-17017

Add refresh/readAttribute logic to retrieve the initial state fast.

- zigbee-illuminance-sensor
- zigbee-lock
- zigbee-switch
- zigbee-window-treatment