### PR TITLE
Matter Switch: Permit Aggregator devices to create EDGE_CHILD devices

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -43,7 +43,7 @@ function SwitchLifecycleHandlers.device_added(driver, device)
 end
 
 function SwitchLifecycleHandlers.do_configure(driver, device)
-  if device.network_type == device_lib.NETWORK_TYPE_MATTER and not switch_utils.detect_bridge(device) then
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
     switch_cfg.set_device_control_options(device)
     device_cfg.match_profile(driver, device)
   elseif device.network_type == device_lib.NETWORK_TYPE_CHILD then
@@ -54,7 +54,7 @@ function SwitchLifecycleHandlers.do_configure(driver, device)
 end
 
 function SwitchLifecycleHandlers.driver_switched(driver, device)
-  if device.network_type == device_lib.NETWORK_TYPE_MATTER and not switch_utils.detect_bridge(device) then
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
     device_cfg.match_profile(driver, device)
   end
 end
@@ -71,7 +71,7 @@ function SwitchLifecycleHandlers.info_changed(driver, device, event, args)
     end
   end
 
-  if device.network_type == device_lib.NETWORK_TYPE_MATTER and not switch_utils.detect_bridge(device) then
+  if device.network_type == device_lib.NETWORK_TYPE_MATTER then
     if device.matter_version.software ~= args.old_st_store.matter_version.software then
       device_cfg.match_profile(driver, device)
     end

--- a/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
@@ -205,7 +205,7 @@ end
 function DeviceConfiguration.match_profile(driver, device)
   if profiling_data_still_required(device) then return end
 
-  local default_endpoint_id = switch_utils.find_default_endpoint(device)
+  local default_endpoint_id, default_device_type = switch_utils.find_default_endpoint(device)
   local optional_component_capabilities
   local updated_profile
 
@@ -213,6 +213,9 @@ function DeviceConfiguration.match_profile(driver, device)
   if #server_onoff_ep_ids > 0 then
     ChildConfiguration.create_or_update_child_devices(driver, device, server_onoff_ep_ids, default_endpoint_id, SwitchDeviceConfiguration.assign_profile_for_onoff_ep)
   end
+
+  -- Allow Bridges to create child on/off devices, but don't attempt to re-profile the main Bridge device.
+  if default_device_type == fields.DEVICE_TYPE_ID.AGGREGATOR then return end
 
   if switch_utils.tbl_contains(server_onoff_ep_ids, default_endpoint_id) then
     updated_profile = SwitchDeviceConfiguration.assign_profile_for_onoff_ep(device, default_endpoint_id)

--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -146,7 +146,7 @@ end
 --- find_default_endpoint is a helper function to handle situations where
 --- device does not have endpoint ids in sequential order from 1
 function utils.find_default_endpoint(device)
-  -- Buttons should not be set on the main component for the Aqara Climate Sensor W100,
+  -- Buttons should not be set on the main component for the Aqara Climate Sensor W100
   if utils.get_product_override_field(device, "is_climate_sensor_w100") then
     return device.MATTER_DEFAULT_ENDPOINT
   end
@@ -161,16 +161,22 @@ function utils.find_default_endpoint(device)
     return nil
   end
 
+  -- After camera, use aggregator as default if it is found
+  local aggregator_ep_ids = utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.AGGREGATOR)
+  if #aggregator_ep_ids > 0 then
+    return aggregator_ep_ids[1], fields.DEVICE_TYPE_ID.AGGREGATOR
+  end
+
   -- Return the first fan endpoint as the default endpoint if any is found
   local fan_endpoint_ids = utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.FAN)
   if #fan_endpoint_ids > 0 then
-    return get_first_non_zero_endpoint(fan_endpoint_ids)
+    return get_first_non_zero_endpoint(fan_endpoint_ids), fields.DEVICE_TYPE_ID.FAN
   end
 
   -- Return the first water valve endpoint as the default endpoint if any is found
   local water_valve_endpoint_ids = utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.WATER_VALVE)
   if #water_valve_endpoint_ids > 0 then
-    return get_first_non_zero_endpoint(water_valve_endpoint_ids)
+    return get_first_non_zero_endpoint(water_valve_endpoint_ids), fields.DEVICE_TYPE_ID.WATER_VALVE
   end
 
   -- If both onoff and momentary switch endpoints are present, check the device type on the first onoff
@@ -183,19 +189,19 @@ function utils.find_default_endpoint(device)
   if #onoff_ep_ids > 0 and #momentary_switch_ep_ids > 0 then
     local default_endpoint_id = get_first_non_zero_endpoint(onoff_ep_ids)
     if utils.device_type_supports_button_switch_combination(device, default_endpoint_id) then
-      return default_endpoint_id
+      return default_endpoint_id, fields.DEVICE_TYPE_ID.LIGHT.DIMMABLE
     else
       device.log.warn("The main switch endpoint does not contain a supported device type for a component configuration with buttons")
-      return get_first_non_zero_endpoint(momentary_switch_ep_ids)
+      return get_first_non_zero_endpoint(momentary_switch_ep_ids), fields.DEVICE_TYPE_ID.GENERIC_SWITCH
     end
   elseif #onoff_ep_ids > 0 then
-    return get_first_non_zero_endpoint(onoff_ep_ids)
+    return get_first_non_zero_endpoint(onoff_ep_ids), fields.DEVICE_TYPE_ID.LIGHT.ON_OFF
   elseif #momentary_switch_ep_ids > 0 then
-    return get_first_non_zero_endpoint(momentary_switch_ep_ids)
+    return get_first_non_zero_endpoint(momentary_switch_ep_ids), fields.DEVICE_TYPE_ID.GENERIC_SWITCH
   end
 
   device.log.warn(string.format("Did not find default endpoint, will use endpoint %d instead", device.MATTER_DEFAULT_ENDPOINT))
-  return device.MATTER_DEFAULT_ENDPOINT
+  return device.MATTER_DEFAULT_ENDPOINT, utils.find_primary_device_type(utils.get_endpoint_info(device, device.MATTER_DEFAULT_ENDPOINT))
 end
 
 function utils.component_to_endpoint(device, component)
@@ -369,10 +375,6 @@ function utils.deep_equals(a, b, opts, seen)
   local mt_a = getmetatable(a)
   local mt_b = getmetatable(b)
   return utils.deep_equals(mt_a, mt_b, opts, seen)
-end
-
-function utils.detect_bridge(device)
-  return #utils.get_endpoints_by_device_type(device, fields.DEVICE_TYPE_ID.AGGREGATOR) > 0
 end
 
 --- Generalizes the 'get_latest_state' function to be callable with extra endpoint information, described below,

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
@@ -38,7 +38,7 @@ local mock_bridge = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
       },
       device_types = {
-        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
+        {device_type_id = 0x0101, device_type_revision = 1} -- Dimmable Light
       }
     },
     {
@@ -53,7 +53,7 @@ local mock_bridge = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
       },
       device_types = {
-        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
+        {device_type_id = 0x0101, device_type_revision = 1} -- Dimmable Light
       }
     }
   }
@@ -83,6 +83,22 @@ local function test_init_mock_bridge()
   test.mock_device.add_test_device(mock_bridge)
   test.socket.device_lifecycle:__queue_receive({ mock_bridge.id, "added" })
   test.socket.device_lifecycle:__queue_receive({ mock_bridge.id, "init" })
+  test.socket.matter:__expect_send({ mock_bridge.id, clusters.LevelControl.attributes.Options:write(mock_bridge, 1, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF) })
+  test.socket.matter:__expect_send({ mock_bridge.id, clusters.LevelControl.attributes.Options:write(mock_bridge, 2, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF) })
+  mock_bridge:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "nil 1",
+    profile = "light-level",
+    parent_device_id = mock_bridge.id,
+    parent_assigned_child_key = string.format("%d", 1)
+  })
+  mock_bridge:expect_device_create({
+    type = "EDGE_CHILD",
+    label = "nil 2",
+    profile = "light-level",
+    parent_device_id = mock_bridge.id,
+    parent_assigned_child_key = string.format("%d", 2)
+  })
   test.socket.device_lifecycle:__queue_receive({ mock_bridge.id, "doConfigure" })
   mock_bridge:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end


### PR DESCRIPTION
# Description of Change
Per spec, aggregator devices are allowed to have endpoints that are not bridged nodes. We should work towards allowing these endpoints to be exposed, rather than artificially constricting what can be controlled via the edge driver.

For example, some of the work completed [here](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2858) can be more generically supported with a change like this.

# Summary of Completed Tests
Tested with HAGER device pre-configured with multiple light endpoints.

