### PR TITLE
Branching registryCredentialsId based off region and nodeLabel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,11 +24,42 @@ def getChangedDrivers() {
   return drivers
 }
 
+def get_region() {
+  def uri = new URI(env.JENKINS_URL)
+  def region = uri.host.endsWith('.cn') ? 'cn' : 'global'
+  return region
+}
+
+// Gate artifactory-credentials for prod nodes in cn due to a docker authentication error arising in that environment
+def getDockerCredentialId() {
+    def nodeLabel = params.NODE_LABEL ?: 'production'
+    def region = get_region()
+    if (nodeLabel == 'production' && region == 'cn') {
+      return 'artifactory-credentials'
+    }
+    else {
+      return 'artifactory'
+    }
+}
+// Gate RegistryUrl for prod nodes in cn due to a docker authentication error arising in that environment
+def getRegistryUrl() {
+  def nodeLabel = params.NODE_LABEL ?: 'production'
+  def region = get_region()
+  if (nodeLabel == 'production' && region == 'cn') {
+    return 'https://registry.artifactoryedge.streleng.cn'
+  } else {
+    // Default
+    return ''
+  }
+}
+
 pipeline {
   agent {
     docker {
       image 'python:3.10'
       label  "${params.NODE_LABEL ?: 'production'}"
+      registryUrl getRegistryUrl()
+      registryCredentialsId getDockerCredentialId()
       args '--entrypoint= -u 0:0'
     }
   }


### PR DESCRIPTION
This change looks to solve a jenkins workflow error in which the CN prod runner fails due to a credential error. The targeted logic of 'artifactory-credentials' when on the CN prod jenkins runner have been tested to work in a test environment. This change should  have the affect of changing `registryCredentialsId` only and the registryURL for CN Prod.
| Region | Environment | Credentials | RegistryURL |
|--------|--------|--------|--------|
| Global | Staging | artifactory | <empty/default> |
| Global | Prod | artifactory | <empty/default> |
| China | Staging | artifactory | <empty/default> |
| China | Prod | artifactory-credentials | registry.artifactoryedge.streleng.cn |
