### PR TITLE
Update tests that fail to changes in finding children

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -370,8 +370,11 @@ test.register_coroutine_test(
 test.register_coroutine_test(
   "Switch child device: Set color temperature should send the appropriate commands",
   function()
-    test.mock_device.add_test_device(mock_child)
     test.wait_for_events()
+    test.mock_device.add_test_device(mock_child)
+    -- The parent device is already initialized at this point, so we must manually
+    -- queue an infoChanged event to update its live child_ids field via load_updated_data().
+    test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed({child_ids = {mock_child.id}}))
     test.socket.capability:__queue_receive({
       mock_child.id,
       { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {1800} }

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_home_energy_meter_gen8_1_phase.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_home_energy_meter_gen8_1_phase.lua
@@ -128,7 +128,12 @@ test.register_coroutine_test(
         )
       end
     end
-  end
+  end,
+  {
+    test_init = function()
+      test.mock_device.add_test_device(mock_parent)
+    end
+  }
 )
 
 test.register_coroutine_test(

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_home_energy_meter_gen8_2_phase.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_home_energy_meter_gen8_2_phase.lua
@@ -128,7 +128,12 @@ test.register_coroutine_test(
         )
       end
     end
-  end
+  end,
+  {
+    test_init = function()
+      test.mock_device.add_test_device(mock_parent)
+    end
+  }
 )
 
 test.register_coroutine_test(

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_home_energy_meter_gen8_3_phase.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_home_energy_meter_gen8_3_phase.lua
@@ -128,7 +128,12 @@ test.register_coroutine_test(
         )
       end
     end
-  end
+  end,
+  {
+    test_init = function()
+      test.mock_device.add_test_device(mock_parent)
+    end
+  }
 )
 
 test.register_coroutine_test(


### PR DESCRIPTION
With the change to use the child_ids field for finding children, there were a few tests that were dependent on the old functionality, this updates the tests to function correctly

This is a test only change and should not impact any device behavior
