### PR TITLE
Matter Media: Account for MinLevel and MaxLevel for volume control

### DIFF
--- a/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
+++ b/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright © 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"


### PR DESCRIPTION
This change accounts for the `MinLevel` and `MaxLevel` attributes when converting between level values used by the device and percentage values used by the `audioVolume` capability.

[ ](https://smartthings.atlassian.net/browse/CHAD-17266)