### PR TITLE
GHA: Fix warnings

### DIFF
--- a/tools/run_driver_tests_p.py
+++ b/tools/run_driver_tests_p.py
@@ -29,8 +29,8 @@ def per_driver_task(driver_dir):
   else:
     failure_output = None
   if driver_dir.name in CHANGED_DRIVERS:
-    with driver_dir.parent.parent.parent.joinpath("tools/coverage_output").joinpath(driver_dir.name+"_coverage.xml") as outfile:
-      subprocess.run("luacov-cobertura -o {} -c {}".format(outfile, LUACOV_CONFIG), shell=True)
+    outfile = driver_dir.parent.parent.parent.joinpath("tools/coverage_output").joinpath(driver_dir.name+"_coverage.xml")
+    subprocess.run("luacov-cobertura -o {} -c {}".format(outfile, LUACOV_CONFIG), shell=True)
   return failure_output
 
 def run_test(test_file):


### PR DESCRIPTION
# Description of Change
Fix some warnings in the driver test runs via GHA and otherwise.

In [this action](https://github.com/SmartThingsCommunity/SmartThingsEdgeDrivers/actions/runs/29937840701/job/88983911182), we can see:


```
/home/runner/work/SmartThingsEdgeDrivers/SmartThingsEdgeDrivers/tools/run_driver_tests_p.py:32: DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
  with driver_dir.parent.parent.parent.joinpath("tools/coverage_output").joinpath(driver_dir.name+"_coverage.xml") as outfile:
/home/runner/work/SmartThingsEdgeDrivers/SmartThingsEdgeDrivers/tools/run_driver_tests_p.py:32: DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
```

This warning occurred because `outfile` was used as a file path string in a shell command — not as an open file, and therefore the  `with` block was meaningless. This makes that all explicit.