### PR TITLE
Matter Ikea Dual Button: Added missing refresh on embedded device config

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/ikea-2-button-battery.yml
+++ b/drivers/SmartThings/matter-switch/profiles/ikea-2-button-battery.yml
@@ -36,6 +36,9 @@ deviceConfig:
     - component: main
       capability: battery
       version: 1
+    - component: main
+      capability: refresh
+      version: 1
     - component: button2
       capability: button
       version: 1


### PR DESCRIPTION
# Description of Change

The refresh command does not send to the IKEA device.