### PR TITLE
Matter Energy: Fix powerConsumptionReport delta, rename energy parameter, and fix endpoint typo

### DIFF
--- a/drivers/SmartThings/matter-energy/src/init.lua
+++ b/drivers/SmartThings/matter-energy/src/init.lua
@@ -474,7 +474,7 @@ local function report_power_consumption_to_st_energy(device, component, latest_t
 
   -- Calculate the energy delta between reports
   local energy_delta_wh = 0.0
-  local previous_imported_report = device:get_latest_state("main", capabilities.powerConsumptionReport.ID,
+  local previous_imported_report = device:get_latest_state(component.id, capabilities.powerConsumptionReport.ID,
     capabilities.powerConsumptionReport.powerConsumption.NAME)
   if previous_imported_report and previous_imported_report.energy then
     energy_delta_wh = math.max(latest_total_imported_energy_wh - previous_imported_report.energy, 0.0)

--- a/drivers/SmartThings/matter-energy/src/init.lua
+++ b/drivers/SmartThings/matter-energy/src/init.lua
@@ -461,7 +461,7 @@ local function device_energy_mgmt_mode_attr_handler(driver, device, ib, response
   end
 end
 
-local function report_power_consumption_to_st_energy(device, component, latest_total_imported_energy_wh)
+local function report_power_consumption_to_st_energy(device, component, latest_total_energy_wh)
   local current_time = os.time()
 
   local last_report_timestamp_field = component.id == "exportedEnergy" and LAST_EXPORTED_REPORT_TIMESTAMP or LAST_IMPORTED_REPORT_TIMESTAMP
@@ -477,7 +477,7 @@ local function report_power_consumption_to_st_energy(device, component, latest_t
   local previous_imported_report = device:get_latest_state(component.id, capabilities.powerConsumptionReport.ID,
     capabilities.powerConsumptionReport.powerConsumption.NAME)
   if previous_imported_report and previous_imported_report.energy then
-    energy_delta_wh = math.max(latest_total_imported_energy_wh - previous_imported_report.energy, 0.0)
+    energy_delta_wh = math.max(latest_total_energy_wh - previous_imported_report.energy, 0.0)
   end
 
   -- Report the energy consumed during the time interval. The unit of these values should be 'Wh'
@@ -485,7 +485,7 @@ local function report_power_consumption_to_st_energy(device, component, latest_t
     start = epoch_to_iso8601(last_time),
     ["end"] = epoch_to_iso8601(current_time - 1),
     deltaEnergy = energy_delta_wh,
-    energy = latest_total_imported_energy_wh
+    energy = latest_total_energy_wh
   }))
 end
 

--- a/drivers/SmartThings/matter-energy/src/init.lua
+++ b/drivers/SmartThings/matter-energy/src/init.lua
@@ -327,7 +327,7 @@ local function evse_supply_state_handler(driver, device, ib, response)
   local evse_supply_state = ib.data.value
 
   local latest_evse_state = device:get_latest_state(
-    device:endpoint_to_component(ib.endopint_id),
+    device:endpoint_to_component(ib.endpoint_id),
     capabilities.evseState.ID,
     capabilities.evseState.state.NAME
   )

--- a/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
@@ -269,7 +269,7 @@ test.register_coroutine_test(
       mock_device:generate_test_message("importedEnergy",
         capabilities.powerConsumptionReport.powerConsumption({
           energy = 200,
-          deltaEnergy = 0.0,
+          deltaEnergy = 100,
           start = "1970-01-01T00:15:01Z",
           ["end"] = "1970-01-01T00:48:20Z"
         }))
@@ -278,20 +278,20 @@ test.register_coroutine_test(
     test.socket.matter:__queue_receive({ mock_device.id, clusters.ElectricalEnergyMeasurement.attributes
         .CumulativeEnergyExported:build_test_report_data(mock_device,
       BATTERY_STORAGE_EP,
-      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 400000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) --400Wh
+      clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 500000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) }) --500Wh
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("exportedEnergy",
       capabilities.energyMeter.energy({
-        value = 400, unit = "Wh"
+        value = 500, unit = "Wh"
       }))
     )
 
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("exportedEnergy",
         capabilities.powerConsumptionReport.powerConsumption({
-          energy = 400,
-          deltaEnergy = 0.0,
+          energy = 500,
+          deltaEnergy = 100,
           start = "1970-01-01T00:15:01Z",
           ["end"] = "1970-01-01T00:48:20Z"
         }))


### PR DESCRIPTION
# Description of Change

## Summary

This PR contains three small fixes for the Matter Energy driver:

1. **Fix powerConsumptionReport delta calculation**: The energy delta was incorrectly reading from the `"main"` component instead of the actual component (`importedEnergy`/`exportedEnergy`), causing incorrect `deltaEnergy` values (always 0 for non-main components).

2. **Rename energy parameter**: `latest_total_imported_energy_wh` → `latest_total_energy_wh` since the function handles both imported and exported energy.

3. **Fix typo**: `ib.endopint_id` → `ib.endpoint_id` in `evse_supply_state_handler`.

## Changes

- `drivers/SmartThings/matter-energy/src/init.lua`:
  - Changed `device:get_latest_state("main", ...)` → `device:get_latest_state(component.id, ...)`
  - Renamed `latest_total_imported_energy_wh` → `latest_total_energy_wh`
  - Fixed `ib.endopint_id` → `ib.endpoint_id`

- `drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua`:
  - Updated test expectations to verify non-zero `deltaEnergy` values (100 Wh)

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Summary of Completed Tests
