### PR TITLE
Add `videoCapture2` to `detailView` in `deviceConfig`

### DIFF
--- a/drivers/SmartThings/matter-switch/profiles/camera.yml
+++ b/drivers/SmartThings/matter-switch/profiles/camera.yml
@@ -134,6 +134,9 @@ deviceConfig:
     - component: main
       capability: motionSensor
       version: 1
+    - component: main
+      capability: videoCapture2
+      version: 1
   automation:
     conditions:
     - component: main


### PR DESCRIPTION
The iOS camera plugin relies on the presence of `videoCapture2` in `detailView` of the presentation. Since the addition of explicit presentation for the capability, we need to explicitly include it in the device config of the profile for it be present in the device presentation.

Tested with SDK camera app on iOS that doesn't show the recorder icon before this change, but does so on this commit.