### PR TITLE
Removing pull_request and leaving pull_request_target

### DIFF
--- a/.github/workflows/jenkins-driver-tests.yml
+++ b/.github/workflows/jenkins-driver-tests.yml
@@ -1,15 +1,8 @@
 name: Run Jenkins driver tests
 on:
-  pull_request:
-    paths:
-      - 'drivers/**'
-
   pull_request_target:
     paths:
       - 'drivers/**'
-
-permissions:
-  statuses: write
 
 jobs:
   trigger-driver-test:


### PR DESCRIPTION
Removing `pull_request` as a trigger for `jenkins-driver-tests.yml` as `pull_request_target` has fixed the issue of collaborators unable to trigger Jenkins jobs.