### PR TITLE
Adding HCv0.61 to Jenkins driver test matrix

### DIFF
--- a/.github/workflows/jenkins-driver-tests.yml
+++ b/.github/workflows/jenkins-driver-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         version:
-          [ 59, 60, dev]
+          [ 59, 60, 61, dev]
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Verified that 0.61 lua libs artifacts are available. Appending 61 to the testing matrix for the drivers testing Jenkins route.
