### PR TITLE
Matter Switch: Fix Unit Test file for Parent/Child devices

### DIFF
--- a/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
@@ -345,7 +345,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColor(mock_device, extended_color_ep_id, 15182, 21547, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+        clusters.ColorControl.server.commands.MoveToColor(mock_device, extended_color_ep_id, 15182, 21547, fields.ZERO_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
       }
     },
     {
@@ -420,7 +420,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, extended_color_ep_id, 555, fields.TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, extended_color_ep_id, 555, fields.ZERO_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
       }
     }, -- 555 is expected since it is re-bounded by the given range
 
@@ -446,7 +446,7 @@ test.register_message_test(
       direction = "send",
       message = {
         mock_device.id,
-        clusters.ColorControl.server.commands.StepColorTemperature(mock_device, extended_color_ep_id, clusters.ColorControl.types.StepModeEnum.DOWN, 80, fields.TRANSITION_TIME_FAST, 153, 555, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
+        clusters.ColorControl.server.commands.StepColorTemperature(mock_device, extended_color_ep_id, clusters.ColorControl.types.StepModeEnum.DOWN, 80, fields.DEFAULT_STEP_TRANSITION_TIME, 153, 555, fields.OPTIONS_MASK, fields.IGNORE_COMMAND_IF_OFF)
       },
     },
   },


### PR DESCRIPTION
# Description of Change
Between the back-to-back merges of [this PR](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2930) and [this PR](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2915), which both touch very similar pieces of code, I made a mistake in my rebasing that led one of the test files to never run at all, which is why the CI didn't catch it. It had to do with a couple renamed fields that were renamed without being rebased in a different PR that used the original field names.

# Summary of Completed Tests
Unit tests fixed.