### PR TITLE
Matter Switch: update subscribe logic

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/init.lua
@@ -49,10 +49,10 @@ end
 function CameraLifecycleHandlers.info_changed(driver, device, event, args)
   if camera_utils.profile_changed(device.profile.components, args.old_st_store.profile.components) then
     camera_cfg.initialize_camera_capabilities(device)
+    device:subscribe()
     if #switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.DOORBELL) > 0 then
       button_cfg.configure_buttons(device, device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH}))
     end
-    device:subscribe()
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -139,7 +139,7 @@ function AttributeHandlers.color_temperature_mireds_handler(driver, device, ib, 
 end
 
 function AttributeHandlers.current_x_handler(driver, device, ib, response)
-  if device:get_field(fields.COLOR_MODE) == fields.HUE_SAT_COLOR_MODE then
+  if device:get_field(fields.COLOR_MODE) == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
     return
   end
   local y = device:get_field(fields.RECEIVED_Y)
@@ -157,7 +157,7 @@ function AttributeHandlers.current_x_handler(driver, device, ib, response)
 end
 
 function AttributeHandlers.current_y_handler(driver, device, ib, response)
-  if device:get_field(fields.COLOR_MODE) == fields.HUE_SAT_COLOR_MODE then
+  if device:get_field(fields.COLOR_MODE) == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
     return
   end
   local x = device:get_field(fields.RECEIVED_X)
@@ -173,15 +173,17 @@ function AttributeHandlers.current_y_handler(driver, device, ib, response)
 end
 
 function AttributeHandlers.color_mode_handler(driver, device, ib, response)
-  if ib.data.value == device:get_field(fields.COLOR_MODE) or (ib.data.value ~= fields.HUE_SAT_COLOR_MODE and ib.data.value ~= fields.X_Y_COLOR_MODE) then
-    return
+  if ib.data.value == device:get_field(fields.COLOR_MODE)
+    or (ib.data.value ~= clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION
+    and ib.data.value ~= clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY) then
+      return
   end
   device:set_field(fields.COLOR_MODE, ib.data.value)
   local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
-  if ib.data.value == fields.HUE_SAT_COLOR_MODE then
+  if ib.data.value == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
     req:merge(clusters.ColorControl.attributes.CurrentHue:read())
     req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-  elseif ib.data.value == fields.X_Y_COLOR_MODE then
+  elseif ib.data.value == clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY then
     req:merge(clusters.ColorControl.attributes.CurrentX:read())
     req:merge(clusters.ColorControl.attributes.CurrentY:read())
   end

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -1,26 +1,12 @@
 -- Copyright © 2025 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
-local clusters = require "st.matter.clusters"
-local capabilities = require "st.capabilities"
-local version = require "version"
-
--- Include driver-side definitions when lua libs api version is < 11
-if version.api < 11 then
-  clusters.ElectricalEnergyMeasurement = require "embedded_clusters.ElectricalEnergyMeasurement"
-  clusters.ElectricalPowerMeasurement = require "embedded_clusters.ElectricalPowerMeasurement"
-end
-
 local SwitchFields = {}
-
-SwitchFields.HUE_SAT_COLOR_MODE = clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION
-SwitchFields.X_Y_COLOR_MODE = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
 
 SwitchFields.MOST_RECENT_TEMP = "mostRecentTemp"
 SwitchFields.RECEIVED_X = "receivedX"
 SwitchFields.RECEIVED_Y = "receivedY"
 SwitchFields.HUESAT_SUPPORT = "huesatSupport"
-
 
 SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT = 1000000
 
@@ -191,120 +177,5 @@ SwitchFields.TRANSITION_TIME = 0 --1/10ths of a second
 -- to take effect when the switch/light is off.
 SwitchFields.OPTIONS_MASK = 0x01
 SwitchFields.OPTIONS_OVERRIDE = 0x01
-
-
-SwitchFields.supported_capabilities = {
-  capabilities.audioMute,
-  capabilities.audioRecording,
-  capabilities.audioVolume,
-  capabilities.battery,
-  capabilities.batteryLevel,
-  capabilities.button,
-  capabilities.cameraPrivacyMode,
-  capabilities.cameraViewportSettings,
-  capabilities.colorControl,
-  capabilities.colorTemperature,
-  capabilities.energyMeter,
-  capabilities.fanMode,
-  capabilities.fanSpeedPercent,
-  capabilities.hdr,
-  capabilities.illuminanceMeasurement,
-  capabilities.imageControl,
-  capabilities.level,
-  capabilities.localMediaStorage,
-  capabilities.mechanicalPanTiltZoom,
-  capabilities.motionSensor,
-  capabilities.nightVision,
-  capabilities.powerMeter,
-  capabilities.powerConsumptionReport,
-  capabilities.relativeHumidityMeasurement,
-  capabilities.sounds,
-  capabilities.switch,
-  capabilities.switchLevel,
-  capabilities.temperatureMeasurement,
-  capabilities.valve,
-  capabilities.videoStreamSettings,
-  capabilities.webrtc,
-  capabilities.zoneManagement
-}
-
-SwitchFields.device_type_attribute_map = {
-  [SwitchFields.DEVICE_TYPE_ID.LIGHT.ON_OFF] = {
-    clusters.OnOff.attributes.OnOff
-  },
-  [SwitchFields.DEVICE_TYPE_ID.LIGHT.DIMMABLE] = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel
-  },
-  [SwitchFields.DEVICE_TYPE_ID.LIGHT.COLOR_TEMPERATURE] = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel,
-    clusters.ColorControl.attributes.ColorTemperatureMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds
-  },
-  [SwitchFields.DEVICE_TYPE_ID.LIGHT.EXTENDED_COLOR] = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel,
-    clusters.ColorControl.attributes.ColorTemperatureMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
-    clusters.ColorControl.attributes.CurrentHue,
-    clusters.ColorControl.attributes.CurrentSaturation,
-    clusters.ColorControl.attributes.CurrentX,
-    clusters.ColorControl.attributes.CurrentY,
-    clusters.ColorControl.attributes.ColorMode
-  },
-  [SwitchFields.DEVICE_TYPE_ID.ON_OFF_PLUG_IN_UNIT] = {
-    clusters.OnOff.attributes.OnOff
-  },
-  [SwitchFields.DEVICE_TYPE_ID.DIMMABLE_PLUG_IN_UNIT] = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel
-  },
-  [SwitchFields.DEVICE_TYPE_ID.SWITCH.ON_OFF_LIGHT] = {
-    clusters.OnOff.attributes.OnOff
-  },
-  [SwitchFields.DEVICE_TYPE_ID.SWITCH.DIMMER] = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel
-  },
-  [SwitchFields.DEVICE_TYPE_ID.SWITCH.COLOR_DIMMER] = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel,
-    clusters.ColorControl.attributes.ColorTemperatureMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
-    clusters.ColorControl.attributes.CurrentHue,
-    clusters.ColorControl.attributes.CurrentSaturation,
-    clusters.ColorControl.attributes.CurrentX,
-    clusters.ColorControl.attributes.CurrentY,
-    clusters.ColorControl.attributes.ColorMode
-  },
-  [SwitchFields.DEVICE_TYPE_ID.GENERIC_SWITCH] = {
-    clusters.PowerSource.attributes.BatPercentRemaining,
-    clusters.Switch.events.InitialPress,
-    clusters.Switch.events.LongPress,
-    clusters.Switch.events.ShortRelease,
-    clusters.Switch.events.MultiPressComplete
-  },
-  [SwitchFields.DEVICE_TYPE_ID.ELECTRICAL_SENSOR] = {
-    clusters.ElectricalPowerMeasurement.attributes.ActivePower,
-    clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported,
-    clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported
-  }
-}
 
 return SwitchFields

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -55,7 +55,7 @@ local mock_device = test.mock_device.build_test_matter_device({
 })
 
 local mock_device_electrical_sensor = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("power-energy-powerConsumption.yml"),
+  profile = t_utils.get_profile_definition("plug-energy-powerConsumption.yml"),
   manufacturer_info = {
     vendor_id = 0x130A,
     product_id = 0x0050,

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
@@ -59,34 +59,15 @@ local mock_bridge = test.mock_device.build_test_matter_device({
   }
 })
 
-local cluster_subscribe_list = {
-  clusters.OnOff.attributes.OnOff
-}
-
 local function test_init_mock_bridge()
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_bridge)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_bridge))
-    end
-  end
-  test.socket.matter:__expect_send({mock_bridge.id, subscribe_request})
   test.mock_device.add_test_device(mock_bridge)
 end
 
 test.register_coroutine_test(
   "Profile should not change for devices with aggregator device type (bridges)",
   function()
-    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_bridge)
-    for i, cluster in ipairs(cluster_subscribe_list) do
-      if i > 1 then
-        subscribe_request:merge(cluster:subscribe(mock_bridge))
-      end
-    end
     test.socket.device_lifecycle:__queue_receive({ mock_bridge.id, "added" })
-    test.socket.matter:__expect_send({mock_bridge.id, subscribe_request})
     test.socket.device_lifecycle:__queue_receive({ mock_bridge.id, "init" })
-    test.socket.matter:__expect_send({mock_bridge.id, subscribe_request})
     test.socket.device_lifecycle:__queue_receive({ mock_bridge.id, "doConfigure" })
     mock_bridge:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -122,6 +122,19 @@ local mock_device = test.mock_device.build_test_matter_device({
 local subscribe_request
 local subscribed_attributes = {
   clusters.CameraAvStreamManagement.attributes.AttributeList,
+  clusters.CameraAvStreamManagement.attributes.StatusLightEnabled,
+  clusters.OnOff.attributes.OnOff,
+  clusters.LevelControl.attributes.CurrentLevel,
+  clusters.LevelControl.attributes.MaxLevel,
+  clusters.LevelControl.attributes.MinLevel,
+  clusters.ColorControl.attributes.ColorTemperatureMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+  clusters.ColorControl.attributes.CurrentHue,
+  clusters.ColorControl.attributes.CurrentSaturation,
+  clusters.ColorControl.attributes.CurrentX,
+  clusters.ColorControl.attributes.CurrentY,
+  clusters.ColorControl.attributes.ColorMode,
 }
 
 local function test_init()
@@ -153,60 +166,125 @@ end
 
 test.set_test_init_function(test_init)
 
-local function update_device_profile()
-  test.socket.matter:__set_channel_ordering("relaxed")
-  local uint32 = require "st.matter.data_types.Uint32"
-  local expected_metadata = {
-    optional_component_capabilities = {
+local additional_subscribed_attributes = {
+  clusters.CameraAvStreamManagement.attributes.HDRModeEnabled,
+  clusters.CameraAvStreamManagement.attributes.ImageRotation,
+  clusters.CameraAvStreamManagement.attributes.NightVision,
+  clusters.CameraAvStreamManagement.attributes.NightVisionIllum,
+  clusters.CameraAvStreamManagement.attributes.ImageFlipHorizontal,
+  clusters.CameraAvStreamManagement.attributes.ImageFlipVertical,
+  clusters.CameraAvStreamManagement.attributes.SoftRecordingPrivacyModeEnabled,
+  clusters.CameraAvStreamManagement.attributes.SoftLivestreamPrivacyModeEnabled,
+  clusters.CameraAvStreamManagement.attributes.HardPrivacyModeOn,
+  clusters.CameraAvStreamManagement.attributes.TwoWayTalkSupport,
+  clusters.CameraAvStreamManagement.attributes.SpeakerMuted,
+  clusters.CameraAvStreamManagement.attributes.MicrophoneMuted,
+  clusters.CameraAvStreamManagement.attributes.SpeakerVolumeLevel,
+  clusters.CameraAvStreamManagement.attributes.SpeakerMaxLevel,
+  clusters.CameraAvStreamManagement.attributes.SpeakerMinLevel,
+  clusters.CameraAvStreamManagement.attributes.MicrophoneVolumeLevel,
+  clusters.CameraAvStreamManagement.attributes.MicrophoneMaxLevel,
+  clusters.CameraAvStreamManagement.attributes.MicrophoneMinLevel,
+  clusters.CameraAvStreamManagement.attributes.StatusLightBrightness,
+  clusters.CameraAvStreamManagement.attributes.StatusLightEnabled,
+  clusters.CameraAvStreamManagement.attributes.RateDistortionTradeOffPoints,
+  clusters.CameraAvStreamManagement.attributes.LocalSnapshotRecordingEnabled,
+  clusters.CameraAvStreamManagement.attributes.LocalVideoRecordingEnabled,
+  clusters.CameraAvStreamManagement.attributes.MaxEncodedPixelRate,
+  clusters.CameraAvStreamManagement.attributes.VideoSensorParams,
+  clusters.CameraAvStreamManagement.attributes.AllocatedVideoStreams,
+  clusters.CameraAvStreamManagement.attributes.Viewport,
+  clusters.CameraAvStreamManagement.attributes.MinViewportResolution,
+  clusters.CameraAvStreamManagement.attributes.AttributeList,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.MPTZPosition,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.MPTZPresets,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.MaxPresets,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.ZoomMax,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.PanMax,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.PanMin,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.TiltMax,
+  clusters.CameraAvSettingsUserLevelManagement.attributes.TiltMin,
+  clusters.Chime.attributes.InstalledChimeSounds,
+  clusters.Chime.attributes.SelectedChime,
+  clusters.ZoneManagement.attributes.MaxZones,
+  clusters.ZoneManagement.attributes.Zones,
+  clusters.ZoneManagement.attributes.Triggers,
+  clusters.ZoneManagement.attributes.SensitivityMax,
+  clusters.ZoneManagement.attributes.Sensitivity,
+  clusters.ZoneManagement.events.ZoneTriggered,
+  clusters.ZoneManagement.events.ZoneStopped,
+  clusters.OnOff.attributes.OnOff,
+  clusters.LevelControl.attributes.CurrentLevel,
+  clusters.LevelControl.attributes.MaxLevel,
+  clusters.LevelControl.attributes.MinLevel,
+  clusters.ColorControl.attributes.ColorTemperatureMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+  clusters.ColorControl.attributes.CurrentHue,
+  clusters.ColorControl.attributes.CurrentSaturation,
+  clusters.ColorControl.attributes.CurrentX,
+  clusters.ColorControl.attributes.CurrentY,
+  clusters.OccupancySensing.attributes.Occupancy,
+  clusters.Switch.server.events.InitialPress,
+  clusters.Switch.server.events.LongPress,
+  clusters.Switch.server.events.ShortRelease,
+  clusters.Switch.server.events.MultiPressComplete
+}
+
+local expected_metadata = {
+  optional_component_capabilities = {
+    {
+      "main",
       {
-        "main",
-        {
-          "videoCapture2",
-          "cameraViewportSettings",
-          "localMediaStorage",
-          "audioRecording",
-          "cameraPrivacyMode",
-          "imageControl",
-          "hdr",
-          "nightVision",
-          "mechanicalPanTiltZoom",
-          "videoStreamSettings",
-          "zoneManagement",
-          "webrtc",
-          "motionSensor",
-          "sounds",
-        }
-      },
-      {
-        "statusLed",
-        {
-          "switch",
-          "mode"
-        }
-      },
-      {
-        "speaker",
-        {
-          "audioMute",
-          "audioVolume"
-        }
-      },
-      {
-        "microphone",
-        {
-          "audioMute",
-          "audioVolume"
-        }
-      },
-      {
-        "doorbell",
-        {
-          "button"
-        }
+        "videoCapture2",
+        "cameraViewportSettings",
+        "localMediaStorage",
+        "audioRecording",
+        "cameraPrivacyMode",
+        "imageControl",
+        "hdr",
+        "nightVision",
+        "mechanicalPanTiltZoom",
+        "videoStreamSettings",
+        "zoneManagement",
+        "webrtc",
+        "motionSensor",
+        "sounds",
       }
     },
-    profile = "camera"
-  }
+    {
+      "statusLed",
+      {
+        "switch",
+        "mode"
+      }
+    },
+    {
+      "speaker",
+      {
+        "audioMute",
+        "audioVolume"
+      }
+    },
+    {
+      "microphone",
+      {
+        "audioMute",
+        "audioVolume"
+      }
+    },
+    {
+      "doorbell",
+      {
+        "button"
+      }
+    }
+  },
+  profile = "camera"
+}
+
+local function update_device_profile()
+  local uint32 = require "st.matter.data_types.Uint32"
   test.socket.matter:__queue_receive({
     mock_device.id,
     clusters.CameraAvStreamManagement.attributes.AttributeList:build_test_report_data(mock_device, CAMERA_EP, {
@@ -219,6 +297,7 @@ local function update_device_profile()
   local updated_device_profile = t_utils.get_profile_definition(
     "camera.yml", {enabled_optional_capabilities = expected_metadata.optional_component_capabilities}
   )
+  test.wait_for_events()
   test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed({ profile = updated_device_profile }))
   test.socket.capability:__expect_send(
     mock_device:generate_test_message("main", capabilities.webrtc.supportedFeatures(
@@ -258,77 +337,12 @@ local function update_device_profile()
       {"setSoftRecordingPrivacyMode", "setSoftLivestreamPrivacyMode"}
     ))
   )
-  local additional_subscribed_attributes = {
-    clusters.CameraAvStreamManagement.attributes.HDRModeEnabled,
-    clusters.CameraAvStreamManagement.attributes.ImageRotation,
-    clusters.CameraAvStreamManagement.attributes.NightVision,
-    clusters.CameraAvStreamManagement.attributes.NightVisionIllum,
-    clusters.CameraAvStreamManagement.attributes.ImageFlipHorizontal,
-    clusters.CameraAvStreamManagement.attributes.ImageFlipVertical,
-    clusters.CameraAvStreamManagement.attributes.SoftRecordingPrivacyModeEnabled,
-    clusters.CameraAvStreamManagement.attributes.SoftLivestreamPrivacyModeEnabled,
-    clusters.CameraAvStreamManagement.attributes.HardPrivacyModeOn,
-    clusters.CameraAvStreamManagement.attributes.TwoWayTalkSupport,
-    clusters.CameraAvStreamManagement.attributes.SpeakerMuted,
-    clusters.CameraAvStreamManagement.attributes.MicrophoneMuted,
-    clusters.CameraAvStreamManagement.attributes.SpeakerVolumeLevel,
-    clusters.CameraAvStreamManagement.attributes.SpeakerMaxLevel,
-    clusters.CameraAvStreamManagement.attributes.SpeakerMinLevel,
-    clusters.CameraAvStreamManagement.attributes.MicrophoneVolumeLevel,
-    clusters.CameraAvStreamManagement.attributes.MicrophoneMaxLevel,
-    clusters.CameraAvStreamManagement.attributes.MicrophoneMinLevel,
-    clusters.CameraAvStreamManagement.attributes.StatusLightBrightness,
-    clusters.CameraAvStreamManagement.attributes.StatusLightEnabled,
-    clusters.CameraAvStreamManagement.attributes.RateDistortionTradeOffPoints,
-    clusters.CameraAvStreamManagement.attributes.LocalSnapshotRecordingEnabled,
-    clusters.CameraAvStreamManagement.attributes.LocalVideoRecordingEnabled,
-    clusters.CameraAvStreamManagement.attributes.MaxEncodedPixelRate,
-    clusters.CameraAvStreamManagement.attributes.VideoSensorParams,
-    clusters.CameraAvStreamManagement.attributes.AllocatedVideoStreams,
-    clusters.CameraAvStreamManagement.attributes.Viewport,
-    clusters.CameraAvStreamManagement.attributes.MinViewportResolution,
-    clusters.CameraAvStreamManagement.attributes.AttributeList,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.MPTZPosition,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.MPTZPresets,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.MaxPresets,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.ZoomMax,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.PanMax,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.PanMin,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.TiltMax,
-    clusters.CameraAvSettingsUserLevelManagement.attributes.TiltMin,
-    clusters.Chime.attributes.InstalledChimeSounds,
-    clusters.Chime.attributes.SelectedChime,
-    clusters.ZoneManagement.attributes.MaxZones,
-    clusters.ZoneManagement.attributes.Zones,
-    clusters.ZoneManagement.attributes.Triggers,
-    clusters.ZoneManagement.attributes.SensitivityMax,
-    clusters.ZoneManagement.attributes.Sensitivity,
-    clusters.ZoneManagement.events.ZoneTriggered,
-    clusters.ZoneManagement.events.ZoneStopped,
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel,
-    clusters.ColorControl.attributes.ColorTemperatureMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
-    clusters.ColorControl.attributes.CurrentHue,
-    clusters.ColorControl.attributes.CurrentSaturation,
-    clusters.ColorControl.attributes.CurrentX,
-    clusters.ColorControl.attributes.CurrentY,
-    clusters.ColorControl.attributes.ColorMode,
-    clusters.OccupancySensing.attributes.Occupancy,
-    clusters.Switch.server.events.InitialPress,
-    clusters.Switch.server.events.LongPress,
-    clusters.Switch.server.events.ShortRelease,
-    clusters.Switch.server.events.MultiPressComplete
-  }
   for _, attr in ipairs(additional_subscribed_attributes) do
     subscribe_request:merge(attr:subscribe(mock_device))
   end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, DOORBELL_EP)})
   test.socket.capability:__expect_send(mock_device:generate_test_message("doorbell", capabilities.button.button.pushed({state_change = false})))
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 end
 
 -- Matter Handler UTs

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -126,6 +126,7 @@ local cluster_subscribe_list = {
   clusters.ColorControl.attributes.ColorTemperatureMireds,
   clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
   clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+  clusters.ColorControl.attributes.ColorMode,
 }
 
 local function set_color_mode(device, endpoint, color_mode)

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch_device_types.lua
@@ -439,14 +439,8 @@ local mock_device_light_level_motion = test.mock_device.build_test_matter_device
 
 local function test_init_parent_child_switch_types()
   test.mock_device.add_test_device(mock_device_parent_child_switch_types)
-  local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_child_switch_types)
-
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "added" })
-  test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
-
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "init" })
-  test.socket.matter:__expect_send({mock_device_parent_child_switch_types.id, subscribe_request})
-
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_switch_types.id, "doConfigure" })
   test.socket.matter:__expect_send({
     mock_device_parent_child_switch_types.id,
@@ -483,13 +477,10 @@ end
 
 local function test_init_parent_client_child_server()
   test.mock_device.add_test_device(mock_device_parent_client_child_server)
-  local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_parent_client_child_server)
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "added" })
-  test.socket.matter:__expect_send({mock_device_parent_client_child_server.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "init" })
-  test.socket.matter:__expect_send({mock_device_parent_client_child_server.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_client_child_server.id, "doConfigure" })
   mock_device_parent_client_child_server:expect_metadata_update({ profile = "switch-binary" })
@@ -597,25 +588,9 @@ end
 local function test_init_parent_child_different_types()
   test.mock_device.add_test_device(mock_device_parent_child_different_types)
   local cluster_subscribe_list = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.LevelControl.attributes.CurrentLevel,
-    clusters.LevelControl.attributes.MaxLevel,
-    clusters.LevelControl.attributes.MinLevel,
-    clusters.ColorControl.attributes.ColorTemperatureMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
-    clusters.ColorControl.attributes.CurrentHue,
-    clusters.ColorControl.attributes.CurrentSaturation,
-    clusters.ColorControl.attributes.CurrentX,
-    clusters.ColorControl.attributes.CurrentY,
-    clusters.ColorControl.attributes.ColorMode,
+    clusters.OnOff.attributes.OnOff
   }
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_parent_child_different_types)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_parent_child_different_types))
-    end
-  end
   test.socket.device_lifecycle:__queue_receive({ mock_device_parent_child_different_types.id, "added" })
   test.socket.matter:__expect_send({mock_device_parent_child_different_types.id, subscribe_request})
 

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -245,7 +245,7 @@ local function test_init_parent_child_endpoints_non_sequential()
     clusters.ColorControl.attributes.CurrentSaturation,
     clusters.ColorControl.attributes.CurrentX,
     clusters.ColorControl.attributes.CurrentY,
-    clusters.ColorControl.attributes.ColorMode
+    clusters.ColorControl.attributes.ColorMode,
   }
   local subscribe_request = cluster_subscribe_list[1]:subscribe(unsup_mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -239,7 +239,7 @@ local function test_init_parent_child_endpoints_non_sequential()
     clusters.ColorControl.attributes.CurrentSaturation,
     clusters.ColorControl.attributes.CurrentX,
     clusters.ColorControl.attributes.CurrentY,
-      clusters.ColorControl.attributes.ColorMode,
+    clusters.ColorControl.attributes.ColorMode,
   }
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_parent_child_endpoints_non_sequential)
   for i, cluster in ipairs(cluster_subscribe_list) do


### PR DESCRIPTION
# Description of Change
Override generic matter switch handling of device:subscribe() to more properly and generically handle child devices.

# Summary of Completed Tests
Tested multiple parent/child devices where the children had unique subscriptions from the parent device.

