### PR TITLE
zwave-lock: Add missing DATE_GET handler to Time CC

### DIFF
--- a/drivers/SmartThings/zwave-lock/src/init.lua
+++ b/drivers/SmartThings/zwave-lock/src/init.lua
@@ -77,7 +77,8 @@ local driver_template = {
   },
   zwave_handlers = {
     [cc.TIME] = {
-      [0x01] = zwave_handlers.time_get_handler -- used by DanaLock
+      [0x01] = zwave_handlers.time_get_handler, -- used by DanaLock
+      [0x03] = zwave_handlers.date_get_handler
     },
     [cc.NOTIFICATION] = {
       [Notification.REPORT] = zwave_handlers.notification_report

--- a/drivers/SmartThings/zwave-lock/src/lock_handlers/zwave_responses.lua
+++ b/drivers/SmartThings/zwave-lock/src/lock_handlers/zwave_responses.lua
@@ -240,4 +240,17 @@ function ZwaveHandlers.time_get_handler(driver, device, cmd)
   )
 end
 
+function ZwaveHandlers.date_get_handler(driver, device, cmd)
+  local Time = (require "st.zwave.CommandClass.Time")({ version = 1 })
+  local time = os.date("*t")
+  device:send_to_component(
+    Time:DateReport({
+      year = time.year,
+      month = time.month,
+      day = time.day
+    }),
+    device:endpoint_to_component(cmd.src_channel)
+  )
+end
+
 return ZwaveHandlers

--- a/drivers/SmartThings/zwave-lock/src/test/test_lock_battery.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_lock_battery.lua
@@ -140,4 +140,25 @@ test.register_coroutine_test(
   }
 )
 
+test.register_coroutine_test(
+  "The driver should respond correctly to a date get",
+  function ()
+    test.socket.zwave:__queue_receive({ mock_device.id, Time:DateGet({},{
+        encap = zw.ENCAP.AUTO,
+        src_channel = 0,
+        dst_channels = {}
+      })
+    })
+    local time = os.date("*t")
+    test.socket.zwave:__expect_send(Time:DateReport({
+      year = time.year,
+      month = time.month,
+      day = time.day
+    }):build_test_tx(mock_device.id))
+  end,
+  {
+     min_api_version = 17
+  }
+)
+
 test.run_registered_tests()


### PR DESCRIPTION
Hi! I came across #3076 while digging around the Z-Wave lock driver and noticed nobody had picked it up yet, so here's a fix.

The driver registers a handler for `TIME_GET` but not `DATE_GET`, so a lock doing a full Time CC sync gets its date request silently dropped — the hub ACKs at the MAC layer but never answers. This PR adds a `DATE_GET` handler that responds with the current date, mirroring the existing `TIME_GET` handler.

Credit to @maksymzdzitowiecki for the root cause analysis in the issue. One small correction from the proposed snippet there: `os.date("*t").year` already returns the full year (e.g. 2026), and `DateReport` serializes it as a 16-bit value (`write_be_u16`), so the year should be passed through as-is — adding 1900 would put us in the year 3926 :)

Added a test next to the existing `TIME_GET` one in `test_lock_battery.lua`. All zwave-lock tests pass locally against `lua_libs-api_v20` (51/51).

Fixes #3076