### PR TITLE
Add AGENTS.md and a set of skills to help agents in this repository

### DIFF
--- a/.agents/skills/dev-workflow/SKILL.md
+++ b/.agents/skills/dev-workflow/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: dev-workflow
+description: Setting up the development environment, deploying Edge Drivers to hubs, and sharing drivers with other users via channels and invites
+---
+
+# SmartThings Edge Driver Development Workflow
+
+This skill covers environment setup, driver deployment to hubs, and sharing
+drivers with other users through channels and invite links.
+
+---
+
+## Environment Setup
+
+### 1. Install Lua 5.3
+
+Edge Drivers are Lua-based. Install the Lua 5.3 runtime for local development
+and linting:
+
+```bash
+# Ubuntu / Debian
+sudo apt install lua5.3
+
+# macOS
+brew install lua@5.3
+
+# Windows
+# Download the Lua 5.3 binary from https://luabinaries.sourceforge.net/download.html
+# Or install via scoop:
+scoop install lua
+# Or via chocolatey:
+choco install lua53
+```
+
+### 2. lua_libs Directory
+
+The `lua_libs/` directory contains the SmartThings Lua libraries that are
+available on the hub at runtime. These correspond to the assets attached to the
+latest release on GitHub:
+
+<https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/releases/latest>
+
+Download the lua_libs archive from the release assets and
+extract it into the repository root if it is missing or needs updating.
+
+### 3. Configure LUA_PATH
+
+Set `LUA_PATH` so that `require` resolves both your driver modules and the
+SmartThings library modules in `lua_libs/`:
+
+```bash
+export LUA_PATH="./?.lua;./?/init.lua;$(pwd)/lua_libs/?.lua;$(pwd)/lua_libs/?/init.lua;;"
+```
+
+Run it from the repository root so `$(pwd)` resolves correctly.
+
+
+### 4. Install the SmartThings CLI
+
+The CLI is required for packaging, deploying, and managing drivers and
+channels on the platform.
+
+```bash
+# Via npm (requires Node.js >= 24.8.0)
+npm install -g @smartthings/cli
+
+# macOS via Homebrew
+brew install smartthingscommunity/smartthings/smartthings
+
+# Linux / Windows
+# Download the binary or installer from:
+# https://github.com/SmartThingsCommunity/smartthings-cli/releases
+```
+
+Verify the installation:
+
+```bash
+smartthings --version
+```
+
+The CLI uses browser-based OAuth login by default. Run `smartthings devices` to trigger
+the login flow.
+
+### 5. Python Requirements (Testing)
+
+Some test and tooling scripts require Python dependencies:
+
+```bash
+pip install -r tools/requirements.txt
+```
+
+### 6. Install Luacheck (Linting)
+
+Luacheck provides static analysis for Lua source files. It requires LuaRocks
+(the Lua package manager).
+
+**Install LuaRocks first:**
+
+```bash
+# Ubuntu / Debian
+sudo apt install luarocks
+
+# macOS
+brew install luarocks
+
+# Windows
+# Download the installer from https://luarocks.org/releases/
+# Or via chocolatey:
+choco install luarocks
+```
+
+**Then install Luacheck:**
+
+```bash
+# Via LuaRocks (all platforms)
+luarocks install luacheck
+
+# macOS alternative (installs both luarocks and luacheck)
+brew install luacheck
+```
+
+Run it against a driver directory:
+
+```bash
+luacheck --config .github/workflows/.luacheckrc drivers/SmartThings/zigbee-switch/
+```
+
+---
+
+## Deploying Drivers
+
+### Overview
+
+Deploying a driver to a physical hub requires three things:
+
+1. A **channel** you own.
+2. The hub **enrolled** in that channel.
+3. The driver **packaged and uploaded** through the CLI.
+
+### Step 1: Create a Channel
+
+```bash
+smartthings edge:channels:create
+```
+
+You will be prompted for a name and description. Note the returned channel ID.
+
+### Step 2: Enroll Your Hub
+
+```bash
+smartthings edge:channels:enroll <hub-id>
+```
+
+Select the channel when prompted, or pass `--channel <channel-id>`.
+
+Find your hub ID with:
+
+```bash
+smartthings devices --type HUB
+```
+
+### Step 3: Package and Install the Driver
+
+The `edge:drivers:package` command can build, upload, assign to a channel, and
+install in one step:
+
+```bash
+smartthings edge:drivers:package <path-to-driver-dir> \
+  --hub=<hub-uuid> \
+  --channel=<channel-id>
+```
+
+For example:
+
+```bash
+smartthings edge:drivers:package drivers/SmartThings/zwave-switch \
+  --hub=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee \
+  --channel=11111111-2222-3333-4444-555555555555
+```
+
+### Other Useful Deployment Commands
+
+```bash
+# List drivers installed on a hub
+smartthings edge:drivers:installed --hub=<hub-uuid>
+
+# Stream logs from a driver on the hub
+smartthings edge:drivers:logcat <driver-id> --hub=<hub-uuid>
+
+# Uninstall a driver from a hub
+smartthings edge:drivers:uninstall <driver-id> --hub=<hub-uuid>
+
+# Remove unused drivers from a hub
+smartthings edge:drivers:prune --hub=<hub-uuid>
+
+# Switch a device to a different driver
+smartthings edge:drivers:switch <device-id>
+```
+
+---
+
+## Sharing Drivers
+
+### Creating an Invite Link
+
+Invite links let other users install your driver from your channel without
+giving them ownership of the driver or channel.
+
+```bash
+smartthings edge:channels:invites:create
+```
+
+You will be prompted to select a channel and a driver. The command returns an
+invite URL of the form:
+
+```
+https://bestow-regional.api.smartthings.com/invite/<invite-id>
+```
+
+Share this URL with users. They open it in a browser or the SmartThings mobile
+app to accept the invitation.
+
+### Enrollment Flow for Recipients
+
+1. The recipient opens the invite link.
+2. They log in to their Samsung / SmartThings account.
+3. They select a hub to enroll in the channel.
+4. The driver can be selected to install to that hub.
+
+### Managing Invites
+
+```bash
+# List existing invites
+smartthings edge:channels:invites
+
+# Delete an invite
+smartthings edge:channels:invites:delete <invite-id>
+```
+
+### Managing Channel Assignments
+
+```bash
+# Assign a specific driver version to a channel
+smartthings edge:channels:assign <driver-id> <version>
+
+# List drivers assigned to a channel
+smartthings edge:channels:drivers <channel-id>
+
+# Remove a driver from a channel
+smartthings edge:channels:unassign <driver-id>
+```
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Create channel | `smartthings edge:channels:create` |
+| Enroll hub | `smartthings edge:channels:enroll <hub-id>` |
+| Package & deploy | `smartthings edge:drivers:package <dir> --hub=<id> --channel=<id>` |
+| Stream logs | `smartthings edge:drivers:logcat <driver-id> --hub=<id>` |
+| Create invite | `smartthings edge:channels:invites:create` |
+| List installed drivers | `smartthings edge:drivers:installed --hub=<id>` |

--- a/.agents/skills/linting-and-style/SKILL.md
+++ b/.agents/skills/linting-and-style/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: linting-and-style
+description: Running luacheck for Lua linting and following code style conventions in Edge Driver development
+---
+
+# Linting and Code Style for Edge Drivers
+
+## Running Luacheck
+
+```bash
+luacheck --config .github/workflows/.luacheckrc <path>
+```
+
+### Examples
+
+```bash
+# Lint a specific driver
+luacheck --config .github/workflows/.luacheckrc drivers/SmartThings/zigbee-switch/
+
+# Lint a single file
+luacheck --config .github/workflows/.luacheckrc drivers/SmartThings/zigbee-switch/src/init.lua
+
+# Lint the entire repo
+luacheck --config .github/workflows/.luacheckrc .
+```
+
+Luacheck runs automatically in CI on pull requests that modify files under `drivers/` (see `.github/workflows/luacheck.yml`).
+
+## Code Style Conventions
+
+These conventions are observed across the Edge Driver codebase:
+
+### General
+
+- **Indentation**: 2 spaces, no tabs
+- **Strings**: Use double quotes `"string"` for module requires and general strings
+- **Local variables**: Always use `local` for variables and functions at module scope
+- **Line length**: No enforced limit, but most code stays under 120 characters
+
+### Naming
+
+- **Variables and functions**: `snake_case` (e.g., `local mock_device`, `local function test_init()`)
+- **Constants**: `UPPER_SNAKE_CASE` for true constants (e.g., `SENSOR_BINARY`)
+- **Modules**: Return a table at the end of the file (`return module_name`)
+
+### Requires and Imports
+
+```lua
+-- Standard library requires first
+local capabilities = require "st.capabilities"
+local zw = require "st.zwave"
+
+-- Then test/integration requires
+local test = require "integration_test"
+local t_utils = require "integration_test.utils"
+
+-- Then protocol-specific requires
+local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
+```
+
+### Function Style
+
+- Prefer `local function name()` over `local name = function()`
+- Handler functions typically receive `(driver, device, ...)` arguments
+- Use early returns for guard clauses
+
+### Tables
+
+- Trailing commas are common and acceptable in multi-line tables
+- Align table entries for readability in test manifests
+
+### Comments
+
+- Use `--` for single-line comments
+- Minimal inline comments; code should be self-documenting
+
+Copyright header at the top of every file:
+```lua
+-- Copyright 2026 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+```
+
+### File Organization for Drivers
+
+```
+driver-name/
+  src/
+    init.lua           -- Main driver entry point
+    <sub_modules>.lua  -- Additional driver modules
+    test/
+      test_*.lua       -- Test files (must start with test_)
+  profiles/
+    *.yml              -- Device profiles
+  fingerprints.yml     -- Device fingerprints
+  config.yml           -- Driver configuration
+```

--- a/.agents/skills/testing-edge-drivers/SKILL.md
+++ b/.agents/skills/testing-edge-drivers/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: testing-edge-drivers
+description: Running and writing integration tests for SmartThings Edge Drivers using the Python test harness and Lua integration test framework
+---
+
+# Testing SmartThings Edge Drivers
+
+## Running Tests
+
+Tests are run via the Python test harness:
+
+```bash
+python3 tools/run_driver_tests.py [options]
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `-v` | Print individual test names and pass/fail status |
+| `-vv` | Print test names, status, and full logs on failures (recommended) |
+| `-vvv` | Print all logs from all tests |
+| `-f <filter>` | Only run tests whose file path matches the regex filter |
+| `-j <file>` | Output JUnit XML results to the specified file |
+| `-c [files]` | Run with luacov code coverage |
+| `--html` | Generate HTML coverage reports (use with `-c`) |
+
+### Filter Examples
+
+```bash
+# Run all tests for a specific driver
+python3 tools/run_driver_tests.py -vv -f "zwave-smoke-alarm"
+
+# Run a specific test file
+python3 tools/run_driver_tests.py -vv -f "test_zwave_smoke_detector"
+
+# Run all zigbee switch tests
+python3 tools/run_driver_tests.py -vv -f "zigbee-switch"
+
+# Run all virtual device tests
+python3 tools/run_driver_tests.py -vv -f "virtual"
+```
+
+The filter is a regex applied to the full file path. The harness searches for files matching `drivers/*/*/src/test/test_*.lua`.
+
+### Python Requirements
+
+Install dependencies before running tests:
+
+```bash
+pip install -r tools/requirements.txt
+```
+
+Required packages: `junit_xml`, `requests`, `PyYAML`, `regex`.
+
+### How Tests Execute
+
+The Python harness (`tools/run_driver_tests.py`):
+1. Globs for all `test_*.lua` files under `drivers/*/src/test/`
+2. Filters by the `-f` regex if provided
+3. Changes directory to the driver's `src/` directory (two levels up from the test file)
+4. Runs each test file with `lua <test_file>`
+5. Parses stdout for `Running test`, `PASSED`, `FAILED`, and summary lines
+6. Reports totals and exits with code 1 if any tests failed
+
+## Integration Test Framework
+
+The framework lives in `lua_libs/integration_test/` and is required as `integration_test` in test files. It provides:
+
+### Core Modules
+
+| Module | Purpose |
+|--------|---------|
+| `integration_test` (init.lua) | Main test runner, registration, mock device builder |
+| `integration_test.utils` | Utility functions like `get_profile_definition()` |
+| `integration_test.mock_device` | Build mock Zigbee, Z-Wave, Matter, or generic devices |
+| `integration_test.zwave_test_utils` | Z-Wave specific helpers (e.g., `zwave_test_build_receive_command`) |
+| `integration_test.zigbee_test_utils` | Zigbee specific helpers |
+| `integration_test.mock_socket` | Mock socket layer with channel-based message routing |
+
+### Channels
+
+The test framework uses channels to simulate communication between the driver and the platform:
+
+- `zwave` - Z-Wave protocol messages
+- `zigbee` - Zigbee protocol messages
+- `matter` - Matter protocol messages
+- `capability` - SmartThings capability events (commands from cloud, events to cloud)
+- `device_lifecycle` - Device lifecycle events (init, added, removed, etc.)
+- `driver_lifecycle` - Driver lifecycle events
+- `timer` - Timer-related events
+
+Each channel supports two directions:
+- `receive` - Messages sent TO the driver (incoming commands, device reports)
+- `send` - Messages sent FROM the driver (capability events, protocol commands)
+
+## Writing Tests
+
+### Test File Structure
+
+Every test file follows this pattern:
+
+```lua
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local t_utils = require "integration_test.utils"
+
+-- 1. Build mock device(s)
+local mock_device = test.mock_device.build_test_generic_device({
+  profile = t_utils.get_profile_definition("my-profile.yml"),
+})
+
+-- 2. Define test init function (runs before each test)
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
+end
+test.set_test_init_function(test_init)
+
+-- 3. Register tests (message tests or coroutine tests)
+
+-- 4. Run all registered tests
+test.run_registered_tests()
+```
+
+### Building Mock Devices
+
+```lua
+-- Generic device (no protocol)
+local mock = test.mock_device.build_test_generic_device({
+  profile = t_utils.get_profile_definition("profile-name.yml"),
+  preferences = { ["certifiedpreferences.somePref"] = true },
+})
+
+-- Z-Wave device
+local zw = require "st.zwave"
+local mock = test.mock_device.build_test_zwave_device({
+  profile = t_utils.get_profile_definition("profile-name.yml"),
+  zwave_endpoints = {
+    {
+      command_classes = {
+        { value = zw.SENSOR_BINARY },
+        { value = zw.NOTIFICATION },
+      }
+    }
+  }
+})
+
+-- Zigbee device
+local mock = test.mock_device.build_test_zigbee_device({
+  profile = t_utils.get_profile_definition("profile-name.yml"),
+  zigbee_endpoints = { ... }
+})
+```
+
+### Message Tests (`register_message_test`)
+
+Message tests define an ordered sequence of receive/send message pairs. Each receive triggers the driver handler, and the subsequent sends are the expected outputs.
+
+```lua
+test.register_message_test(
+  "Test description",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        { capability = "switch", component = "main", command = "on", args = {} }
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
+    }
+  },
+  {
+    min_api_version = 17  -- optional version constraint
+  }
+)
+```
+
+The manifest is an array of message entries. The framework groups them into blocks: each block starts with a `receive` followed by zero or more `send` entries. The receives are queued on the mock channel; the sends are set as expectations. The driver processes the receive and the framework asserts the expected sends occurred.
+
+### Coroutine Tests (`register_coroutine_test`)
+
+For more complex test logic (multiple interactions, state changes, conditional assertions, timer manipulation):
+
+```lua
+test.register_coroutine_test(
+  "Test with complex logic",
+  function()
+    -- Queue a lifecycle event
+    test.socket.device_lifecycle():__queue_receive({ mock_device.id, "init" })
+    test.socket.device_lifecycle():__queue_receive(
+      mock_device:generate_info_changed({
+        preferences = { ["certifiedpreferences.somePref"] = false }
+      })
+    )
+    test.wait_for_events()
+
+    -- Now send a capability command and expect a response
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "switch", component = "main", command = "on", args = {} }
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.switch.switch.on())
+    )
+  end,
+  {
+    min_api_version = 17
+  }
+)
+```
+
+Key coroutine test APIs:
+- `test.socket.<channel>:__queue_receive(msg)` - Queue a message for the driver to receive
+- `test.socket.<channel>:__expect_send(msg)` - Set an expectation for a message the driver should send
+- `test.wait_for_events()` - Yield to let the driver process queued messages and check expectations
+- `test.mock_time.advance_time(seconds)` - Advance the mock clock
+
+### Real Example: Z-Wave Smoke Detector Test
+
+From `drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua`:
+
+```lua
+local test = require "integration_test"
+local capabilities = require "st.capabilities"
+local zw = require "st.zwave"
+local zw_test_utils = require "integration_test.zwave_test_utils"
+local t_utils = require "integration_test.utils"
+
+local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 2 })
+
+local sensor_endpoints = {
+  {
+    command_classes = {
+      { value = zw.SENSOR_BINARY },
+      { value = zw.SENSOR_ALARM },
+      { value = zw.NOTIFICATION },
+    }
+  }
+}
+
+local mock_device = test.mock_device.build_test_zwave_device({
+  profile = t_utils.get_profile_definition("smoke-battery-temperature-tamperalert-temperaturealarm.yml"),
+  zwave_endpoints = sensor_endpoints
+})
+
+local function test_init()
+  test.mock_device.add_test_device(mock_device)
+end
+test.set_test_init_function(test_init)
+
+test.register_message_test(
+  "Sensor Binary report (smoke) should be handled",
+  {
+    {
+      channel = "zwave",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        zw_test_utils.zwave_test_build_receive_command(
+          SensorBinary:Report({
+            sensor_type = SensorBinary.sensor_type.SMOKE,
+            sensor_value = SensorBinary.sensor_value.DETECTED_AN_EVENT
+          })
+        )
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main",
+        capabilities.smokeDetector.smoke.detected())
+    }
+  },
+  { min_api_version = 17 }
+)
+
+test.run_registered_tests()
+```
+
+## Common Test Patterns
+
+### Testing Capability Commands (cloud -> device)
+
+Receive on `capability` channel, expect protocol message on `zwave`/`zigbee`/`matter`:
+
+```lua
+{
+  channel = "capability",
+  direction = "receive",
+  message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = {} } }
+},
+{
+  channel = "zwave",
+  direction = "send",
+  message = ...  -- expected Z-Wave command
+}
+```
+
+### Testing Device Reports (device -> cloud)
+
+Receive on protocol channel, expect capability event on `capability`:
+
+```lua
+{
+  channel = "zwave",
+  direction = "receive",
+  message = { mock_device.id, zw_test_utils.zwave_test_build_receive_command(...) }
+},
+{
+  channel = "capability",
+  direction = "send",
+  message = mock_device:generate_test_message("main", capabilities.switch.switch.on())
+}
+```
+
+### Testing Lifecycle Events
+
+```lua
+test.socket.device_lifecycle():__queue_receive({ mock_device.id, "added" })
+test.socket.device_lifecycle():__queue_receive({ mock_device.id, "init" })
+test.socket.device_lifecycle():__queue_receive({ mock_device.id, "doConfigure" })
+```
+
+### Testing Preference Changes
+
+```lua
+test.socket.device_lifecycle():__queue_receive(
+  mock_device:generate_info_changed({
+    preferences = { ["certifiedpreferences.myPref"] = new_value }
+  })
+)
+```
+
+### Optional Test Parameters
+
+The `opts` table passed to `register_message_test` or `register_coroutine_test` supports:
+
+| Field | Description |
+|-------|-------------|
+| `min_api_version` | Skip test if API version is below this (commonly set to 17) |
+| `max_api_version` | Skip test if API version is above this |
+| `test_init` | Per-test init function (overrides the global `set_test_init_function`) |
+| `expected_error` | String or array of Lua patterns for expected errors |
+| `inner_block_ordering` | Set to `"relaxed"` to allow sends in any order within a block |

--- a/.agents/skills/understanding-lua-libraries/SKILL.md
+++ b/.agents/skills/understanding-lua-libraries/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: understanding-lua-libraries
+description: Understanding the SmartThings Edge Driver Lua libraries - driver lifecycle, message dispatchers, default handlers, and protocol message objects
+---
+
+# SmartThings Edge Driver Lua Library Architecture
+
+## 1. Driver Initialization and Run Loop
+
+A driver is created by calling `Driver("name", template)` (or a protocol-specific variant like `ZigbeeDriver("name", template)`). The template is a Lua table containing handler tables and configuration.
+
+The base `Driver.init` (in `lua_libs/st/driver.lua`) does the following:
+- Sets `out_driver.NAME` from the name argument
+- Initializes handler tables: `capability_handlers`, `lifecycle_handlers`, `message_handlers`
+- Opens communication channels via cosock sockets: `capability_channel`, `environment_channel`, `lifecycle_channel`, `driver_lifecycle_channel`, and optionally `discovery_channel`
+- Initializes a datastore and device cache tables
+- Calls `Driver.standardize_sub_drivers()` to normalize the `sub_drivers` list
+- Builds the `lifecycle_dispatcher` and `capability_dispatcher` from handlers + sub_drivers
+- Registers channel handlers so inbound messages get routed to the correct handler function
+
+The `driver:run()` call starts the cosock event loop, which runs forever processing messages from all registered channels.
+
+## 2. Message Dispatchers
+
+The dispatcher system (`lua_libs/st/dispatcher.lua`) is a hierarchical message routing tree. The base class `MessageDispatcher` provides:
+
+- **`default_handlers`** - handlers at this level of the hierarchy.
+- **`child_dispatchers`** - sub-dispatchers (from sub_drivers) that may override defaults
+- **`can_handle(driver, device, ...)`** - returns true if this dispatcher or a child can handle the message
+- **`dispatch(driver, device, ...)`** - finds and executes the matching handler
+
+### Dispatch logic
+
+1. The dispatcher calls `can_handle` on each child dispatcher
+2. If any children can handle: **only the children handle it** (parent defaults are NOT called)
+3. If multiple children match: ALL matching children receive the message
+4. If NO children match: parent defaults are used
+5. This is recursive -- sub-drivers can have sub-drivers
+
+### Dispatcher types
+
+| Dispatcher | Class | Handles |
+|------------|-------|---------|
+| `capability_dispatcher` | `CapabilityCommandDispatcher` | Capability commands from the platform (on, off, setLevel, etc.) |
+| `lifecycle_dispatcher` | `DeviceLifecycleDispatcher` | Device lifecycle events (added, init, removed, etc.) |
+| `zigbee_message_dispatcher` | `ZigbeeMessageDispatcher` | Incoming Zigbee messages (attribute reports, cluster commands, ZDO) |
+| `zwave_dispatcher` | `ZwaveDispatcher` | Incoming Z-Wave commands |
+| `matter_dispatcher` | `MatterMessageDispatcher` | Incoming Matter interaction responses |
+| `secret_data_dispatcher` | `SecretDataDispatcher` | Security/secret data events |
+
+Each protocol-specific driver (ZigbeeDriver, ZwaveDriver, MatterDriver) adds its own dispatcher on top of the base Driver's capability and lifecycle dispatchers.
+
+**Zigbee handler structure:**
+```lua
+zigbee_handlers = {
+  attr = {    -- attribute reports / read responses
+    [ClusterID] = {
+      [AttributeID] = handler_function,
+    }
+  },
+  global = {  -- global ZCL commands
+    [ClusterID] = {
+      [CommandID] = handler_function,
+    }
+  },
+  cluster = { -- cluster-specific commands
+    [ClusterID] = {
+      [CommandID] = handler_function,
+    }
+  },
+  zdo = {     -- ZDO commands
+    [ClusterID] = handler_function,
+  }
+}
+```
+
+**Z-Wave handler structure:**
+```lua
+zwave_handlers = {
+  [cc.SWITCH_BINARY] = {          -- command class
+    [SwitchBinary.REPORT] = handler_function,  -- command ID
+  },
+}
+```
+
+**Matter handler structure:**
+```lua
+matter_handlers = {
+  attr = {
+    [ClusterID] = {
+      [AttributeID] = handler_function,
+    }
+  },
+  cmd_response = { ... },
+  event = { ... },
+  fallback = handler_function,
+}
+```
+
+**Capability handler structure:**
+```lua
+capability_handlers = {
+  [capabilities.switch.ID] = {
+    [capabilities.switch.commands.on.NAME] = handle_on,
+    [capabilities.switch.commands.off.NAME] = handle_off,
+  },
+  [capabilities.switchLevel.ID] = {
+    [capabilities.switchLevel.commands.setLevel.NAME] = handle_set_level,
+  },
+}
+```
+
+## 3. Sub-Drivers Pattern
+
+Sub-drivers allow device-specific behavior overrides gated by a `can_handle` function. A sub-driver is a table with:
+- `NAME` (string)
+- `can_handle(opts, driver, device, ...) -> boolean`
+- Protocol handlers (zigbee_handlers, zwave_handlers, matter_handlers)
+- `capability_handlers`, `lifecycle_handlers`
+- Optional nested `sub_drivers`
+
+In practice, sub-drivers are often organized as separate files under `src/sub_drivers/` for clarity, and required in the main driver template.
+
+
+### Dispatch Logic
+
+1. The dispatcher calls `can_handle` on each child dispatcher
+2. If any children can handle: **only the children handle it** (parent defaults are NOT called)
+3. If multiple children match: ALL matching children receive the message
+4. If NO children match: parent defaults are used
+5. This is recursive -- sub-drivers can have sub-drivers
+
+### Lazy Loading
+
+Sub-drivers support lazy loading for memory optimization:
+- `Driver.lazy_load_sub_driver(sub_driver)`: Strips handlers, keeps only `can_handle` and `NAME`
+- `Driver.lazy_load_sub_driver_v2(require_path)`: Even more efficient; only requires `can_handle` and `sub_drivers` modules separately
+- A sub-driver with no handlers defined is automatically treated as lazy-loadable
+
+New sub-drivers must be:
+1. Listed in the parent's `sub_drivers.lua` (or the equivalent sub_drivers table)
+2. Have a `can_handle.lua` that correctly identifies the target devices
+3. Have an `init.lua` that returns the sub-driver table
+
+If any of these are missing, the sub-driver will not be loaded.
+
+
+## 4. Lifecycle Events
+
+Device lifecycle events are dispatched through the `DeviceLifecycleDispatcher`. The key events:
+
+1. **`init`** -- Called for every device on driver startup (existing devices) and after `added` for new devices. Used for setting up component/endpoint mappings and device fields.
+2. **`added`** -- Called only when a device is first paired. NOT called for existing devices when a driver is updated. After `added`, a synthetic `init` is automatically dispatched.
+3. **`doConfigure`** -- Called when the device needs configuration (typically after pairing).
+4. **`infoChanged`** -- Called when device metadata changes (e.g., preferences updated). Receives `args.old_st_store` for comparison.
+5. **`removed`** -- Called when device is removed.
+6. **`driverSwitched`** -- Called when device switches to this driver.
+
+Register lifecycle handlers in the template:
+```lua
+lifecycle_handlers = {
+  init = device_init,
+  added = device_added,
+  removed = device_removed,
+  doConfigure = device_do_configure,
+  infoChanged = info_changed_handler,
+}
+```
+
+Handler signature: `function(driver, device, event, args)`
+
+**Default behaviors provided by the framework:**
+- `driverSwitched`: Base Driver marks device as `NONFUNCTIONAL`. ZigbeeDriver overrides this to check capability matching and marks as `PROVISIONED` if all capabilities match.
+- `doConfigure`: ZigbeeDriver defaults to `device_management.configure` which sends attribute reporting configuration.
+- `added`: After a successful `added` callback, the framework automatically queues a synthetic `init` event.
+- `doConfigure`: After success, the framework transitions the device to `PROVISIONED` state.
+- Unhandled lifecycle events log a trace message and are otherwise ignored (fallback handler).
+
+**Critical timing knowledge for lifecycle events**
+
+1. **`init` on driver startup**. After hub restart the radio may not be ready and sending Zigbee/Z-Wave commands in `init` can fail.
+2. **`added` is NOT called for existing devices** on driver update. Only called on first pair. Code that must run for existing devices should go in `init` (for non-radio operations) or use `driverSwitched`.
+3. **`doConfigure` is called any time a device is added with the TYPED provisioning state** and is the right place for device-specific configuration commands.
+4. **`infoChanged` receives `args.old_st_store`** for comparing old vs new preferences. Drivers should check if a preference actually changed before acting on it.
+
+## 5. Key Imports and Require Paths
+
+```lua
+-- Base driver (for virtual/LAN devices)
+local Driver = require "st.driver"
+
+-- Protocol-specific drivers
+local ZigbeeDriver = require "st.zigbee"
+local ZwaveDriver = require "st.zwave.driver"
+local MatterDriver = require "st.matter.driver"
+
+-- Capabilities
+local capabilities = require "st.capabilities"
+
+-- Zigbee defaults (pre-built handlers for common capabilities)
+local defaults = require "st.zigbee.defaults"
+
+-- Zigbee clusters (for building commands/reading attributes)
+local zcl_clusters = require "st.zigbee.zcl"
+
+-- Z-Wave command classes
+local cc = require "st.zwave.CommandClass"
+local SwitchBinary = require "st.zwave.CommandClass.SwitchBinary"
+
+-- Matter clusters
+local clusters = require "st.matter.clusters"
+
+-- Utilities
+local utils = require "st.utils"
+local json = require "st.json"
+local log = require "log"
+
+-- Coroutine runtime
+local cosock = require "cosock"
+
+-- LAN utils
+local socket = cosock.socket
+local luncheon = require "luncheon"
+local luxure = require "luxure"
+local lustre = require "lustre"
+```
+
+### Zigbee driver example (from zigbee-switch)
+
+```lua
+local capabilities = require "st.capabilities"
+local ZigbeeDriver = require "st.zigbee"
+local defaults = require "st.zigbee.defaults"
+
+local template = {
+  supported_capabilities = {
+    capabilities.switch,
+    capabilities.switchLevel,
+    capabilities.colorControl,
+    capabilities.colorTemperature,
+  },
+  sub_drivers = require("sub_drivers"),
+  lifecycle_handlers = {
+    init = device_init,
+    added = device_added,
+  },
+}
+
+-- Register default Zigbee handlers for all supported capabilities
+defaults.register_for_default_handlers(template,
+  template.supported_capabilities,
+  {native_capability_cmds_enabled = true, native_capability_attrs_enabled = true}
+)
+
+local driver = ZigbeeDriver("zigbee_switch", template)
+driver:run()
+```
+
+This pattern - declare supported capabilities, register defaults, add overrides via sub_drivers and lifecycle_handlers, then construct and run - is the standard structure
+for all protocol-based Edge drivers.
+
+## 6. Default Handlers and Protocol-Specific Default Functionality
+
+When a driver declares `supported_capabilities` in its template, the framework automatically registers default handlers for each capability. The registration uses `or`-merge
+logic: **driver-defined handlers always take precedence over defaults.** If the driver already registered a handler for a given cluster/attribute/command slot, the default
+is silently skipped.
+
+Registration happens in `st.{zigbee,zwave,matter}.defaults.init.lua` via `register_for_default_handlers(driver, capabilities, opts)`:
+1. Iterates `supported_capabilities`
+2. For each capability, requires the corresponding defaults module
+3. Merges `zigbee_handlers`, `zwave_handlers`, or `matter_handlers` (only where driver hasn't defined one)
+4. Also merges `attribute_configurations` (Zigbee), `get_refresh_commands` (Z-Wave), or `subscribed_attributes` (Matter)
+
+### Zigbee specific default functionality
+
+The default `doConfigure` handler (`device_management.configure`):
+1. Sends a `refresh` command (reads all configured attributes)
+2. Calls `device:configure()` which iterates all configured attributes and for each:
+   - Sends a ZDO Bind Request
+   - Sends a Configure Reporting command with the attribute's min/max interval, data type, and reportable change
+3. Also handles IAS Zone enrollment if the device supports cluster `0x0500`
+
+### Z-Wave specific default functionality
+
+doConfigure calls `device:default_configure()` which calls `device:refresh()`. The default refresh iterates `get_refresh_commands` from all default capability modules and sends Get commands for each supported CC.
+Refresh collects `get_refresh_commands` from all default modules, sends Get commands
+
+### Matter specific default functionality
+
+TODO
+
+## 7. Unit Test Framework
+
+Load the `testing-edge-drivers` skill for details on the built in unit test framework for to test Zigbee, Z-Wave, and Matter drivers.
+

--- a/.agents/skills/understanding-profiles/SKILL.md
+++ b/.agents/skills/understanding-profiles/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: understanding-profiles
+description: Understanding and defining SmartThings capabilities, device profiles, preferences, and embedded device configurations for Edge Drivers
+---
+
+# SmartThings Capabilities, Profiles, and Preferences
+
+## 1. What Are Capabilities?
+
+Capabilities are the fundamental abstraction in SmartThings. They define what a device can do and what state it can report. Each capability consists of:
+
+- **Attributes**: State/status values (e.g., `switch` has attribute `switch` with values `on`/`off`)
+- **Commands**: Actions that control the device (e.g., `on()`, `off()`, `setLevel(level)`)
+
+A capability definition specifies data types, units, and constraints for its attributes and commands.
+
+### Data Types
+| Type | Example | Description |
+|------|---------|-------------|
+| string | `"locked"` | May have enum or pattern constraints |
+| integer | `5` | Whole number, may have min/max |
+| number | `5.5` | Fractional values allowed |
+| boolean | `true` | true or false |
+| object | `{x: 12}` | Map of name-value pairs |
+| array | `["heat","cool"]` | List of single type |
+
+### Common Capabilities
+- `switch` - on/off control
+- `switchLevel` - dimming (0-100)
+- `temperatureMeasurement` - temperature reading
+- `battery` - battery percentage
+- `contactSensor` - open/closed
+- `motionSensor` - active/inactive
+- `lock` - locked/unlocked
+- `thermostatMode`, `thermostatHeatingSetpoint`, `thermostatCoolingSetpoint`
+- `colorTemperature`, `colorControl`
+- `refresh` - request device state update
+- `firmwareUpdate` - OTA firmware management
+- `healthCheck` - device connectivity monitoring
+
+Full reference: https://developer.smartthings.com/docs/devices/capabilities/capabilities-reference
+
+## 2. Standard vs Custom Capabilities
+
+### Standard Capabilities
+Standard capabilities live under the `smartthings` namespace but are referenced without a namespace prefix:
+```yaml
+- id: switch
+  version: 1
+- id: temperatureMeasurement
+  version: 1
+```
+
+### Custom Capabilities
+Custom capabilities use the format `namespace.capabilityName`:
+```yaml
+- id: perfectlife6617.customGarageDoor
+  version: 1
+```
+
+A namespace is auto-generated per developer account (e.g., `perfectlife6617`). Custom capabilities are created via the SmartThings CLI:
+```
+smartthings capabilities:create -i capability.json
+```
+
+Custom capabilities require a Capability Presentation to render properly in the app.
+
+## 3. Device Profile YAML Format
+
+Device profiles define which capabilities a device exposes, organized into components. They live in `profiles/` directories within driver packages.
+
+### Basic Profile Example (from `zwave-lock`)
+```yaml
+name: base-lock
+components:
+- id: main
+  capabilities:
+  - id: lock
+    version: 1
+  - id: lockCodes
+    version: 1
+  - id: battery
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: SmartLock
+```
+
+### Multi-Component Profile (from `zigbee-fan`)
+```yaml
+name: fan-light
+components:
+  - id: main
+    label: Fan
+    capabilities:
+      - id: switch
+        version: 1
+      - id: fanSpeed
+        version: 1
+        config:
+          values:
+            - key: "fanSpeed.value"
+              range: [0, 3]
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: Fan
+  - id: light
+    label: Light
+    capabilities:
+      - id: switch
+        version: 1
+      - id: switchLevel
+        version: 1
+        config:
+          values:
+            - key: "level.value"
+              range: [0, 100]
+      - id: refresh
+        version: 1
+    categories:
+      - name: Light
+```
+
+### Profile with Embedded Config and Preferences (from `zigbee-contact`)
+```yaml
+name: multi-sensor
+components:
+- id: main
+  capabilities:
+  - id: contactSensor
+    version: 1
+  - id: temperatureMeasurement
+    version: 1
+  - id: threeAxis
+    version: 1
+  - id: accelerationSensor
+    version: 1
+  - id: battery
+    version: 1
+  - id: firmwareUpdate
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: MultiFunctionalSensor
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+  - preferenceId: certifiedpreferences.garageSensor
+    explicit: true
+```
+
+### Key Profile Rules
+- Must have at least one component; the primary is always `id: main`
+- Use multiple components when the same capability is needed more than once (e.g., multi-gang switch)
+- Each component needs at least one capability
+- `categories` determines the device icon in the app (e.g., `SmartLock`, `Fan`, `Light`, `Thermostat`, `MultiFunctionalSensor`)
+- `version: 1` is always used (only version supported)
+
+## 4. Embedded Device Configurations
+
+Embedded device configs let you customize the SmartThings app UI directly in the profile YAML, without creating a separate Device Presentation. Only supported by Edge Drivers.
+
+### Range Constraint
+```yaml
+- id: colorTemperature
+  config:
+    values:
+      - key: "colorTemperature.value"
+        range: [2600, 6200]
+```
+
+### Enabled Values (filter enum options)
+```yaml
+- id: thermostatOperatingState
+  version: 1
+  config:
+    values:
+      - key: "thermostatOperatingState.value"
+        enabledValues:
+          - heating
+          - cooling
+          - fan only
+          - idle
+```
+
+### Separate Attribute vs Command Values
+```yaml
+- id: thermostatMode
+  config:
+    values:
+      - key: thermostatMode.value
+        enabledValues:
+          - off
+          - heat
+          - eco
+      - key: setThermostatMode
+        enabledValues:
+          - off
+          - heat
+```
+
+### Enum Commands
+```yaml
+- id: alarm
+  config:
+    values:
+      - key: alarm.value
+        enabledValues:
+          - off
+          - siren
+      - key: "{{enumCommands}}"
+        enabledValues:
+          - off
+          - siren
+```
+
+When you package the driver, the platform auto-generates a Device Presentation from these configs.
+
+## 5. Preferences
+
+Preferences let users configure device behavior from Settings in the SmartThings app.
+
+### Two Types
+
+**Explicit (shared/reusable):** Defined externally, referenced by ID in the profile:
+```yaml
+preferences:
+  - preferenceId: tempOffset
+    explicit: true
+```
+
+Standard explicit preferences include: `tempOffset`, `humidityOffset`, `motionSensitivity`, `reportingInterval`, `reverse`, `presetPosition`, `username`, `password`.
+
+`tempOffset` and `humidityOffset` are automatically applied by the platform to attribute values - no driver code needed.
+
+**Embedded (inline in profile):** Defined directly in the profile YAML:
+```yaml
+preferences:
+  - title: "IP Address"
+    name: ipAddress
+    description: "IP address of the Pi-Hole"
+    required: true
+    preferenceType: string
+    definition:
+      minLength: 7
+      maxLength: 15
+      stringType: text
+      default: localhost
+```
+
+### Preference Types
+| Type | Definition Fields |
+|------|------------------|
+| boolean | `default` |
+| integer | `minimum`, `maximum`, `default` |
+| number | `minimum`, `maximum`, `default` |
+| string | `stringType` (text/paragraph/password), `minLength`, `maxLength`, `default` |
+| enumeration | `options` (key-value map), `default` (must match a key) |
+
+### Accessing Preferences in Lua
+
+Query current value:
+```lua
+local offset = device.preferences.tempOffset
+local level = command.args.level + device.preferences.levelOffset
+```
+
+Handle preference changes via `infoChanged` lifecycle:
+```lua
+local function device_info_changed(driver, device, event, args)
+  if args.old_st_store.preferences.sensitivityLevel ~= device.preferences.sensitivityLevel then
+    device:send(<message_to_control_device>)
+  end
+end
+```
+
+For sleepy Z-Wave devices, use `device:set_update_preferences_fn(fn)` which fires on wakeup.
+
+## 6. config.yml
+
+The `config.yml` file is the driver package manifest. It lives at the root of each driver directory.
+
+```yaml
+name: 'Zigbee Thermostat'
+defaultProfile: 'thermostat-battery-powerSource'
+packageKey: 'zigbee-thermostat'
+permissions:
+  zigbee: {}
+description: "SmartThings driver for Zigbee thermostat devices"
+vendorSupportInformation: "https://support.smartthings.com"
+```
+
+### Fields
+| Field | Description |
+|-------|-------------|
+| `name` | Human-readable driver name |
+| `packageKey` | Unique package identifier |
+| `permissions` | Protocol access: `zigbee: {}`, `zwave: {}`, `lan: {}`, `matter: {}` |
+| `description` | Driver description |
+| `defaultProfile` | Profile name used when no fingerprint match specifies one |
+| `vendorSupportInformation` | Support URL |
+
+## 7. Fingerprints
+
+Fingerprints map physical devices to profiles. They live in `fingerprints.yml` at the driver root.
+
+### Zigbee Fingerprints
+```yaml
+zigbeeManufacturer:
+  - id: "LUMI/lumi.motion.ac02"
+    deviceLabel: Aqara Motion Sensor P1
+    manufacturer: LUMI
+    model: lumi.motion.ac02
+    deviceProfileName: motion-illuminance-battery-aqara
+  - id: "SmartThings/motionv5"
+    deviceLabel: Motion Sensor
+    manufacturer: SmartThings
+    model: motionv5
+    deviceProfileName: motion-temp-battery
+
+zigbeeGeneric:
+  - id: kickstarter/motion/1
+    deviceLabel: SmartThings Motion Sensor
+    zigbeeProfiles:
+      - 0xFC01
+    deviceIdentifiers:
+      - 0x013A
+    deviceProfileName: smartsense-motion
+```
+
+### Key Fingerprint Fields
+| Field | Description |
+|-------|-------------|
+| `id` | Unique identifier for the fingerprint |
+| `deviceLabel` | Default label shown to users |
+| `manufacturer` | Device manufacturer string |
+| `model` | Device model string |
+| `deviceProfileName` | Which profile from `profiles/` to use |
+| `zigbeeProfiles` | (zigbeeGeneric) Zigbee profile IDs |
+| `deviceIdentifiers` | (zigbeeGeneric) Zigbee device type IDs |
+
+Z-Wave fingerprints use `manufacturerId`, `productType`, and `productId` instead.
+
+## 8. Relationship: config.yml + Profiles + Fingerprints
+
+```
+driver/
+├── config.yml              # Package manifest, declares defaultProfile
+├── fingerprints.yml        # Maps hardware → profile by deviceProfileName
+├── profiles/
+│   ├── basic-device.yml    # Profile A
+│   └── advanced-device.yml # Profile B
+└── src/
+    └── init.lua            # Driver logic
+```
+
+Flow:
+1. A device joins the hub
+2. The platform matches it against `fingerprints.yml` entries
+3. The matched fingerprint's `deviceProfileName` selects which profile to use
+4. If no fingerprint matches, `defaultProfile` from `config.yml` is used
+5. The profile defines capabilities, components, categories, and preferences
+6. Embedded `config` in the profile customizes the app UI
+7. The driver's Lua code handles capability commands and emits attribute events

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,52 @@
+ You are working in the SmartThings Edge Drivers repository. Drivers are written in **Lua 5.3** and
+ run on SmartThings hubs. They translate Zigbee, Z-Wave, Matter, and LAN protocol messages into
+ SmartThings capability commands and events.
+
+ For full context, read `AGENTS.md` at the repository root. It covers driver structure, lifecycle,
+ profiles, and available skills for deeper domain knowledge.
+
+ ## Standard Commands
+
+ ```bash
+ # Run tests
+ python3 tools/run_driver_tests.py -vv -f <driver-name>
+
+ # Lint
+ luacheck --config .github/workflows/.luacheckrc <path>
+
+ # Deploy
+ smartthings edge:drivers:package <driver-dir> --hub=<hub-uuid> --channel=<channel-id>
+```
+
+## Rules
+
+Always:
+
+ - Run tests before considering a change complete
+ - Run luacheck on modified Lua files
+ - Use existing standard capabilities before creating custom ones
+ - Follow existing driver structure patterns
+
+Ask before:
+
+ - Modifying device profile YAML files (changes affect production devices)
+ - Adding new custom capabilities
+ - Changing config.yml permissions
+
+Never:
+
+ - Commit hardcoded API keys or tokens
+ - Skip tests for driver changes
+ - Use Lua features beyond 5.3
+
+## Skills
+
+Load these files for deeper knowledge when working in each area:
+
+| Task | Skill file |
+|------|-----------|
+| Driver lifecycle, dispatch, default handlers       | .agents/skills/understanding-lua-libraries/SKILL.md  |
+| Profiles, capabilities, preferences, fingerprints  | .agents/skills/understanding-profiles/SKILL.md       |
+| Writing and running tests                          | .agents/skills/testing-edge-drivers/SKILL.md         |
+| Luacheck / code style                              | .agents/skills/linting-and-style/SKILL.md            |
+| Environment setup, deploying, sharing via channels | .agents/skills/dev-workflow/SKILL.md                 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# SmartThings Edge Drivers — Agent Instructions
+
+You are an expert Lua 5.3 engineer and SmartThings Edge Driver maintainer. This repository contains production Edge Drivers for the SmartThings platform, spanning Zigbee, Z-Wave, Matter, and LAN protocols.
+
+Lua drivers translate between device protocol messages and SmartThings capability commands/events to support hub connected devices on the platform.
+
+## Repository Structure
+
+```
+drivers/           # Edge Drivers organized by vendor (SmartThings/, Aqara/, etc.)
+  <vendor>/<driver>/
+    config.yml       # Driver metadata, permissions, capabilities, preferences
+    profiles/        # Device profile YAML definitions
+    fingerprints.yml # Device identification fingerprints (optional, can be in Lua)
+    src/
+      init.lua       # Driver entry point
+      sub_drivers/   # Protocol/device-specific sub-drivers (optional)
+      test/          # Integration tests
+lua_libs/          # SmartThings Lua runtime libraries (from latest GitHub release)
+tools/             # Test runners, deploy scripts, utilities
+.github/workflows/ # CI: tests, luacheck, packaging
+```
+
+## Standard Commands
+
+### Run Tests
+```bash
+python3 tools/run_driver_tests.py -vv -f <filter_string>
+```
+The filter matches against driver directory/file names. Load the `testing-edge-drivers` skill for details.
+
+### Lint
+```bash
+luacheck --config .github/workflows/.luacheckrc <path>
+```
+Load the `linting-and-style` skill for configuration details and common fixes.
+
+### Deploy a Driver
+```bash
+smartthings edge:drivers:package <path_to_driver_dir> --hub=<device_uuid> --channel=<channel_id>
+```
+Load the `dev-workflow` skill for channel setup and sharing instructions.
+
+## Driver Anatomy
+
+Drivers live under `drivers/<Vendor>/<driver-name>/`. The canonical layout is:
+
+```
+drivers/<Vendor>/<driver-name>/
+  config.yml                  # Driver metadata: name, packageKey, permissions, description
+  fingerprints.yml            # Device matching rules (Zigbee, Z-Wave, Matter only)
+  search-parameters.yml       # SSDP/mDNS discovery hints (LAN drivers only)
+  profiles/
+    <profile-name>.yml        # One file per device profile
+  src/
+    init.lua                  # Driver entry point; creates template and calls :run()
+    sub_drivers.lua           # Optional: list of sub-driver require paths
+    <sub-driver-name>/
+      init.lua                # Sub-driver table: NAME, can_handle, handlers
+      can_handle.lua          # Optional: separated device-matching function
+      fingerprints.lua        # Optional: Lua-side fingerprint list for can_handle
+```
+
+Load the `understanding-lua-libraries` skill for detailed information on the driver framework.
+
+### Fingerprints (`fingerprints.yml`)
+
+Fingerprints tell the platform which driver to assign to a newly-joined device.
+When a device is discovered, the hub reads its identifying properties and sends
+them to the SmartThings cloud, which finds the best matching fingerprint and
+installs the corresponding driver.
+
+Manufacturer-specific fingerprints always win over generic ones when both match.
+
+LAN drivers do **not** use `fingerprints.yml`. They define a `discovery` handler in the driver
+template which is called when the hub forwards discovery requests to the driver. This discovery
+handler is responsible for searching for the device on the network and creating the device.
+
+### Device Profiles (`profiles/*.yml`)
+
+A profile declares the SmartThings **capabilities** a device exposes, grouped into
+**components**. The `main` component is the primary one. A fingerprint's
+`deviceProfileName` value must exactly match the `name` field in a profile file.
+
+Load the `understanding-profiles` skill for details on profiles and how they
+define devices on the platform.
+
+## Lua Libraries (`lua_libs/`)
+
+The `lua_libs/` directory at the repository root is setup by the developer and not committed
+to the repository. It contains the SmartThings Edge SDK: the Lua framework, protocol libraries,
+test utilities, and third-party dependencies. **This directory must be present for tests to run.**
+Load the `dev-workflow` skill to help with initial setup.
+
+Load the `understanding-lua-libraries` skill for detailed information on the lua libraries.
+
+---
+
+## Rules
+
+### ✅ ALWAYS
+- Run tests before considering a change complete
+- Run luacheck on modified Lua files
+- Use existing capabilities from the SmartThings reference before creating custom ones
+- Follow the existing driver structure patterns in this repo
+- Use `require` paths relative to `src/` for driver code, and `lua_libs/` for library code
+
+### ⚠️ ASK FIRST
+- Before modifying device profile YAML files (changes affect production devices)
+- Before adding new custom capabilities
+- Before changing `config.yml` permissions
+- Before modifying shared library code in `lua_libs/`
+
+### 🚫 NEVER
+- Commit hardcoded API keys, tokens, or hub UUIDs
+- Modify files in `lua_libs/` (these come from upstream releases)
+- Skip tests for driver changes
+- Use Lua features beyond 5.3 (the hub runtime is Lua 5.3)
+
+## Available Skills
+
+Load these for deeper domain knowledge:
+
+| Skill | When to Use | Skill file |
+|-------|-------------|------------|
+| `understanding-profiles` | Defining or modifying capabilities, profiles, preferences, or device configurations | .agents/skills/understanding-profiles/SKILL.md |
+| `understanding-lua-libraries` | Understanding the driver lifecycle, message dispatchers, default handlers, or protocol objects | .agents/skills/understanding-lua-libraries/SKILL.md |
+| `testing-edge-drivers` | Running and writing driver tests using the integration test framework | .agents/skills/testing-edge-drivers/SKILL.md |
+| `linting-and-style` | Running luacheck or fixing style issues | .agents/skills/linting-and-style/SKILL.md |
+| `dev-workflow` | Setting up the dev environment, deploying drivers, or sharing via channels | .agents/skills/dev-workflow/SKILL.md |


### PR DESCRIPTION
These are based on what I have setup for myself locally, but are not exactly the same, so are somewhat untested. Some of the skills and potentially even the AGENTS.md file may be too large for very small models, but I think this will really help anyone using the main cloud provided models and tools like opencode, claude code, codex, etc when working with agents in this repo.