### PR TITLE
Matter Switch: Use Total Wh for PCR if delta < 0.0

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -402,12 +402,13 @@ function utils.report_power_consumption_to_st_energy(device, endpoint_id, total_
 
   local previous_imported_report = utils.get_latest_state_for_endpoint(device, endpoint_id, capabilities.powerConsumptionReport.ID,
     capabilities.powerConsumptionReport.powerConsumption.NAME, { energy = total_imported_energy_wh }) -- default value if nil
+  local delta_energy = total_imported_energy_wh - previous_imported_report.energy
   -- Report the energy consumed during the time interval. The unit of these values should be 'Wh'
   local epoch_to_iso8601 = function(time) return os.date("!%Y-%m-%dT%H:%M:%SZ", time) end -- Return an ISO-8061 timestamp from UTC
   device:emit_event_for_endpoint(endpoint_id, capabilities.powerConsumptionReport.powerConsumption({
     start = epoch_to_iso8601(last_time),
     ["end"] = epoch_to_iso8601(current_time - 1),
-    deltaEnergy = total_imported_energy_wh - previous_imported_report.energy,
+    deltaEnergy = delta_energy >= 0.0 and delta_energy or total_imported_energy_wh, -- clarifying assumption: a negative delta means the meter was reset
     energy = total_imported_energy_wh
   }))
 end

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
@@ -612,7 +612,7 @@ test.register_coroutine_test(
       mock_device_periodic:generate_test_message("main", capabilities.powerConsumptionReport.powerConsumption({
         start = "1970-01-01T00:15:01Z",
         ["end"] = "1970-01-01T00:48:20Z",
-        deltaEnergy = -4.0,
+        deltaEnergy = 19.0,
         energy = 19.0
       }))
     )


### PR DESCRIPTION
# Description of Change
Use total Wh instead of a negative value for the delta of the powerConsumptionReport. This should only ever be negative in the case that the device has had its energy meter reset, so we should avoid spiking the energy report for ST energy in a case like this. 

Since this would occur only on a rare and one-time case, I've elected not to include any extra state to account for the energy delta that would have also accumulated prior to the reset. I think the tradeoff of adding the state vs. what is actually lost favors just losing that bit of state.

# Summary of Completed Tests
Unit tests updated.