### PR TITLE
Fix formatting of SMC0410 First Alert device ID in fingerprints.yml

### DIFF
--- a/drivers/SmartThings/zwave-smoke-alarm/fingerprints.yml
+++ b/drivers/SmartThings/zwave-smoke-alarm/fingerprints.yml
@@ -63,7 +63,7 @@ zwaveManufacturer:
     productType: 0x0004
     productId: 0x0003
     deviceProfileName: co-battery
-  - id: "1051/1/1040"
+  - id: 1051/1/1040
     deviceLabel: SMCO410
     manufacturerId: 0x041B
     productId: 0x0410


### PR DESCRIPTION
None of the other numerical ids are in quotes. Was that a mistake? This driver doesn't work for me with this fingerprint for the First Alert New SMCO410 Z-Wave Battery-Powered Smoke Detector & Carbon Monoxide Alarm.

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x ] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x ] I have performed a self-review of my code
- [ x] I have commented my code in hard-to-understand areas
- [ x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Fixed the id formatting by removing quotes around the numerical ID

# Summary of Completed Tests


