### PR TITLE
Organize the Matter Switch field naming conventions

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -101,6 +101,7 @@ function SwitchLifecycleHandlers.device_init(driver, device)
     if #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY}) == 0 then
       device:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.NO_BATTERY, {persist = true})
     end
+    switch_utils.set_transition_times_for_stateless_capabilities(device)
     switch_utils.handle_electrical_sensor_info(device)
     device:extend_device("subscribe", switch_utils.subscribe)
     device:subscribe()

--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -101,7 +101,6 @@ function SwitchLifecycleHandlers.device_init(driver, device)
     if #device:get_endpoints(clusters.PowerSource.ID, {feature_bitmap = clusters.PowerSource.types.PowerSourceFeature.BATTERY}) == 0 then
       device:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.NO_BATTERY, {persist = true})
     end
-    switch_utils.set_transition_times_for_stateless_capabilities(device)
     switch_utils.handle_electrical_sensor_info(device)
     device:extend_device("subscribe", switch_utils.subscribe)
     device:subscribe()
@@ -127,8 +126,8 @@ local matter_driver_template = {
         [clusters.ColorControl.attributes.ColorCapabilities.ID] = attribute_handlers.color_capabilities_handler,
         [clusters.ColorControl.attributes.ColorMode.ID] = attribute_handlers.color_mode_handler,
         [clusters.ColorControl.attributes.ColorTemperatureMireds.ID] = attribute_handlers.color_temperature_mireds_handler,
-        [clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds.ID] = attribute_handlers.color_temp_physical_mireds_bounds_factory(fields.COLOR_TEMP_MIN), -- max mireds = min kelvin
-        [clusters.ColorControl.attributes.ColorTempPhysicalMinMireds.ID] = attribute_handlers.color_temp_physical_mireds_bounds_factory(fields.COLOR_TEMP_MAX), -- min mireds = max kelvin
+        [clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds.ID] = attribute_handlers.color_temp_physical_mireds_bounds_factory(fields.COLOR_TEMP.MIN), -- max mireds = min kelvin
+        [clusters.ColorControl.attributes.ColorTempPhysicalMinMireds.ID] = attribute_handlers.color_temp_physical_mireds_bounds_factory(fields.COLOR_TEMP.MAX), -- min mireds = max kelvin
         [clusters.ColorControl.attributes.CurrentHue.ID] = attribute_handlers.current_hue_handler,
         [clusters.ColorControl.attributes.CurrentSaturation.ID] = attribute_handlers.current_saturation_handler,
         [clusters.ColorControl.attributes.CurrentX.ID] = attribute_handlers.current_x_handler,
@@ -154,8 +153,8 @@ local matter_driver_template = {
       },
       [clusters.LevelControl.ID] = {
         [clusters.LevelControl.attributes.CurrentLevel.ID] = attribute_handlers.level_control_current_level_handler,
-        [clusters.LevelControl.attributes.MaxLevel.ID] = attribute_handlers.level_bounds_handler_factory(fields.LEVEL_MAX),
-        [clusters.LevelControl.attributes.MinLevel.ID] = attribute_handlers.level_bounds_handler_factory(fields.LEVEL_MIN),
+        [clusters.LevelControl.attributes.MaxLevel.ID] = attribute_handlers.level_bounds_handler_factory(fields.LEVEL.MAX),
+        [clusters.LevelControl.attributes.MinLevel.ID] = attribute_handlers.level_bounds_handler_factory(fields.LEVEL.MIN),
       },
       [clusters.OccupancySensing.ID] = {
         [clusters.OccupancySensing.attributes.Occupancy.ID] = attribute_handlers.occupancy_handler,
@@ -178,9 +177,9 @@ local matter_driver_template = {
         [clusters.Switch.attributes.MultiPressMax.ID] = attribute_handlers.multi_press_max_handler
       },
       [clusters.TemperatureMeasurement.ID] = {
-        [clusters.TemperatureMeasurement.attributes.MaxMeasuredValue.ID] = attribute_handlers.temperature_measured_value_bounds_factory(fields.TEMP_MAX),
+        [clusters.TemperatureMeasurement.attributes.MaxMeasuredValue.ID] = attribute_handlers.temperature_measured_value_bounds_factory(fields.TEMPERATURE_MEASUREMENT.MAX),
         [clusters.TemperatureMeasurement.attributes.MeasuredValue.ID] = attribute_handlers.temperature_measured_value_handler,
-        [clusters.TemperatureMeasurement.attributes.MinMeasuredValue.ID] = attribute_handlers.temperature_measured_value_bounds_factory(fields.TEMP_MIN),
+        [clusters.TemperatureMeasurement.attributes.MinMeasuredValue.ID] = attribute_handlers.temperature_measured_value_bounds_factory(fields.TEMPERATURE_MEASUREMENT.MIN),
       },
       [clusters.ValveConfigurationAndControl.ID] = {
         [clusters.ValveConfigurationAndControl.attributes.CurrentLevel.ID] = attribute_handlers.valve_configuration_current_level_handler,

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -67,17 +67,17 @@ function AttributeHandlers.level_bounds_handler_factory(minOrMax)
     if lighting_support and level == 0 then
       level = 1
     end
-    switch_utils.set_field_for_endpoint(device, fields.LEVEL_BOUND_RECEIVED..minOrMax, ib.endpoint_id, level)
-    local min = switch_utils.get_field_for_endpoint(device, fields.LEVEL_BOUND_RECEIVED..fields.LEVEL_MIN, ib.endpoint_id)
-    local max = switch_utils.get_field_for_endpoint(device, fields.LEVEL_BOUND_RECEIVED..fields.LEVEL_MAX, ib.endpoint_id)
+    switch_utils.set_field_for_endpoint(device, fields.LEVEL.BOUND_RECEIVED..minOrMax, ib.endpoint_id, level)
+    local min = switch_utils.get_field_for_endpoint(device, fields.LEVEL.BOUND_RECEIVED..fields.LEVEL.MIN, ib.endpoint_id)
+    local max = switch_utils.get_field_for_endpoint(device, fields.LEVEL.BOUND_RECEIVED..fields.LEVEL.MAX, ib.endpoint_id)
     if min ~= nil and max ~= nil then
       if min < max then
         device:emit_event_for_endpoint(ib.endpoint_id, capabilities.switchLevel.levelRange({ value = {minimum = min, maximum = max} }))
       else
         device.log.warn_with({hub_logs = true}, string.format("Device reported a min level value %d that is not lower than the reported max level value %d", min, max))
       end
-      switch_utils.set_field_for_endpoint(device, fields.LEVEL_BOUND_RECEIVED..fields.LEVEL_MAX, ib.endpoint_id, nil)
-      switch_utils.set_field_for_endpoint(device, fields.LEVEL_BOUND_RECEIVED..fields.LEVEL_MIN, ib.endpoint_id, nil)
+      switch_utils.set_field_for_endpoint(device, fields.LEVEL.BOUND_RECEIVED..fields.LEVEL.MAX, ib.endpoint_id, nil)
+      switch_utils.set_field_for_endpoint(device, fields.LEVEL.BOUND_RECEIVED..fields.LEVEL.MIN, ib.endpoint_id, nil)
     end
   end
 end
@@ -86,7 +86,7 @@ end
 -- [[ COLOR CONTROL CLUSTER ATTRIBUTES ]] --
 
 function AttributeHandlers.current_hue_handler(driver, device, ib, response)
-  if device:get_field(fields.COLOR_MODE) ~= fields.X_Y_COLOR_MODE and ib.data.value ~= nil then
+  if device:get_field(fields.COLOR_CONTROL.COLOR_MODE) ~= clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY and ib.data.value ~= nil then
     local hue = math.floor((ib.data.value / 0xFE * 100) + 0.5)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.hue(hue))
   end
@@ -96,7 +96,7 @@ function AttributeHandlers.current_hue_handler(driver, device, ib, response)
 end
 
 function AttributeHandlers.current_saturation_handler(driver, device, ib, response)
-  if device:get_field(fields.COLOR_MODE) ~= fields.X_Y_COLOR_MODE and ib.data.value ~= nil then
+  if device:get_field(fields.COLOR_CONTROL.COLOR_MODE) ~= clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY and ib.data.value ~= nil then
     local sat = math.floor((ib.data.value / 0xFE * 100) + 0.5)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.saturation(sat))
   end
@@ -110,75 +110,75 @@ function AttributeHandlers.color_temperature_mireds_handler(driver, device, ib, 
   if temp_in_mired == nil then
     return
   end
-  if (temp_in_mired < fields.COLOR_TEMPERATURE_MIRED_MIN or temp_in_mired > fields.COLOR_TEMPERATURE_MIRED_MAX) then
-    device.log.warn_with({hub_logs = true}, string.format("Device reported color temperature %d mired outside of sane range of %.2f-%.2f", temp_in_mired, fields.COLOR_TEMPERATURE_MIRED_MIN, fields.COLOR_TEMPERATURE_MIRED_MAX))
+  if (temp_in_mired < fields.MIRED.MIN_ALLOWED or temp_in_mired > fields.MIRED.MAX_ALLOWED) then
+    device.log.warn_with({hub_logs = true}, string.format("Device reported color temperature %d mired outside of sane range of %.2f-%.2f", temp_in_mired, fields.MIRED.MIN_ALLOWED, fields.MIRED.MAX_ALLOWED))
     return
   end
-  local min_temp_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, ib.endpoint_id)
-  local max_temp_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, ib.endpoint_id)
+  local min_temp_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MIN, ib.endpoint_id)
+  local max_temp_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MAX, ib.endpoint_id)
 
-  local temp = st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/temp_in_mired)
+  local temp = st_utils.round(fields.MIRED.TO_KELVIN_CONVERSION_CONSTANT/temp_in_mired)
   if min_temp_mired ~= nil and temp_in_mired <= min_temp_mired then
-    temp = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP_MAX, ib.endpoint_id)
+    temp = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP.MAX, ib.endpoint_id)
   elseif max_temp_mired ~= nil and temp_in_mired >= max_temp_mired then
-    temp = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP_MIN, ib.endpoint_id)
+    temp = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP.MIN, ib.endpoint_id)
   end
 
   local temp_device = device
   if device:get_field(fields.IS_PARENT_CHILD_DEVICE) == true then
     temp_device = switch_utils.find_child(device, ib.endpoint_id) or device
   end
-  local most_recent_temp = temp_device:get_field(fields.MOST_RECENT_TEMP)
+  local most_recent_temp = temp_device:get_field(fields.COLOR_TEMP.MOST_RECENT_TEMP)
   -- this is to avoid rounding errors from the round-trip conversion of Kelvin to mireds
   if most_recent_temp ~= nil and
-    most_recent_temp <= st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/(temp_in_mired - 1)) and
-    most_recent_temp >= st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/(temp_in_mired + 1)) then
+    most_recent_temp <= st_utils.round(fields.MIRED.TO_KELVIN_CONVERSION_CONSTANT/(temp_in_mired - 1)) and
+    most_recent_temp >= st_utils.round(fields.MIRED.TO_KELVIN_CONVERSION_CONSTANT/(temp_in_mired + 1)) then
       temp = most_recent_temp
   end
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorTemperature.colorTemperature(temp))
 end
 
 function AttributeHandlers.current_x_handler(driver, device, ib, response)
-  if device:get_field(fields.COLOR_MODE) == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
+  if device:get_field(fields.COLOR_CONTROL.COLOR_MODE) == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
     return
   end
-  local y = device:get_field(fields.RECEIVED_Y)
+  local y = device:get_field(fields.COLOR_CONTROL.RECEIVED_Y)
   --TODO it is likely that both x and y attributes are in the response (not guaranteed though)
   -- if they are we can avoid setting fields on the device.
   if y == nil then
-    device:set_field(fields.RECEIVED_X, ib.data.value)
+    device:set_field(fields.COLOR_CONTROL.RECEIVED_X, ib.data.value)
   else
     local x = ib.data.value
     local h, s, _ = color_utils.safe_xy_to_hsv(x, y, nil)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.hue(h))
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.saturation(s))
-    device:set_field(fields.RECEIVED_Y, nil)
+    device:set_field(fields.COLOR_CONTROL.RECEIVED_Y, nil)
   end
 end
 
 function AttributeHandlers.current_y_handler(driver, device, ib, response)
-  if device:get_field(fields.COLOR_MODE) == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
+  if device:get_field(fields.COLOR_CONTROL.COLOR_MODE) == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
     return
   end
-  local x = device:get_field(fields.RECEIVED_X)
+  local x = device:get_field(fields.COLOR_CONTROL.RECEIVED_X)
   if x == nil then
-    device:set_field(fields.RECEIVED_Y, ib.data.value)
+    device:set_field(fields.COLOR_CONTROL.RECEIVED_Y, ib.data.value)
   else
     local y = ib.data.value
     local h, s, _ = color_utils.safe_xy_to_hsv(x, y, nil)
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.hue(h))
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorControl.saturation(s))
-    device:set_field(fields.RECEIVED_X, nil)
+    device:set_field(fields.COLOR_CONTROL.RECEIVED_X, nil)
   end
 end
 
 function AttributeHandlers.color_mode_handler(driver, device, ib, response)
-  if ib.data.value == device:get_field(fields.COLOR_MODE)
+  if ib.data.value == device:get_field(fields.COLOR_CONTROL.COLOR_MODE)
     or (ib.data.value ~= clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION
     and ib.data.value ~= clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY) then
       return
   end
-  device:set_field(fields.COLOR_MODE, ib.data.value)
+  device:set_field(fields.COLOR_CONTROL.COLOR_MODE, ib.data.value)
   local req = im.InteractionRequest(im.InteractionRequest.RequestType.READ, {})
   if ib.data.value == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
     req:merge(clusters.ColorControl.attributes.CurrentHue:read())
@@ -196,7 +196,7 @@ end
 function AttributeHandlers.color_capabilities_handler(driver, device, ib, response)
   if ib.data.value ~= nil then
     if ib.data.value & 0x1 then
-      device:set_field(fields.HUESAT_SUPPORT, true)
+      device:set_field(fields.COLOR_CONTROL.HUESAT_SUPPORT, true)
     end
   end
 end
@@ -207,20 +207,20 @@ function AttributeHandlers.color_temp_physical_mireds_bounds_factory(minOrMax)
     if temp_in_mired == nil then
       return
     end
-    if (temp_in_mired < fields.COLOR_TEMPERATURE_MIRED_MIN or temp_in_mired > fields.COLOR_TEMPERATURE_MIRED_MAX) then
-      device.log.warn_with({hub_logs = true}, string.format("Device reported a color temperature %d mired outside of sane range of %.2f-%.2f", temp_in_mired, fields.COLOR_TEMPERATURE_MIRED_MIN, fields.COLOR_TEMPERATURE_MIRED_MAX))
+    if (temp_in_mired < fields.MIRED.MIN_ALLOWED or temp_in_mired > fields.MIRED.MAX_ALLOWED) then
+      device.log.warn_with({hub_logs = true}, string.format("Device reported a color temperature %d mired outside of sane range of %.2f-%.2f", temp_in_mired, fields.MIRED.MIN_ALLOWED, fields.MIRED.MAX_ALLOWED))
       return
     end
     local temp_in_kelvin = switch_utils.mired_to_kelvin(temp_in_mired, minOrMax)
-    switch_utils.set_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..minOrMax, ib.endpoint_id, temp_in_kelvin)
+    switch_utils.set_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..minOrMax, ib.endpoint_id, temp_in_kelvin)
     -- the minimum color temp in kelvin corresponds to the maximum temp in mireds
-    if minOrMax == fields.COLOR_TEMP_MIN then
-      switch_utils.set_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, ib.endpoint_id, temp_in_mired)
+    if minOrMax == fields.COLOR_TEMP.MIN then
+      switch_utils.set_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MAX, ib.endpoint_id, temp_in_mired)
     else
-      switch_utils.set_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, ib.endpoint_id, temp_in_mired)
+      switch_utils.set_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MIN, ib.endpoint_id, temp_in_mired)
     end
-    local min = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP_MIN, ib.endpoint_id)
-    local max = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP_MAX, ib.endpoint_id)
+    local min = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP.MIN, ib.endpoint_id)
+    local max = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP.MAX, ib.endpoint_id)
     if min ~= nil and max ~= nil then
       if min < max then
         device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorTemperature.colorTemperatureRange({ value = {minimum = min, maximum = max} }))
@@ -450,9 +450,9 @@ function AttributeHandlers.temperature_measured_value_bounds_factory(minOrMax)
     end
     local temp = ib.data.value / 100.0
     local unit = "C"
-    switch_utils.set_field_for_endpoint(device, fields.TEMP_BOUND_RECEIVED..minOrMax, ib.endpoint_id, temp)
-    local min = switch_utils.get_field_for_endpoint(device, fields.TEMP_BOUND_RECEIVED..fields.TEMP_MIN, ib.endpoint_id)
-    local max = switch_utils.get_field_for_endpoint(device, fields.TEMP_BOUND_RECEIVED..fields.TEMP_MAX, ib.endpoint_id)
+    switch_utils.set_field_for_endpoint(device, fields.TEMPERATURE_MEASUREMENT.BOUND_RECEIVED..minOrMax, ib.endpoint_id, temp)
+    local min = switch_utils.get_field_for_endpoint(device, fields.TEMPERATURE_MEASUREMENT.BOUND_RECEIVED..fields.TEMPERATURE_MEASUREMENT.MIN, ib.endpoint_id)
+    local max = switch_utils.get_field_for_endpoint(device, fields.TEMPERATURE_MEASUREMENT.BOUND_RECEIVED..fields.TEMPERATURE_MEASUREMENT.MAX, ib.endpoint_id)
     if min ~= nil and max ~= nil then
       if min < max then
         -- Only emit the capability for RPC version >= 5 (unit conversion for
@@ -460,8 +460,8 @@ function AttributeHandlers.temperature_measured_value_bounds_factory(minOrMax)
         if version.rpc >= 5 then
           device:emit_event_for_endpoint(ib.endpoint_id, capabilities.temperatureMeasurement.temperatureRange({ value = { minimum = min, maximum = max }, unit = unit }))
         end
-        switch_utils.set_field_for_endpoint(device, fields.TEMP_BOUND_RECEIVED..fields.TEMP_MIN, ib.endpoint_id, nil)
-        switch_utils.set_field_for_endpoint(device, fields.TEMP_BOUND_RECEIVED..fields.TEMP_MAX, ib.endpoint_id, nil)
+        switch_utils.set_field_for_endpoint(device, fields.TEMPERATURE_MEASUREMENT.BOUND_RECEIVED..fields.TEMPERATURE_MEASUREMENT.MIN, ib.endpoint_id, nil)
+        switch_utils.set_field_for_endpoint(device, fields.TEMPERATURE_MEASUREMENT.BOUND_RECEIVED..fields.TEMPERATURE_MEASUREMENT.MAX, ib.endpoint_id, nil)
       else
         device.log.warn_with({hub_logs = true}, string.format("Device reported a min temperature %d that is not lower than the reported max temperature %d", min, max))
       end

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -57,8 +57,8 @@ function CapabilityHandlers.handle_step_level(driver, device, cmd)
   if step_size == 0 then return end
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local step_mode = step_size > 0 and clusters.LevelControl.types.StepMode.UP or clusters.LevelControl.types.StepMode.DOWN
-  local transition_time = device:get_field(fields.TRANSITION_TIME.SWITCH_LEVEL_STEP) or fields.TRANSITION_TIME_FAST
-  device:send(clusters.LevelControl.server.commands.Step(device, endpoint_id, step_mode, math.abs(step_size), transition_time, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
+  local transition_time = device:get_field(fields.LEVEL.STEP_TRANSITION_TIME) or fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME
+  device:send(clusters.LevelControl.server.commands.Step(device, endpoint_id, step_mode, math.abs(step_size), transition_time, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF))
 end
 
 
@@ -71,10 +71,10 @@ function CapabilityHandlers.handle_set_color(driver, device, cmd)
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local hue = switch_utils.convert_huesat_st_to_matter(cmd.args.color.hue)
     local sat = switch_utils.convert_huesat_st_to_matter(cmd.args.color.saturation)
-    req = clusters.ColorControl.server.commands.MoveToHueAndSaturation(device, endpoint_id, hue, sat, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    req = clusters.ColorControl.server.commands.MoveToHueAndSaturation(device, endpoint_id, hue, sat, fields.COMMAND_OPTS.ZERO_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.HANDLE_COMMAND_IF_OFF)
   else
     local x, y, _ = st_utils.safe_hsv_to_xy(cmd.args.color.hue, cmd.args.color.saturation)
-    req = clusters.ColorControl.server.commands.MoveToColor(device, endpoint_id, x, y, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    req = clusters.ColorControl.server.commands.MoveToColor(device, endpoint_id, x, y, fields.COMMAND_OPTS.ZERO_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.HANDLE_COMMAND_IF_OFF)
   end
   device:send(req)
 end
@@ -84,7 +84,7 @@ function CapabilityHandlers.handle_set_hue(driver, device, cmd)
   local huesat_endpoints = device:get_endpoints(clusters.ColorControl.ID, {feature_bitmap = clusters.ColorControl.FeatureMap.HUE_AND_SATURATION})
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local hue = switch_utils.convert_huesat_st_to_matter(cmd.args.hue)
-    local req = clusters.ColorControl.server.commands.MoveToHue(device, endpoint_id, hue, 0, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    local req = clusters.ColorControl.server.commands.MoveToHue(device, endpoint_id, hue, 0, fields.COMMAND_OPTS.ZERO_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.HANDLE_COMMAND_IF_OFF)
     device:send(req)
   else
     device.log.warn("Device does not support huesat features on its color control cluster")
@@ -96,7 +96,7 @@ function CapabilityHandlers.handle_set_saturation(driver, device, cmd)
   local huesat_endpoints = device:get_endpoints(clusters.ColorControl.ID, {feature_bitmap = clusters.ColorControl.FeatureMap.HUE_AND_SATURATION})
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local sat = switch_utils.convert_huesat_st_to_matter(cmd.args.saturation)
-    local req = clusters.ColorControl.server.commands.MoveToSaturation(device, endpoint_id, sat, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    local req = clusters.ColorControl.server.commands.MoveToSaturation(device, endpoint_id, sat, fields.COMMAND_OPTS.ZERO_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.HANDLE_COMMAND_IF_OFF)
     device:send(req)
   else
     device.log.warn("Device does not support huesat features on its color control cluster")
@@ -109,17 +109,17 @@ end
 function CapabilityHandlers.handle_set_color_temperature(driver, device, cmd)
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local temp_in_kelvin = cmd.args.temperature
-  local min_temp_kelvin = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP_MIN, endpoint_id)
-  local max_temp_kelvin = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP_MAX, endpoint_id)
+  local min_temp_kelvin = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP.MIN, endpoint_id)
+  local max_temp_kelvin = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_KELVIN..fields.COLOR_TEMP.MAX, endpoint_id)
 
-  local temp_in_mired = st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/temp_in_kelvin)
+  local temp_in_mired = st_utils.round(fields.MIRED.TO_KELVIN_CONVERSION_CONSTANT/temp_in_kelvin)
   if min_temp_kelvin ~= nil and temp_in_kelvin <= min_temp_kelvin then
-    temp_in_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, endpoint_id)
+    temp_in_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MAX, endpoint_id)
   elseif max_temp_kelvin ~= nil and temp_in_kelvin >= max_temp_kelvin then
-    temp_in_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id)
+    temp_in_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MIN, endpoint_id)
   end
-  local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
-  device:set_field(fields.MOST_RECENT_TEMP, cmd.args.temperature, {persist = true})
+  local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.COMMAND_OPTS.ZERO_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.HANDLE_COMMAND_IF_OFF)
+  device:set_field(fields.COLOR_TEMP.MOST_RECENT_TEMP, cmd.args.temperature, {persist = true})
   device:send(req)
 end
 
@@ -136,11 +136,11 @@ function CapabilityHandlers.handle_step_color_temperature_by_percent(driver, dev
   local endpoint_id = device:component_to_endpoint(cmd.component)
   -- before the Matter 1.3 lua libs update (HUB FW 55), there was no ColorControl StepModeEnum type defined
   local step_mode = step_percent_change > 0 and (clusters.ColorControl.types.StepModeEnum and clusters.ColorControl.types.StepModeEnum.DOWN or 3) or (clusters.ColorControl.types.StepModeEnum and clusters.ColorControl.types.StepModeEnum.UP or 1)
-  local min_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id) or fields.DEFAULT_MIRED_MIN
-  local max_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, endpoint_id) or fields.DEFAULT_MIRED_MAX
+  local min_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MIN, endpoint_id) or fields.MIRED.DEFAULT_MIN
+  local max_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP.BOUND_RECEIVED_MIRED..fields.COLOR_TEMP.MAX, endpoint_id) or fields.MIRED.DEFAULT_MAX
   local step_size_in_mireds = st_utils.round((max_mireds - min_mireds) * (math.abs(step_percent_change)/100.0))
-  local transition_time = device:get_field(fields.TRANSITION_TIME.COLOR_TEMP_STEP) or fields.TRANSITION_TIME_FAST
-  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, endpoint_id, step_mode, step_size_in_mireds, transition_time, min_mireds, max_mireds, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
+  local transition_time = device:get_field(fields.COLOR_TEMP.STEP_TRANSITION_TIME) or fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME
+  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, endpoint_id, step_mode, step_size_in_mireds, transition_time, min_mireds, max_mireds, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF))
 end
 
 

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -57,7 +57,8 @@ function CapabilityHandlers.handle_step_level(driver, device, cmd)
   if step_size == 0 then return end
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local step_mode = step_size > 0 and clusters.LevelControl.types.StepMode.UP or clusters.LevelControl.types.StepMode.DOWN
-  device:send(clusters.LevelControl.server.commands.Step(device, endpoint_id, step_mode, math.abs(step_size), fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
+  local transition_time = device:get_field(fields.TRANSITION_TIME.SWITCH_LEVEL_STEP) or fields.TRANSITION_TIME_FAST
+  device:send(clusters.LevelControl.server.commands.Step(device, endpoint_id, step_mode, math.abs(step_size), transition_time, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
 end
 
 
@@ -70,10 +71,10 @@ function CapabilityHandlers.handle_set_color(driver, device, cmd)
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local hue = switch_utils.convert_huesat_st_to_matter(cmd.args.color.hue)
     local sat = switch_utils.convert_huesat_st_to_matter(cmd.args.color.saturation)
-    req = clusters.ColorControl.server.commands.MoveToHueAndSaturation(device, endpoint_id, hue, sat, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    req = clusters.ColorControl.server.commands.MoveToHueAndSaturation(device, endpoint_id, hue, sat, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
   else
     local x, y, _ = st_utils.safe_hsv_to_xy(cmd.args.color.hue, cmd.args.color.saturation)
-    req = clusters.ColorControl.server.commands.MoveToColor(device, endpoint_id, x, y, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    req = clusters.ColorControl.server.commands.MoveToColor(device, endpoint_id, x, y, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
   end
   device:send(req)
 end
@@ -83,7 +84,7 @@ function CapabilityHandlers.handle_set_hue(driver, device, cmd)
   local huesat_endpoints = device:get_endpoints(clusters.ColorControl.ID, {feature_bitmap = clusters.ColorControl.FeatureMap.HUE_AND_SATURATION})
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local hue = switch_utils.convert_huesat_st_to_matter(cmd.args.hue)
-    local req = clusters.ColorControl.server.commands.MoveToHue(device, endpoint_id, hue, 0, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    local req = clusters.ColorControl.server.commands.MoveToHue(device, endpoint_id, hue, 0, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
     device:send(req)
   else
     device.log.warn("Device does not support huesat features on its color control cluster")
@@ -95,7 +96,7 @@ function CapabilityHandlers.handle_set_saturation(driver, device, cmd)
   local huesat_endpoints = device:get_endpoints(clusters.ColorControl.ID, {feature_bitmap = clusters.ColorControl.FeatureMap.HUE_AND_SATURATION})
   if switch_utils.tbl_contains(huesat_endpoints, endpoint_id) then
     local sat = switch_utils.convert_huesat_st_to_matter(cmd.args.saturation)
-    local req = clusters.ColorControl.server.commands.MoveToSaturation(device, endpoint_id, sat, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+    local req = clusters.ColorControl.server.commands.MoveToSaturation(device, endpoint_id, sat, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
     device:send(req)
   else
     device.log.warn("Device does not support huesat features on its color control cluster")
@@ -117,7 +118,7 @@ function CapabilityHandlers.handle_set_color_temperature(driver, device, cmd)
   elseif max_temp_kelvin ~= nil and temp_in_kelvin >= max_temp_kelvin then
     temp_in_mired = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id)
   end
-  local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+  local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.NULL_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
   device:set_field(fields.MOST_RECENT_TEMP, cmd.args.temperature, {persist = true})
   device:send(req)
 end
@@ -138,7 +139,8 @@ function CapabilityHandlers.handle_step_color_temperature_by_percent(driver, dev
   local min_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id) or fields.DEFAULT_MIRED_MIN
   local max_mireds = switch_utils.get_field_for_endpoint(device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MAX, endpoint_id) or fields.DEFAULT_MIRED_MAX
   local step_size_in_mireds = st_utils.round((max_mireds - min_mireds) * (math.abs(step_percent_change)/100.0))
-  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, endpoint_id, step_mode, step_size_in_mireds, fields.TRANSITION_TIME_FAST, min_mireds, max_mireds, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
+  local transition_time = device:get_field(fields.TRANSITION_TIME.COLOR_TEMP_STEP) or fields.TRANSITION_TIME_FAST
+  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, endpoint_id, step_mode, step_size_in_mireds, transition_time, min_mireds, max_mireds, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF))
 end
 
 

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/event_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/event_handlers.lua
@@ -12,15 +12,15 @@ local EventHandlers = {}
 -- [[ SWITCH CLUSTER EVENTS ]] --
 
 function EventHandlers.initial_press_handler(driver, device, ib, response)
-  if switch_utils.get_field_for_endpoint(device, fields.SUPPORTS_MULTI_PRESS, ib.endpoint_id) then
+  if switch_utils.get_field_for_endpoint(device, fields.BUTTON.SUPPORTS_MULTI_PRESS, ib.endpoint_id) then
     -- Receipt of an InitialPress event means we do not want to ignore the next MultiPressComplete event
     -- or else we would potentially not create the expected button capability event
-    switch_utils.set_field_for_endpoint(device, fields.IGNORE_NEXT_MPC, ib.endpoint_id, nil)
-  elseif switch_utils.get_field_for_endpoint(device, fields.INITIAL_PRESS_ONLY, ib.endpoint_id) then
+    switch_utils.set_field_for_endpoint(device, fields.BUTTON.IGNORE_NEXT_MPC, ib.endpoint_id, nil)
+  elseif switch_utils.get_field_for_endpoint(device, fields.BUTTON.INITIAL_PRESS_ONLY, ib.endpoint_id) then
     device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.pushed({state_change = true}))
-  elseif switch_utils.get_field_for_endpoint(device, fields.EMULATE_HELD, ib.endpoint_id) then
+  elseif switch_utils.get_field_for_endpoint(device, fields.BUTTON.EMULATE_HELD, ib.endpoint_id) then
     -- if our button doesn't differentiate between short and long holds, do it in code by keeping track of the press down time
-    switch_utils.set_field_for_endpoint(device, fields.START_BUTTON_PRESS, ib.endpoint_id, lua_socket.gettime(), {persist = false})
+    switch_utils.set_field_for_endpoint(device, fields.BUTTON.START_PRESS, ib.endpoint_id, lua_socket.gettime(), {persist = false})
   end
 end
 
@@ -28,16 +28,16 @@ end
 -- there's also a "long release" event, but this event is required to come first
 function EventHandlers.long_press_handler(driver, device, ib, response)
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.held({state_change = true}))
-  if switch_utils.get_field_for_endpoint(device, fields.SUPPORTS_MULTI_PRESS, ib.endpoint_id) then
+  if switch_utils.get_field_for_endpoint(device, fields.BUTTON.SUPPORTS_MULTI_PRESS, ib.endpoint_id) then
     -- Ignore the next MultiPressComplete event if it is sent as part of this "long press" event sequence
-    switch_utils.set_field_for_endpoint(device, fields.IGNORE_NEXT_MPC, ib.endpoint_id, true)
+    switch_utils.set_field_for_endpoint(device, fields.BUTTON.IGNORE_NEXT_MPC, ib.endpoint_id, true)
   end
 end
 
 function EventHandlers.multi_press_complete_handler(driver, device, ib, response)
   -- in the case of multiple button presses
   -- emit number of times, multiple presses have been completed
-  if ib.data and not switch_utils.get_field_for_endpoint(device, fields.IGNORE_NEXT_MPC, ib.endpoint_id) then
+  if ib.data and not switch_utils.get_field_for_endpoint(device, fields.BUTTON.IGNORE_NEXT_MPC, ib.endpoint_id) then
     local press_value = ib.data.elements.total_number_of_presses_counted.value
     --capability only supports up to 6 presses
     if press_value < 7 then
@@ -53,12 +53,12 @@ function EventHandlers.multi_press_complete_handler(driver, device, ib, response
       device.log.info(string.format("Number of presses (%d) not supported by capability", press_value))
     end
   end
-  switch_utils.set_field_for_endpoint(device, fields.IGNORE_NEXT_MPC, ib.endpoint_id, nil)
+  switch_utils.set_field_for_endpoint(device, fields.BUTTON.IGNORE_NEXT_MPC, ib.endpoint_id, nil)
 end
 
 local function emulate_held_event(device, ep)
   local now = lua_socket.gettime()
-  local press_init = switch_utils.get_field_for_endpoint(device, fields.START_BUTTON_PRESS, ep) or now -- if we don't have an init time, assume instant release
+  local press_init = switch_utils.get_field_for_endpoint(device, fields.BUTTON.START_PRESS, ep) or now -- if we don't have an init time, assume instant release
   if (now - press_init) < fields.TIMEOUT_THRESHOLD then
     if (now - press_init) > fields.HELD_THRESHOLD then
       device:emit_event_for_endpoint(ep, capabilities.button.button.held({state_change = true}))
@@ -66,12 +66,12 @@ local function emulate_held_event(device, ep)
       device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = true}))
     end
   end
-  switch_utils.set_field_for_endpoint(device, fields.START_BUTTON_PRESS, ep, nil, {persist = false})
+  switch_utils.set_field_for_endpoint(device, fields.BUTTON.START_PRESS, ep, nil, {persist = false})
 end
 
 function EventHandlers.short_release_handler(driver, device, ib, response)
-  if not switch_utils.get_field_for_endpoint(device, fields.SUPPORTS_MULTI_PRESS, ib.endpoint_id) then
-    if switch_utils.get_field_for_endpoint(device, fields.EMULATE_HELD, ib.endpoint_id) then
+  if not switch_utils.get_field_for_endpoint(device, fields.BUTTON.SUPPORTS_MULTI_PRESS, ib.endpoint_id) then
+    if switch_utils.get_field_for_endpoint(device, fields.BUTTON.EMULATE_HELD, ib.endpoint_id) then
       emulate_held_event(device, ib.endpoint_id)
     else
       device:emit_event_for_endpoint(ib.endpoint_id, capabilities.button.button.pushed({state_change = true}))

--- a/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
@@ -169,15 +169,15 @@ function ButtonDeviceConfiguration.configure_buttons(device, momentary_switch_ep
       if switch_utils.tbl_contains(msm_eps, ep) then
         supportedButtonValues_event = nil -- deferred to the max press handler
         device:send(clusters.Switch.attributes.MultiPressMax:read(device, ep))
-        switch_utils.set_field_for_endpoint(device, fields.SUPPORTS_MULTI_PRESS, ep, true, {persist = true})
+        switch_utils.set_field_for_endpoint(device, fields.BUTTON.SUPPORTS_MULTI_PRESS, ep, true, {persist = true})
       elseif switch_utils.tbl_contains(msl_eps, ep) then
         supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})
       elseif switch_utils.tbl_contains(msr_eps, ep) then
         supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})
-        switch_utils.set_field_for_endpoint(device, fields.EMULATE_HELD, ep, true, {persist = true})
+        switch_utils.set_field_for_endpoint(device, fields.BUTTON.EMULATE_HELD, ep, true, {persist = true})
       else -- this switch endpoint only supports momentary switch, no release events
         supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})
-        switch_utils.set_field_for_endpoint(device, fields.INITIAL_PRESS_ONLY, ep, true, {persist = true})
+        switch_utils.set_field_for_endpoint(device, fields.BUTTON.INITIAL_PRESS_ONLY, ep, true, {persist = true})
       end
 
       if supportedButtonValues_event then

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -194,8 +194,13 @@ SwitchFields.TEMP_BOUND_RECEIVED = "__temp_bound_received"
 SwitchFields.TEMP_MIN = "__temp_min"
 SwitchFields.TEMP_MAX = "__temp_max"
 
-SwitchFields.TRANSITION_TIME = 0 -- number of 10ths of a second
-SwitchFields.TRANSITION_TIME_FAST = 3 -- 0.3 seconds
+SwitchFields.NULL_TRANSITION_TIME = 0 -- 0.0 seconds
+SwitchFields.TRANSITION_TIME_FAST = 3 -- 0.3 seconds, measured in tenths of a second as per the Matter spec
+
+SwitchFields.TRANSITION_TIME = {
+  SWITCH_LEVEL_STEP = "__switch_level_step_transition_time",
+  COLOR_TEMP_STEP = "__color_temp_step_transition_time",
+}
 
 -- For Level/Color Control cluster commands, this field indicates which bits in the OptionsOverride field are valid. In this case, we specify that the ExecuteIfOff option (bit 1) may be overridden.
 SwitchFields.OPTIONS_MASK = 0x01

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -1,32 +1,7 @@
 -- Copyright © 2025 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
-local st_utils = require "st.utils"
-
 local SwitchFields = {}
-
-SwitchFields.MOST_RECENT_TEMP = "mostRecentTemp"
-SwitchFields.RECEIVED_X = "receivedX"
-SwitchFields.RECEIVED_Y = "receivedY"
-SwitchFields.HUESAT_SUPPORT = "huesatSupport"
-
-SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT = 1000000
-
--- These values are a "sanity check" to check that values we are getting are reasonable
-local COLOR_TEMPERATURE_KELVIN_MAX = 15000
-local COLOR_TEMPERATURE_KELVIN_MIN = 1000
-SwitchFields.COLOR_TEMPERATURE_MIRED_MAX = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MIN) -- 1000 Mireds
-SwitchFields.COLOR_TEMPERATURE_MIRED_MIN = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/COLOR_TEMPERATURE_KELVIN_MAX) -- 67 Mireds
-
--- These values are the config bounds in the default Matter profiles (e.g. light-level-colorTemperature, light-color-level)
-local DEFAULT_KELVIN_MIN = 2200
-local DEFAULT_KELVIN_MAX = 6500
-SwitchFields.DEFAULT_MIRED_MIN = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/DEFAULT_KELVIN_MAX) -- 154 Mireds
-SwitchFields.DEFAULT_MIRED_MAX = st_utils.round(SwitchFields.MIRED_KELVIN_CONVERSION_CONSTANT/DEFAULT_KELVIN_MIN) -- 455 Mireds
-
-SwitchFields.SWITCH_LEVEL_LIGHTING_MIN = 1
-SwitchFields.CURRENT_HUESAT_ATTR_MIN = 0
-SwitchFields.CURRENT_HUESAT_ATTR_MAX = 254
 
 SwitchFields.DEVICE_TYPE_ID = {
   AGGREGATOR = 0x000E,
@@ -69,30 +44,76 @@ SwitchFields.device_type_profile_map = {
   [SwitchFields.DEVICE_TYPE_ID.MOUNTED_DIMMABLE_LOAD_CONTROL] = "switch-level",
 }
 
--- COMPONENT_TO_ENDPOINT_MAP is here to preserve the endpoint mapping for
--- devices that were joined to this driver as MCD devices before the transition
--- to join switch devices as parent-child. This value will exist in the device
--- table for devices that joined prior to this transition, and is also used for
--- button devices that require component mapping.
-SwitchFields.COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
-SwitchFields.IS_PARENT_CHILD_DEVICE = "__is_parent_child_device"
+SwitchFields.LEVEL = {
+  BOUND_RECEIVED = "__level_bound_received",
+  MIN = "__level_min",
+  MAX = "__level_max",
+  STEP_TRANSITION_TIME = "__level_step_transition_time",
+}
 
---- If the ASSIGNED_CHILD_KEY field is populated for an endpoint, it should be
---- used as the key in the get_child_by_parent_assigned_key() function. This allows
---- multiple endpoints to associate with the same child device, though right now child
---- devices are keyed using only one endpoint id.
-SwitchFields.ASSIGNED_CHILD_KEY = "__assigned_child_key"
+SwitchFields.COLOR_TEMP = {
+  BOUND_RECEIVED_KELVIN = "__colorTemp_bound_received_kelvin",
+  BOUND_RECEIVED_MIRED = "__colorTemp_bound_received_mired",
+  MIN = "__color_temp_min",
+  MAX = "__color_temp_max",
+  MOST_RECENT_TEMP = "mostRecentTemp",
+  STEP_TRANSITION_TIME = "__color_temp_step_transition_time",
+}
 
-SwitchFields.COLOR_TEMP_BOUND_RECEIVED_KELVIN = "__colorTemp_bound_received_kelvin"
-SwitchFields.COLOR_TEMP_BOUND_RECEIVED_MIRED = "__colorTemp_bound_received_mired"
-SwitchFields.COLOR_TEMP_MIN = "__color_temp_min"
-SwitchFields.COLOR_TEMP_MAX = "__color_temp_max"
-SwitchFields.LEVEL_BOUND_RECEIVED = "__level_bound_received"
-SwitchFields.LEVEL_MIN = "__level_min"
-SwitchFields.LEVEL_MAX = "__level_max"
-SwitchFields.COLOR_MODE = "__color_mode"
+SwitchFields.COLOR_CONTROL = {
+  RECEIVED_X = "receivedX",
+  RECEIVED_Y = "receivedY",
+  HUESAT_SUPPORT = "huesatSupport",
+  COLOR_MODE = "__color_mode"
+}
 
-SwitchFields.SUBSCRIBED_ATTRIBUTES_KEY = "__subscribed_attributes"
+SwitchFields.TEMPERATURE_MEASUREMENT = {
+  BOUND_RECEIVED = "__temperature_measurement_bound_received",
+  MIN = "__temperature_measurement_min",
+  MAX = "__temperature_measurement_max",
+}
+
+SwitchFields.BUTTON = {
+  START_PRESS = "__start_button_press",
+
+  -- Some switches will send a MultiPressComplete event as part of a long press sequence. Normally the driver will create a
+  -- button capability event on receipt of MultiPressComplete, but in this case that would result in an extra event because
+  -- the "held" capability event is generated when the LongPress event is received. The IGNORE_NEXT_MPC flag is used
+  -- to tell the driver to ignore MultiPressComplete if it is received after a long press to avoid this extra event.
+  IGNORE_NEXT_MPC = "__ignore_next_mpc",
+
+  -- These are essentially storing the supported features of a given endpoint
+  -- TODO: add an is_feature_supported_for_endpoint function to matter.device that takes an endpoint
+  EMULATE_HELD = "__emulate_held", -- for non-MSR (MomentarySwitchRelease) devices we can emulate this on the software side
+  SUPPORTS_MULTI_PRESS = "__multi_button", -- for MSM devices (MomentarySwitchMultiPress), create an event on receipt of MultiPressComplete
+  INITIAL_PRESS_ONLY = "__initial_press_only", -- for devices that support MS (MomentarySwitch), but not MSR (MomentarySwitchRelease)
+}
+
+SwitchFields.MIRED = {
+  TO_KELVIN_CONVERSION_CONSTANT = 1000000,
+
+  -- These values are a "sanity check" to check that values we are getting are reasonable
+  MIN_ALLOWED = 67, -- 15000 Kelvin
+  MAX_ALLOWED = 1000, -- 1000 Kelvin
+
+  -- These values are the config bounds in the default Matter profiles (e.g. light-level-colorTemperature, light-color-level)
+  DEFAULT_MIN = 154, -- 6500 Kelvin
+  DEFAULT_MAX = 455, -- 2200 Kelvin
+}
+
+SwitchFields.COMMAND_OPTS = {
+  -- Transition Time is measured in tenths of a second as per the Matter spec
+  ZERO_TRANSITION_TIME = 0, -- 0 milliseconds
+  DEFAULT_STEP_TRANSITION_TIME = 3, -- 300 milliseconds
+
+  -- For Level/Color Control cluster commands, this field indicates which bits in the OptionsOverride field are valid. 
+  -- In this case, we specify that the ExecuteIfOff option (bit 1) may be overridden.
+  OPTIONS_MASK = 0x01,
+
+  -- the OptionsOverride field's first bit overrides the ExecuteIfOff option, defining whether the command should take effect when the device is off.
+  HANDLE_COMMAND_IF_OFF = 0x01,
+  IGNORE_COMMAND_IF_OFF = 0x00,
+}
 
 SwitchFields.updated_fields = {
   { current_field_name = "__component_to_endpoint_map_button", updated_field_name = SwitchFields.COMPONENT_TO_ENDPOINT_MAP },
@@ -147,6 +168,26 @@ SwitchFields.switch_category_vendor_overrides = {
     {0xEEE2, 0xAB08, 0xAB31, 0xAB04, 0xAB01, 0xAB43, 0xAB02, 0xAB03, 0xAB05}
 }
 
+SwitchFields.SWITCH_LEVEL_LIGHTING_MIN = 1
+SwitchFields.CURRENT_HUESAT_ATTR_MIN = 0
+SwitchFields.CURRENT_HUESAT_ATTR_MAX = 254
+
+SwitchFields.SUBSCRIBED_ATTRIBUTES_KEY = "__subscribed_attributes"
+
+-- COMPONENT_TO_ENDPOINT_MAP is here to preserve the endpoint mapping for
+-- devices that were joined to this driver as MCD devices before the transition
+-- to join switch devices as parent-child. This value will exist in the device
+-- table for devices that joined prior to this transition, and is also used for
+-- button devices that require component mapping.
+SwitchFields.COMPONENT_TO_ENDPOINT_MAP = "__component_to_endpoint_map"
+SwitchFields.IS_PARENT_CHILD_DEVICE = "__is_parent_child_device"
+
+--- If the ASSIGNED_CHILD_KEY field is populated for an endpoint, it should be
+--- used as the key in the get_child_by_parent_assigned_key() function. This allows
+--- multiple endpoints to associate with the same child device, though right now child
+--- devices are keyed using only one endpoint id.
+SwitchFields.ASSIGNED_CHILD_KEY = "__assigned_child_key"
+
 --- stores a table of endpoints that support the Electrical Sensor device type, used during profiling
 --- in AvailableEndpoints and PartsList handlers for SET and TREE PowerTopology features, respectively
 SwitchFields.ELECTRICAL_SENSOR_EPS = "__electrical_sensor_eps"
@@ -171,41 +212,10 @@ SwitchFields.CUMULATIVE_REPORTS_SUPPORTED = "__cumulative_reports_supported"
 SwitchFields.LAST_IMPORTED_REPORT_TIMESTAMP = "__last_imported_report_timestamp"
 SwitchFields.MINIMUM_ST_ENERGY_REPORT_INTERVAL = (15 * 60) -- 15 minutes, reported in seconds
 
-SwitchFields.START_BUTTON_PRESS = "__start_button_press"
 SwitchFields.TIMEOUT_THRESHOLD = 10 --arbitrary timeout
 SwitchFields.HELD_THRESHOLD = 1
 
 -- this is the number of buttons for which we have a static profile already made
 SwitchFields.STATIC_BUTTON_PROFILE_SUPPORTED = {1, 2, 3, 4, 5, 6, 7, 8, 9}
-
--- Some switches will send a MultiPressComplete event as part of a long press sequence. Normally the driver will create a
--- button capability event on receipt of MultiPressComplete, but in this case that would result in an extra event because
--- the "held" capability event is generated when the LongPress event is received. The IGNORE_NEXT_MPC flag is used
--- to tell the driver to ignore MultiPressComplete if it is received after a long press to avoid this extra event.
-SwitchFields.IGNORE_NEXT_MPC = "__ignore_next_mpc"
-
--- These are essentially storing the supported features of a given endpoint
--- TODO: add an is_feature_supported_for_endpoint function to matter.device that takes an endpoint
-SwitchFields.EMULATE_HELD = "__emulate_held" -- for non-MSR (MomentarySwitchRelease) devices we can emulate this on the software side
-SwitchFields.SUPPORTS_MULTI_PRESS = "__multi_button" -- for MSM devices (MomentarySwitchMultiPress), create an event on receipt of MultiPressComplete
-SwitchFields.INITIAL_PRESS_ONLY = "__initial_press_only" -- for devices that support MS (MomentarySwitch), but not MSR (MomentarySwitchRelease)
-
-SwitchFields.TEMP_BOUND_RECEIVED = "__temp_bound_received"
-SwitchFields.TEMP_MIN = "__temp_min"
-SwitchFields.TEMP_MAX = "__temp_max"
-
-SwitchFields.NULL_TRANSITION_TIME = 0 -- 0.0 seconds
-SwitchFields.TRANSITION_TIME_FAST = 3 -- 0.3 seconds, measured in tenths of a second as per the Matter spec
-
-SwitchFields.TRANSITION_TIME = {
-  SWITCH_LEVEL_STEP = "__switch_level_step_transition_time",
-  COLOR_TEMP_STEP = "__color_temp_step_transition_time",
-}
-
--- For Level/Color Control cluster commands, this field indicates which bits in the OptionsOverride field are valid. In this case, we specify that the ExecuteIfOff option (bit 1) may be overridden.
-SwitchFields.OPTIONS_MASK = 0x01
--- the OptionsOverride field's first bit overrides the ExecuteIfOff option, defining whether the command should take effect when the device is off.
-SwitchFields.HANDLE_COMMAND_IF_OFF = 0x01
-SwitchFields.IGNORE_COMMAND_IF_OFF = 0x00
 
 return SwitchFields

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -576,4 +576,13 @@ function utils.subscribe(device)
   end
 end
 
+function utils.set_transition_times_for_stateless_capabilities(device)
+  if device:supports_capability(capabilities.statelessSwitchLevelStep) then
+    device:set_field(fields.TRANSITION_TIME.SWITCH_LEVEL_STEP, fields.TRANSITION_TIME_FAST)
+  end
+  if device:supports_capability(capabilities.statelessColorTemperatureStep) then
+    device:set_field(fields.TRANSITION_TIME.COLOR_TEMP_STEP, fields.TRANSITION_TIME_FAST)
+  end
+end
+
 return utils

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -66,10 +66,10 @@ function utils.mired_to_kelvin(value, minOrMax)
   -- rounding errors from the conversion of Kelvin to mireds.
   local kelvin_step_size = 100
   local rounding_value = 0.5
-  if minOrMax == fields.COLOR_TEMP_MIN then
-    return st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value + 1)) + rounding_value) * kelvin_step_size
-  elseif minOrMax == fields.COLOR_TEMP_MAX then
-    return st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value - 1)) - rounding_value) * kelvin_step_size
+  if minOrMax == fields.COLOR_TEMP.MIN then
+    return st_utils.round(fields.MIRED.TO_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value + 1)) + rounding_value) * kelvin_step_size
+  elseif minOrMax == fields.COLOR_TEMP.MAX then
+    return st_utils.round(fields.MIRED.TO_KELVIN_CONVERSION_CONSTANT / (kelvin_step_size * (value - 1)) - rounding_value) * kelvin_step_size
   else
     log.warn_with({hub_logs = true}, "Attempted to convert temperature unit for an undefined value")
   end
@@ -573,15 +573,6 @@ function utils.subscribe(device)
 
   if #subscribe_request.info_blocks > 0 then
     device:send(subscribe_request)
-  end
-end
-
-function utils.set_transition_times_for_stateless_capabilities(device)
-  if device:supports_capability(capabilities.statelessSwitchLevelStep) then
-    device:set_field(fields.TRANSITION_TIME.SWITCH_LEVEL_STEP, fields.TRANSITION_TIME_FAST)
-  end
-  if device:supports_capability(capabilities.statelessColorTemperatureStep) then
-    device:set_field(fields.TRANSITION_TIME.COLOR_TEMP_STEP, fields.TRANSITION_TIME_FAST)
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_stateless_step.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_stateless_step.lua
@@ -75,7 +75,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device_color_temp.id,
-        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.DOWN, 60, fields.TRANSITION_TIME_FAST, fields.DEFAULT_MIRED_MIN, fields.DEFAULT_MIRED_MAX, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.DOWN, 60, fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME, fields.MIRED.DEFAULT_MIN, fields.MIRED.DEFAULT_MAX, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF)
       },
     },
     {
@@ -99,7 +99,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device_color_temp.id,
-        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.DOWN, 271, fields.TRANSITION_TIME_FAST, fields.DEFAULT_MIRED_MIN, fields.DEFAULT_MIRED_MAX, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.DOWN, 271, fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME, fields.MIRED.DEFAULT_MIN, fields.MIRED.DEFAULT_MAX, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF)
       },
     },
     {
@@ -123,7 +123,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device_color_temp.id,
-        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.UP, 151, fields.TRANSITION_TIME_FAST, fields.DEFAULT_MIRED_MIN, fields.DEFAULT_MIRED_MAX, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device_color_temp, 1, clusters.ColorControl.types.StepModeEnum.UP, 151, fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME, fields.MIRED.DEFAULT_MIN, fields.MIRED.DEFAULT_MAX, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF)
       },
     }
   },
@@ -157,7 +157,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device_color_temp.id,
-        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.UP, 64, fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.UP, 64, fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF)
       },
     },
     {
@@ -181,7 +181,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device_color_temp.id,
-        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.DOWN, 127, fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.DOWN, 127, fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF)
       },
     },
     {
@@ -205,7 +205,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device_color_temp.id,
-        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.UP, 254, fields.TRANSITION_TIME_FAST, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.LevelControl.server.commands.Step(mock_device_color_temp, 1, clusters.LevelControl.types.StepModeEnum.UP, 254, fields.COMMAND_OPTS.DEFAULT_STEP_TRANSITION_TIME, fields.COMMAND_OPTS.OPTIONS_MASK, fields.COMMAND_OPTS.IGNORE_COMMAND_IF_OFF)
       },
     }
   },

--- a/drivers/SmartThings/zigbee-switch/src/stateless_handlers/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/stateless_handlers/init.lua
@@ -13,18 +13,6 @@ local DEFAULT_MIRED_MIN_BOUND = 154 -- 6500 Kelvin (Mireds are the inverse of Ke
 -- Transition Time: The time that shall be taken to perform the step change, in units of 1/10ths of a second.
 local DEFAULT_STATELESS_TRANSITION_TIME = 3 -- 0.3 seconds
 
--- Fields to store the transition times for the stateless capabilities,
--- in case we want to make the native handler implementations configurable in the future
-local TRANSITION_TIME = {
-    SWITCH_LEVEL_STEP = "__switch_level_step_transition_time",
-    COLOR_TEMP_STEP = "__color_temp_step_transition_time",
-}
-
-local function set_transition_time(device, field)
-  device:set_field(field, DEFAULT_STATELESS_TRANSITION_TIME)
-  return DEFAULT_STATELESS_TRANSITION_TIME
-end
-
 -- Options Mask & Override: Indicates which options are being overridden by the Level/ColorControl cluster commands
 local OPTIONS_MASK = 0x01 -- default: The `ExecuteIfOff` option is overriden
 local IGNORE_COMMAND_IF_OFF = 0x00 -- default: the command will not be executed if the device is off
@@ -32,8 +20,7 @@ local IGNORE_COMMAND_IF_OFF = 0x00 -- default: the command will not be executed 
 local function step_color_temperature_by_percent_handler(driver, device, cmd)
   local step_percent_change = cmd.args and cmd.args.stepSize or 0
   if step_percent_change == 0 then return end
-  set_transition_time(device, TRANSITION_TIME.COLOR_TEMP_STEP)
-  local transition_time = DEFAULT_STATELESS_TRANSITION_TIME
+  local transition_time = device:get_field(switch_utils.COLOR_TEMP_STEP_TRANSITION_TIME) or DEFAULT_STATELESS_TRANSITION_TIME
   -- Reminder, stepSize > 0 == Kelvin UP == Mireds DOWN. stepSize < 0 == Kelvin DOWN == Mireds UP
   local step_mode = (step_percent_change > 0) and clusters.ColorControl.types.CcStepMode.DOWN or clusters.ColorControl.types.CcStepMode.UP
   local min_mireds = device:get_field(switch_utils.MIRED_MIN_BOUND)
@@ -50,9 +37,7 @@ end
 local function step_level_handler(driver, device, cmd)
   local step_size = st_utils.round((cmd.args and cmd.args.stepSize or 0)/100.0 * 254)
   if step_size == 0 then return end
-  -- set the transition time as a field so that it can be altered in the native handler implementation as needed
-  set_transition_time(device, TRANSITION_TIME.SWITCH_LEVEL_STEP)
-  local transition_time = DEFAULT_STATELESS_TRANSITION_TIME
+  local transition_time = device:get_field(switch_utils.SWITCH_LEVEL_STEP_TRANSITION_TIME) or DEFAULT_STATELESS_TRANSITION_TIME
   local step_mode = (step_size > 0) and clusters.Level.types.MoveStepMode.UP or clusters.Level.types.MoveStepMode.DOWN
   device:send(clusters.Level.server.commands.Step(device, step_mode, math.abs(step_size), transition_time, OPTIONS_MASK, IGNORE_COMMAND_IF_OFF))
 end

--- a/drivers/SmartThings/zigbee-switch/src/stateless_handlers/init.lua
+++ b/drivers/SmartThings/zigbee-switch/src/stateless_handlers/init.lua
@@ -11,7 +11,19 @@ local DEFAULT_MIRED_MAX_BOUND = 370 -- 2700 Kelvin (Mireds are the inverse of Ke
 local DEFAULT_MIRED_MIN_BOUND = 154 -- 6500 Kelvin (Mireds are the inverse of Kelvin)
 
 -- Transition Time: The time that shall be taken to perform the step change, in units of 1/10ths of a second.
-local TRANSITION_TIME = 3 -- default: 0.3 seconds
+local DEFAULT_STATELESS_TRANSITION_TIME = 3 -- 0.3 seconds
+
+-- Fields to store the transition times for the stateless capabilities,
+-- in case we want to make the native handler implementations configurable in the future
+local TRANSITION_TIME = {
+    SWITCH_LEVEL_STEP = "__switch_level_step_transition_time",
+    COLOR_TEMP_STEP = "__color_temp_step_transition_time",
+}
+
+local function set_transition_time(device, field)
+  device:set_field(field, DEFAULT_STATELESS_TRANSITION_TIME)
+  return DEFAULT_STATELESS_TRANSITION_TIME
+end
 
 -- Options Mask & Override: Indicates which options are being overridden by the Level/ColorControl cluster commands
 local OPTIONS_MASK = 0x01 -- default: The `ExecuteIfOff` option is overriden
@@ -20,6 +32,8 @@ local IGNORE_COMMAND_IF_OFF = 0x00 -- default: the command will not be executed 
 local function step_color_temperature_by_percent_handler(driver, device, cmd)
   local step_percent_change = cmd.args and cmd.args.stepSize or 0
   if step_percent_change == 0 then return end
+  set_transition_time(device, TRANSITION_TIME.COLOR_TEMP_STEP)
+  local transition_time = DEFAULT_STATELESS_TRANSITION_TIME
   -- Reminder, stepSize > 0 == Kelvin UP == Mireds DOWN. stepSize < 0 == Kelvin DOWN == Mireds UP
   local step_mode = (step_percent_change > 0) and clusters.ColorControl.types.CcStepMode.DOWN or clusters.ColorControl.types.CcStepMode.UP
   local min_mireds = device:get_field(switch_utils.MIRED_MIN_BOUND)
@@ -30,14 +44,17 @@ local function step_color_temperature_by_percent_handler(driver, device, cmd)
     max_mireds = DEFAULT_MIRED_MAX_BOUND
   end
   local step_size_in_mireds = st_utils.round((max_mireds - min_mireds) * (math.abs(step_percent_change)/100.0))
-  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, step_mode, step_size_in_mireds, TRANSITION_TIME, min_mireds, max_mireds, OPTIONS_MASK, IGNORE_COMMAND_IF_OFF))
+  device:send(clusters.ColorControl.server.commands.StepColorTemperature(device, step_mode, step_size_in_mireds, transition_time, min_mireds, max_mireds, OPTIONS_MASK, IGNORE_COMMAND_IF_OFF))
 end
 
 local function step_level_handler(driver, device, cmd)
   local step_size = st_utils.round((cmd.args and cmd.args.stepSize or 0)/100.0 * 254)
   if step_size == 0 then return end
+  -- set the transition time as a field so that it can be altered in the native handler implementation as needed
+  set_transition_time(device, TRANSITION_TIME.SWITCH_LEVEL_STEP)
+  local transition_time = DEFAULT_STATELESS_TRANSITION_TIME
   local step_mode = (step_size > 0) and clusters.Level.types.MoveStepMode.UP or clusters.Level.types.MoveStepMode.DOWN
-  device:send(clusters.Level.server.commands.Step(device, step_mode, math.abs(step_size), TRANSITION_TIME, OPTIONS_MASK, IGNORE_COMMAND_IF_OFF))
+  device:send(clusters.Level.server.commands.Step(device, step_mode, math.abs(step_size), transition_time, OPTIONS_MASK, IGNORE_COMMAND_IF_OFF))
 end
 
 local stateless_handlers = {

--- a/drivers/SmartThings/zigbee-switch/src/switch_utils.lua
+++ b/drivers/SmartThings/zigbee-switch/src/switch_utils.lua
@@ -8,6 +8,11 @@ local switch_utils = {}
 switch_utils.MIRED_MAX_BOUND = "__max_mired_bound"
 switch_utils.MIRED_MIN_BOUND = "__min_mired_bound"
 
+-- Fields to store the transition times for the stateless capabilities,
+-- in case native handler implementations need to be re-configured in the future
+switch_utils.SWITCH_LEVEL_STEP_TRANSITION_TIME = "__switch_level_step_transition_time"
+switch_utils.COLOR_TEMP_STEP_TRANSITION_TIME = "__color_temp_step_transition_time"
+
 switch_utils.MIREDS_CONVERSION_CONSTANT = 1000000
 
 switch_utils.convert_mired_to_kelvin = function(mired)


### PR DESCRIPTION
# Description of Change
Done in response to [this comment](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2921#discussion_r3126989665), which made me think that if we were going to try to make a COLOR_TEMP_STEP table, what we really wanted was a COLOR_TEMP table that holds all the color temp-related fields. Then, to make this make sense with all the other assorted fields, I re-organized most of them into structures like this, which I think makes what field is associated with what make more sense from a top-down way.

However, since this is clearly a larger change than was initially suggested, I put this in its own PR for separate review.

As we can see, none of the tests were actually changed, as none of the driver functionality was changed in any way, just the naming conventions.
 
# Summary of Completed Tests


