### PR TITLE
Matter Switch: Explicitly check default endpoint for Water Valves

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
@@ -23,7 +23,7 @@ local FanDeviceConfiguration = {}
 
 function ChildConfiguration.create_or_update_child_devices(driver, device, server_cluster_ep_ids, default_endpoint_id, assign_profile_fn)
   if #server_cluster_ep_ids == 1 and server_cluster_ep_ids[1] == default_endpoint_id then -- no children will be created
-   return
+    return
   end
 
   table.sort(server_cluster_ep_ids)
@@ -209,14 +209,6 @@ function DeviceConfiguration.match_profile(driver, device)
   local optional_component_capabilities
   local updated_profile
 
-  if #embedded_cluster_utils.get_endpoints(device, clusters.ValveConfigurationAndControl.ID) > 0 then
-    updated_profile = "water-valve"
-    if #embedded_cluster_utils.get_endpoints(device, clusters.ValveConfigurationAndControl.ID,
-      {feature_bitmap = clusters.ValveConfigurationAndControl.types.Feature.LEVEL}) > 0 then
-      updated_profile = updated_profile .. "-level"
-    end
-  end
-
   local server_onoff_ep_ids = device:get_endpoints(clusters.OnOff.ID) -- get_endpoints defaults to return EPs supporting SERVER or BOTH
   if #server_onoff_ep_ids > 0 then
     ChildConfiguration.create_or_update_child_devices(driver, device, server_onoff_ep_ids, default_endpoint_id, SwitchDeviceConfiguration.assign_profile_for_onoff_ep)
@@ -238,8 +230,15 @@ function DeviceConfiguration.match_profile(driver, device)
     end
   end
 
-  local fan_device_type_ep_ids = switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.FAN)
-  if #fan_device_type_ep_ids > 0 then
+  if #switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.WATER_VALVE) > 0 then
+    updated_profile = "water-valve"
+    if #embedded_cluster_utils.get_endpoints(device, clusters.ValveConfigurationAndControl.ID,
+      {feature_bitmap = clusters.ValveConfigurationAndControl.types.Feature.LEVEL}) > 0 then
+      updated_profile = updated_profile .. "-level"
+    end
+  end
+
+  if #switch_utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.FAN) > 0 then
     updated_profile, optional_component_capabilities = FanDeviceConfiguration.assign_profile_for_fan_ep(device, default_endpoint_id)
   end
 

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -52,6 +52,7 @@ SwitchFields.DEVICE_TYPE_ID = {
     DIMMER = 0x0104,
     COLOR_DIMMER = 0x0105,
   },
+  WATER_VALVE = 0x0042,
 }
 
 SwitchFields.device_type_profile_map = {

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -151,10 +151,6 @@ function utils.find_default_endpoint(device)
     return device.MATTER_DEFAULT_ENDPOINT
   end
 
-  local onoff_ep_ids = device:get_endpoints(clusters.OnOff.ID)
-  local momentary_switch_ep_ids = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
-  local fan_endpoint_ids = utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.FAN)
-
   local get_first_non_zero_endpoint = function(endpoints)
     table.sort(endpoints)
     for _,ep in ipairs(endpoints) do
@@ -166,23 +162,24 @@ function utils.find_default_endpoint(device)
   end
 
   -- Return the first fan endpoint as the default endpoint if any is found
+  local fan_endpoint_ids = utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.FAN)
   if #fan_endpoint_ids > 0 then
     return get_first_non_zero_endpoint(fan_endpoint_ids)
   end
 
-  -- Return the first onoff endpoint as the default endpoint if no momentary switch endpoints are present
-  if #momentary_switch_ep_ids == 0 and #onoff_ep_ids > 0 then
-    return get_first_non_zero_endpoint(onoff_ep_ids)
-  end
-
-  -- Return the first momentary switch endpoint as the default endpoint if no onoff endpoints are present
-  if #onoff_ep_ids == 0 and #momentary_switch_ep_ids > 0 then
-    return get_first_non_zero_endpoint(momentary_switch_ep_ids)
+  -- Return the first water valve endpoint as the default endpoint if any is found
+  local water_valve_endpoint_ids = utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.WATER_VALVE)
+  if #water_valve_endpoint_ids > 0 then
+    return get_first_non_zero_endpoint(water_valve_endpoint_ids)
   end
 
   -- If both onoff and momentary switch endpoints are present, check the device type on the first onoff
   -- endpoint. If it is not a supported device type, return the first momentary switch endpoint as the
-  -- default endpoint.
+  -- default endpoint. Else return the first onoff endpoint as the default endpoint.
+  --
+  -- If only one of the two types of endpoints are present, return the first endpoint of the present type.
+  local onoff_ep_ids = device:get_endpoints(clusters.OnOff.ID)
+  local momentary_switch_ep_ids = device:get_endpoints(clusters.Switch.ID, {feature_bitmap=clusters.Switch.types.SwitchFeature.MOMENTARY_SWITCH})
   if #onoff_ep_ids > 0 and #momentary_switch_ep_ids > 0 then
     local default_endpoint_id = get_first_non_zero_endpoint(onoff_ep_ids)
     if utils.device_type_supports_button_switch_combination(device, default_endpoint_id) then
@@ -191,6 +188,10 @@ function utils.find_default_endpoint(device)
       device.log.warn("The main switch endpoint does not contain a supported device type for a component configuration with buttons")
       return get_first_non_zero_endpoint(momentary_switch_ep_ids)
     end
+  elseif #onoff_ep_ids > 0 then
+    return get_first_non_zero_endpoint(onoff_ep_ids)
+  elseif #momentary_switch_ep_ids > 0 then
+    return get_first_non_zero_endpoint(momentary_switch_ep_ids)
   end
 
   device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))


### PR DESCRIPTION
# Description of Change
Today, the VDA version of the Water Valve that is often used for testing includes an on/off endpoint on its first endpoint, the same endpoint that exposes Water Valve. Therefore, the VDA version of this device type is currently exposed with the `switch-binary` profile today. This should not affect live water valve devices, since they should not be exposing the onoff cluster on any endpoint. However, since it is allowed per spec, and since it is exposed on a test Matter device today, this fixes the issue. 

Further, it fixes any generic issues in which the Water Valve is exposed on an endpoint that does not match the `MATTER_DEFAULT_ENDPOINT`, and simplifies the checks in `find_default_endpoint`.

# Summary of Completed Tests
  - Successfully onboarded the VDA Water Valve. Before the fix, it onboarded as switch-binary, and afterwards onboarded as water-valve-level. 

