### PR TITLE
run_driver_tests.py: add option to output html coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ lua_libs-api_*
 *.out
 tools/test_output/*
 tools/coverage_output/*
+tools/coverage_output_html/
+tools/__pycache__/
 .DS_Store
 .venv/


### PR DESCRIPTION
This adds an optional argument to the run_driver_tests.py script, which when passed generates HTML coverage reports for the files specified by the --coverage argument. I've found these pretty useful for spotting gaps in code coverage during development.

I've found it particularly useful to use this in a run configuration in my IDE for running `run_driver_tests.py`, with something like this for the script parameters:
```
 --filter $FilePrompt$ --coverage $FilePrompt$ --html
```