### PR TITLE
[Matter Camera] Add videoCapture2 action to embedded device config

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/camera.yml
+++ b/drivers/SmartThings/matter-switch/profiles/camera.yml
@@ -118,6 +118,11 @@ deviceConfig:
     - component: main
       capability: mechanicalPanTiltZoom
       version: 1
+  automation:
+    actions:
+    - component: main
+      capability: videoCapture2
+      version: 1
   dpInfo:
     - os: ios
       dpUri: "storyboard://HMVSController/HMVSViewController"


### PR DESCRIPTION
Adds the `videoCapture2` capability to the embedded device configuration for matter cameras so that the `capture` command can be used for automations.

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests

Tested with routine to confirm that the `capture` command is accessible and triggers a videoCapture on running automation.

Also confirmed that the automation action does not show up if the `videoCapture2` capability is not present on the profile, as expected.

