### PR TITLE
Zigbee Humidity Sensor: Add category to profile

### DIFF
--- a/drivers/SmartThings/zigbee-humidity-sensor/profiles/frient-airquality-humidity-temperature-battery.yml
+++ b/drivers/SmartThings/zigbee-humidity-sensor/profiles/frient-airquality-humidity-temperature-battery.yml
@@ -27,6 +27,8 @@ components:
     version: 1
   - id: refresh
     version: 1
+  categories:
+  - name: AirQualityDetector
 preferences:
   - preferenceId: humidityOffset
     explicit: true


### PR DESCRIPTION
# Description of Change
Profile requires category. Issue initially mentioned [here](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/issues/3077).


