### PR TITLE
Matter Sensor: Fix Global defintion and adjust unit tests

### DIFF
--- a/drivers/SmartThings/matter-sensor/src/embedded_clusters/Global/types/MeasurementTypeEnum.lua
+++ b/drivers/SmartThings/matter-sensor/src/embedded_clusters/Global/types/MeasurementTypeEnum.lua
@@ -2,7 +2,7 @@ local data_types = require "st.matter.data_types"
 local UintABC = require "st.matter.data_types.base_defs.UintABC"
 
 local MeasurementTypeEnum = {}
-local new_mt = UintABC.new_mt({NAME = "MeasurementTypeEnum", ID = data_types.name_to_id_map["Uint8"]}, 1)
+local new_mt = UintABC.new_mt({NAME = "MeasurementTypeEnum", ID = data_types.name_to_id_map["Uint16"]}, 2)
 new_mt.__index.pretty_print = function(self)
   local name_lookup = {
     [self.UNSPECIFIED] = "UNSPECIFIED",

--- a/drivers/SmartThings/matter-sensor/src/sensor_handlers/attribute_handlers.lua
+++ b/drivers/SmartThings/matter-sensor/src/sensor_handlers/attribute_handlers.lua
@@ -13,6 +13,12 @@ if version.api < 13 then
   clusters.Global = require "embedded_clusters.Global"
 end
 
+-- The SOIL_MOISTURE MeasurementTypeEnum variant was added to the Global MeasurementTypeEnum
+-- def in lua libs in api version 21 as a part of the fix for Shared and Global types.
+if version.api < 21 then
+  clusters.Global.types.MeasurementTypeEnum = require "embedded_clusters.Global.types.MeasurementTypeEnum"
+end
+
 local AttributeHandlers = {}
 
 
@@ -84,8 +90,10 @@ function AttributeHandlers.soil_moisture_measured_value_handler(driver, device, 
 end
 
 function AttributeHandlers.soil_moisture_measurement_limits_handler(driver, device, ib, response)
-  local MeasurementAccuracyStruct = require "embedded_clusters.Global.types.MeasurementAccuracyStruct"
-  MeasurementAccuracyStruct:augment_type(ib.data)
+  if version.api < 13 then
+    local MeasurementAccuracyStruct = require "embedded_clusters.Global.types.MeasurementAccuracyStruct"
+    MeasurementAccuracyStruct:augment_type(ib.data)
+  end
   local min_val = ib.data.elements and ib.data.elements.min_measured_value and ib.data.elements.min_measured_value.value
   local max_val = ib.data.elements and ib.data.elements.max_measured_value and ib.data.elements.max_measured_value.value
   if not (min_val and max_val) or (min_val >= max_val) or (min_val < sensor_utils.SOIL_MOISTURE_MIN) or (max_val > sensor_utils.SOIL_MOISTURE_MAX) then

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_soil_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_soil_sensor.lua
@@ -7,10 +7,15 @@ local t_utils = require "integration_test.utils"
 local test = require "integration_test"
 local version = require "version"
 
-clusters.Global = require "embedded_clusters.Global"
+if version.api < 13 then
+  clusters.Global = require "embedded_clusters.Global"
+end
 
 if version.api < 21 then
   clusters.SoilMeasurement = require "embedded_clusters.SoilMeasurement"
+  -- The SOIL_MOISTURE MeasurementTypeEnum variant was added to the Global MeasurementTypeEnum
+  -- def in lua libs in api version 21.
+  clusters.Global.types.MeasurementTypeEnum = require "embedded_clusters.Global.types.MeasurementTypeEnum"
 end
 
 local mock_device = test.mock_device.build_test_matter_device({
@@ -157,6 +162,9 @@ test.register_coroutine_test(
 )
 
 local function build_soil_moisture_limits(min_value, max_value)
+  if version.api < 21 then
+    clusters.Global.types.MeasurementTypeEnum = require "embedded_clusters.Global.types.MeasurementTypeEnum"
+  end
   return clusters.Global.types.MeasurementAccuracyStruct({
     measurement_type = clusters.Global.types.MeasurementTypeEnum.SOIL_MOISTURE,
     measured = true,


### PR DESCRIPTION
# Type of Change

- [ ] WWST Certification Request
     - If this is your first time contributing code:
          - [ ] I have reviewed the README.md file
          - [ ] I have reviewed the CODE_OF_CONDUCT.md file
          - [ ] I have signed the CLA
     - [ ] I plan on entering a WWST Certification Request or have entered a request through the WWST Certification console at developer.smartthings.com
- [x] Bug fix
- [ ] New feature
- [ ] Refactor

# Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have verified my changes by testing with a device or have communicated a plan for testing
- [ ] I am adding new behavior, such as adding a sub-driver, and have added and run new unit tests to cover the new behavior

# Description of Change
Updates the embedded cluster definition to be using the same type that is expected from the lua libs.

Since the lua libs themselves did not have the `SOIL_MOISTURE` enum variant until the API 21 release (FW62), this updates the API checks to make sure that drivers use the embedded cluster definition on hubs without those updated lua libs.

# Summary of Completed Tests


