### PR TITLE
Matter Switch: Register ColorTemperatureMireds native handler

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_handlers/attribute_handlers.lua
@@ -106,6 +106,9 @@ function AttributeHandlers.current_saturation_handler(driver, device, ib, respon
 end
 
 function AttributeHandlers.color_temperature_mireds_handler(driver, device, ib, response)
+  if type(device.register_native_capability_attr_handler) == "function" then
+    device:register_native_capability_attr_handler("colorTemperature", "colorTemperature")
+  end
   local temp_in_mired = ib.data.value
   if temp_in_mired == nil then
     return

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
@@ -294,6 +294,36 @@ test.register_message_test(
 )
 
 test.register_message_test(
+  "Extended Color Child: SetColor command should be handled correctly",
+  {
+    {
+      channel = "capability",
+      direction = "receive",
+      message = {
+        mock_children[extended_color_ep_id].id,
+        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 72 } } }
+      }
+    },
+    {
+      channel = "matter",
+      direction = "send",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToColor(mock_device, extended_color_ep_id, 15182, 21547, fields.ZERO_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
+      }
+    },
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.server.commands.MoveToColor:build_test_command_response(mock_device, extended_color_ep_id)
+      }
+    },
+  }
+)
+
+test.register_message_test(
   "Extended Color Child: X and Y color values should report hue and saturation once both have been received",
   {
     {
@@ -329,60 +359,8 @@ test.register_message_test(
 )
 
 test.register_message_test(
-  "Extended Color Child: colorTemperatureRange, setColorTemperature, stepColorTemperatureByPercent handled appropriately",
+  "Extended Color Child: colorTemperatureRange, setColorTemperature, colorTemperature, stepColorTemperatureByPercent handled appropriately",
   {
-    -- setColorTemperature before a color temperature range is set
-    {
-      channel = "capability",
-      direction = "receive",
-      message = {
-        mock_children[extended_color_ep_id].id,
-        { capability = "colorControl", component = "main", command = "setColor", args = { { hue = 50, saturation = 72 } } }
-      }
-    },
-    {
-      channel = "matter",
-      direction = "send",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColor(mock_device, extended_color_ep_id, 15182, 21547, fields.ZERO_TRANSITION_TIME, fields.OPTIONS_MASK, fields.HANDLE_COMMAND_IF_OFF)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.server.commands.MoveToColor:build_test_command_response(mock_device, extended_color_ep_id)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentX:build_test_report_data(mock_device, extended_color_ep_id, 15091)
-      }
-    },
-    {
-      channel = "matter",
-      direction = "receive",
-      message = {
-        mock_device.id,
-        clusters.ColorControl.attributes.CurrentY:build_test_report_data(mock_device, extended_color_ep_id, 21547)
-      }
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_children[extended_color_ep_id]:generate_test_message("main", capabilities.colorControl.hue(50))
-    },
-    {
-      channel = "capability",
-      direction = "send",
-      message = mock_children[extended_color_ep_id]:generate_test_message("main", capabilities.colorControl.saturation(72))
-    },
-
     -- colorTemperatureRange testing
     {
       channel = "matter",
@@ -432,6 +410,29 @@ test.register_message_test(
       }
     }, -- 555 is expected since it is re-bounded by the given range
 
+    -- colorTemperature testing
+    {
+      channel = "matter",
+      direction = "receive",
+      message = {
+        mock_device.id,
+        clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, extended_color_ep_id, 555)
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_attr_id = "colorTemperature" }
+      }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_children[extended_color_ep_id]:generate_test_message("main", capabilities.colorTemperature.colorTemperature(1800))
+    },
+
     -- stepColorTemperatureByPercent testing
     {
       channel = "capability",
@@ -459,7 +460,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+    min_api_version = 17
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -269,6 +269,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_attr_id = "colorTemperature" }
+      }
+    },
+    {
       channel = "matter",
       direction = "receive",
       message = {
@@ -296,6 +304,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, 1, 0)
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_attr_id = "colorTemperature" }
       }
     }
   },
@@ -397,6 +413,14 @@ test.register_message_test(
       }
     },
     {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_attr_id = "colorTemperature" }
+      }
+    },
+    {
       channel = "capability",
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.colorTemperature.colorTemperature(6000))
@@ -407,6 +431,14 @@ test.register_message_test(
       message = {
         mock_device.id,
         clusters.ColorControl.attributes.ColorTemperatureMireds:build_test_report_data(mock_device, 1, 370)
+      }
+    },
+    {
+      channel = "devices",
+      direction = "send",
+      message = {
+        "register_native_capability_attr_handler",
+        { device_uuid = mock_device.id, capability_id = "colorTemperature", capability_attr_id = "colorTemperature" }
       }
     },
     {


### PR DESCRIPTION
# Description of Change
Allow ColorTemperatureMireds to be registered for native handling

# Summary of Completed Tests
Tested on-device. Unit tests updated- child test added, and I broke a part of that test out into a second test (the git diff looks weird on this front)