### PR TITLE
Fix ledvance unit tests

### DIFF
--- a/drivers/SmartThings/zigbee-switch/src/test/test_ledvance_metering_plug.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_ledvance_metering_plug.lua
@@ -23,6 +23,7 @@ local mock_device = test.mock_device.build_test_zigbee_device(
 zigbee_test_utils.prepare_zigbee_env_info()
 
 local function test_init()
+  test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device)
 end
 
@@ -37,7 +38,10 @@ test.register_coroutine_test(
     test.wait_for_events()
     assert(mock_device:get_field(zigbee_constants.SIMPLE_METERING_MULTIPLIER_KEY) == 1)
     assert(mock_device:get_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY) == 100)
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -49,7 +53,10 @@ test.register_coroutine_test(
     test.wait_for_events()
     assert(mock_device:get_field(zigbee_constants.SIMPLE_METERING_MULTIPLIER_KEY) == 5)
     assert(mock_device:get_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY) == 1000)
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.run_registered_tests()


### PR DESCRIPTION
Device init messages must be disabled before adding the mock device to the test framework for these tests.

For release, this should go with the ledvance WWST commit in #2729 

