### PR TITLE
Matter Switch: Remove ghost events, re-provision after driver switch

### DIFF
--- a/drivers/SmartThings/matter-switch/src/init.lua
+++ b/drivers/SmartThings/matter-switch/src/init.lua
@@ -61,6 +61,7 @@ function SwitchLifecycleHandlers.driver_switched(driver, device)
   if device.network_type == device_lib.NETWORK_TYPE_MATTER and not switch_utils.detect_bridge(device) then
     device_cfg.match_profile(driver, device)
   end
+  device:try_update_metadata({provisioning_state = "PROVISIONED"})
 end
 
 function SwitchLifecycleHandlers.info_changed(driver, device, event, args)

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/aqara_cube/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/aqara_cube/init.lua
@@ -184,7 +184,9 @@ end
 local function do_configure(driver, device) end
 
 -- override driver_switched to prevent it running in the main driver
-local function driver_switched(driver, device) end
+local function driver_switched(driver, device)
+  device:try_update_metadata({provisioning_state = "PROVISIONED"})
+end
 
 local function initial_press_event_handler(driver, device, ib, response)
   if get_field_for_endpoint(device, INITIAL_PRESS_ONLY, ib.endpoint_id) then

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/init.lua
@@ -43,6 +43,7 @@ function CameraLifecycleHandlers.driver_switched(driver, device)
   if #device:get_endpoints(clusters.CameraAvStreamManagement.ID) == 0 then
     camera_cfg.match_profile(device)
   end
+  device:try_update_metadata({provisioning_state = "PROVISIONED"})
 end
 
 function CameraLifecycleHandlers.info_changed(driver, device, event, args)

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/eve_energy/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/eve_energy/init.lua
@@ -246,7 +246,9 @@ end
 local function do_configure(driver, device) end
 
 -- override driver_switched to prevent it running in the main driver
-local function driver_switched(driver, device) end
+local function driver_switched(driver, device)
+  device:try_update_metadata({provisioning_state = "PROVISIONED"})
+end
 
 local function handle_refresh(self, device)
   requestData(device)

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/init.lua
@@ -25,6 +25,7 @@ end
 
 function IkeaScrollLifecycleHandlers.driver_switched(driver, device)
   scroll_cfg.match_profile(driver, device)
+  device:try_update_metadata({provisioning_state = "PROVISIONED"})
 end
 
 function IkeaScrollLifecycleHandlers.info_changed(driver, device, event, args)

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/ikea_scroll/scroll_utils/device_configuration.lua
@@ -22,7 +22,6 @@ function IkeaScrollConfiguration.configure_buttons(device)
   for _, ep in ipairs(scroll_fields.ENDPOINTS_PUSH) do
     device:send(clusters.Switch.attributes.MultiPressMax:read(device, ep))
     switch_utils.set_field_for_endpoint(device, switch_fields.SUPPORTS_MULTI_PRESS, ep, true, {persist = true})
-    device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = false}))
   end
   for _, ep in ipairs(scroll_fields.ENDPOINTS_UP_SCROLL) do -- and by extension, ENDPOINTS_DOWN_SCROLL
     device:emit_event_for_endpoint(ep, capabilities.knob.supportedAttributes({"rotateAmount"}, {visibility = {displayed = false}}))

--- a/drivers/SmartThings/matter-switch/src/sub_drivers/third_reality_mk1/init.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/third_reality_mk1/init.lua
@@ -36,7 +36,6 @@ local function configure_buttons(device)
       device.log.info(string.format("Configuring Supported Values for generic switch endpoint %d", ep))
       local supportedButtonValues_event = capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})
       device:emit_event_for_endpoint(ep, supportedButtonValues_event)
-      device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = false}))
     else
       device.log.info(string.format("Component not found for generic switch endpoint %d. Skipping Supported Value configuration", ep))
     end

--- a/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/device_configuration.lua
@@ -184,7 +184,6 @@ function ButtonDeviceConfiguration.configure_buttons(device, momentary_switch_ep
       if supportedButtonValues_event then
         device:emit_event_for_endpoint(ep, supportedButtonValues_event)
       end
-      device:emit_event_for_endpoint(ep, capabilities.button.button.pushed({state_change = false}))
     else
       device.log.info_with({hub_logs=true}, string.format("Component not found for generic switch endpoint %d. Skipping Supported Value configuration", ep))
     end

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
@@ -97,13 +97,10 @@ local aqara_mock_device = test.mock_device.build_test_matter_device({
 
 local function configure_buttons()
   test.socket.matter:__expect_send({aqara_mock_device.id, clusters.Switch.attributes.MultiPressMax:read(aqara_mock_device, 3)})
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button1", capabilities.button.button.pushed({state_change = false})))
 
   test.socket.matter:__expect_send({aqara_mock_device.id, clusters.Switch.attributes.MultiPressMax:read(aqara_mock_device, 4)})
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button2", capabilities.button.button.pushed({state_change = false})))
 
   test.socket.matter:__expect_send({aqara_mock_device.id, clusters.Switch.attributes.MultiPressMax:read(aqara_mock_device, 5)})
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button3", capabilities.button.button.pushed({state_change = false})))
 end
 
 local function test_init()

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -7,7 +7,6 @@ local capabilities = require "st.capabilities"
 local utils = require "st.utils"
 local dkjson = require "dkjson"
 local clusters = require "st.matter.clusters"
-local button_attr = capabilities.button.button
 local version = require "version"
 
 if version.api < 11 then
@@ -147,16 +146,9 @@ local cumulative_report_val_39 = {
 
 local function configure_buttons()
   test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("main", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button2", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button2", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button3", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button3", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button4", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button4", button_attr.pushed({state_change = false})))
 end
 
 local function test_init()

--- a/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
@@ -156,13 +156,9 @@ local function ikea_scroll_subscribe()
 end
 
 local function expect_configure_buttons()
-  local button_attr = capabilities.button.button
   test.socket.matter:__expect_send({mock_ikea_scroll.id, clusters.Switch.attributes.MultiPressMax:read(mock_ikea_scroll, 3)})
-  test.socket.capability:__expect_send(mock_ikea_scroll:generate_test_message("main", button_attr.pushed({state_change = false})))
   test.socket.matter:__expect_send({mock_ikea_scroll.id, clusters.Switch.attributes.MultiPressMax:read(mock_ikea_scroll, 6)})
-  test.socket.capability:__expect_send(mock_ikea_scroll:generate_test_message("group2", button_attr.pushed({state_change = false})))
   test.socket.matter:__expect_send({mock_ikea_scroll.id, clusters.Switch.attributes.MultiPressMax:read(mock_ikea_scroll, 9)})
-  test.socket.capability:__expect_send(mock_ikea_scroll:generate_test_message("group3", button_attr.pushed({state_change = false})))
   test.socket.capability:__expect_send(mock_ikea_scroll:generate_test_message("main", capabilities.knob.supportedAttributes({"rotateAmount"}, {visibility = {displayed = false}})))
   test.socket.capability:__expect_send(mock_ikea_scroll:generate_test_message("group2", capabilities.knob.supportedAttributes({"rotateAmount"}, {visibility = {displayed = false}})))
   test.socket.capability:__expect_send(mock_ikea_scroll:generate_test_message("group3", capabilities.knob.supportedAttributes({"rotateAmount"}, {visibility = {displayed = false}})))

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
@@ -49,7 +49,6 @@ local expected_initial_press_only_state = true
 
 local function expect_configure_button(device)
   test.socket.capability:__expect_send(device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(device:generate_test_message("main", button_attr.pushed({state_change = false})))
 end
 
 local function test_init_for_lifecycle_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -346,7 +346,6 @@ local function update_device_profile()
   end
   test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, DOORBELL_EP)})
-  test.socket.capability:__expect_send(mock_device:generate_test_message("doorbell", capabilities.button.button.pushed({state_change = false})))
 end
 
 -- Matter Handler UTs
@@ -3001,7 +3000,6 @@ test.register_coroutine_test(
     }
     mock_device:expect_metadata_update(updated_expected_metadata)
     test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, DOORBELL_EP)})
-    test.socket.capability:__expect_send(mock_device:generate_test_message("doorbell", capabilities.button.button.pushed({state_change = false})))
   end,
   {
      min_api_version = 17

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
@@ -179,19 +179,10 @@ local mock_device_battery = test.mock_device.build_test_matter_device(
 
 local function expect_configure_buttons(device)
   test.socket.capability:__expect_send(device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(device:generate_test_message("main", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(device:generate_test_message("button2", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(device:generate_test_message("button2", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(device:generate_test_message("button3", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(device:generate_test_message("button3", button_attr.pushed({state_change = false})))
-
   test.socket.matter:__expect_send({device.id, clusters.Switch.attributes.MultiPressMax:read(device, 50)})
-  test.socket.capability:__expect_send(device:generate_test_message("button4", button_attr.pushed({state_change = false})))
-
   test.socket.matter:__expect_send({device.id, clusters.Switch.attributes.MultiPressMax:read(device, 60)})
-  test.socket.capability:__expect_send(device:generate_test_message("button5", button_attr.pushed({state_change = false})))
 end
 
 local function update_profile()

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_motion.lua
@@ -125,22 +125,11 @@ local CLUSTER_SUBSCRIBE_LIST ={
 
 local function expect_configure_buttons()
   test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("main", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(mock_device:generate_test_message("button2", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(mock_device:generate_test_message("button3", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(mock_device:generate_test_message("button4", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button4", button_attr.pushed({state_change = false})))
-
   test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 50)})
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button5", button_attr.pushed({state_change = false})))
-
   test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, 60)})
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button6", button_attr.pushed({state_change = false})))
 end
 
 -- All messages queued and expectations set are done before the driver is actually run

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -198,13 +198,8 @@ local CLUSTER_SUBSCRIBE_LIST_WITH_CHILD ={
 
 local function expect_configure_buttons()
   test.socket.capability:__expect_send(mock_device:generate_test_message("button1", capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button1", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(mock_device:generate_test_message("button2", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.pushed({state_change = false})))
-
   test.socket.capability:__expect_send(mock_device:generate_test_message("button3", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-  test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = false})))
 end
 
 local function test_init()
@@ -422,7 +417,6 @@ test.register_coroutine_test(
       parent_assigned_child_key = string.format("%d", 7)
     })
     test.socket.capability:__expect_send(unsup_mock_device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-    test.socket.capability:__expect_send(unsup_mock_device:generate_test_message("main", button_attr.pushed({state_change = false})))
     unsup_mock_device:expect_metadata_update({ profile = "2-button" })
     unsup_mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 
@@ -446,10 +440,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({unsup_mock_device.id, subscribe_request})
 
     test.socket.capability:__expect_send(unsup_mock_device:generate_test_message("main", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-    test.socket.capability:__expect_send(unsup_mock_device:generate_test_message("main", button_attr.pushed({state_change = false})))
-
     test.socket.capability:__expect_send(unsup_mock_device:generate_test_message("button2", capabilities.button.supportedButtonValues({"pushed", "held"}, {visibility = {displayed = false}})))
-    test.socket.capability:__expect_send(unsup_mock_device:generate_test_message("button2", button_attr.pushed({state_change = false})))
     end,
   {
     test_init = test_init_mcd_unsupported_switch_device_type,
@@ -471,6 +462,7 @@ test.register_coroutine_test(
     mock_child:expect_metadata_update({ profile = "light-color-level" })
     mock_device:expect_metadata_update({ profile = "light-level-3-button" })
     expect_configure_buttons()
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
      min_api_version = 17

--- a/drivers/SmartThings/matter-switch/src/test/test_third_reality_mk1.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_third_reality_mk1.lua
@@ -185,7 +185,6 @@ local function configure_buttons()
     local component = "F" .. key
     if key == 1 then component = "main" end
     test.socket.capability:__expect_send(mock_device:generate_test_message(component, capabilities.button.supportedButtonValues({"pushed"}, {visibility = {displayed = false}})))
-    test.socket.capability:__expect_send(mock_device:generate_test_message(component, capabilities.button.button.pushed({state_change = false})))
   end
 end
 


### PR DESCRIPTION
# Description of Change
Remove `pushed` event during configuration. This is not a required operation, and generates events not pre-conditioned by a device event.

Set device provisioning state back to PROVISIONED after a `driverSwitched` event to block repeated events.  

# Summary of Completed Tests
Tests updated. Driver switch tested with button device switched. Fresh button onboarding tested.
