### PR TITLE
WWSTCERT-12050 Correct Mini Smart Wi-Fi Plug Matter fingerprint

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -4154,10 +4154,10 @@ matterManufacturer:
     vendorId: 0x1392
     productId: 0x010D
     deviceProfileName: plug-binary
-  - id: "20496/610"
+  - id: "5010/262"
     deviceLabel: Mini Smart Wi-Fi Plug Energy Monitoring Matter
-    vendorId: 0x5010
-    productId: 0x0262
+    vendorId: 0x1392
+    productId: 0x0106
     deviceProfileName: plug-power-energy-powerConsumption
 
 


### PR DESCRIPTION
## Summary
This is a follow-up to https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/3017 to correct the Mini Smart Wi-Fi Plug Energy Monitoring Matter fingerprint id from the decimal/hex-mismatched values.

- WWSTCERT-12050

Jira: https://smartthings.atlassian.net/browse/WWSTCERT-12050?focusedCommentId=1782222