### PR TITLE
Matter Switch: Version gate the extra init event on added

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -38,8 +38,11 @@ function SwitchLifecycleHandlers.device_added(driver, device)
     device:send(clusters.OnOff.attributes.OnOff:read(device))
   end
 
-  -- call device init in case init is not called after added due to device caching
-  SwitchLifecycleHandlers.device_init(driver, device)
+  -- The device init event is guaranteed in FW versions 58+, so this is only needed for older hubs
+  if version.rpc < 10 then
+    -- call device init in case init is not called after added due to device caching
+    SwitchLifecycleHandlers.device_init(driver, device)
+  end
 end
 
 function SwitchLifecycleHandlers.do_configure(driver, device)

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
@@ -130,7 +130,6 @@ local function test_init()
   end
 
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "added" })
-  test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
 
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "init" })
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -181,15 +181,12 @@ local function test_init()
 
   -- Test added -> doConfigure logic
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "added" })
-  test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "init" })
   test.socket.matter:__expect_send({aqara_mock_device.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ aqara_mock_device.id, "doConfigure" })
   configure_buttons()
   aqara_mock_device:expect_metadata_update({ profile = "4-button" })
   aqara_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  -- to test powerConsumptionReport
-  test.timer.__create_and_queue_test_time_advance_timer(60 * 15, "interval", "create_poll_report_schedule")
 
   for _, child in pairs(aqara_mock_children) do
     test.mock_device.add_test_device(child)

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
@@ -181,8 +181,6 @@ local function test_init()
           subscribe_request:merge(cluster:subscribe(mock_device))
       end
   end
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
   test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
 end
 test.set_test_init_function(test_init)
@@ -195,78 +193,8 @@ local function test_init_periodic()
         subscribe_request:merge(cluster:subscribe(mock_device_periodic))
     end
   end
-  test.socket.device_lifecycle:__queue_receive({ mock_device_periodic.id, "added" })
-  test.socket.matter:__expect_send({ mock_device_periodic.id, subscribe_request })
-  test.socket.device_lifecycle:__queue_receive({ mock_device_periodic.id, "init" })
-  test.socket.matter:__expect_send({ mock_device_periodic.id, subscribe_request })
   test.socket.matter:__expect_send({ mock_device_periodic.id, subscribe_request })
 end
-
-test.register_message_test(
-	"On command should send the appropriate commands",
-  {
-		{
-			channel = "capability",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				{ capability = "switch", component = "main", command = "on", args = { } }
-			}
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
-      }
-    },
-		{
-			channel = "matter",
-			direction = "send",
-			message = {
-				mock_device.id,
-				clusters.OnOff.server.commands.On(mock_device, 2)
-			}
-		}
-	},
-	{
-	   min_api_version = 17
-	}
-)
-
-test.register_message_test(
-  "Off command should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "switch", component = "main", command = "off", args = { } }
-      }
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.OnOff.server.commands.Off(mock_device, 2)
-      }
-    }
-  },
-  {
-     min_api_version = 17
-  }
-)
 
 test.register_message_test(
   "Active power measurement should generate correct messages",

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_tree.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_tree.lua
@@ -128,77 +128,9 @@ local function test_init()
           subscribe_request:merge(cluster:subscribe(mock_device))
       end
   end
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
   test.socket.matter:__expect_send({ mock_device.id, subscribe_request })
 end
 test.set_test_init_function(test_init)
-
-test.register_message_test(
-	"On command should send the appropriate commands",
-  {
-		{
-			channel = "capability",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				{ capability = "switch", component = "main", command = "on", args = { } }
-			}
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
-      }
-    },
-		{
-			channel = "matter",
-			direction = "send",
-			message = {
-				mock_device.id,
-				clusters.OnOff.server.commands.On(mock_device, 2)
-			}
-		}
-	},
-	{
-	   min_api_version = 17
-	}
-)
-
-test.register_message_test(
-  "Off command should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "switch", component = "main", command = "off", args = { } }
-      }
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.OnOff.server.commands.Off(mock_device, 2)
-      }
-    }
-  },
-  {
-     min_api_version = 17
-  }
-)
 
 test.register_message_test(
   "Active power measurement should generate correct messages",

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -54,7 +54,7 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
-local mock_device_electrical_sensor = test.mock_device.build_test_matter_device({
+local mock_eve_device_using_electrical_sensor = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("plug-energy-powerConsumption.yml"),
   manufacturer_info = {
     vendor_id = 0x130A,
@@ -112,30 +112,6 @@ local mock_device_electrical_sensor = test.mock_device.build_test_matter_device(
     }
   }
 })
-
-local function test_init_electrical_sensor()
-  test.disable_startup_messages()
-  test.mock_device.add_test_device(mock_device_electrical_sensor)
-  local cluster_subscribe_list = {
-    clusters.OnOff.attributes.OnOff,
-    clusters.ElectricalEnergyMeasurement.attributes.CumulativeEnergyImported,
-    clusters.ElectricalEnergyMeasurement.attributes.PeriodicEnergyImported,
-  }
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_electrical_sensor)
-  for i, clus in ipairs(cluster_subscribe_list) do
-    if i > 1 then subscribe_request:merge(clus:subscribe(mock_device_electrical_sensor)) end
-  end
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_electrical_sensor.id, "added" })
-  test.socket.matter:__expect_send({mock_device_electrical_sensor.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_electrical_sensor.id, "init" })
-  test.socket.matter:__expect_send({mock_device_electrical_sensor.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_electrical_sensor.id, "doConfigure" })
-  mock_device_electrical_sensor:expect_metadata_update({ profile = "plug-energy-powerConsumption" })
-  mock_device_electrical_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-end
 
 local function test_init()
   local cluster_subscribe_list = {
@@ -523,7 +499,7 @@ local cumulative_report_val_39 = {
 test.register_coroutine_test(
   "Cumulative Energy measurement should generate correct messages",
     function()
-      local mock_device = mock_device_electrical_sensor
+      mock_device = mock_eve_device_using_electrical_sensor
 
       test.mock_time.advance_time(901) -- move time 15 minutes past 0 (this can be assumed to be true in practice in all cases)
       test.socket.matter:__queue_receive(
@@ -579,7 +555,10 @@ test.register_coroutine_test(
       )
     end,
     {
-      test_init = test_init_electrical_sensor,
+      test_init = function()
+        test.disable_startup_messages()
+        test.mock_device.add_test_device(mock_eve_device_using_electrical_sensor)
+      end,
       min_api_version = 17
     }
 )

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -4,12 +4,8 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local st_utils = require "st.utils"
 
 local clusters = require "st.matter.clusters"
-local TRANSITION_TIME = 0
-local OPTIONS_MASK = 0x01
-local HANDLE_COMMAND_IF_OFF = 0x01
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("light-color-level-illuminance-motion.yml"),
@@ -40,7 +36,7 @@ local mock_device = test.mock_device.build_test_matter_device({
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
       },
       device_types = {
-        {device_type_id = 0x010C, device_type_revision = 1}  -- ColorTemperatureLight
+        {device_type_id = 0x010D, device_type_revision = 1}  -- Extended Color Light
       }
     },
     {
@@ -64,539 +60,57 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
-local function set_color_mode(device, endpoint, color_mode)
-  test.socket.matter:__queue_receive({
-    device.id,
-    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
-      device, endpoint, color_mode)
-  })
-  local read_req
-  if color_mode == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
-    read_req = clusters.ColorControl.attributes.CurrentHue:read()
-    read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-  else -- color_mode = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
-    read_req = clusters.ColorControl.attributes.CurrentX:read()
-    read_req:merge(clusters.ColorControl.attributes.CurrentY:read())
-  end
-  test.socket.matter:__expect_send({device.id, read_req})
-end
-
-local cluster_subscribe_list = {
-  clusters.OnOff.attributes.OnOff,
-  clusters.LevelControl.attributes.CurrentLevel,
-  clusters.LevelControl.attributes.MaxLevel,
-  clusters.LevelControl.attributes.MinLevel,
-  clusters.ColorControl.attributes.CurrentHue,
-  clusters.ColorControl.attributes.CurrentSaturation,
-  clusters.ColorControl.attributes.CurrentX,
-  clusters.ColorControl.attributes.CurrentY,
-  clusters.ColorControl.attributes.ColorMode,
-  clusters.ColorControl.attributes.ColorTemperatureMireds,
-  clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-  clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
-  clusters.IlluminanceMeasurement.attributes.MeasuredValue,
-  clusters.OccupancySensing.attributes.Occupancy
-}
-
-local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
-for i, cluster in ipairs(cluster_subscribe_list) do
-  if i > 1 then
-    subscribe_request:merge(cluster:subscribe(mock_device))
-  end
-end
-
 local function test_init()
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-  -- the following subscribe is due to the init event sent by the test framework.
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device)
-  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
 end
 test.set_test_init_function(test_init)
 
-local function test_init_x_y_color_mode()
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+local switch_fields = require "switch_utils.fields"
 
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
-  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
-end
-
-test.register_message_test(
-	"On command should send the appropriate commands",
-	{
-		{
-			channel = "capability",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				{ capability = "switch", component = "main", command = "on", args = { } }
-			}
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "on" }
-      }
-    },
-		{
-			channel = "matter",
-			direction = "send",
-			message = {
-				mock_device.id,
-				clusters.OnOff.server.commands.On(mock_device, 1)
-			}
-		}
-	},
-	{
-	   min_api_version = 17
-	}
-)
-
-test.register_message_test(
-  "Off command should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "switch", component = "main", command = "off", args = { } }
-      }
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_cmd_id = "off" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.OnOff.server.commands.Off(mock_device, 1)
-      }
-    }
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-	"Set level command should send the appropriate commands",
-	{
-		{
-			channel = "capability",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				{ capability = "switchLevel", component = "main", command = "setLevel", args = {20,20} }
-			}
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
-      }
-    },
-		{
-			channel = "matter",
-			direction = "send",
-			message = {
-				mock_device.id,
-				clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 1, st_utils.round(20/100.0 * 254), 20, 0 ,0)
-			}
-		},
-		{
-			channel = "matter",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
-			}
-		},
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50)
-      }
-    },
-		{
-			channel = "capability",
-			direction = "send",
-			message = mock_device:generate_test_message("main", capabilities.switchLevel.level(20))
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, true)
-      }
-    },
-		{
-			channel = "capability",
-			direction = "send",
-			message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
-      }
-    },
-	},
-	{
-	   min_api_version = 17
-	}
-)
-
-test.register_message_test(
-	"Current level reports should generate appropriate events",
-	{
-		{
-			channel = "matter",
-			direction = "receive",
-			message = {
-				mock_device.id,
-				clusters.LevelControl.server.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50)
-			}
-		},
-		{
-			channel = "capability",
-			direction = "send",
-			message = mock_device:generate_test_message("main", capabilities.switchLevel.level(math.floor((50 / 254.0 * 100) + 0.5)))
-		},
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
-      }
-    },
-	},
-	{
-	   min_api_version = 17
-	}
-)
-
-local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
-local sat = math.floor((50 * 0xFE) / 100.0 + 0.5)
-
-test.register_message_test(
-  "Set color command should send huesat commands when supported",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorCapabilities:build_test_report_data(mock_device, 1, 0x01)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation:build_test_command_response(mock_device, 1)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, hue)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, sat)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(50))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
-      }
-    },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Set Hue command should send MoveToHue",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "colorControl", component = "main", command = "setHue", args = { 50 } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHue(mock_device, 1, hue, 0, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Set Saturation command should send MoveToSaturation",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "colorControl", component = "main", command = "setSaturation", args = { 50 } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToSaturation(mock_device, 1, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Set color temperature should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {1800} }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, 1, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature:build_test_command_response(mock_device, 1)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, 1, 556)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorTemperature.colorTemperature(1800))
-    },
-  },
-  {
-     min_api_version = 17
-  }
+test.register_coroutine_test(
+  "doConfigure lifecycle event should not re-configure the device profile",
+  function ()
+    mock_device:set_field(switch_fields.profiling_data.BATTERY_SUPPORT, false, {persist = true})
+    mock_device:set_field(switch_fields.profiling_data.POWER_TOPOLOGY, false, {persist = true})
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.matter:__expect_send({mock_device.id, clusters.LevelControl.attributes.Options:write(mock_device, 1, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF)})
+    test.socket.matter:__expect_send({mock_device.id, clusters.ColorControl.attributes.Options:write(mock_device, 1, clusters.ColorControl.types.OptionsBitmap.EXECUTE_IF_OFF)})
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end
 )
 
 test.register_coroutine_test(
-  "X and Y color values should report hue and saturation once both have been received",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(50)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(72)
-      )
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
+  "init should cause device to subscribe to all appropriate clusters", function()
+  local cluster_subscribe_list = {
+    clusters.OnOff.attributes.OnOff,
+    clusters.LevelControl.attributes.CurrentLevel,
+    clusters.LevelControl.attributes.MaxLevel,
+    clusters.LevelControl.attributes.MinLevel,
+    clusters.ColorControl.attributes.CurrentHue,
+    clusters.ColorControl.attributes.CurrentSaturation,
+    clusters.ColorControl.attributes.CurrentX,
+    clusters.ColorControl.attributes.CurrentY,
+    clusters.ColorControl.attributes.ColorMode,
+    clusters.ColorControl.attributes.ColorTemperatureMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+    clusters.ColorControl.attributes.ColorTempPhysicalMinMireds,
+    clusters.IlluminanceMeasurement.attributes.MeasuredValue,
+    clusters.OccupancySensing.attributes.Occupancy
   }
-)
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
 
-test.register_coroutine_test(
-  "X and Y color values have 0 value",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(33)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(100)
-      )
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
-  "Y and X color values should report hue and saturation once both have been received",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(50)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(72)
-      )
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Do not report when receiving a color temperature of 0 mireds",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, 1, 0)
-      }
-    }
-  },
-  {
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+   end,
+   {
      min_api_version = 17
-  }
+   }
 )
 
 test.register_message_test(

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
@@ -6,9 +6,10 @@ local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 local clusters = require "st.matter.clusters"
 local button_attr = capabilities.button.button
-local utils = require "st.utils"
-local dkjson = require "dkjson"
 local uint32 = require "st.matter.data_types.Uint32"
+local fields = require "switch_utils.fields"
+local switch_utils = require "switch_utils.utils"
+local st_utils = require "st.utils"
 
 local mock_device = test.mock_device.build_test_matter_device({
   profile = t_utils.get_profile_definition("button.yml"),
@@ -40,162 +41,75 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
-local mock_device_battery = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("button-battery.yml"),
-  manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
-  matter_version = {hardware = 1, software = 1},
-  endpoints = {
-    {
-      endpoint_id = 0,
-      clusters = {
-        { cluster_id = clusters.Basic.ID, cluster_type = "SERVER" },
-      },
-      device_types = {
-        { device_type_id = 0x0016, device_type_revision = 1 } -- RootNode
-      }
-    },
-    {
-      endpoint_id = 1,
-      clusters = {
-        {
-          cluster_id = clusters.Switch.ID,
-          feature_map = clusters.Switch.types.Feature.MOMENTARY_SWITCH,
-          cluster_type = "SERVER",
-        },
-        {
-          cluster_id = clusters.PowerSource.ID,
-          cluster_type = "SERVER",
-          feature_map = clusters.PowerSource.types.Feature.BATTERY
-        },
-      },
-      device_types = {
-        {device_type_id = 0x000F, device_type_revision = 1} -- Generic Switch
-      }
-    }
-  }
-})
 
-local function expect_configure_buttons(device)
+local expected_component_to_endpoint_map = {
+  ["main"] = 1
+}
+local expected_initial_press_only_state = true
+
+local function expect_configure_button(device)
   test.socket.capability:__expect_send(device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
   test.socket.capability:__expect_send(device:generate_test_message("main", button_attr.pushed({state_change = false})))
 end
 
-local function update_profile()
-  test.socket.matter:__queue_receive({mock_device_battery.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(
-    mock_device_battery, 1, {uint32(clusters.PowerSource.attributes.BatPercentRemaining.ID)}
-  )})
-  expect_configure_buttons(mock_device_battery)
-  mock_device_battery:expect_metadata_update({ profile = "button-battery" })
-end
-
-local function test_init()
-  local CLUSTER_SUBSCRIBE_LIST = {
-    clusters.Switch.server.events.InitialPress,
-    clusters.Switch.server.events.LongPress,
-    clusters.Switch.server.events.ShortRelease,
-    clusters.Switch.server.events.MultiPressComplete,
-  }
-
-  local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
-  for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
-    if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
-  end
-
+local function test_init_for_lifecycle_tests()
   test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device)
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-  expect_configure_buttons(mock_device)
-  mock_device:expect_metadata_update({ profile = "button" })
-  mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end
 
-local function test_init_battery()
-  local CLUSTER_SUBSCRIBE_LIST_BATTERY = {
-    clusters.PowerSource.server.attributes.AttributeList,
-    clusters.PowerSource.server.attributes.BatPercentRemaining,
-    clusters.Switch.server.events.InitialPress,
-    clusters.Switch.server.events.LongPress,
-    clusters.Switch.server.events.ShortRelease,
-    clusters.Switch.server.events.MultiPressComplete,
-  }
-
-  local subscribe_request = CLUSTER_SUBSCRIBE_LIST_BATTERY[1]:subscribe(mock_device_battery)
-  for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST_BATTERY) do
-    if i > 1 then subscribe_request:merge(clus:subscribe(mock_device_battery)) end
-  end
-
+local function test_init_for_message_tests()
   test.disable_startup_messages()
-  test.mock_device.add_test_device(mock_device_battery)
-  test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "added" })
-  test.socket.matter:__expect_send({mock_device_battery.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "init" })
-  test.socket.matter:__expect_send({mock_device_battery.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "doConfigure" })
-  mock_device_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  test.mock_device.add_test_device(mock_device)
+  mock_device:set_field(fields.COMPONENT_TO_ENDPOINT_MAP, expected_component_to_endpoint_map, { persist = true })
+  switch_utils.set_field_for_endpoint(mock_device, fields.INITIAL_PRESS_ONLY, 1, expected_initial_press_only_state, { persist = true })
 end
-
-test.set_test_init_function(test_init)
+test.set_test_init_function(test_init_for_message_tests)
 
 test.register_coroutine_test(
-  "Simulate the profile change update taking affect and the device info changing",
-  function()
-    test.socket.matter:__set_channel_ordering("relaxed")
-    update_profile()
-    test.wait_for_events()
-    local device_info_copy = utils.deep_copy(mock_device_battery.raw_st_data)
-    device_info_copy.profile.id = "buttons-battery"
-    local device_info_json = dkjson.encode(device_info_copy)
-    test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "infoChanged", device_info_json })
-    -- due to the AttributeList being processed in update_profile, setting profiling_data.BATTERY_SUPPORT,
-    -- subsequent subscriptions will not include AttributeList.
-    local UPDATED_CLUSTER_SUBSCRIBE_LIST = {
-      clusters.PowerSource.server.attributes.BatPercentRemaining,
+  "Handle initial init lifecycle event",
+  function ()
+    local CLUSTER_SUBSCRIBE_LIST = {
       clusters.Switch.server.events.InitialPress,
       clusters.Switch.server.events.LongPress,
       clusters.Switch.server.events.ShortRelease,
       clusters.Switch.server.events.MultiPressComplete,
     }
-    local updated_subscribe_request = UPDATED_CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device_battery)
-    for i, clus in ipairs(UPDATED_CLUSTER_SUBSCRIBE_LIST) do
-      if i > 1 then updated_subscribe_request:merge(clus:subscribe(mock_device_battery)) end
+
+    local subscribe_request = CLUSTER_SUBSCRIBE_LIST[1]:subscribe(mock_device)
+    for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
+      if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
     end
-    test.socket.matter:__expect_send({mock_device_battery.id, updated_subscribe_request})
-    expect_configure_buttons(mock_device_battery)
+
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+    test.wait_for_events()
+    assert(mock_device:get_field(fields.profiling_data.BATTERY_SUPPORT) == fields.battery_support.NO_BATTERY, "Device should be marked as not needing battery support")
+    assert(mock_device:get_field(fields.profiling_data.POWER_TOPOLOGY) == false, "Device should be marked as not needing to configure power topology")
   end,
   {
-    test_init = test_init_battery,
+    test_init = test_init_for_lifecycle_tests,
     min_api_version = 17
   }
 )
 
 test.register_coroutine_test(
-  "Handle received BatPercentRemaining from device.",
-  function()
-    update_profile()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device_battery.id,
-        clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
-          mock_device_battery, 1, 150
-        )
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device_battery:generate_test_message(
-        "main", capabilities.battery.battery(math.floor(150 / 2.0 + 0.5))
-      )
-    )
+  "Handle initial doConfigure lifecycle event, where profiling should be skipped",
+  function ()
+    mock_device:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.NO_BATTERY, { persist = true })
+    mock_device:set_field(fields.profiling_data.POWER_TOPOLOGY, false, { persist = true })
+    test.wait_for_events()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    expect_configure_button(mock_device)
+    mock_device:expect_metadata_update({ profile = "button" })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+    test.wait_for_events()
+    assert(switch_utils.deep_equals(st_utils.deep_copy(mock_device:get_field(fields.COMPONENT_TO_ENDPOINT_MAP)), expected_component_to_endpoint_map), "Component to endpoint map should be set in doConfigure")
+    assert(switch_utils.get_field_for_endpoint(mock_device, fields.INITIAL_PRESS_ONLY, 1) == expected_initial_press_only_state, "InitialPressOnly should be true")
+    assert(switch_utils.get_field_for_endpoint(mock_device, fields.SUPPORTS_MULTI_PRESS, 1) == nil, "MultiPress should be nil")
+    assert(switch_utils.get_field_for_endpoint(mock_device, fields.EMULATE_HELD, 1) == nil, "EmulateHeld should be nil")
   end,
   {
-    test_init = test_init_battery,
+    test_init = test_init_for_lifecycle_tests,
     min_api_version = 17
   }
 )
@@ -498,67 +412,205 @@ test.register_message_test(
   }
 )
 
-local function reset_battery_profiling_info()
-  local fields = require "switch_utils.fields"
-  mock_device:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.NO_BATTERY, {persist=true})
+local mock_device_battery = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("button-battery.yml"),
+  manufacturer_info = {vendor_id = 0x0000, product_id = 0x0000},
+  matter_version = {hardware = 1, software = 1},
+  endpoints = {
+    {
+      endpoint_id = 0,
+      clusters = {
+        { cluster_id = clusters.Basic.ID, cluster_type = "SERVER" },
+      },
+      device_types = {
+        { device_type_id = 0x0016, device_type_revision = 1 } -- RootNode
+      }
+    },
+    {
+      endpoint_id = 1,
+      clusters = {
+        {
+          cluster_id = clusters.Switch.ID,
+          feature_map = clusters.Switch.types.Feature.MOMENTARY_SWITCH,
+          cluster_type = "SERVER",
+        },
+        {
+          cluster_id = clusters.PowerSource.ID,
+          cluster_type = "SERVER",
+          feature_map = clusters.PowerSource.types.Feature.BATTERY
+        },
+      },
+      device_types = {
+        {device_type_id = 0x000F, device_type_revision = 1} -- Generic Switch
+      }
+    }
+  }
+})
+
+local function test_init_battery()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_battery)
+end
+
+local function test_init_profile_change_with_battery()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_battery)
+  -- by this point, init will have run and this will have been set to false
+  mock_device_battery:set_field(fields.profiling_data.POWER_TOPOLOGY, false, { persist = true })
 end
 
 test.register_coroutine_test(
-  "Test profile does not change to button-battery when battery percent remaining attribute (attribute ID 12) is not available",
-  function()
-    reset_battery_profiling_info()
-    test.wait_for_events()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(10)})
-      }
-    )
+  "Handle initial init lifecycle event for device with battery",
+  function ()
+    local CLUSTER_SUBSCRIBE_LIST_BATTERY = {
+      clusters.PowerSource.server.attributes.AttributeList,
+      clusters.PowerSource.server.attributes.BatPercentRemaining,
+      clusters.Switch.server.events.InitialPress,
+      clusters.Switch.server.events.LongPress,
+      clusters.Switch.server.events.ShortRelease,
+      clusters.Switch.server.events.MultiPressComplete,
+    }
+
+    local subscribe_request = CLUSTER_SUBSCRIBE_LIST_BATTERY[1]:subscribe(mock_device_battery)
+    for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST_BATTERY) do
+      if i > 1 then subscribe_request:merge(clus:subscribe(mock_device_battery)) end
+    end
+
+    test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "init" })
+    test.socket.matter:__expect_send({mock_device_battery.id, subscribe_request})
+    assert(mock_device_battery:get_field(fields.profiling_data.BATTERY_SUPPORT) == nil, "Device should not have specified battery support yet")
+    assert(mock_device_battery:get_field(fields.profiling_data.POWER_TOPOLOGY) == nil, "Device should be marked as not needing to configure power topology")
   end,
   {
-     min_api_version = 17
+    test_init = test_init_battery,
+    min_api_version = 17
   }
 )
 
 test.register_coroutine_test(
-  "Test profile change to button-batteryLevel when battery percent remaining attribute (attribute ID 14) is available",
+  "Following init events, after battery has been configured, device should not create subscriptions to AttributeList",
   function()
-    reset_battery_profiling_info()
+    mock_device_battery:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.BATTERY_PERCENTAGE, {persist = true})
     test.wait_for_events()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(
-          clusters.PowerSource.attributes.BatChargeLevel.ID
-        )})
-      }
-    )
-    expect_configure_buttons(mock_device)
-    mock_device:expect_metadata_update({ profile = "button-batteryLevel" })
+    local CLUSTER_SUBSCRIBE_LIST_BATTERY = {
+      clusters.PowerSource.server.attributes.BatPercentRemaining,
+      clusters.Switch.server.events.InitialPress,
+      clusters.Switch.server.events.LongPress,
+      clusters.Switch.server.events.ShortRelease,
+      clusters.Switch.server.events.MultiPressComplete,
+    }
+
+    local subscribe_request = CLUSTER_SUBSCRIBE_LIST_BATTERY[1]:subscribe(mock_device_battery)
+    for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST_BATTERY) do
+      if i > 1 then subscribe_request:merge(clus:subscribe(mock_device_battery)) end
+    end
+
+    test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "init" })
+    test.socket.matter:__expect_send({mock_device_battery.id, subscribe_request})
   end,
   {
-     min_api_version = 17
+    test_init = test_init_profile_change_with_battery,
+    min_api_version = 17
   }
 )
 
 test.register_coroutine_test(
-  "Test profile change to button-battery when battery percent remaining attribute (attribute ID 12) is available",
-  function()
-    reset_battery_profiling_info()
-    test.wait_for_events()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device, 1, {uint32(
-          clusters.PowerSource.attributes.BatPercentRemaining.ID
-        )})
-      }
-    )
-    expect_configure_buttons(mock_device)
-    mock_device:expect_metadata_update({ profile = "button-battery" })
+  "Handle initial doConfigure lifecycle event for device with battery, where profiling should be skipped",
+  function ()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "doConfigure" })
+    mock_device_battery:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+    test_init = test_init_profile_change_with_battery,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "PowerSource AttributeList update should trigger profile update",
+  function()
+    test.socket.matter:__queue_receive({mock_device_battery.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(
+      mock_device_battery, 1, {uint32(clusters.PowerSource.attributes.BatPercentRemaining.ID)}
+    )})
+    expect_configure_button(mock_device_battery)
+    mock_device_battery:expect_metadata_update({ profile = "button-battery" })
+  end,
+  {
+    test_init = test_init_profile_change_with_battery,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "PowerSource AttributeList with BatPercentRemaining update should trigger profile update to button-battery",
+  function()
+    test.socket.matter:__queue_receive({mock_device_battery.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(
+      mock_device_battery, 1, {uint32(clusters.PowerSource.attributes.BatPercentRemaining.ID)}
+    )})
+    expect_configure_button(mock_device_battery)
+    mock_device_battery:expect_metadata_update({ profile = "button-battery" })
+  end,
+  {
+    test_init = test_init_profile_change_with_battery,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "PowerSource AttributeList with BatChargeLevel update should trigger profile update to button-batteryLevel",
+  function()
+    test.socket.matter:__queue_receive({mock_device_battery.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(
+      mock_device_battery, 1, {uint32(clusters.PowerSource.attributes.BatChargeLevel.ID)}
+    )})
+    expect_configure_button(mock_device_battery)
+    mock_device_battery:expect_metadata_update({ profile = "button-batteryLevel" })
+  end,
+  {
+    test_init = test_init_profile_change_with_battery,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "PowerSource AttributeList with no attributes update should set battery support to false and trigger profile update to button",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_battery.id,
+        clusters.PowerSource.attributes.AttributeList:build_test_report_data(mock_device_battery, 1, {uint32(2)})
+      }
+    )
+    expect_configure_button(mock_device_battery)
+    mock_device_battery:expect_metadata_update({ profile = "button" })
+    test.wait_for_events()
+    assert(mock_device_battery:get_field(fields.profiling_data.BATTERY_SUPPORT) == fields.battery_support.NO_BATTERY, "Device should be marked as not supporting battery")
+  end,
+  {
+    test_init = test_init_profile_change_with_battery,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "BatPercentRemaining attribute event should generate a battery capability report",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device_battery.id,
+        clusters.PowerSource.attributes.BatPercentRemaining:build_test_report_data(
+          mock_device_battery, 1, 150
+        )
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device_battery:generate_test_message(
+        "main", capabilities.battery.battery(math.floor(150 / 2.0 + 0.5))
+      )
+    )
+  end,
+  {
+    test_init = test_init_battery,
+    min_api_version = 17
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
@@ -527,21 +527,6 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
-  "PowerSource AttributeList update should trigger profile update",
-  function()
-    test.socket.matter:__queue_receive({mock_device_battery.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(
-      mock_device_battery, 1, {uint32(clusters.PowerSource.attributes.BatPercentRemaining.ID)}
-    )})
-    expect_configure_button(mock_device_battery)
-    mock_device_battery:expect_metadata_update({ profile = "button-battery" })
-  end,
-  {
-    test_init = test_init_profile_change_with_battery,
-    min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
   "PowerSource AttributeList with BatPercentRemaining update should trigger profile update to button-battery",
   function()
     test.socket.matter:__queue_receive({mock_device_battery.id, clusters.PowerSource.attributes.AttributeList:build_test_report_data(

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_irrigation_system.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_irrigation_system.lua
@@ -123,8 +123,6 @@ local function test_init()
       subscribe_request:merge(cluster:subscribe(mock_irrigation_system))
     end
   end
-  test.socket.device_lifecycle:__queue_receive({ mock_irrigation_system.id, "added" })
-  test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_irrigation_system.id, "init" })
   test.socket.matter:__expect_send({mock_irrigation_system.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_irrigation_system.id, "doConfigure" })

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -127,9 +127,6 @@ local function test_init()
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
 
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request}) -- since all fan capabilities are optional, nothing is initially subscribed to
-
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
@@ -221,10 +221,6 @@ local function test_init()
   test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device) -- make sure the cache is populated
 
-  -- added sets a bunch of fields on the device, and calls init
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-
   -- init results in subscription interaction
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
@@ -253,9 +249,6 @@ local function test_init_battery()
 
   test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device_battery)
-
-  test.socket.matter:__expect_send({mock_device_battery.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "added" })
 
   test.socket.matter:__expect_send({mock_device_battery.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_device_battery.id, "init" })

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_motion.lua
@@ -155,8 +155,6 @@ local function test_init()
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
 
   -- init results in subscription interaction
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -216,8 +216,6 @@ local function test_init()
   for i, clus in ipairs(CLUSTER_SUBSCRIBE_LIST_NO_CHILD) do
     if i > 1 then subscribe_request:merge(clus:subscribe(mock_device)) end
   end
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
 
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
@@ -411,8 +409,6 @@ test.register_coroutine_test(
     for _, cluster in ipairs(CLUSTER_SUBSCRIBE_LIST) do
       subscribe_request:merge(cluster:subscribe(unsup_mock_device))
     end
-    test.socket.device_lifecycle:__queue_receive({ unsup_mock_device.id, "added" })
-    test.socket.matter:__expect_send({unsup_mock_device.id, subscribe_request})
 
     test.socket.device_lifecycle:__queue_receive({ unsup_mock_device.id, "init" })
     test.socket.matter:__expect_send({unsup_mock_device.id, subscribe_request})

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_device_configuration.lua
@@ -151,7 +151,6 @@ test.register_coroutine_test(
     local mock_device = mock_device_plug_with_switch_profile_vendor_override
     local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device)
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
     test.socket.matter:__expect_send({mock_device.id, subscribe_request})
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
@@ -228,7 +227,6 @@ test.register_coroutine_test(
     local subscribe_request = clusters.OnOff.attributes.OnOff:subscribe(mock_device_mounted_on_off_control)
 
     test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "added" })
-    test.socket.matter:__expect_send({mock_device_mounted_on_off_control.id, subscribe_request})
 
     test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_on_off_control.id, "init" })
     test.socket.matter:__expect_send({mock_device_mounted_on_off_control.id, subscribe_request})
@@ -284,7 +282,6 @@ test.register_coroutine_test(
       end
     end
     test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "added" })
-    test.socket.matter:__expect_send({mock_device_mounted_dimmable_load_control.id, subscribe_request})
 
     test.socket.device_lifecycle:__queue_receive({ mock_device_mounted_dimmable_load_control.id, "init" })
     test.socket.matter:__expect_send({mock_device_mounted_dimmable_load_control.id, subscribe_request})

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_sensor_offset_preferences.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_sensor_offset_preferences.lua
@@ -4,8 +4,6 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local utils = require "st.utils"
-local dkjson = require "dkjson"
 local clusters = require "st.matter.clusters"
 
 local mock_device = test.mock_device.build_test_matter_device({
@@ -40,50 +38,11 @@ local mock_device = test.mock_device.build_test_matter_device({
 local function test_init()
     test.disable_startup_messages()
     test.mock_device.add_test_device(mock_device)
-
-    local cluster_subscribe_list = {
-        clusters.Switch.events.InitialPress,
-        clusters.Switch.events.LongPress,
-        clusters.Switch.events.ShortRelease,
-        clusters.Switch.events.MultiPressComplete,
-
-        clusters.TemperatureMeasurement.attributes.MeasuredValue,
-        clusters.TemperatureMeasurement.attributes.MinMeasuredValue,
-        clusters.TemperatureMeasurement.attributes.MaxMeasuredValue,
-
-        clusters.RelativeHumidityMeasurement.attributes.MeasuredValue,
-        clusters.PowerSource.attributes.BatPercentRemaining
-    }
-
-    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
-    for i, cluster in ipairs(cluster_subscribe_list) do
-        if i > 1 then
-            subscribe_request:merge(cluster:subscribe(mock_device))
-        end
-    end
-
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
-    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
-    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-
-    local device_info_copy = utils.deep_copy(mock_device.raw_st_data)
-    device_info_copy.profile.id = "3-button-battery-temperature-humidity"
-    local device_info_json = dkjson.encode(device_info_copy)
-    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "infoChanged", device_info_json})
-    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
 end
 
 test.register_coroutine_test("Read appropriate attribute values after tempOffset preference change", function()
     local report = clusters.TemperatureMeasurement.attributes.MeasuredValue:build_test_report_data(mock_device,1, 2000)
-    mock_device.st_store.preferences = {tempOffset = "0"}
+    test.socket.device_lifecycle():__queue_receive(mock_device:generate_info_changed({ preferences = { tempOffset = "2" } }))
 
     test.socket.matter:__queue_receive({mock_device.id, report})
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",capabilities.temperatureMeasurement.temperature({
@@ -108,7 +67,7 @@ end,
 
 test.register_coroutine_test("Read appropriate attribute values after humidityOffset preference change", function()
     local report = clusters.RelativeHumidityMeasurement.attributes.MeasuredValue:build_test_report_data(mock_device,2, 2000)
-    mock_device.st_store.preferences = {humidityOffset = "0"}
+    test.socket.device_lifecycle():__queue_receive(mock_device:generate_info_changed({ preferences = { humidityOffset = "0" } }))
 
     test.socket.matter:__queue_receive({mock_device.id, report})
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",capabilities.relativeHumidityMeasurement.humidity({

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -4,7 +4,7 @@
 local test = require "integration_test"
 local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
-local st_utils = require "st.utils"
+local fields = require "switch_utils.fields"
 
 local clusters = require "st.matter.clusters"
 local TRANSITION_TIME = 0
@@ -30,84 +30,15 @@ local mock_device = test.mock_device.build_test_matter_device({
     {
       endpoint_id = 1,
       clusters = {
-        {
-          cluster_id = clusters.OnOff.ID,
-          cluster_type = "SERVER",
-          cluster_revision = 1,
-          feature_map = 0, --u32 bitmap
-        },
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
         {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 31},
         {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
       },
       device_types = {
-        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
-      }
-    }
-  }
-})
-
-local mock_device_no_hue_sat = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("switch-color-level.yml"),
-  manufacturer_info = {
-    vendor_id = 0x0000,
-    product_id = 0x0000,
-  },
-  endpoints = {
-    {
-      endpoint_id = 1,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
-      },
-      device_types = {
-        {device_type_id = 0x0100, device_type_revision = 1} -- On/Off Light
-      }
-    }
-  }
-})
-
-local mock_device_color_temp = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
-  manufacturer_info = {
-    vendor_id = 0x0000,
-    product_id = 0x0000,
-  },
-  endpoints = {
-    {
-      endpoint_id = 1,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
-      },
-      device_types = {
-        {device_type_id = 0x0100, device_type_revision = 1}, -- On/Off Light
-        {device_type_id = 0x010C, device_type_revision = 1} -- Color Temperature Light
-      }
-    }
-  }
-})
-
-local mock_device_extended_color = test.mock_device.build_test_matter_device({
-  profile = t_utils.get_profile_definition("light-color-level.yml"),
-  manufacturer_info = {
-    vendor_id = 0x0000,
-    product_id = 0x0000,
-  },
-  endpoints = {
-    {
-      endpoint_id = 1,
-      clusters = {
-        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
-        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
-        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER", feature_map = 2}
-      },
-      device_types = {
-        {device_type_id = 0x0100, device_type_revision = 1}, -- On/Off Light
-        {device_type_id = 0x0101, device_type_revision = 1}, -- Dimmable Light
-        {device_type_id = 0x010C, device_type_revision = 1}, -- Color Temperature Light
-        {device_type_id = 0x010D, device_type_revision = 1}, -- Extended Color Light
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.ON_OFF, device_type_revision = 1},
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.DIMMABLE, device_type_revision = 1},
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.COLOR_TEMPERATURE, device_type_revision = 1},
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.EXTENDED_COLOR, device_type_revision = 1}
       }
     }
   }
@@ -129,151 +60,56 @@ local cluster_subscribe_list = {
   clusters.ColorControl.attributes.ColorMode,
 }
 
-local function set_color_mode(device, endpoint, color_mode)
-  test.socket.matter:__queue_receive({
-    device.id,
-    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
-      device, endpoint, color_mode)
-  })
-  local read_req
-  if color_mode == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
-    read_req = clusters.ColorControl.attributes.CurrentHue:read()
-    read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-  else -- color_mode = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
-    read_req = clusters.ColorControl.attributes.CurrentX:read()
-    read_req:merge(clusters.ColorControl.attributes.CurrentY:read())
-  end
-  test.socket.matter:__expect_send({device.id, read_req})
-end
-
 local function test_init()
+  test.mock_device.add_test_device(mock_device)
+
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
   for i, cluster in ipairs(cluster_subscribe_list) do
     if i > 1 then
       subscribe_request:merge(cluster:subscribe(mock_device))
     end
   end
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
 
-  -- note that since disable_startup_messages is not explicitly called here,
-  -- the following subscribe is due to the init event sent by the test framework.
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
-  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
 end
+
 test.set_test_init_function(test_init)
 
-local function test_init_x_y_color_mode()
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device))
-    end
-  end
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device)
-  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
-end
-
-local function test_init_no_hue_sat()
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_no_hue_sat)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_no_hue_sat))
-    end
-  end
-  test.socket.device_lifecycle:__queue_receive({ mock_device_no_hue_sat.id, "added" })
-  test.socket.matter:__expect_send({mock_device_no_hue_sat.id, subscribe_request})
-
-  test.socket.matter:__expect_send({mock_device_no_hue_sat.id, subscribe_request})
-  test.mock_device.add_test_device(mock_device_no_hue_sat)
-  set_color_mode(mock_device_no_hue_sat, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
-end
-
-
-local cluster_subscribe_list_color_temp = {
-  clusters.OnOff.attributes.OnOff,
-  clusters.LevelControl.attributes.CurrentLevel,
-  clusters.LevelControl.attributes.MaxLevel,
-  clusters.LevelControl.attributes.MinLevel,
-  clusters.ColorControl.attributes.ColorTemperatureMireds,
-  clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
-  clusters.ColorControl.attributes.ColorTempPhysicalMinMireds
-}
-
-local function test_init_color_temp()
-  test.mock_device.add_test_device(mock_device_color_temp)
-  local subscribe_request = cluster_subscribe_list_color_temp[1]:subscribe(mock_device_color_temp)
-  for i, cluster in ipairs(cluster_subscribe_list_color_temp) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_color_temp))
-    end
-  end
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_color_temp.id, "added" })
-  test.socket.matter:__expect_send({mock_device_color_temp.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_color_temp.id, "init" })
-  test.socket.matter:__expect_send({mock_device_color_temp.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_color_temp.id, "doConfigure" })
-  test.socket.matter:__expect_send({
-    mock_device_color_temp.id,
-    clusters.LevelControl.attributes.Options:write(mock_device_color_temp, 1, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF)
-  })
-  test.socket.matter:__expect_send({
-    mock_device_color_temp.id,
-    clusters.ColorControl.attributes.Options:write(mock_device_color_temp, 1, clusters.ColorControl.types.OptionsBitmap.EXECUTE_IF_OFF)
-  })
-  mock_device_color_temp:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.socket.matter:__expect_send({mock_device_color_temp.id, subscribe_request})
-end
-
-local function test_init_extended_color()
-  test.mock_device.add_test_device(mock_device_extended_color)
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device_extended_color)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device_extended_color))
-    end
-  end
-  test.socket.matter:__expect_send({mock_device_extended_color.id, subscribe_request})
-  test.socket.device_lifecycle:__queue_receive({ mock_device_extended_color.id, "added" })
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_extended_color.id, "init" })
-  test.socket.matter:__expect_send({mock_device_extended_color.id, subscribe_request})
-
-  test.socket.device_lifecycle:__queue_receive({ mock_device_extended_color.id, "doConfigure" })
-  test.socket.matter:__expect_send({
-    mock_device_extended_color.id,
-    clusters.LevelControl.attributes.Options:write(mock_device_extended_color, 1, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF)
-  })
-  test.socket.matter:__expect_send({
-    mock_device_extended_color.id,
-    clusters.ColorControl.attributes.Options:write(mock_device_extended_color, 1, clusters.ColorControl.types.OptionsBitmap.EXECUTE_IF_OFF)
-  })
-  mock_device_extended_color:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  test.socket.matter:__expect_send({mock_device_extended_color.id, subscribe_request})
-end
-
-test.register_message_test(
-  "Test that Color Temperature Light device does not switch profiles",
-  {},
+test.register_coroutine_test(
+  "doConfigure properly sets Extended Color Light and does not attempt to switch profiles",
+  function()
+    mock_device:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.NO_BATTERY, { persist = true })
+    mock_device:set_field(fields.profiling_data.POWER_TOPOLOGY, false, { persist = true })
+    test.wait_for_events()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      clusters.LevelControl.attributes.Options:write(mock_device, 1, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF)
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      clusters.ColorControl.attributes.Options:write(mock_device, 1, clusters.ColorControl.types.OptionsBitmap.EXECUTE_IF_OFF)
+    })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
   {
-    test_init = test_init_color_temp,
     min_api_version = 17
   }
 )
 
-test.register_message_test(
-  "Test that Extended Color Light device does not switch profiles",
-  {},
+test.register_coroutine_test(
+  "init creates accurate subscription for Extended Color Light",
+  function()
+    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+    for i, cluster in ipairs(cluster_subscribe_list) do
+      if i > 1 then
+        subscribe_request:merge(cluster:subscribe(mock_device))
+      end
+    end
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  end,
   {
-    test_init = test_init_extended_color,
     min_api_version = 17
   }
 )
@@ -344,342 +180,9 @@ test.register_message_test(
   }
 )
 
-test.register_message_test(
-  "Set level command should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "switchLevel", component = "main", command = "setLevel", args = {20,20} }
-      }
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_cmd_handler",
-        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_cmd_id = "setLevel" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.LevelControl.server.commands.MoveToLevelWithOnOff(mock_device, 1, st_utils.round(20/100.0 * 254), 20, 0 ,0)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.LevelControl.server.commands.MoveToLevelWithOnOff:build_test_command_response(mock_device, 1)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.LevelControl.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.switchLevel.level(20))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, 1, true)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
-      }
-    },
-
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Current level reports should generate appropriate events",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.LevelControl.server.attributes.CurrentLevel:build_test_report_data(mock_device, 1, 50)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.switchLevel.level(st_utils.round((50 / 254.0 * 100) + 0.5)))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switchLevel", capability_attr_id = "level" }
-      }
-    },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
-  "Set color command should send the appropriate commands", function()
-    test.socket.capability:__queue_receive(
-      {
-        mock_device_no_hue_sat.id,
-        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 72 } }},
-      }
-    )
-    test.socket.matter:__expect_send(
-      {
-        mock_device_no_hue_sat.id,
-        clusters.ColorControl.server.commands.MoveToColor(mock_device_no_hue_sat, 1, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device_no_hue_sat.id,
-        clusters.ColorControl.server.commands.MoveToColor:build_test_command_response(mock_device_no_hue_sat, 1)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device_no_hue_sat.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device_no_hue_sat, 1, 15091)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device_no_hue_sat.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device_no_hue_sat, 1, 21547)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device_no_hue_sat:generate_test_message(
-        "main", capabilities.colorControl.hue(50)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device_no_hue_sat:generate_test_message(
-        "main", capabilities.colorControl.saturation(72)
-      )
-    )
-  end,
-  {
-    test_init = test_init_no_hue_sat,
-    min_api_version = 17
-  }
-)
 
 local hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
 local sat = math.floor((50 * 0xFE) / 100.0 + 0.5)
-
-test.register_message_test(
-  "Set color command should send huesat commands when supported",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorCapabilities:build_test_report_data(mock_device, 1, 0x01)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation:build_test_command_response(mock_device, 1)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, hue)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, sat)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(50))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
-      }
-    },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-hue = 0xFE
-sat = 0xFE
-test.register_message_test(
-  "Set color command should clamp invalid huesat values",
-  {
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorCapabilities:build_test_report_data(mock_device, 1, 0x01)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 110, saturation = 110 } } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToHueAndSaturation:build_test_command_response(mock_device, 1)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, hue)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(100))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, sat)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(100))
-    },
-    {
-      channel = "devices",
-      direction = "send",
-      message = {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
-      }
-    },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-hue = math.floor((50 * 0xFE) / 100.0 + 0.5)
-sat = math.floor((50 * 0xFE) / 100.0 + 0.5)
 test.register_message_test(
   "Set Hue command should send MoveToHue",
   {
@@ -773,102 +276,6 @@ test.register_message_test(
   },
   {
      min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
-  "X and Y color values should report hue and saturation once both have been received",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(50)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(72)
-      )
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
-  "X and Y color values have 0 value",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(33)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(100)
-      )
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
-  "Y and X color values should report hue and saturation once both have been received",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(50)
-      )
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(72)
-      )
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
   }
 )
 
@@ -1173,64 +580,6 @@ test.register_message_test(
 )
 
 test.register_coroutine_test(
-  "colorControl capability sent based on CurrentHue and CurrentSaturation due to ColorMode",
-  function()
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorMode:build_test_report_data(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
-      }
-    )
-    local read_hue_sat = clusters.ColorControl.attributes.CurrentHue:read()
-    read_hue_sat:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
-    test.socket.matter:__expect_send(
-      {
-        mock_device.id,
-        read_hue_sat
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, 0xFE),
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.hue(100)
-      )
-    )
-    test.socket.devices:__expect_send(
-      {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, 0xFE),
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_device:generate_test_message(
-        "main", capabilities.colorControl.saturation(100)
-      )
-    )
-    test.socket.devices:__expect_send(
-      {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
-      }
-    )
-  end,
-  {
-    test_init = test_init_x_y_color_mode,
-    min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
   "colorControl capability sent based on CurrentX and CurrentY due to ColorMode",
   function()
     test.socket.matter:__queue_receive(
@@ -1290,6 +639,534 @@ test.register_coroutine_test(
   end,
   {
      min_api_version = 17
+  }
+)
+
+
+local function set_color_mode(device, endpoint, color_mode)
+  test.socket.matter:__queue_receive({
+    device.id,
+    clusters.ColorControl.attributes.ColorMode:build_test_report_data(
+      device, endpoint, color_mode)
+  })
+  local read_req
+  if color_mode == clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION then
+    read_req = clusters.ColorControl.attributes.CurrentHue:read()
+    read_req:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
+  else -- color_mode = clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY
+    read_req = clusters.ColorControl.attributes.CurrentX:read()
+    read_req:merge(clusters.ColorControl.attributes.CurrentY:read())
+  end
+  test.socket.matter:__expect_send({device.id, read_req})
+end
+
+
+
+local function test_init_x_y_color_mode()
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.mock_device.add_test_device(mock_device)
+  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENTX_AND_CURRENTY)
+end
+
+test.register_coroutine_test(
+  "X and Y color values should report hue and saturation once both have been received",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  {
+    test_init = test_init_x_y_color_mode,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "X and Y color values have 0 value",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 0)
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 0)
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(33)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(100)
+      )
+    )
+  end,
+  {
+    test_init = test_init_x_y_color_mode,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "Y and X color values should report hue and saturation once both have been received",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, 1, 21547)
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, 1, 15091)
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  {
+    test_init = test_init_x_y_color_mode,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "colorControl capability sent based on CurrentHue and CurrentSaturation due to ColorMode",
+  function()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorMode:build_test_report_data(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
+      }
+    )
+    local read_hue_sat = clusters.ColorControl.attributes.CurrentHue:read()
+    read_hue_sat:merge(clusters.ColorControl.attributes.CurrentSaturation:read())
+    test.socket.matter:__expect_send(
+      {
+        mock_device.id,
+        read_hue_sat
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, 0xFE),
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.hue(100)
+      )
+    )
+    test.socket.devices:__expect_send(
+      {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, 0xFE),
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main", capabilities.colorControl.saturation(100)
+      )
+    )
+    test.socket.devices:__expect_send(
+      {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
+      }
+    )
+  end,
+  {
+    test_init = test_init_x_y_color_mode,
+    min_api_version = 17
+  }
+)
+
+
+
+local function test_init_with_hue_sat_color_mode_set()
+  test.mock_device.add_test_device(mock_device)
+  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+  for i, cluster in ipairs(cluster_subscribe_list) do
+    if i > 1 then
+      subscribe_request:merge(cluster:subscribe(mock_device))
+    end
+  end
+  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  set_color_mode(mock_device, 1, clusters.ColorControl.types.ColorMode.CURRENT_HUE_AND_CURRENT_SATURATION)
+end
+
+test.register_message_test(
+  "Set color command should send huesat commands when supported",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorCapabilities:build_test_report_data(mock_device, 1, 0x01)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 50 } } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation:build_test_command_response(mock_device, 1)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, hue)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(50))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, sat)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(50))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
+      }
+    },
+  },
+  {
+    test_init = test_init_with_hue_sat_color_mode_set,
+    min_api_version = 17
+  }
+)
+
+hue = 0xFE
+sat = 0xFE
+test.register_message_test(
+  "Set color command should clamp invalid huesat values",
+  {
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorCapabilities:build_test_report_data(mock_device, 1, 0x01)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 110, saturation = 110 } } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation(mock_device, 1, hue, sat, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToHueAndSaturation:build_test_command_response(mock_device, 1)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentHue:build_test_report_data(mock_device, 1, hue)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorControl.hue(100))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "hue" }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.CurrentSaturation:build_test_report_data(mock_device, 1, sat)
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.colorControl.saturation(100))
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorControl", capability_attr_id = "saturation" }
+      }
+    },
+  },
+  {
+    test_init = test_init_with_hue_sat_color_mode_set,
+    min_api_version = 17
+  }
+)
+
+
+
+
+local mock_color_device_no_hue_sat = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("light-color-level.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.EXTENDED_COLOR, device_type_revision = 1}
+      }
+    }
+  }
+})
+
+local function test_init_no_hue_sat()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_color_device_no_hue_sat)
+end
+
+test.register_coroutine_test(
+  "Set color command should send the appropriate commands", function()
+    test.socket.capability:__queue_receive(
+      {
+        mock_color_device_no_hue_sat.id,
+        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 72 } }},
+      }
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_color_device_no_hue_sat.id,
+        clusters.ColorControl.server.commands.MoveToColor(mock_color_device_no_hue_sat, 1, 15182, 21547, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_color_device_no_hue_sat.id,
+        clusters.ColorControl.server.commands.MoveToColor:build_test_command_response(mock_color_device_no_hue_sat, 1)
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_color_device_no_hue_sat.id,
+        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_color_device_no_hue_sat, 1, 15091)
+      }
+    )
+    test.socket.matter:__queue_receive(
+      {
+        mock_color_device_no_hue_sat.id,
+        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_color_device_no_hue_sat, 1, 21547)
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_color_device_no_hue_sat:generate_test_message(
+        "main", capabilities.colorControl.hue(50)
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_color_device_no_hue_sat:generate_test_message(
+        "main", capabilities.colorControl.saturation(72)
+      )
+    )
+  end,
+  {
+    test_init = test_init_no_hue_sat,
+    min_api_version = 17
+  }
+)
+
+
+
+local mock_device_color_temp = test.mock_device.build_test_matter_device({
+  profile = t_utils.get_profile_definition("light-level-colorTemperature.yml"),
+  manufacturer_info = {
+    vendor_id = 0x0000,
+    product_id = 0x0000,
+  },
+  endpoints = {
+    {
+      endpoint_id = 1,
+      clusters = {
+        {cluster_id = clusters.OnOff.ID, cluster_type = "SERVER"},
+        {cluster_id = clusters.ColorControl.ID, cluster_type = "BOTH", feature_map = 30},
+        {cluster_id = clusters.LevelControl.ID, cluster_type = "SERVER"}
+      },
+      device_types = {
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.ON_OFF, device_type_revision = 1},
+        {device_type_id = fields.DEVICE_TYPE_ID.LIGHT.COLOR_TEMPERATURE, device_type_revision = 1}
+      }
+    }
+  }
+})
+
+local function test_init_color_temp()
+  test.disable_startup_messages()
+  test.mock_device.add_test_device(mock_device_color_temp)
+end
+
+test.register_coroutine_test(
+  "doConfigure properly sets Color Temperature Light and does not attempt to switch profiles",
+  function()
+    mock_device:set_field(fields.profiling_data.BATTERY_SUPPORT, fields.battery_support.NO_BATTERY, { persist = true })
+    mock_device:set_field(fields.profiling_data.POWER_TOPOLOGY, false, { persist = true })
+    test.wait_for_events()
+    test.socket.device_lifecycle:__queue_receive({ mock_device_color_temp.id, "doConfigure" })
+    test.socket.matter:__expect_send({
+      mock_device_color_temp.id,
+      clusters.LevelControl.attributes.Options:write(mock_device_color_temp, 1, clusters.LevelControl.types.OptionsBitmap.EXECUTE_IF_OFF)
+    })
+    test.socket.matter:__expect_send({
+      mock_device_color_temp.id,
+      clusters.ColorControl.attributes.Options:write(mock_device_color_temp, 1, clusters.ColorControl.types.OptionsBitmap.EXECUTE_IF_OFF)
+    })
+    mock_device_color_temp:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+    test_init = test_init_color_temp,
+    min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
+  "init creates accurate subscription for Color Temperature Light",
+  function()
+    local cluster_subscribe_list_color_temp = {
+      clusters.OnOff.attributes.OnOff,
+      clusters.LevelControl.attributes.CurrentLevel,
+      clusters.LevelControl.attributes.MaxLevel,
+      clusters.LevelControl.attributes.MinLevel,
+      clusters.ColorControl.attributes.ColorTemperatureMireds,
+      clusters.ColorControl.attributes.ColorTempPhysicalMaxMireds,
+      clusters.ColorControl.attributes.ColorTempPhysicalMinMireds
+    }
+    local subscribe_request = cluster_subscribe_list_color_temp[1]:subscribe(mock_device_color_temp)
+    for i, cluster in ipairs(cluster_subscribe_list_color_temp) do
+      if i > 1 then
+        subscribe_request:merge(cluster:subscribe(mock_device_color_temp))
+      end
+    end
+    test.socket.device_lifecycle:__queue_receive({ mock_device_color_temp.id, "init" })
+    test.socket.matter:__expect_send({mock_device_color_temp.id, subscribe_request})
+  end,
+  {
+    test_init = test_init_color_temp,
+    min_api_version = 17
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_water_valve.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_water_valve.lua
@@ -45,38 +45,31 @@ local mock_device = test.mock_device.build_test_matter_device({
   }
 })
 
-local cluster_subscribe_list = {
-  clusters.ValveConfigurationAndControl.attributes.CurrentState,
-  clusters.ValveConfigurationAndControl.attributes.CurrentLevel
-}
-
 local function test_init()
-  local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
-  for i, cluster in ipairs(cluster_subscribe_list) do
-    if i > 1 then
-      subscribe_request:merge(cluster:subscribe(mock_device))
-    end
-  end
-  test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
-
-  -- the following subscribe is due to the init event sent by the test framework.
-  test.socket.matter:__expect_send({mock_device.id, subscribe_request})
+  test.disable_startup_messages()
   test.mock_device.add_test_device(mock_device)
 end
 test.set_test_init_function(test_init)
 
-
 test.register_coroutine_test(
-  "Test profile change on init for water valve parent cluster as server",
+  "Device should be added with correct subscription and profile",
   function()
+    local cluster_subscribe_list = {
+      clusters.ValveConfigurationAndControl.attributes.CurrentState,
+      clusters.ValveConfigurationAndControl.attributes.CurrentLevel
+    }
+    local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_device)
+    for i, cluster in ipairs(cluster_subscribe_list) do
+      if i > 1 then
+        subscribe_request:merge(cluster:subscribe(mock_device))
+      end
+    end
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "init" })
+    test.socket.matter:__expect_send({mock_device.id, subscribe_request})
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ profile = "water-valve-level" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  end,
-  {
-    min_api_version = 17
-  }
+  end
 )
 
 test.register_message_test(
@@ -147,16 +140,7 @@ test.register_message_test(
         mock_device.id,
         clusters.ValveConfigurationAndControl.server.commands.Open(mock_device, 1, nil, 25)
       }
-    }
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Set level command should send the appropriate commands",
-  {
+    },
     {
       channel = "capability",
       direction = "receive",
@@ -197,13 +181,6 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Current state reports should generate appropriate events",
-  {
     {
       channel = "matter",
       direction = "receive",
@@ -217,15 +194,6 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.valve.valve.open())
     },
-  },
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Current state reports should generate appropriate events",
-  {
     {
       channel = "matter",
       direction = "receive",

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
@@ -145,8 +145,6 @@ local function test_init_mock_3switch()
   }
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_3switch)
-  test.socket.device_lifecycle:__queue_receive({ mock_3switch.id, "added" })
-  test.socket.matter:__expect_send({mock_3switch.id, subscribe_request})
 
   -- the following subscribe is due to the init event sent by the test framework.
   test.socket.matter:__expect_send({mock_3switch.id, subscribe_request})
@@ -161,8 +159,6 @@ local function test_init_mock_2switch()
   }
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_2switch)
-  test.socket.device_lifecycle:__queue_receive({ mock_2switch.id, "added" })
-  test.socket.matter:__expect_send({mock_2switch.id, subscribe_request})
 
   test.socket.matter:__expect_send({mock_2switch.id, subscribe_request})
   test.mock_device.add_test_device(mock_2switch)
@@ -176,8 +172,6 @@ local function test_init_mock_3switch_non_sequential()
   }
   test.socket.matter:__set_channel_ordering("relaxed")
   local subscribe_request = cluster_subscribe_list[1]:subscribe(mock_3switch_non_sequential)
-  test.socket.device_lifecycle:__queue_receive({ mock_3switch_non_sequential.id, "added" })
-  test.socket.matter:__expect_send({mock_3switch_non_sequential.id, subscribe_request})
 
   test.socket.matter:__expect_send({mock_3switch_non_sequential.id, subscribe_request})
   test.mock_device.add_test_device(mock_3switch_non_sequential)


### PR DESCRIPTION
# Description of Change
As of Hub FW 58, the caching issues have been solved and so this extra event is not required any longer. 

# Summary of Completed Tests
This changeset is large primarily because I took this opportunity to restructure several test files that were checking the entire added -> init -> doConfigure cycle for every test, or that were testing pieces of code that were already tested elsewhere verbatim. I also just removed the added check in several places for simplicity, rather than re-versioning ~100 tests.

In particular, I really took the hammer to [test_matter_switch.lua‎](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2938/changes#diff-e3a5fd063cee499ccdbc8f49df165cd06bbc0b389e4bddacc8acfd407dab37f3) and [test_light_illuminance_motion.lua‎](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2938/changes#diff-c6d721e804fe1a90b244e4d823e7f396abd57142a36bf0cc8e98497073890f2e), since there was significant overlap between these 2 and they were the first ones I looked at. I think a similar treatment is likely due for many of our Generic Switch tests, but I selectively reworked pieces as time permitted.

