### PR TITLE
zigbee-window-treatment: Don't halve battery percentage for IKEA devices

### DIFF
--- a/drivers/SmartThings/zigbee-window-treatment/src/ikea/can_handle.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/ikea/can_handle.lua
@@ -1,0 +1,11 @@
+-- Copyright 2026 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local can_handle_ikea = function(opts, driver, device)
+  if device:get_manufacturer() == "IKEA of Sweden" then
+    return true, require("ikea")
+  end
+  return false
+end
+
+return can_handle_ikea

--- a/drivers/SmartThings/zigbee-window-treatment/src/ikea/init.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/ikea/init.lua
@@ -1,0 +1,30 @@
+-- Copyright 2026 SmartThings, Inc.
+-- Licensed under the Apache License, Version 2.0
+
+local capabilities = require "st.capabilities"
+local clusters = require "st.zigbee.zcl.clusters"
+local utils = require "st.utils"
+local PowerConfiguration = clusters.PowerConfiguration
+
+-- IKEA devices report BatteryPercentageRemaining in 1% units (0-100)
+-- rather than the 0.5% units (0-200) defined by the ZCL spec, so the
+-- default handler would halve the reported percentage. Emit the raw
+-- value instead, matching the IKEA handling in the zigbee-button and
+-- zigbee-dimmer-remote drivers.
+local function battery_perc_attr_handler(driver, device, value, zb_rx)
+  device:emit_event(capabilities.battery.battery(utils.clamp_value(value.value, 0, 100)))
+end
+
+local ikea_window_treatment = {
+  NAME = "ikea window treatment",
+  zigbee_handlers = {
+    attr = {
+      [PowerConfiguration.ID] = {
+        [PowerConfiguration.attributes.BatteryPercentageRemaining.ID] = battery_perc_attr_handler
+      }
+    }
+  },
+  can_handle = require("ikea.can_handle"),
+}
+
+return ikea_window_treatment

--- a/drivers/SmartThings/zigbee-window-treatment/src/sub_drivers.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/sub_drivers.lua
@@ -16,5 +16,6 @@ local sub_drivers = {
    lazy_load_if_possible("screen-innovations"),
    lazy_load_if_possible("VIVIDSTORM"),
    lazy_load_if_possible("HOPOsmart"),
+   lazy_load_if_possible("ikea"),
 }
 return sub_drivers

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_battery_ikea.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_battery_ikea.lua
@@ -10,6 +10,7 @@ local capabilities = require "st.capabilities"
 local t_utils = require "integration_test.utils"
 
 local WindowCovering = clusters.WindowCovering
+local PowerConfiguration = clusters.PowerConfiguration
 
 local mock_device = test.mock_device.build_test_zigbee_device(
   { profile = t_utils.get_profile_definition("window-treatment-battery.yml"),
@@ -350,6 +351,35 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end,
+  {
+     min_api_version = 17
+  }
+)
+
+test.register_message_test(
+  "Battery percentage reports should not be halved for IKEA devices",
+  {
+    {
+      channel = "zigbee",
+      direction = "receive",
+      message = { mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:build_test_attr_report(mock_device, 100) }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.battery.battery(100))
+    },
+    {
+      channel = "zigbee",
+      direction = "receive",
+      message = { mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:build_test_attr_report(mock_device, 55) }
+    },
+    {
+      channel = "capability",
+      direction = "send",
+      message = mock_device:generate_test_message("main", capabilities.battery.battery(55))
+    }
+  },
   {
      min_api_version = 17
   }


### PR DESCRIPTION
This addresses #2679.

IKEA blinds (FYRTUR/KADRILJ) report `BatteryPercentageRemaining` in 1% units (0–100) rather than the 0.5% units defined by the ZCL spec, so the default handler halves the value and a fully charged battery shows ~50% in the app.

This adds an IKEA subdriver that emits the reported value as-is. The repo already handles IKEA battery reports this way in two other drivers — `zigbee-button` (`zigbee-multi-button/ikea/init.lua`) and `zigbee-dimmer-remote` (`IKEAofSweden/init.lua`) — so this brings `zigbee-window-treatment` in line with that existing convention.

The subdriver matches on manufacturer only, mirroring the `zigbee-button` precedent; both IKEA entries in this driver's `fingerprints.yml` report `IKEA of Sweden`.

Added battery test cases to `test_zigbee_window_shade_battery_ikea.lua` (which previously only covered window shade states). All zigbee-window-treatment tests pass locally against `lua_libs-api_v20`.

Fixes #2679