### PR TITLE
Partner Testing Self Registration New Matter Lock added for Durin

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua
@@ -34,6 +34,7 @@ local NEW_MATTER_LOCK_PRODUCTS = {
   {0x1421, 0x0042}, -- Kwikset Halo Select Plus
   {0x1421, 0x0081}, -- Kwikset Aura Reach
   {0x1236, 0xa538}, -- Schlage Sense Pro
+  {0x1623, 0x3001}, -- Durin, Door Manager
 }
 
 return NEW_MATTER_LOCK_PRODUCTS


### PR DESCRIPTION
Check all that apply

Self-registration for Partner Testing for Durin Inc.

# Checklist

- [ ] I have added a new matter lock to the list of new lock devices in fingerprints.lua

# Description of Change

A new matter lock for Durin Inc. with VID and PID has been added to fingerprints.lua for Matter lock New Devices in SmartThings.

# Summary of Completed Tests


