### PR TITLE
Add support for Irrigation System device type

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -4165,6 +4165,11 @@ matterGeneric:
     deviceTypes:
       - id: 0x0110 # Mounted Dimmable Load Control
     deviceProfileName: switch-level
+  - id: "matter/irrigation-system"
+    deviceLabel: Matter Irrigation System
+    deviceTypes:
+      - id: 0x0040 # Irrigation System
+    deviceProfileName: irrigation-system
   - id: "matter/water-valve"
     deviceLabel: Matter Water Valve
     deviceTypes:

--- a/drivers/SmartThings/matter-switch/profiles/irrigation-system.yml
+++ b/drivers/SmartThings/matter-switch/profiles/irrigation-system.yml
@@ -1,0 +1,26 @@
+name: irrigation-system
+components:
+- id: main
+  capabilities:
+    - id: valve
+      version: 1
+    - id: level
+      version: 1
+      config:
+        values:
+          - key: "level.value"
+            range: [0, 100]
+      optional: true
+    - id: flowMeasurement
+      version: 1
+      optional: true
+    - id: operationalState
+      version: 1
+      optional: true
+    - id: firmwareUpdate
+      version: 1
+    - id: refresh
+      version: 1
+  categories:
+  - name: Irrigation
+

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -8,9 +8,9 @@ local clusters = require "st.matter.clusters"
 local log = require "log"
 local version = require "version"
 local cfg = require "switch_utils.device_configuration"
+local button_cfg = cfg.ButtonCfg
 local device_cfg = cfg.DeviceCfg
 local switch_cfg = cfg.SwitchCfg
-local button_cfg = cfg.ButtonCfg
 local fields = require "switch_utils.fields"
 local switch_utils = require "switch_utils.utils"
 local attribute_handlers = require "switch_handlers.attribute_handlers"
@@ -47,6 +47,7 @@ function SwitchLifecycleHandlers.do_configure(driver, device)
     switch_cfg.set_device_control_options(device)
     device_cfg.match_profile(driver, device)
   elseif device.network_type == device_lib.NETWORK_TYPE_CHILD then
+    device_cfg.match_child_profile(driver, device)
     -- because get_parent_device() may cause race conditions if used in init, an initial child subscribe is handled in doConfigure.
     -- all future calls to subscribe will be handled by the parent device in init
     device:subscribe()
@@ -148,6 +149,11 @@ local matter_driver_template = {
         [clusters.FanControl.attributes.FanModeSequence.ID] = attribute_handlers.fan_mode_sequence_handler,
         [clusters.FanControl.attributes.PercentCurrent.ID] = attribute_handlers.percent_current_handler
       },
+      [clusters.FlowMeasurement.ID] = {
+        [clusters.FlowMeasurement.attributes.MeasuredValue.ID] = attribute_handlers.flow_attr_handler,
+        [clusters.FlowMeasurement.attributes.MinMeasuredValue.ID] = attribute_handlers.flow_attr_handler_factory(fields.FLOW_MIN),
+        [clusters.FlowMeasurement.attributes.MaxMeasuredValue.ID] = attribute_handlers.flow_attr_handler_factory(fields.FLOW_MAX)
+      },
       [clusters.IlluminanceMeasurement.ID] = {
         [clusters.IlluminanceMeasurement.attributes.MeasuredValue.ID] = attribute_handlers.illuminance_measured_value_handler
       },
@@ -158,6 +164,11 @@ local matter_driver_template = {
       },
       [clusters.OccupancySensing.ID] = {
         [clusters.OccupancySensing.attributes.Occupancy.ID] = attribute_handlers.occupancy_handler,
+      },
+      [clusters.OperationalState.ID] = {
+        [clusters.OperationalState.attributes.AcceptedCommandList.ID] = attribute_handlers.operational_state_accepted_command_list_attr_handler,
+        [clusters.OperationalState.attributes.OperationalState.ID] = attribute_handlers.operational_state_attr_handler,
+        [clusters.OperationalState.attributes.OperationalError.ID] = attribute_handlers.operational_error_attr_handler
       },
       [clusters.OnOff.ID] = {
         [clusters.OnOff.attributes.OnOff.ID] = attribute_handlers.on_off_attr_handler,
@@ -226,23 +237,33 @@ local matter_driver_template = {
     [capabilities.fanSpeedPercent.ID] = {
       clusters.FanControl.attributes.PercentCurrent
     },
+    [capabilities.flowMeasurement.ID] = {
+      clusters.FlowMeasurement.attributes.MeasuredValue,
+      clusters.FlowMeasurement.attributes.MinMeasuredValue,
+      clusters.FlowMeasurement.attributes.MaxMeasuredValue
+    },
     [capabilities.illuminanceMeasurement.ID] = {
       clusters.IlluminanceMeasurement.attributes.MeasuredValue
-    },
-    [capabilities.motionSensor.ID] = {
-      clusters.OccupancySensing.attributes.Occupancy
     },
     [capabilities.level.ID] = {
       clusters.ValveConfigurationAndControl.attributes.CurrentLevel
     },
-    [capabilities.switch.ID] = {
-      clusters.OnOff.attributes.OnOff
+    [capabilities.motionSensor.ID] = {
+      clusters.OccupancySensing.attributes.Occupancy
+    },
+    [capabilities.operationalState.ID] = {
+      clusters.OperationalState.attributes.AcceptedCommandList,
+      clusters.OperationalState.attributes.OperationalState,
+      clusters.OperationalState.attributes.OperationalError
     },
     [capabilities.powerMeter.ID] = {
       clusters.ElectricalPowerMeasurement.attributes.ActivePower
     },
     [capabilities.relativeHumidityMeasurement.ID] = {
       clusters.RelativeHumidityMeasurement.attributes.MeasuredValue
+    },
+    [capabilities.switch.ID] = {
+      clusters.OnOff.attributes.OnOff
     },
     [capabilities.switchLevel.ID] = {
       clusters.LevelControl.attributes.CurrentLevel,
@@ -287,6 +308,10 @@ local matter_driver_template = {
     [capabilities.level.ID] = {
       [capabilities.level.commands.setLevel.NAME] = capability_handlers.handle_set_level
     },
+    [capabilities.operationalState.ID] = {
+      [capabilities.operationalState.commands.pause.NAME] = capability_handlers.handle_operational_state_pause,
+      [capabilities.operationalState.commands.resume.NAME] = capability_handlers.handle_operational_state_resume
+    },
     [capabilities.statelessColorTemperatureStep.ID] = {
       [capabilities.statelessColorTemperatureStep.commands.stepColorTemperatureByPercent.NAME] = capability_handlers.handle_step_color_temperature_by_percent,
     },
@@ -319,6 +344,7 @@ local matter_driver_template = {
     capabilities.energyMeter,
     capabilities.fanMode,
     capabilities.fanSpeedPercent,
+    capabilities.flowMeasurement,
     capabilities.hdr,
     capabilities.illuminanceMeasurement,
     capabilities.imageControl,
@@ -327,6 +353,7 @@ local matter_driver_template = {
     capabilities.mechanicalPanTiltZoom,
     capabilities.motionSensor,
     capabilities.nightVision,
+    capabilities.operationalState,
     capabilities.powerMeter,
     capabilities.powerConsumptionReport,
     capabilities.relativeHumidityMeasurement,

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -550,4 +550,79 @@ function AttributeHandlers.percent_current_handler(driver, device, ib, response)
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.fanSpeedPercent.percent(ib.data.value))
 end
 
+
+-- [[ OPERATIONAL STATE CLUSTER ATTRIBUTES ]] --
+
+function AttributeHandlers.operational_state_accepted_command_list_attr_handler(driver, device, ib, response)
+  if ib.data.elements == nil then return end
+  local accepted_command_list = {}
+  for _, accepted_command in ipairs(ib.data.elements) do
+    local accepted_command_id = accepted_command.value
+    if fields.operational_state_command_map[accepted_command_id] ~= nil then
+      table.insert(accepted_command_list, fields.operational_state_command_map[accepted_command_id])
+    end
+  end
+  local event = capabilities.operationalState.supportedCommands(accepted_command_list, {visibility = {displayed = false}})
+  device:emit_event_for_endpoint(ib.endpoint_id, event)
+end
+
+function AttributeHandlers.operational_state_attr_handler(driver, device, ib, response)
+  if ib.data.value == clusters.OperationalState.types.OperationalStateEnum.STOPPED then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.operationalState.stopped())
+  elseif ib.data.value == clusters.OperationalState.types.OperationalStateEnum.RUNNING then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.operationalState.running())
+  elseif ib.data.value == clusters.OperationalState.types.OperationalStateEnum.PAUSED then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.operationalState.paused())
+  end
+end
+
+function AttributeHandlers.operational_error_attr_handler(driver, device, ib, response)
+  if ib.data.elements == nil or ib.data.elements.error_state_id == nil or ib.data.elements.error_state_id.value == nil then return end
+  if version.api < 10 then
+    clusters.OperationalState.types.ErrorStateStruct:augment_type(ib.data)
+  end
+  local operationalError = ib.data.elements.error_state_id.value
+  if operationalError == clusters.OperationalState.types.ErrorStateEnum.UNABLE_TO_START_OR_RESUME then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.operationalState.unableToStartOrResume())
+  elseif operationalError == clusters.OperationalState.types.ErrorStateEnum.UNABLE_TO_COMPLETE_OPERATION then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.operationalState.unableToCompleteOperation())
+  elseif operationalError == clusters.OperationalState.types.ErrorStateEnum.COMMAND_INVALID_IN_STATE then
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.operationalState.operationalState.commandInvalidInCurrentState())
+  end
+end
+
+
+-- [[ FLOW MEASUREMENT CLUSTER ATTRIBUTES ]] --
+
+function AttributeHandlers.flow_attr_handler(driver, device, ib, response)
+  local measured_value = ib.data.value
+  if measured_value ~= nil then
+    local flow = measured_value / 10.0
+    local unit = "m^3/h"
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.flowMeasurement.flow({value = flow, unit = unit}))
+  end
+end
+
+function AttributeHandlers.flow_attr_handler_factory(minOrMax)
+  return function(driver, device, ib, response)
+    if ib.data.value == nil then
+      return
+    end
+    local flow_bound = ib.data.value / 10.0
+    local unit = "m^3/h"
+    switch_utils.set_field_for_endpoint(device, fields.FLOW_BOUND_RECEIVED..minOrMax, ib.endpoint_id, flow_bound)
+    local min = switch_utils.get_field_for_endpoint(device, fields.FLOW_BOUND_RECEIVED..fields.FLOW_MIN, ib.endpoint_id)
+    local max = switch_utils.get_field_for_endpoint(device, fields.FLOW_BOUND_RECEIVED..fields.FLOW_MAX, ib.endpoint_id)
+    if min ~= nil and max ~= nil then
+      if min < max then
+        device:emit_event_for_endpoint(ib.endpoint_id, capabilities.flowMeasurement.flowRange({ value = { minimum = min, maximum = max }, unit = unit }))
+        switch_utils.set_field_for_endpoint(device, fields.FLOW_BOUND_RECEIVED..fields.FLOW_MIN, ib.endpoint_id, nil)
+        switch_utils.set_field_for_endpoint(device, fields.FLOW_BOUND_RECEIVED..fields.FLOW_MAX, ib.endpoint_id, nil)
+      else
+        device.log.warn_with({hub_logs = true}, string.format("Device reported a min flow measurement %d that is not lower than the reported max flow measurement %d", min, max))
+      end
+    end
+  end
+end
+
 return AttributeHandlers

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -232,4 +232,21 @@ function CapabilityHandlers.handle_reset_energy_meter(driver, device, cmd)
   end
 end
 
+
+-- [[ OPERATIONAL STATE CAPABILITY COMMANDS ]] --
+
+function CapabilityHandlers.handle_operational_state_resume(driver, device, cmd)
+  local endpoint_id = device:get_endpoints(clusters.OperationalState.ID)[1]
+  device:send(clusters.OperationalState.server.commands.Resume(device, endpoint_id))
+  device:send(clusters.OperationalState.attributes.OperationalState:read(device, endpoint_id))
+  device:send(clusters.OperationalState.attributes.OperationalError:read(device, endpoint_id))
+end
+
+function CapabilityHandlers.handle_operational_state_pause(driver, device, cmd)
+  local endpoint_id = device:get_endpoints(clusters.OperationalState.ID)[1]
+  device:send(clusters.OperationalState.server.commands.Pause(device, endpoint_id))
+  device:send(clusters.OperationalState.attributes.OperationalState:read(device, endpoint_id))
+  device:send(clusters.OperationalState.attributes.OperationalError:read(device, endpoint_id))
+end
+
 return CapabilityHandlers

--- a/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
@@ -20,6 +20,7 @@ local ChildConfiguration = {}
 local SwitchDeviceConfiguration = {}
 local ButtonDeviceConfiguration = {}
 local FanDeviceConfiguration = {}
+local ValveDeviceConfiguration = {}
 
 function ChildConfiguration.create_or_update_child_devices(driver, device, server_cluster_ep_ids, default_endpoint_id, assign_profile_fn)
   if #server_cluster_ep_ids == 1 and server_cluster_ep_ids[1] == default_endpoint_id then -- no children will be created
@@ -30,7 +31,7 @@ function ChildConfiguration.create_or_update_child_devices(driver, device, serve
   for device_num, ep_id in ipairs(server_cluster_ep_ids) do
     if ep_id ~= default_endpoint_id then -- don't create a child device that maps to the main endpoint
       local label_and_name = string.format("%s %d", device.label, device_num)
-      local child_profile, _ = assign_profile_fn(device, ep_id, true)
+      local child_profile, optional_component_capabilities = assign_profile_fn(device, ep_id, true)
       local existing_child_device = device:get_field(fields.IS_PARENT_CHILD_DEVICE) and switch_utils.find_child(device, ep_id)
       if not existing_child_device then
         driver:try_create_device({
@@ -43,7 +44,8 @@ function ChildConfiguration.create_or_update_child_devices(driver, device, serve
         })
       else
         existing_child_device:try_update_metadata({
-          profile = child_profile
+          profile = child_profile,
+          optional_component_capabilities = optional_component_capabilities
         })
       end
     end
@@ -73,7 +75,6 @@ function FanDeviceConfiguration.assign_profile_for_fan_ep(device, server_fan_ep_
   table.insert(optional_supported_component_capabilities, {"main", main_component_capabilities})
   return "fan-modular", optional_supported_component_capabilities
 end
-
 
 function SwitchDeviceConfiguration.assign_profile_for_onoff_ep(device, server_onoff_ep_id, is_child_device)
   local ep_info = switch_utils.get_endpoint_info(device, server_onoff_ep_id)
@@ -190,8 +191,55 @@ function ButtonDeviceConfiguration.configure_buttons(device, momentary_switch_ep
   end
 end
 
+function ValveDeviceConfiguration.assign_profile_for_irrigation_system_ep(device, irrigation_system_ep_id, is_child_device)
+  local main_component_capabilities = {}
+  local profile_name = "irrigation-system"
+
+  local valve_ep_ids = switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.WATER_VALVE)
+  table.sort(valve_ep_ids)
+  local supports_level = switch_utils.find_cluster_on_ep(
+    switch_utils.get_endpoint_info(device, is_child_device and irrigation_system_ep_id or valve_ep_ids[1]),
+    clusters.ValveConfigurationAndControl.ID,
+    {feature_bitmap = clusters.ValveConfigurationAndControl.types.Feature.LEVEL}
+  )
+  if supports_level then
+    table.insert(main_component_capabilities, capabilities.level.ID)
+  end
+
+  if is_child_device then
+    return profile_name, {{"main", main_component_capabilities}}
+  end
+
+  local irrigation_system_ep_info = switch_utils.get_endpoint_info(device, irrigation_system_ep_id)
+  if switch_utils.find_cluster_on_ep(irrigation_system_ep_info, clusters.FlowMeasurement.ID) then
+    table.insert(main_component_capabilities, capabilities.flowMeasurement.ID)
+  end
+  if switch_utils.find_cluster_on_ep(irrigation_system_ep_info, clusters.OperationalState.ID) then
+    table.insert(main_component_capabilities, capabilities.operationalState.ID)
+  end
+
+  return profile_name, {{"main", main_component_capabilities}}
+end
+
 
 -- [[ PROFILE MATCHING AND CONFIGURATIONS ]] --
+
+function DeviceConfiguration.match_child_profile(driver, device)
+  local parent_device = device:get_parent_device()
+  local irrigation_system_ep_ids = switch_utils.get_endpoints_by_device_type(
+    parent_device,
+    fields.DEVICE_TYPE_ID.IRRIGATION_SYSTEM
+  )
+  if #irrigation_system_ep_ids > 0 then
+    ChildConfiguration.create_or_update_child_devices(
+      driver,
+      parent_device,
+      {device:get_endpoint()},
+      nil,
+      ValveDeviceConfiguration.assign_profile_for_irrigation_system_ep
+    )
+  end
+end
 
 local function profiling_data_still_required(device)
   for _, field in pairs(fields.profiling_data) do
@@ -230,7 +278,12 @@ function DeviceConfiguration.match_profile(driver, device)
     end
   end
 
-  if #switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.WATER_VALVE) > 0 then
+  local irrigation_system_ep_ids = switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.IRRIGATION_SYSTEM)
+  local valve_ep_ids = switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.WATER_VALVE)
+  if #irrigation_system_ep_ids > 0 then
+    updated_profile, optional_component_capabilities = ValveDeviceConfiguration.assign_profile_for_irrigation_system_ep(device, irrigation_system_ep_ids[1], false)
+    ChildConfiguration.create_or_update_child_devices(driver, device, valve_ep_ids, default_endpoint_id, ValveDeviceConfiguration.assign_profile_for_irrigation_system_ep)
+  elseif #valve_ep_ids > 0 then
     updated_profile = "water-valve"
     if #embedded_cluster_utils.get_endpoints(device, clusters.ValveConfigurationAndControl.ID,
       {feature_bitmap = clusters.ValveConfigurationAndControl.types.Feature.LEVEL}) > 0 then
@@ -255,7 +308,9 @@ function DeviceConfiguration.match_profile(driver, device)
 end
 
 return {
+  ButtonCfg = ButtonDeviceConfiguration,
+  ChildCfg = ChildConfiguration,
   DeviceCfg = DeviceConfiguration,
   SwitchCfg = SwitchDeviceConfiguration,
-  ButtonCfg = ButtonDeviceConfiguration
+  ValveCfg = ValveDeviceConfiguration
 }

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -1,6 +1,8 @@
 -- Copyright © 2025 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
+local clusters = require "st.matter.clusters"
+
 local SwitchFields = {}
 
 SwitchFields.MOST_RECENT_TEMP = "mostRecentTemp"
@@ -32,6 +34,7 @@ SwitchFields.DEVICE_TYPE_ID = {
   ELECTRICAL_SENSOR = 0x0510,
   FAN = 0x002B,
   GENERIC_SWITCH = 0x000F,
+  IRRIGATION_SYSTEM = 0x0040,
   MOUNTED_ON_OFF_CONTROL = 0x010F,
   MOUNTED_DIMMABLE_LOAD_CONTROL = 0x0110,
   ON_OFF_PLUG_IN_UNIT = 0x010A,
@@ -85,6 +88,9 @@ SwitchFields.LEVEL_BOUND_RECEIVED = "__level_bound_received"
 SwitchFields.LEVEL_MIN = "__level_min"
 SwitchFields.LEVEL_MAX = "__level_max"
 SwitchFields.COLOR_MODE = "__color_mode"
+SwitchFields.FLOW_BOUND_RECEIVED = "__flow_bound_received"
+SwitchFields.FLOW_MIN = "__flow_min"
+SwitchFields.FLOW_MAX = "__flow_max"
 
 SwitchFields.SUBSCRIBED_ATTRIBUTES_KEY = "__subscribed_attributes"
 
@@ -139,6 +145,11 @@ SwitchFields.switch_category_vendor_overrides = {
     {0x0004},
   [0x139C] = -- Zemismart
     {0xEEE2, 0xAB08, 0xAB31, 0xAB04, 0xAB01, 0xAB43, 0xAB02, 0xAB03, 0xAB05}
+}
+
+SwitchFields.operational_state_command_map = {
+  [clusters.OperationalState.commands.Pause.ID] = "pause",
+  [clusters.OperationalState.commands.Resume.ID] = "resume"
 }
 
 --- stores a table of endpoints that support the Electrical Sensor device type, used during profiling

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_irrigation_system.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_irrigation_system.lua
@@ -1,0 +1,477 @@
+-- Copyright © 2026 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local capabilities = require "st.capabilities"
+local clusters = require "st.matter.clusters"
+local t_utils = require "integration_test.utils"
+local test = require "integration_test"
+local version = require "version"
+
+if version.api < 11 then
+  clusters.ValveConfigurationAndControl = require "embedded_clusters.ValveConfigurationAndControl"
+end
+
+local endpoints = {
+  ROOT_EP = 0,
+  IRRIGATION_SYSTEM_EP = 1,
+  VALVE_1_EP = 2,
+  VALVE_2_EP = 3,
+  VALVE_3_EP = 4
+}
+
+-- Mock device representing an irrigation system with 3 valve endpoints
+local mock_irrigation_system = test.mock_device.build_test_matter_device({
+  label = "Matter Irrigation System",
+  profile = t_utils.get_profile_definition("irrigation-system.yml"),
+  manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
+  matter_version = {hardware = 1, software = 1},
+  endpoints = {
+    {
+      endpoint_id = endpoints.ROOT_EP,
+      clusters = {
+        {cluster_id = clusters.Basic.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0016, device_type_revision = 1} -- RootNode
+      }
+    },
+    {
+      endpoint_id = endpoints.IRRIGATION_SYSTEM_EP,
+      clusters = {
+        {cluster_id = clusters.Descriptor.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.FlowMeasurement.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.OperationalState.ID, cluster_type = "SERVER"},
+      },
+      device_types = {
+        {device_type_id = 0x0040, device_type_revision = 1} -- Irrigation System
+      }
+    },
+    {
+      endpoint_id = endpoints.VALVE_1_EP,
+      clusters = {
+        {
+          cluster_id = clusters.ValveConfigurationAndControl.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 2 -- LEVEL feature
+        },
+      },
+      device_types = {
+        {device_type_id = 0x0042, device_type_revision = 1} -- Water Valve
+      }
+    },
+    {
+      endpoint_id = endpoints.VALVE_2_EP,
+      clusters = {
+        {
+          cluster_id = clusters.ValveConfigurationAndControl.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 2 -- LEVEL feature
+        },
+      },
+      device_types = {
+        {device_type_id = 0x0042, device_type_revision = 1} -- Water Valve
+      }
+    },
+    {
+      endpoint_id = endpoints.VALVE_3_EP,
+      clusters = {
+        {
+          cluster_id = clusters.ValveConfigurationAndControl.ID,
+          cluster_type = "SERVER",
+          cluster_revision = 1,
+          feature_map = 2 -- LEVEL feature
+        },
+      },
+      device_types = {
+        {device_type_id = 0x0042, device_type_revision = 1} -- Water Valve
+      }
+    }
+  }
+})
+
+local mock_children = {}
+for _, endpoint in ipairs(mock_irrigation_system.endpoints) do
+  if endpoint.endpoint_id == 3 or endpoint.endpoint_id == 4 then
+    local child_data = {
+      profile = t_utils.get_profile_definition("water-valve-level.yml"),
+      device_network_id = string.format("%s:%d", mock_irrigation_system.id, endpoint.endpoint_id),
+      parent_device_id = mock_irrigation_system.id,
+      parent_assigned_child_key = string.format("%d", endpoint.endpoint_id)
+    }
+    mock_children[endpoint.endpoint_id] = test.mock_device.build_test_child_device(child_data)
+  end
+end
+
+local subscribe_request
+
+local expected_metadata = {
+  optional_component_capabilities = { { "main", { "level", "flowMeasurement", "operationalState", } } },
+  profile = "irrigation-system"
+}
+
+local function test_init()
+  test.mock_device.add_test_device(mock_irrigation_system)
+  local cluster_subscribe_list = {
+    clusters.ValveConfigurationAndControl.attributes.CurrentState,
+    clusters.ValveConfigurationAndControl.attributes.CurrentLevel,
+  }
+  subscribe_request = cluster_subscribe_list[1]:subscribe(mock_irrigation_system)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_irrigation_system))
+    end
+  end
+  test.socket.device_lifecycle:__queue_receive({ mock_irrigation_system.id, "added" })
+  test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
+  test.socket.device_lifecycle:__queue_receive({ mock_irrigation_system.id, "init" })
+  test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
+  test.socket.device_lifecycle:__queue_receive({ mock_irrigation_system.id, "doConfigure" })
+  mock_irrigation_system:expect_metadata_update(expected_metadata)
+  mock_irrigation_system:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  for _, child in pairs(mock_children) do
+    test.mock_device.add_test_device(child)
+  end
+  for i = 3,4 do
+    mock_irrigation_system:expect_device_create({
+      type = "EDGE_CHILD",
+      label = string.format("Matter Irrigation System %d", i - 1),
+      profile = "irrigation-system",
+      parent_device_id = mock_irrigation_system.id,
+      parent_assigned_child_key = string.format("%d", i)
+    })
+  end
+  test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
+end
+test.set_test_init_function(test_init)
+
+
+local additional_subscribed_attributes = {
+  clusters.FlowMeasurement.attributes.MeasuredValue,
+  clusters.FlowMeasurement.attributes.MaxMeasuredValue,
+  clusters.FlowMeasurement.attributes.MinMeasuredValue,
+  clusters.OperationalState.attributes.AcceptedCommandList,
+  clusters.OperationalState.attributes.OperationalError,
+  clusters.OperationalState.attributes.OperationalState,
+}
+
+local function update_device_profile()
+  local updated_device_profile = t_utils.get_profile_definition(
+    "irrigation-system.yml", { enabled_optional_capabilities = expected_metadata.optional_component_capabilities }
+  )
+  test.wait_for_events()
+  test.socket.device_lifecycle:__queue_receive(mock_irrigation_system:generate_info_changed({ profile = updated_device_profile }))
+  for _, attr in ipairs(additional_subscribed_attributes) do
+    subscribe_request:merge(attr:subscribe(mock_irrigation_system))
+  end
+  test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
+end
+
+test.register_coroutine_test(
+  "Parent device: Open command should send the appropriate commands",
+  function()
+    test.socket.capability:__queue_receive({
+      mock_irrigation_system.id,
+      { capability = "valve", component = "main", command = "open", args = { } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.commands.Open(mock_irrigation_system, endpoints.VALVE_1_EP)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Parent device: Close command should send the appropriate commands",
+  function()
+    test.socket.capability:__queue_receive({
+      mock_irrigation_system.id,
+      { capability = "valve", component = "main", command = "close", args = { } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.commands.Close(mock_irrigation_system, endpoints.VALVE_1_EP)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Parent device: Set level command should send the appropriate commands",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.capability:__queue_receive({
+      mock_irrigation_system.id,
+      { capability = "level", component = "main", command = "setLevel", args = { 75 } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.commands.Open(mock_irrigation_system, endpoints.VALVE_1_EP, nil, 75)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Parent device: Current state closed should generate closed event",
+  function()
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.attributes.CurrentState:build_test_report_data(
+        mock_irrigation_system,
+        endpoints.VALVE_1_EP,
+        0
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_irrigation_system:generate_test_message("main", capabilities.valve.valve.closed())
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Parent device: Current level reports should generate appropriate events",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.attributes.CurrentLevel:build_test_report_data(
+        mock_irrigation_system,
+        endpoints.VALVE_1_EP,
+        60
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_irrigation_system:generate_test_message("main", capabilities.level.level(60))
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Flow reports should generate correct messages",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.FlowMeasurement.server.attributes.MeasuredValue:build_test_report_data(mock_irrigation_system, 1, 20 * 10)
+    })
+    test.socket.capability:__expect_send(
+      mock_irrigation_system:generate_test_message(
+        "main",
+        capabilities.flowMeasurement.flow({ value = 20.0, unit = "m^3/h" })
+      )
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Min and max flow attributes set capability constraint",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.FlowMeasurement.attributes.MinMeasuredValue:build_test_report_data(mock_irrigation_system, 1, 20)
+    })
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.FlowMeasurement.attributes.MaxMeasuredValue:build_test_report_data(mock_irrigation_system, 1, 5000)
+    })
+    test.socket.capability:__expect_send(
+      mock_irrigation_system:generate_test_message(
+        "main",
+        capabilities.flowMeasurement.flowRange({
+          value = { minimum = 2.0, maximum = 500.0 },
+          unit = "m^3/h"
+        })
+      )
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Child device valve 2: Open command should send the appropriate commands",
+  function()
+    test.socket.capability:__queue_receive({
+      mock_children[endpoints.VALVE_2_EP].id,
+      { capability = "valve", component = "main", command = "open", args = { } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.commands.Open(mock_irrigation_system, endpoints.VALVE_2_EP)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Child device valve 2: Set level command should send the appropriate commands",
+  function()
+    test.socket.capability:__queue_receive({
+      mock_children[endpoints.VALVE_2_EP].id,
+      { capability = "level", component = "main", command = "setLevel", args = { 40 } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.commands.Open(mock_irrigation_system, endpoints.VALVE_2_EP, nil, 40)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Child device valve 2: Current state closed should generate closed event",
+  function()
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.attributes.CurrentState:build_test_report_data(
+        mock_irrigation_system,
+        endpoints.VALVE_2_EP,
+        0
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_children[endpoints.VALVE_2_EP]:generate_test_message("main", capabilities.valve.valve.closed())
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "Child device valve 3: Close command should send the appropriate commands",
+  function()
+    test.socket.capability:__queue_receive({
+      mock_children[endpoints.VALVE_3_EP].id,
+      { capability = "valve", component = "main", command = "close", args = { } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.commands.Close(mock_irrigation_system, endpoints.VALVE_3_EP)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Child device valve 3: Current level reports should generate appropriate events",
+  function()
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.ValveConfigurationAndControl.server.attributes.CurrentLevel:build_test_report_data(
+        mock_irrigation_system,
+        endpoints.VALVE_3_EP,
+        100
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_children[endpoints.VALVE_3_EP]:generate_test_message("main", capabilities.level.level(100))
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "OperationalState attribute running should generate running event",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.OperationalState.attributes.OperationalState:build_test_report_data(
+        mock_irrigation_system,
+        endpoints.IRRIGATION_SYSTEM_EP,
+        clusters.OperationalState.types.OperationalStateEnum.RUNNING
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_irrigation_system:generate_test_message("main", capabilities.operationalState.operationalState.running())
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "OperationalState OperationalError UNABLE_TO_COMPLETE_OPERATION should generate unableToCompleteOperation event",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_irrigation_system.id,
+      clusters.OperationalState.attributes.OperationalError:build_test_report_data(
+        mock_irrigation_system,
+        endpoints.IRRIGATION_SYSTEM_EP, { error_state_id = clusters.OperationalState.types.ErrorStateEnum.UNABLE_TO_COMPLETE_OPERATION }
+      )
+    })
+    test.socket.capability:__expect_send(
+      mock_irrigation_system:generate_test_message("main", capabilities.operationalState.operationalState.unableToCompleteOperation())
+    )
+  end
+)
+
+test.register_coroutine_test(
+  "OperationalState resume command should send Resume and re-read state/error to irrigation system EP",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.capability:__queue_receive({
+      mock_irrigation_system.id,
+      { capability = "operationalState", component = "main", command = "resume", args = { } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.OperationalState.server.commands.Resume(mock_irrigation_system, endpoints.IRRIGATION_SYSTEM_EP)
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.OperationalState.attributes.OperationalState:read(mock_irrigation_system, endpoints.IRRIGATION_SYSTEM_EP)
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.OperationalState.attributes.OperationalError:read(mock_irrigation_system, endpoints.IRRIGATION_SYSTEM_EP)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "OperationalState pause command should send Pause and re-read state/error to irrigation system EP",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.capability:__queue_receive({
+      mock_irrigation_system.id,
+      { capability = "operationalState", component = "main", command = "pause", args = { } }
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.OperationalState.server.commands.Pause(mock_irrigation_system, endpoints.IRRIGATION_SYSTEM_EP)
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.OperationalState.attributes.OperationalState:read(mock_irrigation_system, endpoints.IRRIGATION_SYSTEM_EP)
+    })
+    test.socket.matter:__expect_send({
+      mock_irrigation_system.id,
+      clusters.OperationalState.attributes.OperationalError:read(mock_irrigation_system, endpoints.IRRIGATION_SYSTEM_EP)
+    })
+  end
+)
+
+test.register_coroutine_test(
+  "Child device doConfigure: update child profile based on its endpoint configuration",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_children[endpoints.VALVE_2_EP].id, "doConfigure" })
+    mock_children[endpoints.VALVE_2_EP]:expect_metadata_update({
+      profile = "irrigation-system",
+      optional_component_capabilities = {{"main", {"level"}}}
+    })
+    mock_children[endpoints.VALVE_2_EP]:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
+  end
+)
+
+test.run_registered_tests()
+


### PR DESCRIPTION
This adds support for the Irrigation System device type, introduced with Matter 1.5.

Tested with VDA Irrigation System
[ ](https://smartthings.atlassian.net/browse/CHAD-17520)