### PR TITLE
Provision driver switch in Matter Lock

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/init.lua
@@ -400,6 +400,7 @@ end
 
 local function driver_switched(driver, device)
   match_profile(driver, device, false)
+  device:try_update_metadata({provisioning_state = "PROVISIONED"})
 end
 
 -- Matter Handler

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
@@ -82,6 +82,22 @@ end
 
 test.set_test_init_function(test_init)
 
+
+test.register_coroutine_test(
+  "Handle driverSwitched event",
+  function()
+    test.socket.device_lifecycle:__queue_receive({ mock_device.id, "driverSwitched" })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.lock.supportedLockCommands({"lock", "unlock"}, {visibility = {displayed = false}}))
+    )
+    mock_device:expect_metadata_update({ profile = "lock-user-pin-schedule" })
+    mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
+  end,
+  {
+     min_api_version = 17
+  }
+)
+
 test.register_coroutine_test(
   "Handle received OperatingMode(Normal, Vacation) from Matter device.",
   function()


### PR DESCRIPTION
See description [here](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2978). Copying this work in other drivers.