### PR TITLE
Chad 17092 zwave sensor lazy-loading v2

### DIFF
--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_aeotec_multisensor(opts, self, device, ...)
+  local FINGERPRINTS = require("aeotec-multisensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      local subdriver = require("aeotec-multisensor")
+      return true, subdriver
+    end
+  end
+  return false
+end
+
+return can_handle_aeotec_multisensor

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/fingerprints.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local AEOTEC_MULTISENSOR_FINGERPRINTS = {
+  { manufacturerId = 0x0086, productId = 0x0064 }, -- MultiSensor 6
+  { manufacturerId = 0x0371, productId = 0x0018 }, -- MultiSensor 7
+}
+
+return AEOTEC_MULTISENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
@@ -1,37 +1,11 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
-
-local AEOTEC_MULTISENSOR_FINGERPRINTS = {
-  { manufacturerId = 0x0086, productId = 0x0064 }, -- MultiSensor 6
-  { manufacturerId = 0x0371, productId = 0x0018 }, -- MultiSensor 7
-}
-
-local function can_handle_aeotec_multisensor(opts, self, device, ...)
-  for _, fingerprint in ipairs(AEOTEC_MULTISENSOR_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      local subdriver = require("aeotec-multisensor")
-      return true, subdriver
-    end
-  end
-  return false
-end
 
 local function notification_report_handler(self, device, cmd)
   local event
@@ -61,12 +35,9 @@ local aeotec_multisensor = {
       [Notification.REPORT] = notification_report_handler
     }
   },
-  sub_drivers = {
-    require("aeotec-multisensor/multisensor-6"),
-    require("aeotec-multisensor/multisensor-7")
-  },
+  sub_drivers = require("aeotec-multisensor.sub_drivers"),
   NAME = "aeotec multisensor",
-  can_handle = can_handle_aeotec_multisensor
+  can_handle = require("aeotec-multisensor.can_handle"),
 }
 
 return aeotec_multisensor

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/init.lua
@@ -38,6 +38,7 @@ local aeotec_multisensor = {
   sub_drivers = require("aeotec-multisensor.sub_drivers"),
   NAME = "aeotec multisensor",
   can_handle = require("aeotec-multisensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return aeotec_multisensor

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_multisensor_6(opts, self, device, ...)
+local MULTISENSOR_6_PRODUCT_ID = 0x0064
+  if device.zwave_product_id == MULTISENSOR_6_PRODUCT_ID then
+    return true, require("aeotec-multisensor.multisensor-6")
+  end
+  return false
+end
+return can_handle_multisensor_6

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -19,12 +10,8 @@ local cc = require "st.zwave.CommandClass"
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 2 })
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({version = 2})
 
-local MULTISENSOR_6_PRODUCT_ID = 0x0064
 local PREFERENCE_NUM = 9
 
-local function can_handle_multisensor_6(opts, self, device, ...)
-  return device.zwave_product_id == MULTISENSOR_6_PRODUCT_ID
-end
 
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
@@ -62,7 +49,7 @@ local multisensor_6 = {
     }
   },
   NAME = "aeotec multisensor 6",
-  can_handle = can_handle_multisensor_6
+  can_handle = require("aeotec-multisensor.multisensor-6.can_handle"),
 }
 
 return multisensor_6

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-6/init.lua
@@ -50,6 +50,7 @@ local multisensor_6 = {
   },
   NAME = "aeotec multisensor 6",
   can_handle = require("aeotec-multisensor.multisensor-6.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return multisensor_6

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_multisensor_7(opts, self, device, ...)
+  local MULTISENSOR_7_PRODUCT_ID = 0x0018
+  if device.zwave_product_id == MULTISENSOR_7_PRODUCT_ID then
+    return true, require("aeotec-multisensor.multisensor-7")
+  end
+  return false
+end
+
+return can_handle_multisensor_7

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -19,12 +10,7 @@ local cc = require "st.zwave.CommandClass"
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 2 })
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 2 })
 
-local MULTISENSOR_7_PRODUCT_ID = 0x0018
 local PREFERENCE_NUM = 10
-
-local function can_handle_multisensor_7(opts, self, device, ...)
-  return device.zwave_product_id == MULTISENSOR_7_PRODUCT_ID
-end
 
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
@@ -62,7 +48,7 @@ local multisensor_7 = {
     }
   },
   NAME = "aeotec multisensor 7",
-  can_handle = can_handle_multisensor_7
+  can_handle = require("aeotec-multisensor.multisensor-7.can_handle"),
 }
 
 return multisensor_7

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/multisensor-7/init.lua
@@ -49,6 +49,7 @@ local multisensor_7 = {
   },
   NAME = "aeotec multisensor 7",
   can_handle = require("aeotec-multisensor.multisensor-7.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return multisensor_7

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-multisensor/sub_drivers.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("aeotec-multisensor/multisensor-6"),
+   lazy_load_if_possible("aeotec-multisensor/multisensor-7"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_zwave_water_temp_humidity_sensor(opts, driver, device, ...)
+  local FINGERPRINTS = require("aeotec-water-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      local subdriver = require("aeotec-water-sensor")
+      return true, subdriver
+    end
+  end
+  return false
+end
+
+return can_handle_zwave_water_temp_humidity_sensor

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/fingerprints.lua
@@ -1,0 +1,11 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZWAVE_WATER_TEMP_HUMIDITY_FINGERPRINTS = {
+  { manufacturerId = 0x0371, productType = 0x0002, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro EU
+  { manufacturerId = 0x0371, productType = 0x0102, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro US
+  { manufacturerId = 0x0371, productType = 0x0202, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro AU
+  { manufacturerId = 0x0371, productId = 0x0012 } -- Aeotec Water Sensor 7
+}
+
+return ZWAVE_WATER_TEMP_HUMIDITY_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -18,23 +9,8 @@ local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
 
-local ZWAVE_WATER_TEMP_HUMIDITY_FINGERPRINTS = {
-  { manufacturerId = 0x0371, productType = 0x0002, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro EU
-  { manufacturerId = 0x0371, productType = 0x0102, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro US
-  { manufacturerId = 0x0371, productType = 0x0202, productId = 0x0013 }, -- Aeotec Water Sensor 7 Pro AU
-  { manufacturerId = 0x0371, productId = 0x0012 } -- Aeotec Water Sensor 7
-}
 
 --- Determine whether the passed device is zwave water temperature humidiry sensor
-local function can_handle_zwave_water_temp_humidity_sensor(opts, driver, device, ...)
-  for _, fingerprint in ipairs(ZWAVE_WATER_TEMP_HUMIDITY_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      local subdriver = require("aeotec-water-sensor")
-      return true, subdriver
-    end
-  end
-  return false
-end
 
 --- Default handler for notification command class reports
 ---
@@ -68,7 +44,7 @@ local zwave_water_temp_humidity_sensor = {
     },
   },
   NAME = "zwave water temp humidity sensor",
-  can_handle = can_handle_zwave_water_temp_humidity_sensor
+  can_handle = require("aeotec-water-sensor.can_handle"),
 }
 
 return zwave_water_temp_humidity_sensor

--- a/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/aeotec-water-sensor/init.lua
@@ -45,6 +45,7 @@ local zwave_water_temp_humidity_sensor = {
   },
   NAME = "zwave water temp humidity sensor",
   can_handle = require("aeotec-water-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return zwave_water_temp_humidity_sensor

--- a/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/can_handle.lua
@@ -1,0 +1,35 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local cc = require "st.zwave.CommandClass"
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+
+-- doing refresh would cause incorrect state for device, see comments in wakeup-no-poll
+local NORTEK_FP = {mfr = 0x014F, prod = 0x2001, model = 0x0102} -- NorTek open/close sensor
+local POPP_THERMOSTAT_FP = {mfr = 0x0002, prod = 0x0115, model = 0xA010} --Popp thermostat
+local AEOTEC_MULTISENSOR_6_FP = {mfr = 0x0086, model = 0x0064} --Aeotec multisensor 6
+local AEOTEC_MULTISENSOR_7_FP = {mfr = 0x0371, model = 0x0018} --Aeotec multisensor 7
+local ENERWAVE_MOTION_FP = {mfr = 0x011A} --Enerwave motion sensor
+local HOMESEER_MULTI_SENSOR_FP = {mfr = 0x001E, prod = 0x0002, model = 0x0001} -- Homeseer multi sensor HSM100
+local SENSATIVE_STRIP_FP = {mfr = 0x019A, model = 0x000A}
+local FPS = {NORTEK_FP, POPP_THERMOSTAT_FP,
+             AEOTEC_MULTISENSOR_6_FP, AEOTEC_MULTISENSOR_7_FP,
+             ENERWAVE_MOTION_FP, HOMESEER_MULTI_SENSOR_FP, SENSATIVE_STRIP_FP}
+
+local function can_handle(opts, driver, device, cmd, ...)
+  local version = require "version"
+  if version.api == 6 and
+    cmd.cmd_class == cc.WAKE_UP and
+    cmd.cmd_id == WakeUp.NOTIFICATION then
+
+    for _, fp in ipairs(FPS) do
+      if device:id_match(fp.mfr, fp.prod, fp.model) then return false end
+    end
+    local subdriver = require("apiv6_bugfix")
+    return true, subdriver
+  else
+    return false
+  end
+end
+
+return can_handle

--- a/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/init.lua
@@ -1,33 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 local cc = require "st.zwave.CommandClass"
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
-
--- doing refresh would cause incorrect state for device, see comments in wakeup-no-poll
-local NORTEK_FP = {mfr = 0x014F, prod = 0x2001, model = 0x0102} -- NorTek open/close sensor
-local POPP_THERMOSTAT_FP = {mfr = 0x0002, prod = 0x0115, model = 0xA010} --Popp thermostat
-local AEOTEC_MULTISENSOR_6_FP = {mfr = 0x0086, model = 0x0064} --Aeotec multisensor 6
-local AEOTEC_MULTISENSOR_7_FP = {mfr = 0x0371, model = 0x0018} --Aeotec multisensor 7
-local ENERWAVE_MOTION_FP = {mfr = 0x011A} --Enerwave motion sensor
-local HOMESEER_MULTI_SENSOR_FP = {mfr = 0x001E, prod = 0x0002, model = 0x0001} -- Homeseer multi sensor HSM100
-local SENSATIVE_STRIP_FP = {mfr = 0x019A, model = 0x000A}
-local FPS = {NORTEK_FP, POPP_THERMOSTAT_FP,
-             AEOTEC_MULTISENSOR_6_FP, AEOTEC_MULTISENSOR_7_FP,
-             ENERWAVE_MOTION_FP, HOMESEER_MULTI_SENSOR_FP, SENSATIVE_STRIP_FP}
-
-local function can_handle(opts, driver, device, cmd, ...)
-  local version = require "version"
-  if version.api == 6 and
-    cmd.cmd_class == cc.WAKE_UP and
-    cmd.cmd_id == WakeUp.NOTIFICATION then
-
-    for _, fp in ipairs(FPS) do
-      if device:id_match(fp.mfr, fp.prod, fp.model) then return false end
-    end
-    local subdriver = require("apiv6_bugfix")
-    return true, subdriver
-  else
-    return false
-  end
-end
 
 local function wakeup_notification(driver, device, cmd)
   device:refresh()
@@ -40,7 +15,7 @@ local apiv6_bugfix = {
     }
   },
   NAME = "apiv6_bugfix",
-  can_handle = can_handle
+  can_handle = require("apiv6_bugfix.can_handle"),
 }
 
 return apiv6_bugfix

--- a/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/apiv6_bugfix/init.lua
@@ -16,6 +16,7 @@ local apiv6_bugfix = {
   },
   NAME = "apiv6_bugfix",
   can_handle = require("apiv6_bugfix.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return apiv6_bugfix

--- a/drivers/SmartThings/zwave-sensor/src/configurations.lua
+++ b/drivers/SmartThings/zwave-sensor/src/configurations.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass.Configuration

--- a/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_enerwave_motion_sensor(opts, driver, device, cmd, ...)
+  local ENERWAVE_MFR = 0x011A
+  if device.zwave_manufacturer_id == ENERWAVE_MFR then
+    local subdriver = require("enerwave-motion-sensor")
+    return true, subdriver
+  else return false end
+end
+
+return can_handle_enerwave_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -19,15 +9,6 @@ local cc = require "st.zwave.CommandClass"
 local Association = (require "st.zwave.CommandClass.Association")({version=2})
 --- @type st.zwave.CommandClass.WakeUp
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({version=1})
-
-local ENERWAVE_MFR = 0x011A
-
-local function can_handle_enerwave_motion_sensor(opts, driver, device, cmd, ...)
-  if device.zwave_manufacturer_id == ENERWAVE_MFR then
-    local subdriver = require("enerwave-motion-sensor")
-    return true, subdriver
-  else return false end
-end
 
 local function wakeup_notification(driver, device, cmd)
   --Note sending WakeUpIntervalGet the first time a device wakes up will happen by default in Lua libs 0.49.x and higher
@@ -58,7 +39,7 @@ local enerwave_motion_sensor = {
     doConfigure = do_configure
   },
   NAME = "enerwave_motion_sensor",
-  can_handle = can_handle_enerwave_motion_sensor
+  can_handle = require("enerwave-motion-sensor.can_handle")
 }
 
 return enerwave_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/enerwave-motion-sensor/init.lua
@@ -39,7 +39,8 @@ local enerwave_motion_sensor = {
     doConfigure = do_configure
   },
   NAME = "enerwave_motion_sensor",
-  can_handle = require("enerwave-motion-sensor.can_handle")
+  can_handle = require("enerwave-motion-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return enerwave_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/everspring-motion-light-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/everspring-motion-light-sensor/can_handle.lua
@@ -1,0 +1,17 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_everspring_motion_light(opts, driver, device, ...)
+  local EVERSPRING_MOTION_LIGHT_FINGERPRINT = { mfr = 0x0060, prod = 0x0012, model = 0x0001 }
+  if device:id_match(
+    EVERSPRING_MOTION_LIGHT_FINGERPRINT.mfr,
+    EVERSPRING_MOTION_LIGHT_FINGERPRINT.prod,
+    EVERSPRING_MOTION_LIGHT_FINGERPRINT.model
+  ) then
+    local subdriver = require("everspring-motion-light-sensor")
+    return true, subdriver
+  end
+  return false
+end
+
+return can_handle_everspring_motion_light

--- a/drivers/SmartThings/zwave-sensor/src/everspring-motion-light-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/everspring-motion-light-sensor/init.lua
@@ -1,33 +1,11 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({version=2,strict=true})
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({version=2})
-
-local EVERSPRING_MOTION_LIGHT_FINGERPRINT = { mfr = 0x0060, prod = 0x0012, model = 0x0001 }
-
-local function can_handle_everspring_motion_light(opts, driver, device, ...)
-  if device:id_match(
-    EVERSPRING_MOTION_LIGHT_FINGERPRINT.mfr,
-    EVERSPRING_MOTION_LIGHT_FINGERPRINT.prod,
-    EVERSPRING_MOTION_LIGHT_FINGERPRINT.model
-  ) then
-    local subdriver = require("everspring-motion-light-sensor")
-    return true, subdriver
-  else return false end
-end
 
 local function device_added(driver, device)
   device:emit_event(capabilities.motionSensor.motion.inactive())
@@ -40,7 +18,7 @@ local everspring_motion_light = {
   lifecycle_handlers = {
     added = device_added
   },
-  can_handle = can_handle_everspring_motion_light
+  can_handle = require("everspring-motion-light-sensor.can_handle"),
 }
 
 return everspring_motion_light

--- a/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_ezmultipli_multipurpose_sensor(opts, driver, device, ...)
+  local EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS = { manufacturerId = 0x001E, productType = 0x0004, productId = 0x0001 }
+  if device:id_match(EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS.manufacturerId,
+      EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS.productType,
+      EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS.productId) then
+    local subdriver = require("ezmultipli-multipurpose-sensor")
+    return true, subdriver
+  end
+  return false
+end
+
+return can_handle_ezmultipli_multipurpose_sensor

--- a/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.utils
@@ -27,17 +18,6 @@ local SwitchColor = (require "st.zwave.CommandClass.SwitchColor")({version=1})
 local SwitchBinary = (require "st.zwave.CommandClass.SwitchBinary")({version=2})
 
 local CAP_CACHE_KEY = "st.capabilities." .. capabilities.colorControl.ID
-
-local EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS = { manufacturerId = 0x001E, productType = 0x0004, productId = 0x0001 }
-
-local function can_handle_ezmultipli_multipurpose_sensor(opts, driver, device, ...)
-  if device:id_match(EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS.manufacturerId,
-      EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS.productType,
-      EZMULTIPLI_MULTIPURPOSE_SENSOR_FINGERPRINTS.productId) then
-    local subdriver = require("ezmultipli-multipurpose-sensor")
-    return true, subdriver
-  else return false end
-end
 
 local function basic_report_handler(driver, device, cmd)
   local event
@@ -102,7 +82,7 @@ local ezmultipli_multipurpose_sensor = {
       [capabilities.colorControl.commands.setColor.NAME] = set_color
     }
   },
-  can_handle = can_handle_ezmultipli_multipurpose_sensor
+  can_handle = require("ezmultipli-multipurpose-sensor.can_handle"),
 }
 
 return ezmultipli_multipurpose_sensor

--- a/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/ezmultipli-multipurpose-sensor/init.lua
@@ -83,6 +83,7 @@ local ezmultipli_multipurpose_sensor = {
     }
   },
   can_handle = require("ezmultipli-multipurpose-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return ezmultipli_multipurpose_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_door_window_sensor(opts, driver, device, ...)
+  local FINGERPRINTS = require("fibaro-door-window-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.prod, fingerprint.productId) then
+      local subdriver = require("fibaro-door-window-sensor")
+      return true, subdriver
+    end
+  end
+  return false
+end
+
+return can_handle_fibaro_door_window_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_door_window_sensor_1(opts, driver, device, cmd, ...)
+  local FINGERPRINTS = require("fibaro-door-window-sensor.fibaro-door-window-sensor-1.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("fibaro-door-window-sensor.fibaro-door-window-sensor-1")
+    end
+  end
+  return false
+end
+
+return can_handle_fibaro_door_window_sensor_1

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/fingerprints.lua
@@ -1,0 +1,8 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FIBARO_DOOR_WINDOW_SENSOR_1_FINGERPRINTS = {
+  { manufacturerId = 0x010F, prod = 0x0501, productId = 0x1002 }
+}
+
+return FIBARO_DOOR_WINDOW_SENSOR_1_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
@@ -20,19 +9,6 @@ local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=
 local SensorAlarm = (require "st.zwave.CommandClass.SensorAlarm")({ version = 1 })
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 1 })
 local configurationsMap = require "configurations"
-
-local FIBARO_DOOR_WINDOW_SENSOR_1_FINGERPRINTS = {
-  { manufacturerId = 0x010F, prod = 0x0501, productId = 0x1002 }
-}
-
-local function can_handle_fibaro_door_window_sensor_1(opts, driver, device, cmd, ...)
-  for _, fingerprint in ipairs(FIBARO_DOOR_WINDOW_SENSOR_1_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function sensor_alarm_report_handler(driver, device, cmd)
   if (cmd.args.sensor_state == SensorAlarm.sensor_state.ALARM) then
@@ -92,7 +68,7 @@ local fibaro_door_window_sensor_1 = {
   [capabilities.refresh.ID] = {
     [capabilities.refresh.commands.refresh.NAME] = do_refresh
   },
-  can_handle = can_handle_fibaro_door_window_sensor_1
+  can_handle = require("fibaro-door-window-sensor.fibaro-door-window-sensor-1.can_handle"),
 }
 
 return fibaro_door_window_sensor_1

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-1/init.lua
@@ -69,6 +69,7 @@ local fibaro_door_window_sensor_1 = {
     [capabilities.refresh.commands.refresh.NAME] = do_refresh
   },
   can_handle = require("fibaro-door-window-sensor.fibaro-door-window-sensor-1.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return fibaro_door_window_sensor_1

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_door_window_sensor_2(opts, driver, device, cmd, ...)
+  local FINGERPRINTS = require("fibaro-door-window-sensor.fibaro-door-window-sensor-2.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      return true, require("fibaro-door-window-sensor.fibaro-door-window-sensor-2")
+    end
+  end
+  return false
+end
+
+return can_handle_fibaro_door_window_sensor_2

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FIBARO_DOOR_WINDOW_SENSOR_2_FINGERPRINTS = {
+  { manufacturerId = 0x010F, productType = 0x0702, productId = 0x1000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / Europe
+  { manufacturerId = 0x010F, productType = 0x0702, productId = 0x2000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / NA
+  { manufacturerId = 0x010F, productType = 0x0702, productId = 0x3000 } -- Fibaro Open/Closed Sensor 2 (FGDW-002) / ANZ
+}
+
+return FIBARO_DOOR_WINDOW_SENSOR_2_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
@@ -1,37 +1,11 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Alarm
 local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 2 })
-
-local FIBARO_DOOR_WINDOW_SENSOR_2_FINGERPRINTS = {
-  { manufacturerId = 0x010F, productType = 0x0702, productId = 0x1000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / Europe
-  { manufacturerId = 0x010F, productType = 0x0702, productId = 0x2000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / NA
-  { manufacturerId = 0x010F, productType = 0x0702, productId = 0x3000 } -- Fibaro Open/Closed Sensor 2 (FGDW-002) / ANZ
-}
-
-local function can_handle_fibaro_door_window_sensor_2(opts, driver, device, cmd, ...)
-  for _, fingerprint in ipairs(FIBARO_DOOR_WINDOW_SENSOR_2_FINGERPRINTS) do
-    if device:id_match( fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      return true
-    end
-  end
-  return false
-end
 
 local function emit_event_if_latest_state_missing(device, component, capability, attribute_name, value)
   if device:get_latest_state(component, capability.ID, attribute_name) == nil then
@@ -83,7 +57,7 @@ local fibaro_door_window_sensor_2 = {
   lifecycle_handlers = {
     added = device_added
   },
-  can_handle = can_handle_fibaro_door_window_sensor_2,
+  can_handle = require("fibaro-door-window-sensor.fibaro-door-window-sensor-2.can_handle"),
 }
 
 return fibaro_door_window_sensor_2

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fibaro-door-window-sensor-2/init.lua
@@ -58,6 +58,7 @@ local fibaro_door_window_sensor_2 = {
     added = device_added
   },
   can_handle = require("fibaro-door-window-sensor.fibaro-door-window-sensor-2.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return fibaro_door_window_sensor_2

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/fingerprints.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local FIBARO_DOOR_WINDOW_SENSOR_FINGERPRINTS = {
+  { manufacturerId = 0x010F, prod = 0x0700, productId = 0x1000 }, -- Fibaro Open/Closed Sensor (FGK-10x) / Europe
+  { manufacturerId = 0x010F, prod = 0x0700, productId = 0x2000 }, -- Fibaro Open/Closed Sensor (FGK-10x) / NA
+  { manufacturerId = 0x010F, prod = 0x0702, productId = 0x1000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / Europe
+  { manufacturerId = 0x010F, prod = 0x0702, productId = 0x2000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / NA
+  { manufacturerId = 0x010F, prod = 0x0702, productId = 0x3000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / ANZ
+  { manufacturerId = 0x010F, prod = 0x0701, productId = 0x2001 }, -- Fibaro Open/Closed Sensor with temperature (FGK-10X) / NA
+  { manufacturerId = 0x010F, prod = 0x0701, productId = 0x1001 }, -- Fibaro Open/Closed Sensor
+  { manufacturerId = 0x010F, prod = 0x0501, productId = 0x1002 }  -- Fibaro Open/Closed Sensor
+}
+
+return FIBARO_DOOR_WINDOW_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local cc = require "st.zwave.CommandClass"
 local capabilities = require "st.capabilities"
@@ -23,27 +12,6 @@ local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 2 })
 local preferencesMap = require "preferences"
 
 local FIBARO_DOOR_WINDOW_SENSOR_WAKEUP_INTERVAL = 21600 --seconds
-
-local FIBARO_DOOR_WINDOW_SENSOR_FINGERPRINTS = {
-  { manufacturerId = 0x010F, prod = 0x0700, productId = 0x1000 }, -- Fibaro Open/Closed Sensor (FGK-10x) / Europe
-  { manufacturerId = 0x010F, prod = 0x0700, productId = 0x2000 }, -- Fibaro Open/Closed Sensor (FGK-10x) / NA
-  { manufacturerId = 0x010F, prod = 0x0702, productId = 0x1000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / Europe
-  { manufacturerId = 0x010F, prod = 0x0702, productId = 0x2000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / NA
-  { manufacturerId = 0x010F, prod = 0x0702, productId = 0x3000 }, -- Fibaro Open/Closed Sensor 2 (FGDW-002) / ANZ
-  { manufacturerId = 0x010F, prod = 0x0701, productId = 0x2001 }, -- Fibaro Open/Closed Sensor with temperature (FGK-10X) / NA
-  { manufacturerId = 0x010F, prod = 0x0701, productId = 0x1001 }, -- Fibaro Open/Closed Sensor
-  { manufacturerId = 0x010F, prod = 0x0501, productId = 0x1002 }  -- Fibaro Open/Closed Sensor
-}
-
-local function can_handle_fibaro_door_window_sensor(opts, driver, device, ...)
-  for _, fingerprint in ipairs(FIBARO_DOOR_WINDOW_SENSOR_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.prod, fingerprint.productId) then
-      local subdriver = require("fibaro-door-window-sensor")
-      return true, subdriver
-    end
-  end
-  return false
-end
 
 local function parameterNumberToParameterName(preferences,parameterNumber)
   for id, parameter in pairs(preferences) do
@@ -154,11 +122,8 @@ local fibaro_door_window_sensor = {
       [capabilities.refresh.commands.refresh.NAME] = do_refresh
     }
   },
-  sub_drivers = {
-    require("fibaro-door-window-sensor/fibaro-door-window-sensor-1"),
-    require("fibaro-door-window-sensor/fibaro-door-window-sensor-2")
-  },
-  can_handle = can_handle_fibaro_door_window_sensor
+  sub_drivers = require("fibaro-door-window-sensor.sub_drivers"),
+  can_handle = require("fibaro-door-window-sensor.can_handle"),
 }
 
 return fibaro_door_window_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/init.lua
@@ -124,6 +124,7 @@ local fibaro_door_window_sensor = {
   },
   sub_drivers = require("fibaro-door-window-sensor.sub_drivers"),
   can_handle = require("fibaro-door-window-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return fibaro_door_window_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-door-window-sensor/sub_drivers.lua
@@ -1,0 +1,9 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require "lazy_load_subdriver"
+local sub_drivers = {
+   lazy_load_if_possible("fibaro-door-window-sensor/fibaro-door-window-sensor-1"),
+   lazy_load_if_possible("fibaro-door-window-sensor/fibaro-door-window-sensor-2"),
+}
+return sub_drivers

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_flood_sensor(opts, driver, device, ...)
+    local FIBARO_MFR_ID = 0x010F
+    local FIBARO_FLOOD_PROD_TYPES = { 0x0000, 0x0B00 }
+    if device:id_match(FIBARO_MFR_ID, FIBARO_FLOOD_PROD_TYPES, nil) then
+        local subdriver = require("fibaro-flood-sensor")
+        return true, subdriver
+    end
+    return false
+end
+
+return can_handle_fibaro_flood_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -25,17 +16,6 @@ local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 
 
 local preferences = require "preferences"
 local configurations = require "configurations"
-
-local FIBARO_MFR_ID = 0x010F
-local FIBARO_FLOOD_PROD_TYPES = { 0x0000, 0x0B00 }
-
-local function can_handle_fibaro_flood_sensor(opts, driver, device, ...)
-  if device:id_match(FIBARO_MFR_ID, FIBARO_FLOOD_PROD_TYPES, nil) then
-    local subdriver = require("fibaro-flood-sensor")
-    return true, subdriver
-  else return false end
-end
-
 
 local function basic_set_handler(self, device, cmd)
   local value = cmd.args.target_value and cmd.args.target_value or cmd.args.value
@@ -96,7 +76,7 @@ local fibaro_flood_sensor = {
   lifecycle_handlers = {
     doConfigure = do_configure
   },
-  can_handle = can_handle_fibaro_flood_sensor
+  can_handle = require("fibaro-flood-sensor.can_handle"),
 }
 
 return fibaro_flood_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-flood-sensor/init.lua
@@ -77,6 +77,7 @@ local fibaro_flood_sensor = {
     doConfigure = do_configure
   },
   can_handle = require("fibaro-flood-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return fibaro_flood_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_fibaro_motion_sensor(opts, driver, device, ...)
+
+  local FIBARO_MOTION_MFR = 0x010F
+  local FIBARO_MOTION_PROD = 0x0800
+  if device:id_match(FIBARO_MOTION_MFR, FIBARO_MOTION_PROD) then
+    local subdriver = require("fibaro-motion-sensor")
+    return true, subdriver
+  end
+  return false
+end
+
+return can_handle_fibaro_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
@@ -18,15 +8,6 @@ local cc = require "st.zwave.CommandClass"
 local SensorAlarm = (require "st.zwave.CommandClass.SensorAlarm")({ version = 1 })
 local capabilities = require "st.capabilities"
 
-local FIBARO_MOTION_MFR = 0x010F
-local FIBARO_MOTION_PROD = 0x0800
-
-local function can_handle_fibaro_motion_sensor(opts, driver, device, ...)
-  if device:id_match(FIBARO_MOTION_MFR, FIBARO_MOTION_PROD) then
-    local subdriver = require("fibaro-motion-sensor")
-    return true, subdriver
-  else return false end
-end
 
 local function sensor_alarm_report(driver, device, cmd)
   if (cmd.args.sensor_state ~= SensorAlarm.sensor_state.NO_ALARM) then
@@ -43,7 +24,7 @@ local fibaro_motion_sensor = {
       [SensorAlarm.REPORT] = sensor_alarm_report
     }
   },
-  can_handle = can_handle_fibaro_motion_sensor
+  can_handle = require("fibaro-motion-sensor.can_handle")
 }
 
 return fibaro_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/fibaro-motion-sensor/init.lua
@@ -24,7 +24,8 @@ local fibaro_motion_sensor = {
       [SensorAlarm.REPORT] = sensor_alarm_report
     }
   },
-  can_handle = require("fibaro-motion-sensor.can_handle")
+  can_handle = require("fibaro-motion-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return fibaro_motion_sensor

--- a/drivers/SmartThings/zwave-sensor/src/firmware-version/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/firmware-version/can_handle.lua
@@ -1,0 +1,21 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local capabilities = require "st.capabilities"
+
+--This sub_driver will populate the currentVersion (firmware) when the firmwareUpdate capability is enabled
+local FINGERPRINTS = {
+  { manufacturerId = 0x027A, productType = 0x7000, productId = 0xE002 } -- Zooz ZSE42 Water Sensor
+}
+
+return function(opts, driver, device, ...)
+  if device:supports_capability_by_id(capabilities.firmwareUpdate.ID) then
+    for _, fingerprint in ipairs(FINGERPRINTS) do
+      if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+        local subDriver = require("firmware-version")
+        return true, subDriver
+      end
+    end
+  end
+  return false
+end

--- a/drivers/SmartThings/zwave-sensor/src/firmware-version/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/firmware-version/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2025 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -20,22 +10,6 @@ local Version = (require "st.zwave.CommandClass.Version")({ version = 1 })
 --- @type st.zwave.CommandClass.WakeUp
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
---This sub_driver will populate the currentVersion (firmware) when the firmwareUpdate capability is enabled
-local FINGERPRINTS = {
-  { manufacturerId = 0x027A, productType = 0x7000, productId = 0xE002 } -- Zooz ZSE42 Water Sensor
-}
-
-local function can_handle_fw(opts, driver, device, ...)
-  if device:supports_capability_by_id(capabilities.firmwareUpdate.ID) then
-    for _, fingerprint in ipairs(FINGERPRINTS) do
-      if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-        local subDriver = require("firmware-version")
-        return true, subDriver
-      end
-    end
-  end
-  return false
-end
 
 --Runs upstream handlers (ex zwave_handlers)
 local function call_parent_handler(handlers, self, device, event, args)
@@ -73,7 +47,7 @@ end
 
 local firmware_version = {
   NAME = "firmware_version",
-  can_handle = can_handle_fw,
+  can_handle = require("firmware-version.can_handle"),
 
   lifecycle_handlers = {
     added = added_handler,

--- a/drivers/SmartThings/zwave-sensor/src/firmware-version/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/firmware-version/init.lua
@@ -59,7 +59,8 @@ local firmware_version = {
     [cc.WAKE_UP] = {
       [WakeUp.NOTIFICATION] = wakeup_notification
     }
-  }
+  },
+  shared_device_thread_enabled = true,
 }
 
 return firmware_version

--- a/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/can_handle.lua
@@ -1,0 +1,20 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+--- Determine whether the passed device is glentronics water leak sensor
+---
+--- @param driver Driver driver instance
+--- @param device Device device isntance
+--- @return boolean true if the device proper, else false
+local function can_handle_glentronics_water_leak_sensor(opts, driver, device, ...)
+  local GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS = { manufacturerId = 0x0084, productType = 0x0093, productId = 0x0114 } -- glentronics water leak sensor
+  if device:id_match(
+      GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS.manufacturerId,
+      GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS.productType,
+      GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS.productId) then
+    return true, require("glentronics-water-leak-sensor")
+  end
+  return false
+end
+
+return can_handle_glentronics_water_leak_sensor

--- a/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/init.lua
@@ -1,39 +1,13 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
-
-local GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS = { manufacturerId = 0x0084, productType = 0x0093, productId = 0x0114 } -- glentronics water leak sensor
-
---- Determine whether the passed device is glentronics water leak sensor
----
---- @param driver Driver driver instance
---- @param device Device device isntance
---- @return boolean true if the device proper, else false
-local function can_handle_glentronics_water_leak_sensor(opts, driver, device, ...)
-  if device:id_match(
-      GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS.manufacturerId,
-      GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS.productType,
-      GLENTRONICS_WATER_LEAK_SENSOR_FINGERPRINTS.productId) then
-    local subdriver = require("glentronics-water-leak-sensor")
-    return true, subdriver
-  else return false end
-end
 
 local function notification_report_handler(self, device, cmd)
   local event
@@ -78,7 +52,7 @@ local glentronics_water_leak_sensor = {
     added = device_added
   },
   NAME = "glentronics water leak sensor",
-  can_handle = can_handle_glentronics_water_leak_sensor
+  can_handle = require("glentronics-water-leak-sensor.can_handle"),
 }
 
 return glentronics_water_leak_sensor

--- a/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/glentronics-water-leak-sensor/init.lua
@@ -53,6 +53,7 @@ local glentronics_water_leak_sensor = {
   },
   NAME = "glentronics water leak sensor",
   can_handle = require("glentronics-water-leak-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return glentronics_water_leak_sensor

--- a/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/can_handle.lua
@@ -1,0 +1,20 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+--- Determine whether the passed device is homeseer multi sensor
+---
+--- @param driver Driver driver instance
+--- @param device Device device instance
+--- @return boolean true if the device proper, else false
+local function can_handle_homeseer_multi_sensor(opts, driver, device, ...)
+    local HOMESEER_MULTI_SENSOR_FINGERPRINTS = { manufacturerId = 0x001E, productType = 0x0002, productId = 0x0001 } -- Homeseer multi sensor HSM100
+    if device:id_match(
+      HOMESEER_MULTI_SENSOR_FINGERPRINTS.manufacturerId,
+      HOMESEER_MULTI_SENSOR_FINGERPRINTS.productType,
+      HOMESEER_MULTI_SENSOR_FINGERPRINTS.productId) then
+        return true, require("homeseer-multi-sensor")
+    end
+    return false
+end
+
+return can_handle_homeseer_multi_sensor

--- a/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -21,23 +12,6 @@ local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({version = 5})
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1})
-
-local HOMESEER_MULTI_SENSOR_FINGERPRINTS = { manufacturerId = 0x001E, productType = 0x0002, productId = 0x0001 } -- Homeseer multi sensor HSM100
-
---- Determine whether the passed device is homeseer multi sensor
----
---- @param driver Driver driver instance
---- @param device Device device instance
---- @return boolean true if the device proper, else false
-local function can_handle_homeseer_multi_sensor(opts, driver, device, ...)
-  if device:id_match(
-      HOMESEER_MULTI_SENSOR_FINGERPRINTS.manufacturerId,
-      HOMESEER_MULTI_SENSOR_FINGERPRINTS.productType,
-      HOMESEER_MULTI_SENSOR_FINGERPRINTS.productId) then
-    local subdriver = require("homeseer-multi-sensor")
-    return true, subdriver
-  else return false end
-end
 
 local function basic_set_handler(self, device, cmd)
   if cmd.args.value ~= nil then
@@ -87,7 +61,7 @@ local homeseer_multi_sensor = {
     init = device_init,
   },
   NAME = "homeseer multi sensor",
-  can_handle = can_handle_homeseer_multi_sensor
+  can_handle = require("homeseer-multi-sensor.can_handle"),
 }
 
 return homeseer_multi_sensor

--- a/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/homeseer-multi-sensor/init.lua
@@ -62,6 +62,7 @@ local homeseer_multi_sensor = {
   },
   NAME = "homeseer multi sensor",
   can_handle = require("homeseer-multi-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return homeseer_multi_sensor

--- a/drivers/SmartThings/zwave-sensor/src/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -26,19 +15,6 @@ local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
 local preferences = require "preferences"
 local configurations = require "configurations"
-
-local function lazy_load_if_possible(sub_driver_name)
-  -- gets the current lua libs api version
-  local version = require "version"
-
-  -- version 9 will include the lazy loading functions
-  if version.api >= 9 then
-    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
-  else
-    return require(sub_driver_name)
-  end
-
-end
 
 --- Handle preference changes
 ---
@@ -134,27 +110,7 @@ local driver_template = {
     capabilities.powerMeter,
     capabilities.smokeDetector
   },
-  sub_drivers = {
-    lazy_load_if_possible("zooz-4-in-1-sensor"),
-    lazy_load_if_possible("vision-motion-detector"),
-    lazy_load_if_possible("fibaro-flood-sensor"),
-    lazy_load_if_possible("aeotec-water-sensor"),
-    lazy_load_if_possible("glentronics-water-leak-sensor"),
-    lazy_load_if_possible("homeseer-multi-sensor"),
-    lazy_load_if_possible("fibaro-door-window-sensor"),
-    lazy_load_if_possible("sensative-strip"),
-    lazy_load_if_possible("enerwave-motion-sensor"),
-    lazy_load_if_possible("aeotec-multisensor"),
-    lazy_load_if_possible("zwave-water-leak-sensor"),
-    lazy_load_if_possible("everspring-motion-light-sensor"),
-    lazy_load_if_possible("ezmultipli-multipurpose-sensor"),
-    lazy_load_if_possible("fibaro-motion-sensor"),
-    lazy_load_if_possible("v1-contact-event"),
-    lazy_load_if_possible("timed-tamper-clear"),
-    lazy_load_if_possible("wakeup-no-poll"),
-    lazy_load_if_possible("firmware-version"),
-    lazy_load_if_possible("apiv6_bugfix"),
-  },
+  sub_drivers = require("sub_drivers"),
   lifecycle_handlers = {
     added = added_handler,
     init = device_init,

--- a/drivers/SmartThings/zwave-sensor/src/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/init.lua
@@ -125,6 +125,7 @@ local driver_template = {
       [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
+  shared_device_thread_enabled = true,
 }
 
 defaults.register_for_default_handlers(driver_template,

--- a/drivers/SmartThings/zwave-sensor/src/lazy_load_subdriver.lua
+++ b/drivers/SmartThings/zwave-sensor/src/lazy_load_subdriver.lua
@@ -1,0 +1,18 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
+return function(sub_driver_name)
+  -- gets the current lua libs api version
+  local ZwaveDriver = require "st.zwave.driver"
+  local version = require "version"
+
+  if version.api >= 16 then
+    return ZwaveDriver.lazy_load_sub_driver_v2(sub_driver_name)
+  elseif version.api >= 9 then
+    return ZwaveDriver.lazy_load_sub_driver(require(sub_driver_name))
+  else
+    return require(sub_driver_name)
+  end
+
+end

--- a/drivers/SmartThings/zwave-sensor/src/preferences.lua
+++ b/drivers/SmartThings/zwave-sensor/src/preferences.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 --- @type st.zwave.CommandClass.Configuration
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version=4 })

--- a/drivers/SmartThings/zwave-sensor/src/sensative-strip/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sensative-strip/can_handle.lua
@@ -1,0 +1,14 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_sensative_strip(opts, driver, device, cmd, ...)
+  local SENSATIVE_MFR = 0x019A
+  local SENSATIVE_MODEL = 0x000A
+  if device:id_match(SENSATIVE_MFR, nil, SENSATIVE_MODEL) then
+    local subdriver = require("sensative-strip")
+    return true, subdriver
+  end
+  return false
+end
+
+return can_handle_sensative_strip

--- a/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
@@ -19,19 +9,10 @@ local Configuration = (require "st.zwave.CommandClass.Configuration")({ version 
 --- @type st.zwave.CommandClass.WakeUp
 local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 
-local SENSATIVE_MFR = 0x019A
-local SENSATIVE_MODEL = 0x000A
 local LEAKAGE_ALARM_PARAM = 12
 local LEAKAGE_ALARM_OFF = 0
 local SENSATIVE_COMFORT_PROFILE = "illuminance-temperature"
 local CONFIG_REPORT_RECEIVED = "configReportReceived"
-
-local function can_handle_sensative_strip(opts, driver, device, cmd, ...)
-  if device:id_match(SENSATIVE_MFR, nil, SENSATIVE_MODEL) then
-    local subdriver = require("sensative-strip")
-    return true, subdriver
-  else return false end
-end
 
 local function configuration_report(driver, device, cmd)
   local parameter_number = cmd.args.parameter_number
@@ -75,7 +56,7 @@ local sensative_strip = {
     doConfigure = do_configure
   },
   NAME = "sensative_strip",
-  can_handle = can_handle_sensative_strip
+  can_handle = require("sensative-strip.can_handle")
 }
 
 return sensative_strip

--- a/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sensative-strip/init.lua
@@ -56,7 +56,8 @@ local sensative_strip = {
     doConfigure = do_configure
   },
   NAME = "sensative_strip",
-  can_handle = require("sensative-strip.can_handle")
+  can_handle = require("sensative-strip.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return sensative_strip

--- a/drivers/SmartThings/zwave-sensor/src/sub_drivers.lua
+++ b/drivers/SmartThings/zwave-sensor/src/sub_drivers.lua
@@ -1,0 +1,26 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local lazy_load_if_possible = require("lazy_load_subdriver")
+
+return {
+    lazy_load_if_possible("zooz-4-in-1-sensor"),
+    lazy_load_if_possible("vision-motion-detector"),
+    lazy_load_if_possible("fibaro-flood-sensor"),
+    lazy_load_if_possible("aeotec-water-sensor"),
+    lazy_load_if_possible("glentronics-water-leak-sensor"),
+    lazy_load_if_possible("homeseer-multi-sensor"),
+    lazy_load_if_possible("fibaro-door-window-sensor"),
+    lazy_load_if_possible("sensative-strip"),
+    lazy_load_if_possible("enerwave-motion-sensor"),
+    lazy_load_if_possible("aeotec-multisensor"),
+    lazy_load_if_possible("zwave-water-leak-sensor"),
+    lazy_load_if_possible("everspring-motion-light-sensor"),
+    lazy_load_if_possible("ezmultipli-multipurpose-sensor"),
+    lazy_load_if_possible("fibaro-motion-sensor"),
+    lazy_load_if_possible("v1-contact-event"),
+    lazy_load_if_possible("timed-tamper-clear"),
+    lazy_load_if_possible("wakeup-no-poll"),
+    lazy_load_if_possible("firmware-version"),
+    lazy_load_if_possible("apiv6_bugfix"),
+}

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeon_multisensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeon_multisensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_7.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_7.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_gen5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_gen5.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor_7.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor_7.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_enerwave_motion_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_enerwave_motion_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everpsring_sp817.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everpsring_sp817.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_PIR_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_PIR_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_ST814.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_ST814.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_illuminance_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_illuminance_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_motion_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_motion_light_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_ezmultipli_multipurpose_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_ezmultipli_multipurpose_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_1.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_1.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_2.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_2.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor_zw5.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor_zw5.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_generic_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_generic_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_glentronics_water_leak_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_glentronics_water_leak_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_homeseer_multi_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_homeseer_multi_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_no_wakeup_poll.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_no_wakeup_poll.lua
@@ -1,16 +1,6 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
@@ -115,4 +105,3 @@ test.register_message_test(
 )
 
 test.run_registered_tests()
-

--- a/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local zw = require "st.zwave"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_smartthings_water_leak_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_smartthings_water_leak_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_v1_contact_event.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_v1_contact_event.lua
@@ -1,16 +1,6 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_vision_motion_detector.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_vision_motion_detector.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zooz_4_in_1_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zooz_4_in_1_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_light_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_temp_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_temp_light_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_water_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_water_sensor.lua
@@ -1,16 +1,6 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
 
 local test = require "integration_test"
 local capabilities = require "st.capabilities"

--- a/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/can_handle.lua
@@ -1,0 +1,23 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_tamper_event(opts, driver, device, cmd, ...)
+  local cc = require "st.zwave.CommandClass"
+  local Notification = (require "st.zwave.CommandClass.Notification")({ version = 4 })
+  local FIBARO_DOOR_WINDOW_MFR_ID = 0x010F
+
+  if device.zwave_manufacturer_id ~= FIBARO_DOOR_WINDOW_MFR_ID and
+    opts.dispatcher_class == "ZwaveDispatcher" and
+    cmd ~= nil and
+    cmd.cmd_class ~= nil and
+    cmd.cmd_class == cc.NOTIFICATION and
+    cmd.cmd_id == Notification.REPORT and
+    cmd.args.notification_type == Notification.notification_type.HOME_SECURITY and
+    (cmd.args.event == Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED or
+    cmd.args.event == Notification.event.home_security.TAMPERING_PRODUCT_MOVED) then
+      return true, require("timed-tamper-clear")
+    end
+    return false
+end
+
+return can_handle_tamper_event

--- a/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
@@ -20,23 +11,6 @@ local capabilities = require "st.capabilities"
 
 local TAMPER_TIMER = "_tamper_timer"
 local TAMPER_CLEAR = 10
-local FIBARO_DOOR_WINDOW_MFR_ID = 0x010F
-
-local function can_handle_tamper_event(opts, driver, device, cmd, ...)
-  if device.zwave_manufacturer_id ~= FIBARO_DOOR_WINDOW_MFR_ID and
-    opts.dispatcher_class == "ZwaveDispatcher" and
-    cmd ~= nil and
-    cmd.cmd_class ~= nil and
-    cmd.cmd_class == cc.NOTIFICATION and
-    cmd.cmd_id == Notification.REPORT and
-    cmd.args.notification_type == Notification.notification_type.HOME_SECURITY and
-    (cmd.args.event == Notification.event.home_security.TAMPERING_PRODUCT_COVER_REMOVED or
-    cmd.args.event == Notification.event.home_security.TAMPERING_PRODUCT_MOVED) then
-      local subdriver = require("timed-tamper-clear")
-      return true, subdriver
-    else return false
-    end
-end
 
 -- This behavior is from zwave-door-window-sensor.groovy. We've seen this behavior
 -- in Ecolink and several other z-wave sensors that do not send tamper clear events
@@ -60,7 +34,7 @@ local timed_tamper_clear = {
     }
   },
   NAME = "timed tamper clear",
-  can_handle = can_handle_tamper_event
+  can_handle = require("timed-tamper-clear.can_handle"),
 }
 
 return timed_tamper_clear

--- a/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/timed-tamper-clear/init.lua
@@ -35,6 +35,7 @@ local timed_tamper_clear = {
   },
   NAME = "timed tamper clear",
   can_handle = require("timed-tamper-clear.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return timed_tamper_clear

--- a/drivers/SmartThings/zwave-sensor/src/v1-contact-event/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/v1-contact-event/can_handle.lua
@@ -1,0 +1,22 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_v1_contact_event(opts, driver, device, cmd, ...)
+  local cc = require "st.zwave.CommandClass"
+  local Notification = (require "st.zwave.CommandClass.Notification")({ version = 4 })
+
+  if opts.dispatcher_class == "ZwaveDispatcher" and
+    cmd ~= nil and
+    cmd.cmd_class ~= nil and
+    cmd.cmd_class == cc.NOTIFICATION and
+    cmd.cmd_id == Notification.REPORT and
+    cmd.args.notification_type == Notification.notification_type.HOME_SECURITY and
+    cmd.args.v1_alarm_type == 0x07 then
+      local subdriver = require("v1-contact-event")
+      return true, subdriver
+    else
+      return false
+    end
+end
+
+return can_handle_v1_contact_event

--- a/drivers/SmartThings/zwave-sensor/src/v1-contact-event/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/v1-contact-event/init.lua
@@ -1,16 +1,5 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
@@ -18,20 +7,6 @@ local cc = require "st.zwave.CommandClass"
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 4 })
 local capabilities = require "st.capabilities"
 
-local function can_handle_v1_contact_event(opts, driver, device, cmd, ...)
-  if opts.dispatcher_class == "ZwaveDispatcher" and
-    cmd ~= nil and
-    cmd.cmd_class ~= nil and
-    cmd.cmd_class == cc.NOTIFICATION and
-    cmd.cmd_id == Notification.REPORT and
-    cmd.args.notification_type == Notification.notification_type.HOME_SECURITY and
-    cmd.args.v1_alarm_type == 0x07 then
-      local subdriver = require("v1-contact-event")
-      return true, subdriver
-    else
-      return false
-    end
-end
 
 -- This behavior is from zwave-door-window-sensor.groovy, where it is
 -- indicated that certain monoprice sensors had this behavior. Also,
@@ -53,7 +28,7 @@ local v1_contact_event = {
     }
   },
   NAME = "v1 contact event",
-  can_handle = can_handle_v1_contact_event
+  can_handle = require("v1-contact-event.can_handle"),
 }
 
 return v1_contact_event

--- a/drivers/SmartThings/zwave-sensor/src/v1-contact-event/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/v1-contact-event/init.lua
@@ -29,6 +29,7 @@ local v1_contact_event = {
   },
   NAME = "v1 contact event",
   can_handle = require("v1-contact-event.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return v1_contact_event

--- a/drivers/SmartThings/zwave-sensor/src/vision-motion-detector/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/vision-motion-detector/can_handle.lua
@@ -1,0 +1,17 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+--- Determine whether the passed device is zwave-plus-motion-temp-sensor
+local function can_handle_vision_motion_detector(opts, driver, device, ...)
+  local VISION_MOTION_DETECTOR_FINGERPRINTS = { manufacturerId = 0x0109, productType = 0x2002, productId = 0x0205 } -- Vision Motion Detector ZP3102
+  if device:id_match(
+    VISION_MOTION_DETECTOR_FINGERPRINTS.manufacturerId,
+    VISION_MOTION_DETECTOR_FINGERPRINTS.productType,
+    VISION_MOTION_DETECTOR_FINGERPRINTS.productId
+  ) then
+    return true, require("vision-motion-detector")
+  end
+  return false
+end
+
+return can_handle_vision_motion_detector

--- a/drivers/SmartThings/zwave-sensor/src/vision-motion-detector/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/vision-motion-detector/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -21,20 +12,6 @@ local Alarm = (require "st.zwave.CommandClass.Alarm")({ version = 1 })
 local Configuration = (require "st.zwave.CommandClass.Configuration")({ version = 1 })
 --- @type st.zwave.CommandClass.Notification
 local Notification = (require "st.zwave.CommandClass.Notification")({ version = 3 })
-
-local VISION_MOTION_DETECTOR_FINGERPRINTS = { manufacturerId = 0x0109, productType = 0x2002, productId = 0x0205 } -- Vision Motion Detector ZP3102
-
---- Determine whether the passed device is zwave-plus-motion-temp-sensor
-local function can_handle_vision_motion_detector(opts, driver, device, ...)
-  if device:id_match(
-    VISION_MOTION_DETECTOR_FINGERPRINTS.manufacturerId,
-    VISION_MOTION_DETECTOR_FINGERPRINTS.productType,
-    VISION_MOTION_DETECTOR_FINGERPRINTS.productId
-  ) then
-    local subdriver = require("vision-motion-detector")
-    return true, subdriver
-  else return false end
-end
 
 --- Handler for notification report command class from sensor
 ---
@@ -83,7 +60,7 @@ local vision_motion_detector = {
     doConfigure = do_configure,
   },
   NAME = "Vision motion detector",
-  can_handle = can_handle_vision_motion_detector
+  can_handle = require("vision-motion-detector.can_handle"),
 }
 
 return vision_motion_detector

--- a/drivers/SmartThings/zwave-sensor/src/vision-motion-detector/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/vision-motion-detector/init.lua
@@ -61,6 +61,7 @@ local vision_motion_detector = {
   },
   NAME = "Vision motion detector",
   can_handle = require("vision-motion-detector.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return vision_motion_detector

--- a/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/can_handle.lua
@@ -1,0 +1,12 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle(opts, driver, device, ...)
+  local fingerprint = {manufacturerId = 0x014F, productType = 0x2001, productId = 0x0102} -- NorTek open/close sensor
+  if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+    return true, require("wakeup-no-poll")
+  end
+  return false
+end
+
+return can_handle

--- a/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2023 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2023 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
@@ -20,17 +11,6 @@ local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({version = 2})
 --- @type st.zwave.CommandClass.Battery
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
-
-local fingerprint = {manufacturerId = 0x014F, productType = 0x2001, productId = 0x0102} -- NorTek open/close sensor
-
-local function can_handle(opts, driver, device, ...)
-  if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-    local subdriver = require("wakeup-no-poll")
-    return true, subdriver
-  else
-    return false
-  end
-end
 
 -- Nortek open/closed sensors _always_ respond with "open" when polled, and they are polled after wakeup
 local function wakeup_notification(driver, device, cmd)
@@ -53,7 +33,7 @@ local wakeup_no_poll = {
       [WakeUp.NOTIFICATION] = wakeup_notification
     }
   },
-  can_handle = can_handle
+  can_handle = require("wakeup-no-poll.can_handle"),
 }
 
 return wakeup_no_poll

--- a/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/wakeup-no-poll/init.lua
@@ -34,6 +34,7 @@ local wakeup_no_poll = {
     }
   },
   can_handle = require("wakeup-no-poll.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return wakeup_no_poll

--- a/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_zooz_4_in_1_sensor(opts, driver, device, ...)
+  local FINGERPRINTS = require("zooz-4-in-1-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
+      local subdriver = require("zooz-4-in-1-sensor")
+      return true, subdriver
+    end
+  end
+  return false
+end
+
+return can_handle_zooz_4_in_1_sensor

--- a/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/fingerprints.lua
@@ -1,0 +1,10 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local ZOOZ_4_IN_1_FINGERPRINTS = {
+  { manufacturerId = 0x027A, productType = 0x2021, productId = 0x2101 }, -- Zooz 4-in-1 sensor
+  { manufacturerId = 0x0109, productType = 0x2021, productId = 0x2101 }, -- ZP3111US 4-in-1 Motion
+  { manufacturerId = 0x0060, productType = 0x0001, productId = 0x0004 } -- Everspring Immune Pet PIR Sensor SP815
+}
+
+return ZOOZ_4_IN_1_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/init.lua
@@ -1,16 +1,7 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+
 
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
@@ -22,22 +13,8 @@ local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ ve
 --- @type st.utils
 local utils = require "st.utils"
 
-local ZOOZ_4_IN_1_FINGERPRINTS = {
-  { manufacturerId = 0x027A, productType = 0x2021, productId = 0x2101 }, -- Zooz 4-in-1 sensor
-  { manufacturerId = 0x0109, productType = 0x2021, productId = 0x2101 }, -- ZP3111US 4-in-1 Motion
-  { manufacturerId = 0x0060, productType = 0x0001, productId = 0x0004 } -- Everspring Immune Pet PIR Sensor SP815
-}
 
 --- Determine whether the passed device is zooz_4_in_1_sensor
-local function can_handle_zooz_4_in_1_sensor(opts, driver, device, ...)
-  for _, fingerprint in ipairs(ZOOZ_4_IN_1_FINGERPRINTS) do
-    if device:id_match(fingerprint.manufacturerId, fingerprint.productType, fingerprint.productId) then
-      local subdriver = require("zooz-4-in-1-sensor")
-      return true, subdriver
-    end
-  end
-  return false
-end
 
 --- Handler for notification report command class
 ---
@@ -109,7 +86,7 @@ local zooz_4_in_1_sensor = {
     }
   },
   NAME = "zooz 4 in 1 sensor",
-  can_handle = can_handle_zooz_4_in_1_sensor
+  can_handle = require("zooz-4-in-1-sensor.can_handle"),
 }
 
 return zooz_4_in_1_sensor

--- a/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zooz-4-in-1-sensor/init.lua
@@ -87,6 +87,7 @@ local zooz_4_in_1_sensor = {
   },
   NAME = "zooz 4 in 1 sensor",
   can_handle = require("zooz-4-in-1-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return zooz_4_in_1_sensor

--- a/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/can_handle.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/can_handle.lua
@@ -1,0 +1,15 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local function can_handle_water_leak_sensor(opts, driver, device, ...)
+  local FINGERPRINTS = require("zwave-water-leak-sensor.fingerprints")
+  for _, fingerprint in ipairs(FINGERPRINTS) do
+    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
+      local subdriver = require("zwave-water-leak-sensor")
+      return true, subdriver
+    end
+  end
+  return false
+end
+
+return can_handle_water_leak_sensor

--- a/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/fingerprints.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/fingerprints.lua
@@ -1,0 +1,19 @@
+-- Copyright 2025 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local WATER_LEAK_SENSOR_FINGERPRINTS = {
+  {mfr = 0x0084, prod = 0x0063, model = 0x010C},  -- SmartThings Water Leak Sensor
+  {mfr = 0x0084, prod = 0x0053, model = 0x0216},  -- FortrezZ Water Leak Sensor
+  {mfr = 0x021F, prod = 0x0003, model = 0x0085},  -- Dome Leak Sensor
+  {mfr = 0x0258, prod = 0x0003, model = 0x0085},  -- NEO Coolcam Water Sensor
+  {mfr = 0x0258, prod = 0x0003, model = 0x1085},  -- NEO Coolcam Water Sensor
+  {mfr = 0x0258, prod = 0x0003, model = 0x2085},  -- NEO Coolcam Water Sensor
+  {mfr = 0x0086, prod = 0x0002, model = 0x007A},  -- Aeotec Water Sensor 6 (EU)
+  {mfr = 0x0086, prod = 0x0102, model = 0x007A},  -- Aeotec Water Sensor 6 (US)
+  {mfr = 0x0086, prod = 0x0202, model = 0x007A},  -- Aeotec Water Sensor 6 (AU)
+  {mfr = 0x000C, prod = 0x0201, model = 0x000A},  -- HomeSeer LS100+ Water Sensor
+  {mfr = 0x0173, prod = 0x4C47, model = 0x4C44},  -- Leak Gopher Z-Wave Leak Detector
+  {mfr = 0x027A, prod = 0x7000, model = 0xE002}   -- Zooz ZSE42 XS Water Leak Sensor
+}
+
+return WATER_LEAK_SENSOR_FINGERPRINTS

--- a/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/init.lua
@@ -1,46 +1,9 @@
--- Copyright 2022 SmartThings
---
--- Licensed under the Apache License, Version 2.0 (the "License");
--- you may not use this file except in compliance with the License.
--- You may obtain a copy of the License at
---
---     http://www.apache.org/licenses/LICENSE-2.0
---
--- Unless required by applicable law or agreed to in writing, software
--- distributed under the License is distributed on an "AS IS" BASIS,
--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
--- See the License for the specific language governing permissions and
--- limitations under the License.
+-- Copyright 2022 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
 
 local capabilities = require "st.capabilities"
 local cc = require "st.zwave.CommandClass"
 local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
-
-
-local WATER_LEAK_SENSOR_FINGERPRINTS = {
-  {mfr = 0x0084, prod = 0x0063, model = 0x010C},  -- SmartThings Water Leak Sensor
-  {mfr = 0x0084, prod = 0x0053, model = 0x0216},  -- FortrezZ Water Leak Sensor
-  {mfr = 0x021F, prod = 0x0003, model = 0x0085},  -- Dome Leak Sensor
-  {mfr = 0x0258, prod = 0x0003, model = 0x0085},  -- NEO Coolcam Water Sensor
-  {mfr = 0x0258, prod = 0x0003, model = 0x1085},  -- NEO Coolcam Water Sensor
-  {mfr = 0x0258, prod = 0x0003, model = 0x2085},  -- NEO Coolcam Water Sensor
-  {mfr = 0x0086, prod = 0x0002, model = 0x007A},  -- Aeotec Water Sensor 6 (EU)
-  {mfr = 0x0086, prod = 0x0102, model = 0x007A},  -- Aeotec Water Sensor 6 (US)
-  {mfr = 0x0086, prod = 0x0202, model = 0x007A},  -- Aeotec Water Sensor 6 (AU)
-  {mfr = 0x000C, prod = 0x0201, model = 0x000A},  -- HomeSeer LS100+ Water Sensor
-  {mfr = 0x0173, prod = 0x4C47, model = 0x4C44},  -- Leak Gopher Z-Wave Leak Detector
-  {mfr = 0x027A, prod = 0x7000, model = 0xE002}   -- Zooz ZSE42 XS Water Leak Sensor
-}
-
-local function can_handle_water_leak_sensor(opts, driver, device, ...)
-  for _, fingerprint in ipairs(WATER_LEAK_SENSOR_FINGERPRINTS) do
-    if device:id_match(fingerprint.mfr, fingerprint.prod, fingerprint.model) then
-      local subdriver = require("zwave-water-leak-sensor")
-      return true, subdriver
-    end
-  end
-  return false
-end
 
 local function basic_set_handler(driver, device, cmd)
   local value = cmd.args.target_value and cmd.args.target_value or cmd.args.value
@@ -54,7 +17,7 @@ local water_leak_sensor = {
       [Basic.SET] = basic_set_handler
     }
   },
-  can_handle = can_handle_water_leak_sensor
+  can_handle = require("zwave-water-leak-sensor.can_handle"),
 }
 
 return water_leak_sensor

--- a/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/init.lua
+++ b/drivers/SmartThings/zwave-sensor/src/zwave-water-leak-sensor/init.lua
@@ -18,6 +18,7 @@ local water_leak_sensor = {
     }
   },
   can_handle = require("zwave-water-leak-sensor.can_handle"),
+  shared_device_thread_enabled = true,
 }
 
 return water_leak_sensor


### PR DESCRIPTION
# Description of Change
Lazy loading of zwave-sensor sub-drivers. Re-using the [commits from the first PR to main](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2646), then adding in the redundant driver loading in `can_handle` fix.


# Summary of Completed Tests
- Ran regular driver tests locally on latest scripting-engine `python3 tools/run_driver_tests.py`
- Copied and modified `drivers/SmartThings/zwave-sensor/src/test/test_zwave_sensor.lua` to set `version.api = 10`
   - Tests passed
   - Tests failed when a `can_handle` is removed in a subdriver

