### PR TITLE
Matter Switch: Update ST Energy Reporting Interval for Multi-Plugs

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -92,6 +92,7 @@ SwitchFields.updated_fields = {
   { current_field_name = "__switch_intialized", updated_field_name = nil },
   { current_field_name = "__energy_management_endpoint", updated_field_name = nil },
   { current_field_name = "__total_imported_energy", updated_field_name = nil },
+  { current_field_name = "__last_imported_report_timestamp", updated_field_name = nil },
 }
 
 SwitchFields.vendor_overrides = {

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -373,13 +373,13 @@ end
 
 function utils.report_power_consumption_to_st_energy(device, endpoint_id, total_imported_energy_wh)
   local current_time = os.time()
-  local last_time = device:get_field(fields.LAST_IMPORTED_REPORT_TIMESTAMP) or 0
+  local last_time = utils.get_field_for_endpoint(device, fields.LAST_IMPORTED_REPORT_TIMESTAMP, endpoint_id) or 0
 
   -- Ensure that the previous report was sent at least 15 minutes ago
   if fields.MINIMUM_ST_ENERGY_REPORT_INTERVAL >= (current_time - last_time) then
     return
   end
-  device:set_field(fields.LAST_IMPORTED_REPORT_TIMESTAMP, current_time, { persist = true })
+  utils.set_field_for_endpoint(device, fields.LAST_IMPORTED_REPORT_TIMESTAMP, endpoint_id, current_time, { persist = true })
 
   local previous_imported_report = utils.get_latest_state_for_endpoint(device, endpoint_id, capabilities.powerConsumptionReport.ID,
     capabilities.powerConsumptionReport.powerConsumption.NAME, { energy = total_imported_energy_wh }) -- default value if nil

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
@@ -529,8 +529,14 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_child:generate_test_message("main", capabilities.energyMeter.energy({ value = 19.0, unit = "Wh" }))
     )
-    -- no powerConsumptionReport will be emitted now, since it has not been 15 minutes since the previous report (even though it was the parent).
-
+    test.socket.capability:__expect_send(
+      mock_child:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
+        start = "1970-01-01T00:00:00Z",
+        ["end"] = "1970-01-01T00:15:00Z",
+        deltaEnergy = 0.0,
+        energy = 19.0
+      }))
+    )
 
     test.wait_for_events()
     test.mock_time.advance_time(1500)
@@ -565,7 +571,7 @@ test.register_coroutine_test(
       mock_child:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
         start = "1970-01-01T00:15:01Z",
         ["end"] = "1970-01-01T00:40:00Z",
-        deltaEnergy = 0.0,
+        deltaEnergy = 1.0,
         energy = 20.0
       }))
     )
@@ -582,7 +588,14 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 20.0, unit = "Wh" }))
     )
-    -- no powerConsumptionReport will be emitted now, since it has not been 15 minutes since the previous report (even though it was the child).
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
+        start = "1970-01-01T00:15:01Z",
+        ["end"] = "1970-01-01T00:40:00Z",
+        deltaEnergy = 1.0,
+        energy = 20.0
+      }))
+    )
   end,
   { test_init = test_init }
 )


### PR DESCRIPTION
# Description of Change
At present, the minimum 15 minute ST Energy interval is handled as a single value for the entire Matter device. However, multi-plug devices may be represented on the platform as 2+ devices, and perhaps this 15 minute interval should be evaluated differently for each of these devices since ST Energy evaluates them as completely separate devices, rather than uniquely.

# Summary of Completed Tests
Unit tests updated, tested on-device.
