### PR TITLE
IKEA Scroll: Populate subscribed attributes key to fix refresh

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/utils.lua
@@ -4,6 +4,7 @@
 local im = require "st.matter.interaction_model"
 local clusters = require "st.matter.clusters"
 local scroll_fields = require "sub_drivers.ikea_scroll.scroll_utils.fields"
+local switch_fields = require "switch_utils.fields"
 
 local IkeaScrollUtils = {}
 
@@ -28,11 +29,18 @@ function IkeaScrollUtils.subscribe(device)
       subscribe_request:with_info_block(ib)
     end
   end
+  local cluster_id = clusters.PowerSource.ID
+  local attr_id = clusters.PowerSource.attributes.BatPercentRemaining.ID
   local ib = im.InteractionInfoBlock(
-    scroll_fields.ENDPOINT_POWER_SOURCE, clusters.PowerSource.ID, clusters.PowerSource.attributes.BatPercentRemaining.ID
+    scroll_fields.ENDPOINT_POWER_SOURCE, cluster_id, attr_id
   )
   subscribe_request:with_info_block(ib)
   device:send(subscribe_request)
+
+  local subscribed_attrs = device:get_field(switch_fields.SUBSCRIBED_ATTRIBUTES_KEY) or {}
+  subscribed_attrs[cluster_id] = subscribed_attrs[cluster_id] or {}
+  subscribed_attrs[cluster_id][attr_id] = ib
+  device:set_field(switch_fields.SUBSCRIBED_ATTRIBUTES_KEY, subscribed_attrs)
 end
 
 return IkeaScrollUtils

--- a/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
@@ -781,4 +781,16 @@ test.register_message_test(
   }
 )
 
+test.register_coroutine_test(
+  "Refresh necessary attributes",
+  function()
+    test.socket.capability:__queue_receive(
+      {mock_ikea_scroll.id, {capability = "refresh", component = "main", command = "refresh", args = {}}}
+    )
+    local read_request = clusters.PowerSource.attributes.BatPercentRemaining:read(mock_ikea_scroll, 0)
+    test.socket.matter:__expect_send({mock_ikea_scroll.id, read_request})
+    test.wait_for_events()
+  end
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
`SUBSCRIBED_ATTRIBUTES_KEY` should be populated in `IkeaScrollUtils.subscribe` to ensure that attributes are read following a refresh command.