### PR TITLE
Matter Switch: Handle nullable case for ActivePower

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -251,6 +251,9 @@ function AttributeHandlers.active_power_handler(driver, device, ib, response)
   if ib.data.value then
     local watt_value = ib.data.value / 1000 -- convert received milliwatt to watt
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.powerMeter.power({ value = watt_value, unit = "W"}))
+  else
+    -- note: we don't support nullable types, so this handles the Null case for ActivePower
+    device:emit_event_for_endpoint(ib.endpoint_id, capabilities.powerMeter.power({ value = 0, unit = "W"}))
   end
   if type(device.register_native_capability_attr_handler) == "function" then
     device:register_native_capability_attr_handler("powerMeter","power")


### PR DESCRIPTION
# Description of Change
If no power is currently being used when the driver is starting or restarting, devices generally report Null as their value. This should be taken as 0.0 for a better user experience that is more consistent with other protocols.

# Summary of Completed Tests
Tested on-device. Since we do not support the TLV-encoded null type in lua right now, we cannot make a unit test for this case.


