### PR TITLE
Matter Switch: Register setColorTemperature native handler

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -128,12 +128,12 @@ function AttributeHandlers.color_temperature_mireds_handler(driver, device, ib, 
   if device:get_field(fields.IS_PARENT_CHILD_DEVICE) == true then
     temp_device = switch_utils.find_child(device, ib.endpoint_id) or device
   end
-  local most_recent_temp = temp_device:get_field(fields.MOST_RECENT_TEMP)
+  local latest_requested_kelvin = temp_device:get_field(fields.LATEST_REQUESTED_KELVIN)
   -- this is to avoid rounding errors from the round-trip conversion of Kelvin to mireds
-  if most_recent_temp ~= nil and
-    most_recent_temp <= st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/(temp_in_mired - 1)) and
-    most_recent_temp >= st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/(temp_in_mired + 1)) then
-      temp = most_recent_temp
+  if latest_requested_kelvin and
+    latest_requested_kelvin <= st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/(temp_in_mired - 1)) and
+    latest_requested_kelvin >= st_utils.round(fields.MIRED_KELVIN_CONVERSION_CONSTANT/(temp_in_mired + 1)) then
+      temp = latest_requested_kelvin
   end
   device:emit_event_for_endpoint(ib.endpoint_id, capabilities.colorTemperature.colorTemperature(temp))
 end

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -124,7 +124,7 @@ function CapabilityHandlers.handle_set_color_temperature(driver, device, cmd)
     temp_in_mired = switch_utils.get_field_for_endpoint(field_device, fields.COLOR_TEMP_BOUND_RECEIVED_MIRED..fields.COLOR_TEMP_MIN, endpoint_id)
   end
   local req = clusters.ColorControl.server.commands.MoveToColorTemperature(device, endpoint_id, temp_in_mired, fields.ZERO_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
-  device:set_field(fields.MOST_RECENT_TEMP, cmd.args.temperature, {persist = true})
+  device:set_field(fields.LATEST_REQUESTED_KELVIN, cmd.args.temperature)
   device:send(req)
 end
 

--- a/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/capability_handlers.lua
@@ -107,6 +107,9 @@ end
 -- [[ COLOR TEMPERATURE CAPABILITY COMMANDS ]] --
 
 function CapabilityHandlers.handle_set_color_temperature(driver, device, cmd)
+  if type(device.register_native_capability_cmd_handler) == "function" then
+    device:register_native_capability_cmd_handler(cmd.capability, cmd.command)
+  end
   local endpoint_id = device:component_to_endpoint(cmd.component)
   local temp_in_kelvin = cmd.args.temperature
   -- note: the field containing the color temp bounds will be associated with a parent device

--- a/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/fields.lua
@@ -5,7 +5,7 @@ local clusters = require "st.matter.clusters"
 
 local SwitchFields = {}
 
-SwitchFields.MOST_RECENT_TEMP = "mostRecentTemp"
+SwitchFields.LATEST_REQUESTED_KELVIN = "mostRecentTemp"
 SwitchFields.RECEIVED_X = "receivedX"
 SwitchFields.RECEIVED_Y = "receivedY"
 SwitchFields.HUESAT_SUPPORT = "huesatSupport"
@@ -100,6 +100,7 @@ SwitchFields.updated_fields = {
   { current_field_name = "__energy_management_endpoint", updated_field_name = nil },
   { current_field_name = "__total_imported_energy", updated_field_name = nil },
   { current_field_name = "__last_imported_report_timestamp", updated_field_name = nil },
+  { current_field_name = "mostRecentTemp", updated_field_name = nil },
 }
 
 SwitchFields.vendor_overrides = {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -5,11 +5,6 @@ local capabilities = require "st.capabilities"
 local clusters = require "st.matter.generated.zap_clusters"
 local t_utils = require "integration_test.utils"
 local test = require "integration_test"
-local version = require "version"
-
-local TRANSITION_TIME = 0
-local OPTIONS_MASK = 0x01
-local HANDLE_COMMAND_IF_OFF = 0x01
 
 local mock_device_ep1 = 1
 local mock_device_ep2 = 2
@@ -171,98 +166,6 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device_capabilities_disabled:generate_info_changed({}))
   end,
   { test_init = function() test.mock_device.add_test_device(mock_device_capabilities_disabled) end }
-)
-
-
-test.register_coroutine_test(
-  "Switch capability should send the appropriate commands", function()
-    test.socket.capability:__queue_receive(
-      {
-        mock_child.id,
-        { capability = "switch", component = "main", command = "on", args = { } }
-      }
-    )
-    if version.api >= 11 then
-      test.socket.devices:__expect_send(
-        {
-          "register_native_capability_cmd_handler",
-          { device_uuid = mock_child.id, capability_id = "switch", capability_cmd_id = "on" }
-        }
-      )
-    end
-    test.socket.matter:__expect_send(
-      {
-        mock_device.id,
-        clusters.OnOff.server.commands.On(mock_device, mock_device_ep1)
-      }
-    )
-    test.socket.matter:__queue_receive(
-      {
-        mock_device.id,
-        clusters.OnOff.attributes.OnOff:build_test_report_data(mock_device, mock_device_ep1, true)
-      }
-    )
-    test.socket.devices:__expect_send(
-      {
-        "register_native_capability_attr_handler",
-        { device_uuid = mock_device.id, capability_id = "switch", capability_attr_id = "switch" }
-      }
-    )
-    test.socket.capability:__expect_send(
-      mock_child:generate_test_message(
-        "main", capabilities.switch.switch.on()
-      )
-    )
-  end,
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_message_test(
-  "Set color temperature should send the appropriate commands",
-  {
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_child.id,
-        { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {1800} }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, mock_device_ep1, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColorTemperature:build_test_command_response(mock_device, mock_device_ep1)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, mock_device_ep1, 556)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_child:generate_test_message("main", capabilities.colorTemperature.colorTemperature(1800))
-    },
-  },
-  {
-     min_api_version = 17
-  }
 )
 
 local FanMode = clusters.FanControl.attributes.FanMode

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -7,11 +7,7 @@ local t_utils = require "integration_test.utils"
 
 local clusters = require "st.matter.generated.zap_clusters"
 
-local TRANSITION_TIME = 0
-local OPTIONS_MASK = 0x01
-local HANDLE_COMMAND_IF_OFF = 0x01
 local button_attr = capabilities.button.button
-
 
 local mock_device_ep1 = 1
 local mock_device_ep2 = 2
@@ -354,35 +350,6 @@ test.register_coroutine_test(
       )
     })
     test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = true})))
-  end,
-  {
-     min_api_version = 17
-  }
-)
-
-test.register_coroutine_test(
-  "Switch child device: Set color temperature should send the appropriate commands",
-  function()
-    test.mock_device.add_test_device(mock_child)
-    test.wait_for_events()
-    test.socket.capability:__queue_receive({
-      mock_child.id,
-      { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {1800} }
-    })
-    test.socket.matter:__expect_send({
-      mock_device.id,
-      clusters.ColorControl.server.commands.MoveToColorTemperature(mock_device, mock_device_ep5, 556, TRANSITION_TIME, OPTIONS_MASK, HANDLE_COMMAND_IF_OFF)
-    })
-    test.socket.matter:__queue_receive({
-      mock_device.id,
-      clusters.ColorControl.server.commands.MoveToColorTemperature:build_test_command_response(mock_device, mock_device_ep5)
-    })
-    test.wait_for_events()
-    test.socket.matter:__queue_receive({
-      mock_device.id,
-      clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, mock_device_ep5, 556)
-    })
-    test.socket.capability:__expect_send(mock_child:generate_test_message("main", capabilities.colorTemperature.colorTemperature(1800)))
   end,
   {
      min_api_version = 17

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
@@ -416,6 +416,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_children[extended_color_ep_id].id, capability_id = "colorTemperature", capability_cmd_id = "setColorTemperature" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -245,6 +245,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_cmd_id = "setColorTemperature" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -445,6 +453,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_cmd_id = "setColorTemperature" }
+      }
+    },
+    {
       channel = "matter",
       direction = "send",
       message = {
@@ -458,6 +474,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         { capability = "colorTemperature", component = "main", command = "setColorTemperature", args = {2700} }
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_cmd_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_cmd_id = "setColorTemperature" }
       }
     },
     {


### PR DESCRIPTION
# Description of Change

We currently only attempt native handler registration in the [default handler](https://github.ecodesamsung.com/iot-hub/scripting-engine/blob/main/lua_libs/st/matter/defaults/colorTemperature.lua) for the setColorTemperature -> Matter command. This means that no devices actually using the Matter Switch driver will use this native handler.

I also renamed the variable, since mostRecentTemp is 1. pretty inaccurate for what's actually going on, and 2. is very unclear.

I also de-persisted the variable to match the default handler, and therefore the native handler expectations. Since this is only used to store command state, we have no need to persist this.

# Summary of Completed Tests
This native handler has been in production for a while, so testing is fairly sufficient. This just adds the actual registration.

Some unit tests updated, and while checking the failing tests I removed a couple effectively duplicate tests, as a part of the general cleanup work I've been doing to not duplicate tests, for more effective development moving forward. To "extra" prove these tests were repetitions, the luacov analyzer didn't notice any drop in testing coverage.     


On-device testing:
```
2026-05-20T17:42:47.428149367Z INFO Matter Switch  <MatterDevice: 2a93fa5f-29bc-4e29-bcb6-139aafb56bae [1D988282F1D82423-50221DCCC136EE1A] (Matter Color Light)> registering for colorTemperature:setColorTemperature command to be handled natively
2026-05-20T17:42:47.505209367Z INFO Matter Switch  <MatterDevice: 2a93fa5f-29bc-4e29-bcb6-139aafb56bae [1D988282F1D82423-50221DCCC136EE1A] (Matter Color Light)> sending InteractionRequest: <InteractionRequest || type: INVOKE, info_blocks: [<InteractionInfoBlock || endpoint: 0x16, cluster: ColorControl, command: MoveToColorTemperature, data: Structure: {options_mask: \x01, options_override: \x01, transition_time: \x00\x00, color_temperature_mireds: \x01\x11, }>]>

....

2026-05-20T17:43:27.258294705Z INFO Matter Switch  hub handled command: 2a93fa5f-29bc-4e29-bcb6-139aafb56bae:main:colorTemperature:setColorTemperature [3698]
2026-05-20T17:43:27.259362122Z INFO Matter Switch  hub sending: Interaction request (2a93fa5f-29bc-4e29-bcb6-139aafb56bae): <type: Invoke, info_blocks: [<endpoint: 0x16, cluster: 0x300, command: 0x0a, tlv: [15, 25, 00, 0e, 01, 24, 01, 00, 24, 02, 01, 24, 03, 01, 18]>], timed: false
```
