### PR TITLE
Revert "WWSTCERT-12165 Aqara Smart Lock J200"

### DIFF
--- a/drivers/SmartThings/matter-lock/fingerprints.yml
+++ b/drivers/SmartThings/matter-lock/fingerprints.yml
@@ -25,11 +25,6 @@ matterManufacturer:
     vendorId: 0x115F
     productId: 0x2804
     deviceProfileName: lock
-  - id: "4447/10253"
-    deviceLabel: Aqara Smart Lock J200
-    vendorId: 0x115F
-    productId: 0x280D
-    deviceProfileName: lock-modular
   #Eufy
   - id: "5427/1"
     deviceLabel: eufy Smart Lock E31

--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua
@@ -11,7 +11,6 @@ local NEW_MATTER_LOCK_PRODUCTS = {
   {0x115f, 0x280e}, -- AQARA Smart Gate Lock U500
   {0x115f, 0x280f}, -- AQARA Smart Rim Lock U500
   {0x115f, 0x2810}, -- AQARA Smart Glass Door Lock U500
-  {0x115F, 0x280D}, -- Aqara Smart Lock J200
   {0x147F, 0x0001}, -- U-tec
   {0x147F, 0x0007}, -- ULTRALOQ Bolt Pro Smart Matter Door Lock
   {0x147F, 0x0008}, -- Ultraloq, Bolt Smart Matter Door Lock


### PR DESCRIPTION
## Summary
- revert PR #3022 since the associated WWST cert application was rejected.
- remove the Aqara Smart Lock J200 fingerprint from `drivers/SmartThings/matter-lock/fingerprints.yml`
- remove the Aqara Smart Lock J200 product entry from `drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua`