### PR TITLE
Matter Lock: Add clear user failure test during defaultSchedule

### DIFF
--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
@@ -2100,7 +2100,6 @@ test.register_coroutine_test(
   }
 )
 
--- mock_device:set_field(lock_utils.COTA_CRED, "654123", {persist = true}) --overwrite random cred for test expectation
 test.register_coroutine_test(
   "Add Guest User and failure response ",
   function()
@@ -2231,5 +2230,114 @@ test.register_coroutine_test(
      min_api_version = 17
   }
 )
+
+test.register_coroutine_test(
+  "Add Guest User and failure response, and ClearUser command fails as well",
+  function()
+    test.socket.capability:__queue_receive(
+      {
+        mock_device.id,
+        {
+          capability = capabilities.lockCredentials.ID,
+          command = "addCredential",
+          args = {0, "guest", "pin", "654123"}
+        },
+      }
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device.id,
+        DoorLock.server.commands.SetCredential(
+          mock_device, 1, -- endpoint
+          DoorLock.types.DataOperationTypeEnum.ADD, -- operation_type
+          DoorLock.types.CredentialStruct(
+            {credential_type = DoorLock.types.CredentialTypeEnum.PIN, credential_index = 1}
+          ), -- credential
+          "654123", -- credential_data
+          nil, -- user_index
+          nil, -- user_status
+          DoorLock.types.UserTypeEnum.SCHEDULE_RESTRICTED_USER -- user_type
+        ),
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        DoorLock.client.commands.SetCredentialResponse:build_test_command_response(
+          mock_device, 1,
+          DoorLock.types.DlStatus.SUCCESS, -- status
+          1, -- user_index
+          2 -- next_credential_index
+        ),
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.lockUsers.users({{userIndex = 1, userType = "guest"}}, {visibility={displayed=false}})
+      )
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.lockCredentials.credentials(
+          {{credentialIndex=1, credentialType="pin", userIndex=1}}, {visibility={displayed=false}}
+        )
+      )
+    )
+    test.socket.matter:__expect_send(
+      {
+        mock_device.id,
+        DoorLock.server.commands.SetYearDaySchedule(
+          mock_device, 1, -- endpoint
+          1, -- year_day_index
+          1, -- user_index
+          0, -- local_start_time
+          0xffffffff -- local_end_time
+        ),
+      }
+    )
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        DoorLock.server.commands.SetYearDaySchedule:build_test_command_response(
+          mock_device, 1,
+          DoorLock.types.DlStatus.FAILURE -- status
+        ),
+      }
+    )
+    test.socket.matter:__expect_send({
+      mock_device.id,
+      DoorLock.server.commands.ClearUser(
+        mock_device, 1,
+        1
+      )
+    })
+    test.wait_for_events()
+    test.socket.matter:__queue_receive(
+      {
+        mock_device.id,
+        DoorLock.server.commands.ClearUser:build_test_command_response(
+          mock_device, 1,
+          DoorLock.types.DlStatus.FAILURE -- status
+        ),
+      }
+    )
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message(
+        "main",
+        capabilities.lockCredentials.commandResult(
+          {commandName="addCredential", statusCode="success", userIndex=1}, {state_change=true, visibility={displayed=false}}
+        )
+      )
+    )
+  end,
+  {
+     min_api_version = 17
+  }
+)
+
 
 test.run_registered_tests()


### PR DESCRIPTION
# Description of Change
Add test for ClearUser case where it fails to remove the credentials during the defaultSchedule creation.

# Summary of Completed Tests
Test added