### PR TITLE
Jenkins Driver Test Reporting 

### DIFF
--- a/.github/workflows/jenkins-driver-tests.yml
+++ b/.github/workflows/jenkins-driver-tests.yml
@@ -19,14 +19,15 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
-            core.setOutput('status_url', (await github.rest.repos.createCommitStatus({
+            let response = await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: context.sha,
+              sha: context.payload.pull_request.head.sha,
               state: 'pending',
               description: 'Jenkins job triggered...',
               context: 'Driver Tests (${{ matrix.version }})'
-            })).data.url);
+            });
+            core.setOutput('status_url', response.data.url);
       - name: Trigger Jenkins Generic Webhook
         env:
           JENKINS_WEBHOOK_TOKEN: ${{ secrets.JENKINS_WEBHOOK_TOKEN }}


### PR DESCRIPTION
This change aims to solve the issue of the status of the Jenkins driver tests not showing up.

Previously, using `context.sha` when creating a commit status in the github action, would work with `pull_request` as the `context.sha` in a `pull_request` event would point at the head of the PR and have no issues. But in order to allow for statuses to be created by non ST developers, we moved to using `pull_request_target` where `context.sha` looks to be pointing at the base of the PR which always ended up being the HEAD of `main`. Changing the sha to `context.payload.pull_request.head.sha` should fix this issue by pointing to the latest commit SHA for the PR.

Because `pull_request_target` doesn't run off the working branch for security reasons, in this PR, we won't see a status created as it will still use the workflow that is currently on main. So these changes will not show to be working until merged.