### PR TITLE
Add motionSensor condition, and imageCapture action

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/camera.yml
+++ b/drivers/SmartThings/matter-switch/profiles/camera.yml
@@ -111,6 +111,16 @@ deviceConfig:
             capability: imageCapture
             version: 1
             value: image.value
+          overlayIcons:
+            - iconUrl: "res://ic_camera_motion_detected"
+              visibleCondition:
+                component: main
+                capability: motionSensor
+                version: 1
+                value: motion.value
+                valueType: string
+                operator: EQUALS
+                operand: "active"
   detailView:
     - component: main
       capability: webrtc
@@ -118,10 +128,20 @@ deviceConfig:
     - component: main
       capability: mechanicalPanTiltZoom
       version: 1
+    - component: main
+      capability: motionSensor
+      version: 1
   automation:
+    conditions:
+    - component: main
+      capability: motionSensor
+      version: 1
     actions:
     - component: main
       capability: videoCapture2
+      version: 1
+    - component: main
+      capability: imageCapture
       version: 1
   dpInfo:
     - os: ios


### PR DESCRIPTION
This primarily adds the `motionSensor`'s `motion.value` as a condition to automations for camera's device config. In comparing with existing camera device profiles I observed that we have an overlay icon that can be shown in the dashboard view and also noticed that we were missing `imageCapture` as an action so added that as well.

<img width="432" height="285" alt="image" src="https://github.com/user-attachments/assets/a153112c-26e6-422a-a414-1be584abbf78" />

<img width="443" height="577" alt="image" src="https://github.com/user-attachments/assets/7e2f776b-608c-41a8-8014-d4e692e8b431" />
