### PR TITLE
Avoiding URI permissions error and defaulted credentials ID string to empty

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,12 @@ def getChangedDrivers() {
 }
 
 def get_region() {
-  def uri = new URI(env.JENKINS_URL)
-  def region = uri.host.endsWith('.cn') ? 'cn' : 'global'
+  def url = env.JENKINS_URL?.trim()
+  if (url?.endsWith('/')) {
+    url = url[0..-2]
+  }
+
+  def region = url?.endsWith('.cn') ? 'cn' : 'global'
   return region
 }
 
@@ -38,7 +42,7 @@ def getDockerCredentialId() {
       return 'artifactory-credentials'
     }
     else {
-      return 'artifactory'
+      return ''
     }
 }
 // Gate RegistryUrl for prod nodes in cn due to a docker authentication error arising in that environment


### PR DESCRIPTION
Resolves:
```Scripts not permitted to use new java.net.URI java.lang.String...```

And upon being able to test in private pipelines now, resolved the default value for `getDockerCredentialsId()`