### PR TITLE
Matter Switch: Add StatelessStep capability support for SwitchLevel and ColorTemperature

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-1800K-6500K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-1800K-6500K.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1  
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 1800, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-2000K-7000K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-2000K-7000K.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2000, 7000 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-2200K-6500K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-2200K-6500K.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-2700K-6500K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-2700K-6500K.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2700, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-fan.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-fan.yml
@@ -10,12 +10,16 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: colorTemperature
         version: 1
         config:
           values:
             - key: "colorTemperature.value"
               range: [ 2700, 6500 ]
+      - id: statelessColorTemperatureStep
+        version: 1
       - id: colorControl
         version: 1
       - id: fanMode

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-illuminance-motion-1000K-15000K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-illuminance-motion-1000K-15000K.yml
@@ -7,12 +7,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 1000, 15000 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: motionSensor

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level-illuminance-motion.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level-illuminance-motion.yml
@@ -6,12 +6,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: motionSensor

--- a/drivers/SmartThings/matter-switch/profiles/light-color-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-color-level.yml
@@ -10,12 +10,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-level-2-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-2-button.yml
@@ -10,6 +10,8 @@ components:
         values:
           - key: "level.value"
             range: [1, 100]
+    - id: statelessSwitchLevelStep
+      version: 1
     - id: firmwareUpdate
       version: 1
     - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-3-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-3-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-4-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-4-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-5-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-5-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-6-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-6-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1              
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-7-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-7-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-8-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-8-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1              
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-ColorTemperature-1500-9000k.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-ColorTemperature-1500-9000k.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 1500, 9000 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-level-button.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-button.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: firmwareUpdate
         version: 1
       - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-2200K-6500K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-2200K-6500K.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-2700K-6500K.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-2700K-6500K.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2700, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-2710k-6500k.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature-2710k-6500k.yml
@@ -11,12 +11,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2710, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-colorTemperature.yml
@@ -10,12 +10,16 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/light-level-energy-powerConsumption.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-energy-powerConsumption.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: energyMeter
         version: 1
       - id: powerConsumptionReport

--- a/drivers/SmartThings/matter-switch/profiles/light-level-motion.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-motion.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: motionSensor
         version: 1
       - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-level-power-energy-powerConsumption.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-power-energy-powerConsumption.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: powerMeter
         version: 1
       - id: energyMeter

--- a/drivers/SmartThings/matter-switch/profiles/light-level-power.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level-power.yml
@@ -10,6 +10,8 @@ components:
           values:
             - key: "level.value"
               range: [1, 100]
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: powerMeter
         version: 1
       - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/light-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/light-level.yml
@@ -10,6 +10,8 @@ components:
       values:
         - key: "level.value"
           range: [1, 100]
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/plug-level-energy-powerConsumption.yml
+++ b/drivers/SmartThings/matter-switch/profiles/plug-level-energy-powerConsumption.yml
@@ -6,6 +6,8 @@ components:
         version: 1
       - id: switchLevel
         version: 1
+      - id: statelessSwitchLevelStep
+        version: 1
       - id: energyMeter
         version: 1
       - id: powerConsumptionReport

--- a/drivers/SmartThings/matter-switch/profiles/plug-level-power-energy-powerConsumption.yml
+++ b/drivers/SmartThings/matter-switch/profiles/plug-level-power-energy-powerConsumption.yml
@@ -6,6 +6,8 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: powerMeter
     version: 1
   - id: energyMeter

--- a/drivers/SmartThings/matter-switch/profiles/plug-level-power.yml
+++ b/drivers/SmartThings/matter-switch/profiles/plug-level-power.yml
@@ -6,6 +6,8 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: powerMeter
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/plug-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/plug-level.yml
@@ -6,6 +6,8 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/switch-color-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/switch-color-level.yml
@@ -6,12 +6,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: colorControl
     version: 1
   - id: firmwareUpdate

--- a/drivers/SmartThings/matter-switch/profiles/switch-level-colorTemperature.yml
+++ b/drivers/SmartThings/matter-switch/profiles/switch-level-colorTemperature.yml
@@ -6,12 +6,16 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: colorTemperature
     version: 1
     config:
       values:
         - key: "colorTemperature.value"
           range: [ 2200, 6500 ]
+  - id: statelessColorTemperatureStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/profiles/switch-level.yml
+++ b/drivers/SmartThings/matter-switch/profiles/switch-level.yml
@@ -6,6 +6,8 @@ components:
     version: 1
   - id: switchLevel
     version: 1
+  - id: statelessSwitchLevelStep
+    version: 1
   - id: firmwareUpdate
     version: 1
   - id: refresh

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -298,6 +298,12 @@ local matter_driver_template = {
     [capabilities.level.ID] = {
       [capabilities.level.commands.setLevel.NAME] = capability_handlers.handle_set_level
     },
+    [capabilities.statelessColorTemperatureStep.ID] = {
+      [capabilities.statelessColorTemperatureStep.commands.stepColorTemperatureByPercent.NAME] = capability_handlers.handle_step_color_temperature_by_percent,
+    },
+    [capabilities.statelessSwitchLevelStep.ID] = {
+      [capabilities.statelessSwitchLevelStep.commands.stepLevel.NAME] = capability_handlers.handle_step_level,
+    },
     [capabilities.switch.ID] = {
       [capabilities.switch.commands.off.NAME] = capability_handlers.handle_switch_off,
       [capabilities.switch.commands.on.NAME] = capability_handlers.handle_switch_on,

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -47,6 +47,17 @@ function CapabilityHandlers.handle_switch_set_level(driver, device, cmd)
 end
 
 
+-- [[ STATELESS SWITCH LEVEL STEP CAPABILITY COMMANDS ]] --
+
+function CapabilityHandlers.handle_step_level(driver, device, cmd)
+  local step_size = st_utils.round((cmd.args and cmd.args.stepSize or 0)/100.0 * 254)
+  if step_size == 0 then return end
+  local endpoint_id = device:component_to_endpoint(cmd.component)
+  local step_mode = step_size > 0 and clusters.LevelControl.types.StepMode.UP or clusters.LevelControl.types.StepMode.DOWN
+  device:send(clusters.LevelControl.server.commands.Step(device, endpoint_id, step_mode, math.abs(step_size), fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
+end
+
+
 -- [[ COLOR CONTROL CAPABILITY COMMANDS ]] --
 
 function CapabilityHandlers.handle_set_color(driver, device, cmd)
@@ -56,10 +67,10 @@ function CapabilityHandlers.handle_set_color(driver, device, cmd)
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local hue = switch_utils.convert_huesat_st_to_matter(cmd.args.color.hue)
     local sat = switch_utils.convert_huesat_st_to_matter(cmd.args.color.saturation)
-    req = clusters.ColorControl.server.commands.MoveToHueAndSaturation(device, endpoint_id, hue, sat, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.OPTIONS_OVERRIDE)
+    req = clusters.ColorControl.server.commands.MoveToHueAndSaturation(device, endpoint_id, hue, sat, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
   else
     local x, y, _ = st_utils.safe_hsv_to_xy(cmd.args.color.hue, cmd.args.color.saturation)
-    req = clusters.ColorControl.server.commands.MoveToColor(device, endpoint_id, x, y, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.OPTIONS_OVERRIDE)
+    req = clusters.ColorControl.server.commands.MoveToColor(device, endpoint_id, x, y, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
   end
   device:send(req)
 end
@@ -69,7 +80,7 @@ function CapabilityHandlers.handle_set_hue(driver, device, cmd)
   local huesat_endpoints = device:get_endpoints(clusters.ColorControl.ID, {feature_bitmap = clusters.ColorControl.FeatureMap.HUE_AND_SATURATION})
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local hue = switch_utils.convert_huesat_st_to_matter(cmd.args.hue)
-    local req = clusters.ColorControl.server.commands.MoveToHue(device, endpoint_id, hue, 0, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.OPTIONS_OVERRIDE)
+    local req = clusters.ColorControl.server.commands.MoveToHue(device, endpoint_id, hue, 0, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
     device:send(req)
   else
     device.log.warn("Device does not support huesat features on its color control cluster")
@@ -81,7 +92,7 @@ function CapabilityHandlers.handle_set_saturation(driver, device, cmd)
   local huesat_endpoints = device:get_endpoints(clusters.ColorControl.ID, {feature_bitmap = clusters.ColorControl.FeatureMap.HUE_AND_SATURATION})
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local sat = switch_utils.convert_huesat_st_to_matter(cmd.args.saturation)
-    local req = clusters.ColorControl.server.commands.MoveToSaturation(device, endpoint_id, sat, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.OPTIONS_OVERRIDE)
+    local req = clusters.ColorControl.server.commands.MoveToSaturation(device, endpoint_id, sat, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
     device:send(req)
   else
     device.log.warn("Device does not support huesat features on its color control cluster")
@@ -103,9 +114,24 @@ function CapabilityHandlers.handle_set_color_temperature(driver, device, cmd)
   elseif max_temp_kelvin ~= nil and temp_in_kelvin >= max_temp_kelvin then
     temp_in_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id)
   end
-  local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.OPTIONS_OVERRIDE)
+  local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
   device:set_field(fields.MOST_RECENT_TEMP, cmd.args.temperature, {persist = true})
   device:send(req)
+end
+
+
+-- [[ STATELESS COLOR TEMPERATURE STEP CAPABILITY COMMANDS ]] --
+
+function CapabilityHandlers.handle_step_color_temperature_by_percent(driver, device, cmd)
+  local step_percent_change = cmd.args and cmd.args.stepSize or 0
+  if step_percent_change == 0 then return end
+  local endpoint_id = device:component_to_endpoint(cmd.component)
+  -- before the Matter 1.3 lua libs update (HUB FW 55), there was no ColorControl StepModeEnum type defined
+  local step_mode = step_percent_change > 0 and (clusters.ColorControl.types.StepModeEnum and clusters.ColorControl.types.StepModeEnum.DOWN or 3) or (clusters.ColorControl.types.StepModeEnum and clusters.ColorControl.types.StepModeEnum.UP or 1)
+  local min_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id) or fields.COLOR_TEMPERATURE_MIRED_MIN -- default min mireds
+  local max_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, endpoint_id) or fields.COLOR_TEMPERATURE_MIRED_MAX -- default max mireds
+  local step_size_in_mireds = st_utils.round((max_mireds - min_mireds) * (math.abs(step_percent_change)/100.0))
+  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, endpoint_id, step_mode, step_size_in_mireds, fields.TRANSITION_TIME_FAST, min_mireds, max_mireds, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
 end
 
 

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -1,6 +1,8 @@
 -- Copyright © 2025 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
+local st_utils = require "st.utils"
+
 local SwitchFields = {}
 
 SwitchFields.MOST_RECENT_TEMP = "mostRecentTemp"
@@ -13,8 +15,8 @@ SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT = 1000000
 -- These values are a "sanity check" to check that values we are getting are reasonable
 local COLOR_TEMPERATURE_KELVIN_MAX = 15000
 local COLOR_TEMPERATURE_KELVIN_MIN = 1000
-SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MIN
-SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MAX
+SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MIN)
+SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MAX)
 
 SwitchFields.SWITCH_LEVEL_LIGHTING_MIN = 1
 SwitchFields.CURRENT_HUESAT_ATTR_MIN = 0
@@ -186,10 +188,13 @@ SwitchFields.TEMP_BOUND_RECEIVED = "__temp_bound_received"
 SwitchFields.TEMP_MIN = "__temp_min"
 SwitchFields.TEMP_MAX = "__temp_max"
 
-SwitchFields.TRANSITION_TIME = 0 --1/10ths of a second
--- When sent with a command, these options mask and override bitmaps cause the command
--- to take effect when the switch/light is off.
+SwitchFields.TRANSITION_TIME = 0 -- number of 10ths of a second
+SwitchFields.TRANSITION_TIME_FAST = 3 -- 0.3 seconds
+
+-- For Level/Color Control cluster commands, this field indicates which bits in the OptionsOverride field are valid. In this case, we specify that the ExecuteIfOff option (bit 1) may be overridden.
 SwitchFields.OPTIONS_MASK = 0x01
-SwitchFields.OPTIONS_OVERRIDE = 0x01
+-- the OptionsOverride field's first bit overrides the ExecuteIfOff option, defining whether the command should take effect when the device is off.
+SwitchFields.HANDLE_COMMAND_IF_OFF = 0x01
+SwitchFields.IGNORE_COMMAND_IF_OFF = 0x00
 
 return SwitchFields

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -9,7 +9,7 @@ local st_utils = require "st.utils"
 local clusters = require "st.matter.clusters"
 local TRANSITION_TIME = 0
 local OPTIONS_MASK = 0x01
-local OPTIONS_OVERRIDE = 0x01
+local HANDLE_COMMAND_IF_OFF = 0x01
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("light-color-level-illuminance-motion.yml"),
@@ -319,7 +319,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -391,7 +391,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHue(mock_device, 1, hue, 0, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToHue(mock_device, 1, hue, 0, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
   }
@@ -413,7 +413,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToSaturation(mock_device, 1, sat, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToSaturation(mock_device, 1, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
   }
@@ -435,7 +435,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -9,7 +9,7 @@ local version = require "version"
 
 local TRANSITION_TIME = 0
 local OPTIONS_MASK = 0x01
-local OPTIONS_OVERRIDE = 0x01
+local HANDLE_COMMAND_IF_OFF = 0x01
 
 local mock_device_ep1 = 1
 local mock_device_ep2 = 2
@@ -178,7 +178,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, mock_device_ep1, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, mock_device_ep1, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -9,7 +9,7 @@ local clusters = require "st.matter.generated.zap_clusters"
 
 local TRANSITION_TIME = 0
 local OPTIONS_MASK = 0x01
-local OPTIONS_OVERRIDE = 0x01
+local HANDLE_COMMAND_IF_OFF = 0x01
 local button_attr = capabilities.button.button
 
 
@@ -366,7 +366,7 @@ test.register_coroutine_test(
     })
     test.socket.matter:__expect_send({
       mock_device.id,
-      clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, mock_device_ep5, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+      clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, mock_device_ep5, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
     })
     test.socket.matter:__queue_receive({
       mock_device.id,

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -9,7 +9,7 @@ local st_utils = require "st.utils"
 local clusters = require "st.matter.clusters"
 local TRANSITION_TIME = 0
 local OPTIONS_MASK = 0x01
-local OPTIONS_OVERRIDE = 0x01
+local HANDLE_COMMAND_IF_OFF = 0x01
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("switch-color-level.yml"),
@@ -451,7 +451,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send(
       {
         mock_device_no_hue_sat.id,
-        clusters.ColorControl.server.commands.MoveToColor(mock_device_no_hue_sat, 1, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColor(mock_device_no_hue_sat, 1, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     )
     test.socket.matter:__queue_receive(
@@ -513,7 +513,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -595,7 +595,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -669,7 +669,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHue(mock_device, 1, hue, 0, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToHue(mock_device, 1, hue, 0, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
   }
@@ -691,7 +691,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToSaturation(mock_device, 1, sat, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToSaturation(mock_device, 1, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
   }
@@ -713,7 +713,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -985,7 +985,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 165, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 165, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -1001,7 +1001,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 365, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 365, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     }
   }

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_lights.lua
@@ -10,7 +10,7 @@ test.disable_startup_messages()
 
 local TRANSITION_TIME = 0
 local OPTIONS_MASK = 0x01
-local OPTIONS_OVERRIDE = 0x01
+local HANDLE_COMMAND_IF_OFF = 0x01
 
 local parent_ep = 10
 local child1_ep = 20
@@ -496,7 +496,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, child2_ep, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, child2_ep, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -571,7 +571,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColor(mock_device, child2_ep, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColor(mock_device, child2_ep, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_parent_child_plugs.lua
@@ -10,7 +10,7 @@ test.disable_startup_messages()
 
 local TRANSITION_TIME = 0
 local OPTIONS_MASK = 0x01
-local OPTIONS_OVERRIDE = 0x01
+local HANDLE_COMMAND_IF_OFF = 0x01
 
 local parent_ep = 10
 local child1_ep = 20
@@ -489,7 +489,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, child2_ep, 556, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, child2_ep, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -564,7 +564,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColor(mock_device, child2_ep, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, OPTIONS_OVERRIDE)
+        clusters.ColorControl.server.commands.MoveToColor(mock_device, child2_ep, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
       }
     },
     {

--- a/drivers/SmartThings/matter-switch/src/test/test_stateless_step.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_stateless_step.lua
@@ -1,0 +1,163 @@
+-- Copyright 2026 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+local clusters = require "st.matter.clusters"
+
+local mock_device_color_temp = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = 0x0100, device_type_revision = 1}, -- On/Off Light
+        {device_type_id = 0x010C, device_type_revision = 1} -- Color Temperature Light
+      }
+    }
+  }
+})
+
+local cluster_subscribe_list = {
+  clusters.OnOff.attributes.OnOff,
+  clusters.LevelControl.attributes.CurrentLevel,
+  clusters.LevelControl.attributes.MaxLevel,
+  clusters.LevelControl.attributes.MinLevel,
+  clusters.ColorControl.attributes.ColorTemperatureMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+  clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+}
+
+local function test_init()
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_color_temp)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device_color_temp))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device_color_temp.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device_color_temp)
+end
+test.set_test_init_function(test_init)
+
+local fields = require "switch_utils.fields"
+
+test.register_message_test(
+  "Color Temperature Step Command Test",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device_color_temp.id,
+        { capability = "statelessColorTemperatureStep", component = "main", command = "stepColorTemperatureByPercent", args = { 20 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_color_temp.id,
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.DOWN, 187, fields.TRANSITION_TIME_FAST, fields.COLOR_TEMPERATURE_MIRED_MIN, fields.COLOR_TEMPERATURE_MIRED_MAX, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+      },
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device_color_temp.id,
+        { capability = "statelessColorTemperatureStep", component = "main", command = "stepColorTemperatureByPercent", args = { 90 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_color_temp.id,
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.DOWN, 840, fields.TRANSITION_TIME_FAST, fields.COLOR_TEMPERATURE_MIRED_MIN, fields.COLOR_TEMPERATURE_MIRED_MAX, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+      },
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device_color_temp.id,
+        { capability = "statelessColorTemperatureStep", component = "main", command = "stepColorTemperatureByPercent", args = { -50 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_color_temp.id,
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.UP, 467, fields.TRANSITION_TIME_FAST, fields.COLOR_TEMPERATURE_MIRED_MIN, fields.COLOR_TEMPERATURE_MIRED_MAX, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+      },
+    }
+  }
+)
+
+
+test.register_message_test(
+  "Level Step Command Test",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device_color_temp.id,
+        { capability = "statelessSwitchLevelStep", component = "main", command = "stepLevel", args = { 25 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_color_temp.id,
+        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.UP, 64, fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+      },
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device_color_temp.id,
+        { capability = "statelessSwitchLevelStep", component = "main", command = "stepLevel", args = { -50 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_color_temp.id,
+        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.DOWN, 127, fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+      },
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device_color_temp.id,
+        { capability = "statelessSwitchLevelStep", component = "main", command = "stepLevel", args = { 100 } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device_color_temp.id,
+        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.UP, 254, fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+      },
+    }
+  }
+)
+
+test.run_registered_tests()


### PR DESCRIPTION
# Description of Change
Update all profiles to support statelessStep capabilities as needed. Include handlers for these step capabilities using the Matter-provided step commands.

This breaks apart the work found in https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2669 so that the stateless capability support can be reviewed as an isolated unit.

# Summary of Completed Tests
Unit tests added. Tested on-device.