### PR TITLE
Luacov Config: Update Exclude Pathing

### DIFF
--- a/tools/config.luacov
+++ b/tools/config.luacov
@@ -3,6 +3,8 @@ configuration = {
     "scripting-engine",
     "lua_libs",
     "test",
+    "embedded_clusters",
+    "embedded_cluster_utils",
     "unofficial",
     "DishwasherAlarm",
     "DishwasherMode",


### PR DESCRIPTION
# Description of Change
Update Luacov exclusion to explicitly ignore the top level `embedded_clusters` path that is found in many Matter drivers, as well as the `embedded_cluster_utils` file, since this file is copied across several drivers, does not have complete test checks, and so having it in the coverage reduces clarity. 


