### PR TITLE
Matter Switch: Add nil check handling for electrical sensor handlers

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -321,6 +321,10 @@ function AttributeHandlers.available_endpoints_handler(driver, device, ib, respo
     return
   end
   local set_topology_eps = device:get_field(fields.ELECTRICAL_SENSOR_EPS)
+  if set_topology_eps == nil then
+    device.log.warn("Received an AvailableEndpoints response but no Electrical Sensor endpoints have been identified as supporting the Power Topology cluster with SET feature. Ignoring this response.")
+    return
+  end
   for i, set_ep_info in pairs(set_topology_eps or {}) do
     if ib.endpoint_id == set_ep_info.endpoint_id then
       -- since EP response is being handled here, remove it from the ELECTRICAL_SENSOR_EPS table
@@ -350,6 +354,10 @@ function AttributeHandlers.parts_list_handler(driver, device, ib, response)
     return
   end
   local tree_topology_eps = device:get_field(fields.ELECTRICAL_SENSOR_EPS)
+  if tree_topology_eps == nil then
+    device.log.warn("Received a PartsList response but no Electrical Sensor endpoints have been identified as supporting the Power Topology cluster with TREE feature. Ignoring this response.")
+    return
+  end
   for i, tree_ep_info in pairs(tree_topology_eps or {}) do
     if ib.endpoint_id == tree_ep_info.endpoint_id then
       -- since EP response is being handled here, remove it from the ELECTRICAL_SENSOR_EPS table


### PR DESCRIPTION
# Description of Change
Normally, these handlers should return early if the profiling_data they help populate have already been filled. However, under certain conditions, a device can 1. end up with us doing a wildcard subscription where we subscribe to every attribute/event it supports, and 2. be handled in a subdriver where the profiling data never gets populated. The fact that a subdriver/driver relationship is not necessarily of 2 distinct pieces (the partsList is an attribute supported by every device, for example) means we should probably work towards removing the separation between lifecycle handlers on generic devices (see [this PR](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2898)), but in the meantime we should probably fix this issue we're seeing in the field.

# Summary of Completed Tests


