### PR TITLE
Matter Camera: Include all supported resolutions

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_utils/fields.lua
@@ -10,6 +10,8 @@ CameraFields.MAX_FRAMES_PER_SECOND = "__max_frames_per_second"
 CameraFields.MAX_VOLUME_LEVEL = "__max_volume_level"
 CameraFields.MIN_VOLUME_LEVEL = "__min_volume_level"
 CameraFields.SUPPORTED_RESOLUTIONS = "__supported_resolutions"
+CameraFields.MAX_RESOLUTION = "__max_resolution"
+CameraFields.MIN_RESOLUTION = "__min_resolution"
 CameraFields.TRIGGERED_ZONES = "__triggered_zones"
 CameraFields.VIEWPORT = "__viewport"
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -683,6 +683,18 @@ local function receive_max_encoded_pixel_rate()
   })
 end
 
+local function receive_min_viewport()
+  test.socket.matter:__queue_receive({
+    mock_device.id,
+    clusters.CameraAvStreamManagement.attributes.MinViewportResolution:build_test_report_data(
+      mock_device, CAMERA_EP, clusters.CameraAvStreamManagement.types.VideoResolutionStruct({
+        width = 1920,
+        height = 1080
+      })
+    )
+  })
+end
+
 local function receive_video_sensor_params()
   test.socket.matter:__queue_receive({
     mock_device.id,
@@ -695,6 +707,15 @@ local function receive_video_sensor_params()
       })
     )
   })
+end
+
+local function emit_min_viewport()
+  test.socket.capability:__expect_send(
+    mock_device:generate_test_message("main", capabilities.cameraViewportSettings.minViewportResolution({
+      width = 1920,
+      height = 1080,
+    }))
+  )
 end
 
 local function emit_video_sensor_parameters()
@@ -719,6 +740,11 @@ local function emit_supported_resolutions()
         width = 3840,
         height = 2160,
         fps = 15
+      },
+      {
+        width = 7360,
+        height = 4912,
+        fps = 0
       }
     }))
   )
@@ -730,12 +756,14 @@ end
 -- videoStreamSettings.supportedResolutions is emitted after all three attributes are received.
 
 test.register_coroutine_test(
-  "Rate Distortion Trade Off Points, MaxEncodedPixelRate, VideoSensorParams reports should generate appropriate events",
+  "Rate Distortion Trade Off Points, MaxEncodedPixelRate, MinViewport, VideoSensorParams reports should generate appropriate events",
   function()
     update_device_profile()
     test.wait_for_events()
     receive_rate_distortion_trade_off_points()
     receive_max_encoded_pixel_rate()
+    receive_min_viewport()
+    emit_min_viewport()
     receive_video_sensor_params()
     emit_video_sensor_parameters()
     emit_supported_resolutions()
@@ -743,11 +771,13 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "Rate Distortion Trade Off Points, VideoSensorParams, MaxEncodedPixelRate reports should generate appropriate events",
+  "Rate Distortion Trade Off Points, MinViewport, VideoSensorParams, MaxEncodedPixelRate reports should generate appropriate events",
   function()
     update_device_profile()
     test.wait_for_events()
     receive_rate_distortion_trade_off_points()
+    receive_min_viewport()
+    emit_min_viewport()
     receive_video_sensor_params()
     emit_video_sensor_parameters()
     receive_max_encoded_pixel_rate()
@@ -756,11 +786,13 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "MaxEncodedPixelRate, VideoSensorParams, Rate Distortion Trade Off Points reports should generate appropriate events",
+  "MaxEncodedPixelRate, MinViewport, VideoSensorParams, Rate Distortion Trade Off Points reports should generate appropriate events",
   function()
     update_device_profile()
     test.wait_for_events()
     receive_max_encoded_pixel_rate()
+    receive_min_viewport()
+    emit_min_viewport()
     receive_video_sensor_params()
     emit_video_sensor_parameters()
     receive_rate_distortion_trade_off_points()


### PR DESCRIPTION
This change adds logic for including the resolutions exposed by the `VideoSensorParams` and `MinViewport` attributes in `supportedResolutions`, rather than only looking at the resolution embedded within `RateDistortionTradeOffPoints`.