### PR TITLE
Matter Camera: fix devices being marked online due to capability inits

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/init.lua
@@ -39,6 +39,13 @@ function CameraLifecycleHandlers.do_configure(driver, device)
   camera_cfg.initialize_camera_capabilities(device)
 end
 
+function CameraLifecycleHandlers.driver_switched(driver, device)
+  camera_utils.update_camera_component_map(device)
+  if #device:get_endpoints(clusters.CameraAvStreamManagement.ID) == 0 then
+    camera_cfg.match_profile(device, false, false)
+  end
+end
+
 function CameraLifecycleHandlers.info_changed(driver, device, event, args)
   if camera_utils.profile_changed(device.profile.components, args.old_st_store.profile.components) then
     camera_cfg.initialize_camera_capabilities(device)
@@ -57,7 +64,7 @@ local camera_handler = {
     init = CameraLifecycleHandlers.device_init,
     infoChanged = CameraLifecycleHandlers.info_changed,
     doConfigure = CameraLifecycleHandlers.do_configure,
-    driverSwitched = CameraLifecycleHandlers.do_configure,
+    driverSwitched = CameraLifecycleHandlers.driver_switched,
     added = CameraLifecycleHandlers.added
   },
   matter_handlers = {


### PR DESCRIPTION
The `driverSwitched` event can be triggered in a few different ways, but since it was pointed to the same handler as `doConfigure,` code that should only be run for new devices was being run whenever this event was received by the driver. This includes `initialize_camera_capabilities`, and resulted in offline devices being marked online. This change adds separate handling for `driverSwitched`, specifically excluding this function as well as `create_child_devices`.