### PR TITLE
Gate videoCapture2 based on PushAvStreamTransport

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_utils/device_configuration.lua
@@ -62,7 +62,9 @@ function CameraDeviceConfiguration.match_profile(device, status_light_enabled_pr
           return clusters.CameraAvStreamManagement.are_features_supported(feature_bitmap, ep_cluster.feature_map)
         end
         if clus_has_feature(clusters.CameraAvStreamManagement.types.Feature.VIDEO) then
-          table.insert(main_component_capabilities, capabilities.videoCapture2.ID)
+          if switch_utils.find_cluster_on_ep(camera_ep, clusters.PushAvStreamTransport.ID, "SERVER") then
+            table.insert(main_component_capabilities, capabilities.videoCapture2.ID)
+          end
           table.insert(main_component_capabilities, capabilities.cameraViewportSettings.ID)
         end
         if clus_has_feature(clusters.CameraAvStreamManagement.types.Feature.LOCAL_STORAGE) then

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -51,6 +51,10 @@ local mock_device = test.mock_device.build_test_matter_device({
           cluster_type = "SERVER"
         },
         {
+          cluster_id = clusters.PushAvStreamTransport.ID,
+          cluster_type = "SERVER"
+        },
+        {
           cluster_id = clusters.ZoneManagement.ID,
           feature_map = clusters.ZoneManagement.types.Feature.TWO_DIMENSIONAL_CARTESIAN_ZONE |
             clusters.ZoneManagement.types.Feature.PER_ZONE_SENSITIVITY,


### PR DESCRIPTION
The VIDEO feature of CameraAvStreamManagement can be enabled on live-view only cameras, so the videoCapture2 capability should also be gated based on the presence of the PushAvStreamTransport clusters (presence of which also implies the presence of TLS clusters).