### PR TITLE
Matter Switch: Persist electrical tags that are used for profiling

### DIFF
--- a/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
+++ b/drivers/SmartThings/matter-switch/src/switch_utils/utils.lua
@@ -431,7 +431,7 @@ function utils.set_fields_for_electrical_sensor_endpoint(device, electrical_sens
     table.sort(associated_endpoint_ids)
     local primary_associated_ep_id = associated_endpoint_ids[1]
     -- map the required electrical tags for this electrical sensor EP with the first associated EP ID, used later during profling.
-    utils.set_field_for_endpoint(device, fields.ELECTRICAL_TAGS, primary_associated_ep_id, tags)
+    utils.set_field_for_endpoint(device, fields.ELECTRICAL_TAGS, primary_associated_ep_id, tags, {persist = true})
     utils.set_field_for_endpoint(device, fields.ASSIGNED_CHILD_KEY, electrical_sensor_ep.endpoint_id, string.format("%d", primary_associated_ep_id), { persist = true })
     return true
   end


### PR DESCRIPTION
# Description of Change
Persist electrical tags that are used when profiling devices that support electrical sensor device types. This should be persisted in the case that re-profiling occurs for some reason, so that these do not need to be intelligently re-checked for, and to defend against any re-profiling that we weren't expecting for whatever reason.


