### PR TITLE
philips-hue: pass correct argument in device initialization

### DIFF
--- a/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
+++ b/drivers/SmartThings/philips-hue/src/stray_device_helper.lua
@@ -82,7 +82,7 @@ function StrayDeviceHelper.process_strays(driver, strays, bridge_device_uuid)
     if cached_device_description then
       table.insert(dnis_to_remove, device.device_network_id)
       lazy_handlers.lifecycle_handlers.initialize_device(
-        driver, device, "added", nil, bridge_device_uuid, cached_device_description
+        driver, device, "added", nil, bridge_device_uuid, device_rid
       )
     end
     ::continue::


### PR DESCRIPTION
Check all that apply

# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change

The added handlers for devices expect this argument to be a device rid and not the entire description. This causes the lookup for the entire description to fail and sends the device back to the stray device loop which sends it back to be initialized and loops over and over. This is specific to non-light devices because the light devices will attempt to get the info from the bridge inside the added handlers (which will fail) but the other added handlers do not.

I need to spend some time reproducing and testing but I believe this happens only after doing a hue bridge pro migration. After this migration, the migrated devices share the same hue resource ids. As seen in the fix for onboarding a migrated hue bridge pro here: https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/pull/2389. Even though the original hue bridge cannot be communicated with, the stray device handler will find info for the stray devices from the hue bridge because the cache is keyed by the RIDs. This may require further changes to separate the discovery cache by bridge similar to the previous pull request but I think this should be fine as is because this info is only used to map the RID to device which is already separated by bridge.

# Summary of Completed Tests

TBD after finding a hue bridge pro. Keeping in draft until I can test.


