### PR TITLE
Matter Switch: Use defaults bounds if any custom bound is missing

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -129,8 +129,13 @@ function CapabilityHandlers.handle_step_color_temperature_by_percent(driver, dev
   local endpoint_id = device:component_to_endpoint(cmd.component)
   -- before the Matter 1.3 lua libs update (HUB FW 55), there was no ColorControl StepModeEnum type defined
   local step_mode = step_percent_change > 0 and (clusters.ColorControl.types.StepModeEnum and clusters.ColorControl.types.StepModeEnum.DOWN or 3) or (clusters.ColorControl.types.StepModeEnum and clusters.ColorControl.types.StepModeEnum.UP or 1)
-  local min_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id) or fields.DEFAULT_MIRED_MIN
-  local max_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, endpoint_id) or fields.DEFAULT_MIRED_MAX
+  local min_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id)
+  local max_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, endpoint_id)
+  -- since colorTemperatureRange is only set after both custom bounds are, use defaults if any custom bound is missing
+  if not (min_mireds and max_mireds) then
+    min_mireds = fields.DEFAULT_MIRED_MIN
+    max_mireds = fields.DEFAULT_MIRED_MAX
+  end
   local step_size_in_mireds = st_utils.round((max_mireds - min_mireds) * (math.abs(step_percent_change)/100.0))
   device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, endpoint_id, step_mode, step_size_in_mireds, fields.TRANSITION_TIME_FAST, min_mireds, max_mireds, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
 end

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -1,8 +1,6 @@
 -- Copyright © 2025 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
-local st_utils = require "st.utils"
-
 local SwitchFields = {}
 
 SwitchFields.MOST_RECENT_TEMP = "mostRecentTemp"
@@ -13,16 +11,12 @@ SwitchFields.HUESAT_SUPPORT = "huesatSupport"
 SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT = 1000000
 
 -- These values are a "sanity check" to check that values we are getting are reasonable
-local COLOR_TEMPERATURE_KELVIN_MAX = 15000
-local COLOR_TEMPERATURE_KELVIN_MIN = 1000
-SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MIN) -- 1000 Mireds
-SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MAX) -- 67 Mireds
+SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = 1000 -- 15000 Kelvin
+SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = 67 -- 1000 Kelvin
 
 -- These values are the config bounds in the default Matter profiles (e.g. light-level-colorTemperature, light-color-level)
-local DEFAULT_KELVIN_MIN = 2200
-local DEFAULT_KELVIN_MAX = 6500
-SwitchFields.DEFAULT_MIRED_MIN = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/DEFAULT_KELVIN_MAX) -- 154 Mireds
-SwitchFields.DEFAULT_MIRED_MAX = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/DEFAULT_KELVIN_MIN) -- 455 Mireds
+SwitchFields.DEFAULT_MIRED_MIN = 154 -- 6500 Kelvin
+SwitchFields.DEFAULT_MIRED_MAX = 455 -- 2200 Kelvin
 
 SwitchFields.SWITCH_LEVEL_LIGHTING_MIN = 1
 SwitchFields.CURRENT_HUESAT_ATTR_MIN = 0

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -11,8 +11,8 @@ SwitchFields.HUESAT_SUPPORT = "huesatSupport"
 SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT = 1000000
 
 -- These values are a "sanity check" to check that values we are getting are reasonable
-SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = 1000 -- 15000 Kelvin
-SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = 67 -- 1000 Kelvin
+SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = 67   -- 15000 Kelvin
+SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = 1000 --  1000 Kelvin
 
 -- These values are the config bounds in the default Matter profiles (e.g. light-level-colorTemperature, light-color-level)
 SwitchFields.DEFAULT_MIRED_MIN = 154 -- 6500 Kelvin


### PR DESCRIPTION
# Description of Change
In the StatelessColorTemperatureStep command, we read the bounds or use defaults. However, since the colorTemperature capability's colorTemperatureRange attribute is only set after both custom bounds are, we should actually use the default bounds if any custom bound is missing to avoid "out of range" errors.

tag-along update: use hardcoded mired fields to avoid messy and unecessary rounding in the fields file

Follow-up discussion may be worthwhile to set the colorTemperatureRange if even one bound is present.

# Summary of Completed Tests
Tested with Zemismart device that gives max/min mireds that are out of "sane" range.

