### PR TITLE
Fixing zigbee-switch tests for ColorTempPhysMireds

### DIFF
--- a/.github/workflows/jenkins-driver-tests.yml
+++ b/.github/workflows/jenkins-driver-tests.yml
@@ -4,6 +4,10 @@ on:
     paths:
       - 'drivers/**'
 
+  pull_request_target:
+    paths:
+      - 'drivers/**'
+
 permissions:
   statuses: write
 
@@ -12,7 +16,7 @@ jobs:
     strategy:
       matrix:
         version:
-          [ 59, 60 ]
+          [ 59, 60, dev]
 
     runs-on: ubuntu-latest
     steps:

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -423,10 +423,155 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 17,
+       max_api_version = 19
     }
 )
 
+test.register_coroutine_test(
+    "lifecycle configure event should configure device",
+    function ()
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+      test.socket.device_lifecycle:__queue_receive({mock_device.id, "doConfigure"})
+
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         OnOff.attributes.OnOff:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         Level.attributes.CurrentLevel:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ColorControl.attributes.ColorTemperatureMireds:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ColorControl.attributes.CurrentHue:read(mock_device)
+      })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ColorControl.attributes.CurrentSaturation:read(mock_device)
+      })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              OnOff.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.InstantaneousDemand:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.CurrentSummationDelivered:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ElectricalMeasurement.attributes.ActivePower:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              Level.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              ColorControl.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 0x0010)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ColorControl.attributes.CurrentHue:configure_reporting(mock_device, 1, 3600, 0x0010)
+      })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ColorControl.attributes.CurrentSaturation:configure_reporting(mock_device, 1, 3600, 0x0010)
+      })
+      test.socket.zigbee:__expect_send({
+                                        mock_device.id,
+                                        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      })
+      test.socket.zigbee:__expect_send({
+                                        mock_device.id,
+                                        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              SimpleMetering.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.InstantaneousDemand:configure_reporting(mock_device, 5, 3600, 5)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.CurrentSummationDelivered:configure_reporting(mock_device, 5, 3600, 1)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         zigbee_test_utils.build_bind_request(mock_device,
+                                                                              zigbee_test_utils.mock_hub_eui,
+                                                                              ElectricalMeasurement.ID)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ElectricalMeasurement.attributes.ActivePower:configure_reporting(mock_device, 5, 3600, 5)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                        ElectricalMeasurement.attributes.ACPowerMultiplier:configure_reporting(mock_device, 1, 43200, 1)
+                                      })
+      test.socket.zigbee:__expect_send({
+                                        mock_device.id,
+                                        ElectricalMeasurement.attributes.ACPowerDivisor:configure_reporting(mock_device, 1, 43200, 1)
+                                      })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ElectricalMeasurement.attributes.ACPowerDivisor:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         ElectricalMeasurement.attributes.ACPowerMultiplier:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.Multiplier:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({
+                                         mock_device.id,
+                                         SimpleMetering.attributes.Divisor:read(mock_device)
+                                       })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
+      mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    end,
+    {
+       min_api_version = 20
+    }
+)
 -- test.register_coroutine_test(
 --     "health check coroutine",
 --     function()

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
@@ -109,7 +109,75 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.commands.MoveToColorTemperature(mock_device, 200, 0)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 20
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
@@ -106,15 +106,85 @@ test.register_coroutine_test(
         OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
       }
     )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
-
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
+  }
+)
+
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OnTransitionTime:write(mock_device, 0) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OffTransitionTime:write(mock_device, 0) })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.commands.MoveToColorTemperature(mock_device, 200, 0)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 17,
+     max_api_version = 19
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
@@ -38,6 +38,71 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     test.socket.zigbee:__set_channel_ordering("relaxed")
 
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
     test.socket.zigbee:__expect_send({
       mock_device.id,
       zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
@@ -78,7 +143,63 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+    min_api_version = 17,
+    max_api_version = 19
+  }
+)
+
+test.register_message_test(
+  "Refresh should read all necessary attributes",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {mock_device.id, {capability = "refresh", component = "main", command = "refresh", args = {}}}
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        OnOff.attributes.OnOff:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        Level.attributes.CurrentLevel:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device)
+       }
+    }
+  },
+  {
+    inner_block_ordering = "relaxed",
+    min_api_version = 20
   }
 )
 
@@ -117,7 +238,8 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 17,
+    max_api_version = 19
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
@@ -81,6 +81,18 @@ test.register_coroutine_test(
         ColorControl.attributes.CurrentSaturation:configure_reporting(mock_device, 1, 3600, 16)
       }
     )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
@@ -90,7 +102,71 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
+  }
+)
+
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.CurrentHue:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.CurrentSaturation:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+    min_api_version = 17,
+    max_api_version = 19
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sengled_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sengled_color_temp_bulb.lua
@@ -69,6 +69,70 @@ test.register_coroutine_test(
         ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
       }
     )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
 
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
@@ -78,7 +142,63 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_message_test(
+  "Refresh should read all necessary attributes",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {mock_device.id, {capability = "refresh", component = "main", command = "refresh", args = {}}}
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        OnOff.attributes.OnOff:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        Level.attributes.CurrentLevel:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device)
+      }
+    }
+  },
+  {
+    inner_block_ordering = "relaxed",
+    min_api_version = 20
   }
 )
 
@@ -117,7 +237,8 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 17,
+    max_api_version = 19
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
@@ -38,6 +38,74 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     test.socket.zigbee:__set_channel_ordering("relaxed")
 
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
     test.socket.zigbee:__expect_send({
       mock_device.id,
       zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
@@ -73,12 +141,66 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
-    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
-    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_message_test(
+  "Refresh should read all necessary attributes",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {mock_device.id, {capability = "refresh", component = "main", command = "refresh", args = {}}}
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        OnOff.attributes.OnOff:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        Level.attributes.CurrentLevel:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device)
+      }
+    },
+    {
+      channel = "zigbee",
+      direction = "send",
+      message = {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device)
+      }
+    }
+  },
+  {
+    inner_block_ordering = "relaxed",
+    min_api_version = 20
   }
 )
 
@@ -117,7 +239,8 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 17,
+    max_api_version = 19
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
@@ -42,10 +42,52 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
   }
+)
+
+test.register_coroutine_test(
+  "Refresh necessary attributes",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "refresh", component = "main", command = "refresh", args = {} } })
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+  end,
+  {
+    min_api_version = 17,
+    max_api_version = 19
+  }
+)
+
+test.register_coroutine_test(
+    "ZLL periodic poll should occur",
+    function()
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+      test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+      test.wait_for_events()
+
+      test.mock_time.advance_time(50000)
+      test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+      test.wait_for_events()
+    end,
+    {
+      test_init = function()
+        test.mock_device.add_test_device(mock_device)
+        test.timer.__create_and_queue_test_time_advance_timer(30, "interval", "polling")
+      end,
+      min_api_version = 20
+    }
 )
 
 test.register_coroutine_test(
@@ -67,8 +109,30 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(30, "interval", "polling")
       end,
-      min_api_version = 17
+      min_api_version = 17,
+      max_api_version = 19
     }
+)
+
+test.register_coroutine_test(
+  "Switch command on should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "on") end
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device)})
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+  end,
+  {
+     min_api_version = 20
+  }
 )
 
 test.register_coroutine_test(
@@ -86,7 +150,29 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_coroutine_test(
+  "Switch command off should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "off") end
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.Off(mock_device)})
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+  end,
+  {
+     min_api_version = 20
   }
 )
 
@@ -105,7 +191,29 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_coroutine_test(
+  "SwitchLevel command setLevel should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = {50} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel") end
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.commands.MoveToLevelWithOnOff(mock_device, math.floor(50 / 100.0 * 254), 0xFFFF)})
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+  end,
+  {
+     min_api_version = 20
   }
 )
 
@@ -124,7 +232,30 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_coroutine_test(
+  "ColorTemperature command setColorTemperature should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(1, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {200} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature") end
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device)})
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.commands.MoveToColorTemperature(mock_device, 5000, 0x0000)})
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+  end,
+  {
+     min_api_version = 20
   }
 )
 
@@ -144,8 +275,8 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
   }
 )
-
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
@@ -40,6 +40,78 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     test.socket.zigbee:__set_channel_ordering("relaxed")
 
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, Level.ID)
+    })
+    test.socket.zigbee:__expect_send({
+      mock_device.id,
+      zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, ColorControl.ID)
+    })
+
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        OnOff.attributes.OnOff:configure_reporting(mock_device, 0, 300, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        Level.attributes.CurrentLevel:configure_reporting(mock_device, 1, 3600, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTemperatureMireds:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.CurrentHue:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.CurrentSaturation:configure_reporting(mock_device, 1, 3600, 16)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMaxMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    test.socket.zigbee:__expect_send(
+      {
+        mock_device.id,
+        ColorControl.attributes.ColorTempPhysicalMinMireds:configure_reporting(mock_device, 1, 43200, 1)
+      }
+    )
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 20
+  }
+)
+
+
+test.register_coroutine_test(
+  "Configure should configure all necessary attributes and refresh device",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+
     test.socket.zigbee:__expect_send({
       mock_device.id,
       zigbee_test_utils.build_bind_request(mock_device, zigbee_test_utils.mock_hub_eui, OnOff.ID)
@@ -88,7 +160,26 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 17,
+     max_api_version = 19
+  }
+)
+
+test.register_coroutine_test(
+  "Refresh necessary attributes",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "refresh", component = "main", command = "refresh", args = {} } })
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+  end,
+  {
+    min_api_version = 20
   }
 )
 
@@ -104,8 +195,36 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
   end,
   {
-     min_api_version = 17
+    min_api_version = 17,
+    max_api_version = 19
   }
+)
+
+test.register_coroutine_test(
+    "ZLL periodic poll should occur",
+    function()
+      test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
+      test.socket.zigbee:__set_channel_ordering("relaxed")
+      test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+      test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+      test.wait_for_events()
+
+      test.mock_time.advance_time(5*60)
+      test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+      test.wait_for_events()
+    end,
+    {
+      test_init = function()
+        test.mock_device.add_test_device(mock_device)
+        test.timer.__create_and_queue_test_time_advance_timer(5*60, "interval", "polling")
+      end,
+      min_api_version = 20
+    }
 )
 
 test.register_coroutine_test(
@@ -129,7 +248,8 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(5*60, "interval", "polling")
       end,
-      min_api_version = 17
+      min_api_version = 17,
+      max_api_version = 19
     }
 )
 
@@ -151,9 +271,38 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "Capability 'switch' command 'on' should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "on") end
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device) })
+
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+
+  end,
+  {
+     min_api_version = 17,
+     max_api_version = 19
   }
 )
 
@@ -175,9 +324,38 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "Capability 'switch' command 'off' should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switch", component = "main", command = "off", args = {} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switch", "off") end
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.Off(mock_device) })
+
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+
+  end,
+  {
+     min_api_version = 17,
+     max_api_version = 19
   }
 )
 
@@ -199,9 +377,38 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "Capability 'switchLevel' command 'setLevel' on should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "switchLevel", component = "main", command = "setLevel", args = { 57 } } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("switchLevel", "setLevel") end
+
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.server.commands.MoveToLevelWithOnOff(mock_device, 144, 0xFFFF) })
+
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+
+  end,
+  {
+     min_api_version = 17,
+     max_api_version = 19
   }
 )
 
@@ -224,9 +431,39 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMaxMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTempPhysicalMinMireds:read(mock_device) })
+
   end,
   {
-     min_api_version = 17
+     min_api_version = 20
+  }
+)
+
+test.register_coroutine_test(
+  "ColorTemperature command setColorTemperature should be handled",
+  function()
+    test.socket.zigbee:__set_channel_ordering("relaxed")
+    test.timer.__create_and_queue_test_time_advance_timer(2, "oneshot")
+    test.socket.capability:__queue_receive({ mock_device.id, { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {200} } })
+    if version.api > 15 then mock_device:expect_native_cmd_handler_registration("colorTemperature", "setColorTemperature") end
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.commands.On(mock_device)})
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.commands.MoveToColorTemperature(mock_device, 5000, 0x0000)})
+
+    test.wait_for_events()
+    test.mock_time.advance_time(2)
+
+    test.socket.zigbee:__expect_send({ mock_device.id, OnOff.attributes.OnOff:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
+    test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
+
+  end,
+  {
+     min_api_version = 17,
+     max_api_version = 19
   }
 )
 


### PR DESCRIPTION
- Fixing tests against dev for expected new messages for the `ColorTempPhysical(min/max)Mireds` attribute
- Adding `dev` to jenkins-driver-tests.yml workflow file matrix