### PR TITLE
Hue: fix issue with small color temp increments

### DIFF
--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -158,8 +158,8 @@ local function _emit_light_events_inner(light_device, light_repr)
   end
 end
 
--- A sufficiently small color temp command can round to the same value in mireks that the device has, so the bridge may not respond to it.
--- To avoid any odd in-app behaviors from the app interface, we should emit_event the kelvin value immediately in this case
+-- A sufficiently small color temp command can transform to the same value (in mireks) that a device already has, so the bridge
+-- may not respond to said command. To avoid any odd behaviors in this case, we should emit a kelvin value change event immediately
 function AttributeEmitters.emit_color_temp_when_mirek_unchanged(device, clamped_kelvin, mirek)
   local current_color_temp = device:get_latest_state("main", capabilities.colorTemperature.ID, capabilities.colorTemperature.colorTemperature.NAME)
   if current_color_temp then

--- a/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/attribute_emitters.lua
@@ -158,6 +158,19 @@ local function _emit_light_events_inner(light_device, light_repr)
   end
 end
 
+-- A sufficiently small color temp command can round to the same value in mireks that the device has, so the bridge may not respond to it.
+-- To avoid any odd in-app behaviors from the app interface, we should emit_event the kelvin value immediately in this case
+function AttributeEmitters.emit_color_temp_when_mirek_unchanged(device, clamped_kelvin, mirek)
+  local current_color_temp = device:get_latest_state("main", capabilities.colorTemperature.ID, capabilities.colorTemperature.colorTemperature.NAME)
+  if current_color_temp then
+    local current_mirek = math.floor(utils.kelvin_to_mirek(current_color_temp))
+    if current_mirek == mirek then
+      log.debug(string.format("Color temp change from %dK to %dK results in same mirek value (%d), emitting event directly", current_color_temp, clamped_kelvin, mirek))
+      device:emit_event(capabilities.colorTemperature.colorTemperature(clamped_kelvin))
+    end
+  end
+end
+
 function AttributeEmitters.connectivity_update(child_device, zigbee_status)
   if child_device == nil or (child_device and child_device.id == nil) then
     log.warn("Tried to emit attribute events for a device that has been deleted")

--- a/drivers/SmartThings/philips-hue/src/handlers/commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/commands.lua
@@ -7,6 +7,7 @@ st_utils.stringify_table = st_utils.stringify_table
 local Consts = require "consts"
 local Fields = require "fields"
 local HueColorUtils = require "utils.cie_utils"
+local attribute_emitters = require "handlers.attribute_emitters"
 
 local utils = require "utils"
 
@@ -147,7 +148,6 @@ end
 ---@param device HueChildDevice
 ---@param args table
 local function do_color_temp_action(driver, device, args)
-  local capabilities = require "st.capabilities"
   local kelvin = args.args.temperature
   local light_id, hue_api = get_light_device_id_and_hue_api_module(driver, device)
   if not (light_id and hue_api) then return end
@@ -155,15 +155,7 @@ local function do_color_temp_action(driver, device, args)
   local min = device:get_field(Fields.MIN_KELVIN) or Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE
   local clamped_kelvin = st_utils.clamp_value(kelvin, min, Consts.MAX_TEMP_KELVIN)
   local mirek = math.floor(utils.kelvin_to_mirek(clamped_kelvin))
-
-  local current_color_temp = device:get_latest_state("main", capabilities.colorTemperature.ID, capabilities.colorTemperature.colorTemperature.NAME)
-  if current_color_temp then
-    local current_mirek = math.floor(utils.kelvin_to_mirek(current_color_temp))
-    if current_mirek == mirek then
-      log.debug(string.format("Color temp change from %dK to %dK results in same mirek value (%d), emitting event directly", current_color_temp, clamped_kelvin, mirek))
-      device:emit_event(capabilities.colorTemperature.colorTemperature(clamped_kelvin))
-    end
-  end
+  attribute_emitters.emit_color_temp_when_mirek_unchanged(device, clamped_kelvin, mirek)
 
   local resp, err = hue_api:set_light_color_temp(light_id, mirek)
   log_command_response_errors(resp, err, "color temp action")

--- a/drivers/SmartThings/philips-hue/src/handlers/commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/commands.lua
@@ -147,6 +147,7 @@ end
 ---@param device HueChildDevice
 ---@param args table
 local function do_color_temp_action(driver, device, args)
+  local capabilities = require "st.capabilities"
   local kelvin = args.args.temperature
   local light_id, hue_api = get_light_device_id_and_hue_api_module(driver, device)
   if not (light_id and hue_api) then return end
@@ -154,6 +155,16 @@ local function do_color_temp_action(driver, device, args)
   local min = device:get_field(Fields.MIN_KELVIN) or Consts.MIN_TEMP_KELVIN_WHITE_AMBIANCE
   local clamped_kelvin = st_utils.clamp_value(kelvin, min, Consts.MAX_TEMP_KELVIN)
   local mirek = math.floor(utils.kelvin_to_mirek(clamped_kelvin))
+
+  local current_color_temp = device:get_latest_state("main", capabilities.colorTemperature.ID, capabilities.colorTemperature.colorTemperature.NAME)
+  if current_color_temp then
+    local current_mirek = math.floor(utils.kelvin_to_mirek(current_color_temp))
+    if current_mirek == mirek then
+      log.debug(string.format("Color temp change from %dK to %dK results in same mirek value (%d), emitting event directly", current_color_temp, clamped_kelvin, mirek))
+      device:emit_event(capabilities.colorTemperature.colorTemperature(clamped_kelvin))
+      return
+    end
+  end
 
   local resp, err = hue_api:set_light_color_temp(light_id, mirek)
   log_command_response_errors(resp, err, "color temp action")

--- a/drivers/SmartThings/philips-hue/src/handlers/commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/commands.lua
@@ -162,7 +162,6 @@ local function do_color_temp_action(driver, device, args)
     if current_mirek == mirek then
       log.debug(string.format("Color temp change from %dK to %dK results in same mirek value (%d), emitting event directly", current_color_temp, clamped_kelvin, mirek))
       device:emit_event(capabilities.colorTemperature.colorTemperature(clamped_kelvin))
-      return
     end
   end
 

--- a/drivers/SmartThings/philips-hue/src/handlers/grouped_light_commands.lua
+++ b/drivers/SmartThings/philips-hue/src/handlers/grouped_light_commands.lua
@@ -4,6 +4,7 @@ local Consts = require "consts"
 local Fields = require "fields"
 local HueColorUtils = require "utils.cie_utils"
 local grouped_utils = require "utils.grouped_utils"
+local attribute_emitters = require "handlers.attribute_emitters"
 local utils = require "utils"
 
 
@@ -165,7 +166,6 @@ end
 ---@param args table
 ---@param aux table auxiliary data needed for the command that the devices all had in common
 local function do_color_temp_action(driver, bridge_device, group, args, aux)
-  local capabilities = require "st.capabilities"
   local kelvin = args.args.temperature
 
   local grouped_light_id = group.grouped_light_rid
@@ -187,14 +187,7 @@ local function do_color_temp_action(driver, bridge_device, group, args, aux)
   local mirek = math.floor(utils.kelvin_to_mirek(clamped_kelvin))
 
   for _, device in ipairs(group.devices) do
-    local current_color_temp = device:get_latest_state("main", capabilities.colorTemperature.ID, capabilities.colorTemperature.colorTemperature.NAME)
-    if current_color_temp then
-      local current_mirek = math.floor(utils.kelvin_to_mirek(current_color_temp))
-      if current_mirek == mirek then
-        log.debug(string.format("Color temp change from %dK to %dK results in same mirek value (%d), emitting event directly", current_color_temp, clamped_kelvin, mirek))
-        device:emit_event(capabilities.colorTemperature.colorTemperature(clamped_kelvin))
-      end
-    end
+    attribute_emitters.emit_color_temp_when_mirek_unchanged(device, clamped_kelvin, mirek)
   end
 
   local resp, err = hue_api:set_grouped_light_color_temp(grouped_light_id, mirek)


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

Incrementing or decrementing the color temp by a small amount can lead to the driver sending the Hue bridge the same value in mireds as the device is already set to, and the bridge not responding, which in turn leads to a spinning wheel in the app and eventually the value being reset to its previous value. This change emits the capability with the updated value without waiting for a response from the bridge if the new mireds value would be the same as the previous.
[ ](https://smartthings.atlassian.net/browse/CHAD-17597)

# Summary of Completed Tests

