### PR TITLE
Add vid/pid of the Aqara U400 to new-matter-lock

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -64,6 +64,7 @@ local NEW_MATTER_LOCK_PRODUCTS = {
   {0x115f, 0x2802}, -- AQARA, U200
   {0x115f, 0x2801}, -- AQARA, U300
   {0x115f, 0x2807}, -- AQARA, U200 Lite
+  {0x115f, 0x2804}, -- AQARA, U400
   {0x147F, 0x0001}, -- U-tec
   {0x147F, 0x0008}, -- Ultraloq, Bolt Smart Matter Door Lock
   {0x144F, 0x4002}, -- Yale, Linus Smart Lock L2


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Add VID/PID of Aqara U400 so that Aqara U400 uses new-matter-lock driver.

# Summary of Completed Tests


