### PR TITLE
Matter Camera: Prevent duplicate zones in triggeredZones report

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_handlers/event_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_handlers/event_handlers.lua
@@ -3,14 +3,23 @@
 
 local camera_fields = require "sub_drivers.camera.camera_utils.fields"
 local capabilities = require "st.capabilities"
-local switch_utils = require "switch_utils.utils"
 
 local CameraEventHandlers = {}
 
+local function has_triggered_zone(triggered_zones, zone_id)
+  for _, zone in ipairs(triggered_zones or {}) do
+    if zone.zoneId == zone_id then
+      return true
+    end
+  end
+  return false
+end
+
 function CameraEventHandlers.zone_triggered_handler(driver, device, ib, response)
   local triggered_zones = device:get_field(camera_fields.TRIGGERED_ZONES) or {}
-  if not switch_utils.tbl_contains(triggered_zones, ib.data.elements.zone.value) then
-    table.insert(triggered_zones, {zoneId = ib.data.elements.zone.value})
+  local zone_id = ib.data.elements.zone.value
+  if not has_triggered_zone(triggered_zones, zone_id) then
+    table.insert(triggered_zones, { zoneId = zone_id })
     device:set_field(camera_fields.TRIGGERED_ZONES, triggered_zones)
     device:emit_event_for_endpoint(ib, capabilities.zoneManagement.triggeredZones(triggered_zones))
   end
@@ -18,12 +27,21 @@ end
 
 function CameraEventHandlers.zone_stopped_handler(driver, device, ib, response)
   local triggered_zones = device:get_field(camera_fields.TRIGGERED_ZONES) or {}
-  for i, v in pairs(triggered_zones) do
-    if v.zoneId == ib.data.elements.zone.value then
-      table.remove(triggered_zones, i)
-      device:set_field(camera_fields.TRIGGERED_ZONES, triggered_zones)
-      device:emit_event_for_endpoint(ib, capabilities.zoneManagement.triggeredZones(triggered_zones))
+  local zone_id = ib.data.elements.zone.value
+  local updated_triggered_zones = {}
+  local zone_removed = false
+
+  for _, zone in ipairs(triggered_zones) do
+    if zone.zoneId ~= zone_id then
+      table.insert(updated_triggered_zones, zone)
+    else
+      zone_removed = true
     end
+  end
+
+  if zone_removed then
+    device:set_field(camera_fields.TRIGGERED_ZONES, updated_triggered_zones)
+    device:emit_event_for_endpoint(ib, capabilities.zoneManagement.triggeredZones(updated_triggered_zones))
   end
 end
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -1472,6 +1472,47 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
+  "Duplicate ZoneTriggered events should not duplicate triggeredZones state",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.ZoneManagement.events.ZoneTriggered:build_test_event_report(mock_device, CAMERA_EP, {
+        zone = 2,
+        reason = clusters.ZoneManagement.types.ZoneEventTriggeredReasonEnum.MOTION
+      })
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.zoneManagement.triggeredZones({{zoneId = 2}}))
+    )
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.ZoneManagement.events.ZoneTriggered:build_test_event_report(mock_device, CAMERA_EP, {
+        zone = 2,
+        reason = clusters.ZoneManagement.types.ZoneEventTriggeredReasonEnum.MOTION
+      })
+    })
+
+    test.socket.matter:__queue_receive({
+      mock_device.id,
+      clusters.ZoneManagement.events.ZoneStopped:build_test_event_report(mock_device, CAMERA_EP, {
+        zone = 2,
+        reason = clusters.ZoneManagement.types.ZoneEventStoppedReasonEnum.ACTION_STOPPED
+      })
+    })
+    test.socket.capability:__expect_send(
+      mock_device:generate_test_message("main", capabilities.zoneManagement.triggeredZones({}))
+    )
+  end,
+  {
+     min_api_version = 17
+  }
+)
+
+test.register_coroutine_test(
   "Button events should generate appropriate events",
   function()
     update_device_profile()


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Prevents duplicate zones from being added to the `triggeredZones` attribute of the `zoneManagement` capability. 

# Summary of Completed Tests
Unit tests added. Tested triggering the same zone multiple times using the GCA and confirmed that no duplicates were emitted.

