### PR TITLE
WWSTCERT-11539 Smart AC Controller

### DIFF
--- a/drivers/SmartThings/matter-thermostat/fingerprints.yml
+++ b/drivers/SmartThings/matter-thermostat/fingerprints.yml
@@ -101,6 +101,12 @@ matterManufacturer:
     vendorId: 0x156A
     productId: 0x0001
     deviceProfileName: air-purifier-hepa-wind-aqs-pm25-meas-pm25-level
+  #Gerlsair
+  - id: "5493/1"
+    deviceLabel: Smart AC Controller
+    vendorId: 0x1575
+    productId: 0x0001
+    deviceProfileName: thermostat-modular
 matterGeneric:
   - id: "matter/hvac/heatcool"
     deviceLabel: Matter Thermostat


### PR DESCRIPTION
Relevant WWST tickets:
- WWSTCERT-11539

Modular profile.
The following capabilities were detected by the STTS during the test:
 - temperatureMeasurement
 - thermostatMode
 - fanMode
 - fanSpeedPercent
 - fanOscillationMode
-  thermostatHeatingSetpoint
 - thermostatCoolingSetpoint
 - relativeHumidityMeasurement
-  firmwareUpdate
 - refresh