### PR TITLE
Matter Switch: Add electrical field settings to driverSwitched

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -54,6 +54,7 @@ end
 
 function SwitchLifecycleHandlers.driver_switched(driver, device)
   if device.network_type == device_lib.NETWORK_TYPE_MATTER and not switch_utils.detect_bridge(device) then
+    switch_utils.handle_electrical_sensor_info(device) -- field settings required for proper setup when switching drivers
     device_cfg.match_profile(driver, device)
   end
 end


### PR DESCRIPTION
# Description of Change
If a driver switch is done on an electrical device, all electrical behavior will be removed, since the fields will not have been set (`added` does not occur on a driver switch). This fixes that by adding the appropriate logic into the switched event.

# Summary of Completed Tests
Tested on-device.

