### PR TITLE
feat(tamper): add multi-device exclusion via id_match loop

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
@@ -43,7 +43,7 @@ local function can_handle_tamper_event(opts, driver, zw_device, cmd, ...)
   -- check exclusion list: if device matches any entry, skip auto-clear
   for _, excluded_device in pairs(excluded_devices) do
     local mfrs          = excluded_device.mfrs
-    local product_types = excluded_device.product_types or nil   
+    local product_types = excluded_device.product_types or nil
     local product_ids   = excluded_device.product_ids   or nil
 
     if mfrs ~= nil then


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [x] I have reviewed the README.md file
          - [x] I have reviewed the CODE_OF_CONDUCT.md file
          - [x] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [x] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Refactored tamper event handling to exclude automatic tamper clearing for specific vendors/products while enabling timed-tamper-clear subdriver for all other Z-Wave sensors.

# Summary of Completed Tests


