### PR TITLE
Matter Sensor: Fix error during nil value logging for soil sensor attribute

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/sensor_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-sensor/src/sensor_handlers/attribute_handlers.lua
@@ -90,6 +90,7 @@ function AttributeHandlers.soil_moisture_measurement_limits_handler(driver, devi
   local max_val = ib.data.elements and ib.data.elements.max_measured_value and ib.data.elements.max_measured_value.value
   if not (min_val and max_val) or (min_val >= max_val) or (min_val < sensor_utils.SOIL_MOISTURE_MIN) or (max_val > sensor_utils.SOIL_MOISTURE_MAX) then
     device.log.warn_with({hub_logs = true}, string.format("Device reported invalid soil moisture limits: min=%s, max=%s", min_val, max_val))
+    return
   end
   sensor_utils.set_field_for_endpoint(device, fields.SOIL_LIMIT_MIN, ib.endpoint_id, min_val)
   sensor_utils.set_field_for_endpoint(device, fields.SOIL_LIMIT_MAX, ib.endpoint_id, max_val)

--- a/drivers/SmartThings/matter-sensor/src/sensor_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-sensor/src/sensor_handlers/attribute_handlers.lua
@@ -89,7 +89,7 @@ function AttributeHandlers.soil_moisture_measurement_limits_handler(driver, devi
   local min_val = ib.data.elements and ib.data.elements.min_measured_value and ib.data.elements.min_measured_value.value
   local max_val = ib.data.elements and ib.data.elements.max_measured_value and ib.data.elements.max_measured_value.value
   if not (min_val and max_val) or (min_val >= max_val) or (min_val < sensor_utils.SOIL_MOISTURE_MIN) or (max_val > sensor_utils.SOIL_MOISTURE_MAX) then
-    device.log.warn_with({hub_logs = true}, string.format("Device reported invalid soil moisture limits: min=%d, max=%d", min_val, max_val))
+    device.log.warn_with({hub_logs = true}, string.format("Device reported invalid soil moisture limits: min=%s, max=%s", min_val, max_val))
   end
   sensor_utils.set_field_for_endpoint(device, fields.SOIL_LIMIT_MIN, ib.endpoint_id, min_val)
   sensor_utils.set_field_for_endpoint(device, fields.SOIL_LIMIT_MAX, ib.endpoint_id, max_val)


### PR DESCRIPTION
# Description of Change
Fixes the "bad argument" error:

with `%d`:
```
> string.format("Device reported invalid soil moisture limits: min=%d, max=%d", min_val, max_val)
stdin:1: bad argument #2 to 'format' (number expected, got nil)
stack traceback:
	[C]: in function 'string.format'
	stdin:1: in main chunk
	[C]: in ?
```

with `%s`:
```
> string.format("Device reported invalid soil moisture limits: min=%s, max=%s", min_val, 2)
Device reported invalid soil moisture limits: min=nil, max=2
```