### PR TITLE
Matter Camera: Add vision.clipAnalysis capability

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/camera.yml
+++ b/drivers/SmartThings/matter-switch/profiles/camera.yml
@@ -47,6 +47,9 @@ components:
       - id: motionSensor
         version: 1
         optional: true
+      - id: vision.clipAnalysis
+        version: 1
+        optional: true
       - id: firmwareUpdate
         version: 1
       - id: refresh


### PR DESCRIPTION
Add `vision.clipAnalysis` capability to the Matter Camera profile.