### PR TITLE
Fix re-subscription timeout after hub replacement and specify target devices 

### DIFF
--- a/drivers/SinuxSoft/britzyhub/fingerprints.yml
+++ b/drivers/SinuxSoft/britzyhub/fingerprints.yml
@@ -1,3 +1,15 @@
+matterManufacturer:
+  - id: "4673/32846"
+    deviceLabel: AIHomeKit
+    vendorId: 0x1241
+    productId: 0x804E
+    deviceProfileName: matter-bridge
+  - id: "5174/32780"
+    deviceLabel: BritzyHub
+    vendorId: 0x1436
+    productId: 0x800C
+    deviceProfileName: matter-bridge
+
 matterGeneric:
   - id: "elevator"
     deviceLabel: Elevator

--- a/drivers/SinuxSoft/britzyhub/profiles/matter-bridge.yml
+++ b/drivers/SinuxSoft/britzyhub/profiles/matter-bridge.yml
@@ -1,0 +1,10 @@
+name: matter-bridge
+components:
+  - id: main
+    capabilities:
+      - id: firmwareUpdate
+        version: 1
+      - id: refresh
+        version: 1
+    categories:
+      - name: Bridges

--- a/drivers/SinuxSoft/britzyhub/src/elevator/init.lua
+++ b/drivers/SinuxSoft/britzyhub/src/elevator/init.lua
@@ -4,6 +4,8 @@
 local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 local log = require "log"
+local britz_utils = require "utils"
+
 
 local elevator_cap = capabilities.elevatorCall
 local onoff_cluster = clusters.OnOff
@@ -39,8 +41,11 @@ local function component_to_endpoint(device, component_name, cluster_id)
 end
 
 local function device_init(driver, device)
-  device:subscribe()
   device:set_component_to_endpoint_fn(component_to_endpoint)
+  device:extend_device("subscribe", britz_utils.make_subscribe({
+    [elevator_cap.ID] = { onoff_cluster.attributes.OnOff }
+  }))
+  device:subscribe()
 end
 
 local function info_changed(driver, device, event, args)

--- a/drivers/SinuxSoft/britzyhub/src/gas-valve/init.lua
+++ b/drivers/SinuxSoft/britzyhub/src/gas-valve/init.lua
@@ -4,6 +4,7 @@
 local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 local log = require "log"
+local britz_utils = require "utils"
 
 local valve_cap = capabilities.safetyValve
 local onoff_cluster = clusters.OnOff
@@ -39,8 +40,11 @@ local function component_to_endpoint(device, component_name, cluster_id)
 end
 
 local function device_init(driver, device)
-  device:subscribe()
   device:set_component_to_endpoint_fn(component_to_endpoint)
+  device:extend_device("subscribe", britz_utils.make_subscribe({
+    [valve_cap.ID] = { onoff_cluster.attributes.OnOff }
+  }))
+  device:subscribe()
 end
 
 local function info_changed(driver, device, event, args)

--- a/drivers/SinuxSoft/britzyhub/src/init.lua
+++ b/drivers/SinuxSoft/britzyhub/src/init.lua
@@ -4,7 +4,14 @@
 local MatterDriver = require "st.matter.driver"
 local log = require "log"
 
+local function bridge_init(driver, device)
+  device:subscribe()
+end
+
 local matter_driver = MatterDriver("britzyhub-matter", {
+  lifecycle_handlers = {
+    init = bridge_init,
+  },
   sub_drivers = {
     require ("elevator"),
     require ("gas-valve"),

--- a/drivers/SinuxSoft/britzyhub/src/utils.lua
+++ b/drivers/SinuxSoft/britzyhub/src/utils.lua
@@ -1,0 +1,33 @@
+-- SinuxSoft (c) 2025
+-- Licensed under the Apache License, Version 2.0
+
+local im = require "st.matter.interaction_model"
+local log = require "log"
+
+local utils = {}
+
+-- Sends subscription request directly via device:send(), following the matter-switch pattern.
+-- The default device:subscribe() reuses cached sessions, which causes timeout after hub
+-- replacement because the hub Node ID changes and all sessions expire.
+-- device:send() creates a new session directly, so it works correctly after hub replacement.
+function utils.make_subscribe(subscribed_attributes)
+  return function(device)
+    local subscribe_request = im.InteractionRequest(im.InteractionRequest.RequestType.SUBSCRIBE, {})
+    for cap_id, attributes in pairs(subscribed_attributes) do
+      if device:supports_capability_by_id(cap_id) then
+        for _, attr in ipairs(attributes) do
+          local cluster_id = (attr._cluster and attr._cluster.ID) or attr.cluster
+          local attr_id = attr.ID or attr.attribute
+          local ib = im.InteractionInfoBlock(nil, cluster_id, attr_id)
+          subscribe_request:with_info_block(ib)
+        end
+      end
+    end
+    if #subscribe_request.info_blocks > 0 then
+      log.info_with({hub_logs=true}, string.format("[britzyhub] subscribe via send: %d blocks", #subscribe_request.info_blocks))
+      device:send(subscribe_request)
+    end
+  end
+end
+
+return utils

--- a/drivers/SinuxSoft/britzyhub/src/vent/init.lua
+++ b/drivers/SinuxSoft/britzyhub/src/vent/init.lua
@@ -4,6 +4,7 @@
 local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 local log = require "log"
+local britz_utils = require "utils"
 
 local VENTILATOR_DEVICE_TYPE_ID = 0xFF03
 
@@ -101,9 +102,10 @@ local function set_fan_mode(driver, device, cmd)
 end
 
 local function device_init(driver, device)
-  device:subscribe()
   device:set_component_to_endpoint_fn(component_to_endpoint)
   device:set_endpoint_to_component_fn(endpoint_to_component)
+  device:extend_device("subscribe", britz_utils.make_subscribe(subscribed_attributes))
+  device:subscribe()
 end
 
 local function info_changed(driver, device, event, args)


### PR DESCRIPTION
- Fix re-subscription timeout after hub replacement
- fingerprints.yml: add matterManufacturer entries (AIHomeKit 0x1241/0x804E, BritzyHub 0x1436/0x800C) and tag generic device types with vendorId

Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [x] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change


# Summary of Completed Tests


