### PR TITLE
Add eufy product

### DIFF
--- a/drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua
+++ b/drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua
@@ -28,6 +28,7 @@ local NEW_MATTER_LOCK_PRODUCTS = {
   {0x1533, 0x0012}, -- eufy, FamiLock E35
   {0x1533, 0x0016}, -- eufy, FamiLock E32
   {0x1533, 0x0014}, -- eufy, FamiLock E40
+  {0x1533, 0x001F}, -- eufy, EAP
   {0x135D, 0x00B1}, -- Nuki, Smart Lock Pro
   {0x135D, 0x00B2}, -- Nuki, Smart Lock
   {0x135D, 0x00C1}, -- Nuki, Smart Lock


### PR DESCRIPTION
## Summary
- add the eufy EAP product fingerprint to the new matter lock product list

## Testing
- python3 tools/run_driver_tests.py -vv -f "matter-lock"
- luacheck --config .github/workflows/.luacheckrc drivers/SmartThings/matter-lock/src/new-matter-lock/fingerprints.lua