### PR TITLE
Test backporting 57 58

### DIFF
--- a/drivers/SmartThings/matter-appliance/src/test/test_cook_top.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_cook_top.lua
@@ -91,7 +91,7 @@ test.register_coroutine_test(
     assert(component_to_endpoint_map["cookSurfaceTwo"] == COOK_SURFACE_TWO_ENDPOINT, "Cook Surface Two Endpoint must be 3")
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -157,7 +157,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_dishwasher.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_dishwasher.lua
@@ -103,7 +103,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -171,7 +171,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -239,7 +239,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -307,7 +307,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -386,7 +386,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -450,7 +450,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -490,7 +490,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -549,7 +549,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_extractor_hood.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_extractor_hood.lua
@@ -176,7 +176,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -339,7 +339,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 test.register_message_test(
@@ -452,7 +452,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -490,7 +490,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -531,7 +531,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -592,7 +592,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -653,7 +653,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -666,7 +666,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_onoff,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -692,7 +692,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_onoff,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -716,7 +716,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_onoff,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_laundry_dryer.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_laundry_dryer.lua
@@ -102,7 +102,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -238,7 +238,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -306,7 +306,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -385,7 +385,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -449,7 +449,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -489,7 +489,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -548,7 +548,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -591,7 +591,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_laundry_washer.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_laundry_washer.lua
@@ -135,7 +135,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -178,7 +178,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_matter_appliance_rpc_5.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_matter_appliance_rpc_5.lua
@@ -458,7 +458,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_dishwasher,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -500,7 +500,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_dishwasher,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -542,7 +542,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_washer,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -584,7 +584,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_washer,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -626,7 +626,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_dryer,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -668,7 +668,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_dryer,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -710,7 +710,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_oven,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -752,7 +752,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_oven,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -794,7 +794,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_refrigerator,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -836,7 +836,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_refrigerator,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -878,7 +878,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_refrigerator,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -920,7 +920,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_refrigerator,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_microwave_oven.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_microwave_oven.lua
@@ -174,7 +174,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -258,7 +258,7 @@ test.register_message_test(
       test_init()
       init_supported_microwave_oven_modes()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -338,7 +338,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -453,7 +453,7 @@ test.register_message_test(
     }, -- on receiving NO ERROR we don't do anything.
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -479,7 +479,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_oven.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_oven.lua
@@ -143,7 +143,7 @@ test.register_coroutine_test(
       "Cook Surface Two Endpoint must be 6")
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -228,7 +228,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -287,7 +287,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -371,7 +371,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -411,7 +411,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -437,7 +437,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -475,7 +475,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -513,7 +513,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -535,7 +535,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -557,7 +557,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-appliance/src/test/test_refrigerator.lua
+++ b/drivers/SmartThings/matter-appliance/src/test/test_refrigerator.lua
@@ -147,7 +147,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -206,7 +206,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -249,7 +249,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -308,7 +308,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -351,7 +351,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-button/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_button.lua
@@ -71,7 +71,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -109,7 +109,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -268,7 +268,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -308,7 +308,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -348,7 +348,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -373,7 +373,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 -- run the tests

--- a/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_button_parent_child.lua
@@ -136,7 +136,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -237,7 +237,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -261,7 +261,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -295,7 +295,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -329,7 +329,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -354,7 +354,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 -- run the tests

--- a/drivers/SmartThings/matter-button/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-button/src/test/test_matter_multi_button.lua
@@ -136,7 +136,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -169,7 +169,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -194,7 +194,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.held({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -243,7 +243,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -283,7 +283,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button4", button_attr.double({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -311,7 +311,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -339,7 +339,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -377,7 +377,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -416,7 +416,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -464,7 +464,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -488,7 +488,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -512,7 +512,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -536,7 +536,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -576,7 +576,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -616,7 +616,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -641,7 +641,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -686,7 +686,7 @@ test.register_message_test(
   -- no double event
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -744,7 +744,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 -- run the tests

--- a/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_battery_storage.lua
@@ -104,7 +104,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 test.register_coroutine_test(
@@ -162,7 +162,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -179,7 +179,7 @@ test.register_coroutine_test(
       capabilities.powerMeter.power({ value = 30.0, unit = "W" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -196,7 +196,7 @@ test.register_coroutine_test(
       capabilities.powerMeter.power({ value = 30.0, unit = "W" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
     test_init = function()
       test_init()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-energy/src/test/test_evse.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_evse.lua
@@ -120,7 +120,7 @@ test.register_coroutine_test(
       "Device Energy Management Endpoint must be 3")
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -150,7 +150,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -201,7 +201,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -225,7 +225,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -271,7 +271,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -317,7 +317,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -340,7 +340,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -364,7 +364,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -438,7 +438,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -541,7 +541,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-energy/src/test/test_evse_energy_meas.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_evse_energy_meas.lua
@@ -118,7 +118,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -152,7 +152,7 @@ test.register_coroutine_test(
     test_init = function()
       test_init()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-energy/src/test/test_solar_power.lua
+++ b/drivers/SmartThings/matter-energy/src/test/test_solar_power.lua
@@ -124,7 +124,7 @@ test.register_coroutine_test(
     capabilities.powerMeter.power({ value = 35.0, unit = "W" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -172,7 +172,7 @@ test.register_coroutine_test(
     test_init = function()
       test_init()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
       clusters.ElectricalEnergyMeasurement.types.EnergyMeasurementStruct({ energy = 100000, start_timestamp = 0, end_timestamp = 0, start_systime = 0, end_systime = 0, apparent_energy = 0, reactive_energy = 0 })) })             --100Wh
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-hrap/src/test/test_thread_border_router_network.lua
+++ b/drivers/SmartThings/matter-hrap/src/test/test_thread_border_router_network.lua
@@ -108,7 +108,7 @@ test.register_coroutine_test(
         })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -143,7 +143,7 @@ test.register_message_test(
       }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -191,7 +191,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -230,7 +230,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -356,7 +356,7 @@ test.register_coroutine_test(
         )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_aqara_matter_lock.lua
@@ -95,7 +95,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -163,7 +163,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -185,7 +185,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -211,7 +211,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -310,7 +310,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -327,7 +327,7 @@ test.register_coroutine_test(
     )
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_bridged_matter_lock.lua
@@ -91,7 +91,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
     mock_device_level:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock.lua
@@ -70,7 +70,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -94,7 +94,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -140,7 +140,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -186,7 +186,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -209,7 +209,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -261,7 +261,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -330,7 +330,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -370,7 +370,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -385,7 +385,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_battery.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_battery.lua
@@ -117,7 +117,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "base-lock" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "base-lock-batteryLevel" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_batteryLevel.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_batteryLevel.lua
@@ -95,7 +95,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_codes.lua
@@ -223,7 +223,7 @@ test.register_coroutine_test(
     expect_reload_all_codes_messages(mock_device)
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -239,7 +239,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -263,7 +263,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -287,7 +287,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -311,7 +311,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -333,7 +333,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -358,7 +358,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -373,7 +373,7 @@ test.register_coroutine_test(
     expect_reload_all_codes_messages(mock_device)
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -418,7 +418,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -456,7 +456,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -562,7 +562,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -611,7 +611,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -671,7 +671,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -706,7 +706,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 test.register_coroutine_test(
@@ -740,7 +740,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -782,7 +782,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -825,7 +825,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -904,7 +904,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -971,7 +971,7 @@ test.register_coroutine_test(
 
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_cota.lua
@@ -143,7 +143,7 @@ test.register_coroutine_test(
     expect_kick_off_cota_process(mock_device)
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -160,7 +160,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -177,7 +177,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -212,7 +212,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -236,7 +236,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -338,7 +338,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -436,7 +436,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -527,7 +527,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, read_attribute_list})
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -587,7 +587,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -627,7 +627,7 @@ test.register_coroutine_test(
     test.mock_time.advance_time(2)
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -708,7 +708,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -743,7 +743,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -751,7 +751,7 @@ test.register_coroutine_test(
   "Delay setting COTA cred if another cred is already being set.", function()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_migration.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_migration.lua
@@ -136,7 +136,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_modular.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_modular.lua
@@ -361,7 +361,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "lock-modular", optional_component_capabilities = {{"main", {"batteryLevel"}}} })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -396,7 +396,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "lock-modular", optional_component_capabilities = {{"main", {"battery"}}} })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -431,7 +431,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_unlatch,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -467,7 +467,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_unlatch,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -503,7 +503,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -540,7 +540,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin_schedule_unlatch,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -574,7 +574,10 @@ test.register_coroutine_test(
     )
     mock_device_modular:expect_metadata_update({ profile = "lock-modular-embedded-unlatch", optional_component_capabilities = {{"main", {"lockUsers", "lockCredentials", "lockSchedules", "battery"}}} })
   end,
-  { test_init = test_init_modular }
+  {
+    test_init = test_init_modular,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -582,7 +585,10 @@ test.register_coroutine_test(
     -- simulate no actual change
     test.socket.device_lifecycle:__queue_receive(mock_device_modular:generate_info_changed({}))
   end,
-  { test_init = test_init_modular }
+  {
+    test_init = test_init_modular,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -619,7 +625,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_modular,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -692,7 +698,7 @@ test.register_coroutine_test(
       test.mock_device.add_test_device(mock_nuki_smart_lock_ultra)
       mock_nuki_smart_lock_ultra:set_field(profiling_data.BATTERY_SUPPORT, battery_support.BATTERY_PERCENTAGE, {persist = true}) -- assume this has been set previously
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_matter_lock_unlatch.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_matter_lock_unlatch.lua
@@ -106,7 +106,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -178,7 +178,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -226,7 +226,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -270,7 +270,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -292,7 +292,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -381,7 +381,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock.lua
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -184,7 +184,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -224,7 +224,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -264,7 +264,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -284,7 +284,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -304,7 +304,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -375,7 +375,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -456,7 +456,7 @@ function()
   test.wait_for_events()
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -473,7 +473,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -493,7 +493,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -512,7 +512,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -533,7 +533,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -557,7 +557,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -579,7 +579,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -601,7 +601,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -623,7 +623,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -649,7 +649,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -748,7 +748,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -975,7 +975,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1044,7 +1044,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1071,7 +1071,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1115,7 +1115,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1164,7 +1164,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1191,7 +1191,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1257,7 +1257,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1284,7 +1284,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1350,7 +1350,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1377,7 +1377,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1442,7 +1442,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1471,7 +1471,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1527,7 +1527,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1590,7 +1590,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1646,7 +1646,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1794,7 +1794,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1823,7 +1823,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1877,7 +1877,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1906,7 +1906,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1978,7 +1978,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2007,7 +2007,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2078,7 +2078,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2107,7 +2107,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2157,7 +2157,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2189,7 +2189,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2257,7 +2257,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2286,7 +2286,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2338,7 +2338,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2370,7 +2370,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2501,7 +2501,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2609,7 +2609,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_aliro.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_aliro.lua
@@ -155,7 +155,10 @@ test.register_coroutine_test(
         capabilities.lockAliro.readerVerificationKey(EXPECTED_PUB_HEX, {visibility = {displayed = false}})
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -176,7 +179,10 @@ test.register_coroutine_test(
         capabilities.lockAliro.readerGroupIdentifier(EXPECTED_GROUP_ID_HEX, {visibility = {displayed = false}})
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -199,7 +205,10 @@ test.register_coroutine_test(
           {visibility = {displayed = false}})
         )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -222,7 +231,10 @@ test.register_coroutine_test(
           {visibility = {displayed = false}})
         )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -245,7 +257,10 @@ test.register_coroutine_test(
           {visibility = {displayed = false}})
         )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -266,7 +281,10 @@ test.register_coroutine_test(
         capabilities.lockAliro.groupResolvingKey(EXPECTED_GROUP_ID_HEX, {visibility = {displayed = false}})
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -289,7 +307,10 @@ test.register_coroutine_test(
           {visibility = {displayed = false}})
         )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -312,7 +333,10 @@ test.register_coroutine_test(
           {visibility = {displayed = false}})
         )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -334,7 +358,10 @@ test.register_coroutine_test(
         capabilities.lockAliro.cardId("3icub18c8pr00", {visibility = {displayed = false}})
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -386,7 +413,10 @@ test.register_coroutine_test(
         )
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -546,7 +576,10 @@ test.register_coroutine_test(
         )
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -585,7 +618,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -660,7 +693,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -730,7 +763,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -800,7 +833,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -957,7 +990,10 @@ test.register_coroutine_test(
         )
       )
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -993,7 +1029,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1066,7 +1102,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1133,7 +1169,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1200,7 +1236,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1229,7 +1265,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.lockAlarm.supportedAlarmValues({"unableToLockTheDoor"}, {visibility = {displayed = false}}))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -1257,7 +1296,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.lockAlarm.supportedAlarmValues({"unableToLockTheDoor"}, {visibility = {displayed = false}}))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_battery.lua
+++ b/drivers/SmartThings/matter-lock/src/test/test_new_matter_lock_battery.lua
@@ -427,7 +427,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "lock" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -458,7 +458,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "lock-batteryLevel" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -490,7 +490,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "lock-battery" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_unlatch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -553,7 +553,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_unlatch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -586,7 +586,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_unlatch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -617,7 +617,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -649,7 +649,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -682,7 +682,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -713,7 +713,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin_schedule_unlatch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -745,7 +745,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin_schedule_unlatch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -778,7 +778,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_user_pin_schedule_unlatch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -799,7 +799,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_battery,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -842,7 +842,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_battery_level,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-media/src/test/test_matter_media_speaker.lua
+++ b/drivers/SmartThings/matter-media/src/test/test_matter_media_speaker.lua
@@ -126,7 +126,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -167,7 +167,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -335,7 +335,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -366,7 +366,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
+++ b/drivers/SmartThings/matter-media/src/test/test_matter_media_video_player.lua
@@ -240,7 +240,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -278,7 +278,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -316,7 +316,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -354,7 +354,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -395,7 +395,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -436,7 +436,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -605,7 +605,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -638,7 +638,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -671,7 +671,7 @@ test.register_coroutine_test(
       mock_device_variable_speed:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/matter-rvc/src/test/test_matter_rvc.lua
+++ b/drivers/SmartThings/matter-rvc/src/test/test_matter_rvc.lua
@@ -227,7 +227,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -243,7 +243,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -274,7 +274,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -302,7 +302,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -330,7 +330,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -357,7 +357,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -378,7 +378,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -419,7 +419,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -457,7 +457,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -575,7 +575,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -632,7 +632,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -689,7 +689,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -743,7 +743,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -797,7 +797,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1032,7 +1032,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1068,7 +1068,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1094,7 +1094,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1120,7 +1120,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -1205,7 +1205,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor.lua
@@ -499,7 +499,7 @@ test.register_coroutine_test(
     test_aqs_device_type_do_configure(mock_device, "aqs-temp-humidity-all-level-all-meas")
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -510,7 +510,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_common,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_level,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -533,7 +533,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_co_co2,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -544,7 +544,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_tvoc,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -568,7 +568,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -590,7 +590,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -625,7 +625,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -695,7 +695,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -720,7 +720,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_common,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -828,7 +828,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor_modular.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_air_quality_sensor_modular.lua
@@ -353,6 +353,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_modular_fingerprint,
+    min_api_version = 15
   }
 )
 
@@ -409,7 +410,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_all,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -439,7 +440,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_common,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -466,7 +467,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device_modular_fingerprint:generate_test_message("main", capabilities.airQualityHealthConcern.supportedAirQualityValues({"unknown", "good", "unhealthy", "moderate", "slightlyUnhealthy"}, {visibility={displayed=false}})))
     test.socket.matter:__expect_send({mock_device_modular_fingerprint.id, subscribe_request_tvoc})
   end,
-  { test_init = test_init_modular_fingerprint }
+  {
+    test_init = test_init_modular_fingerprint,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -475,7 +479,10 @@ test.register_coroutine_test(
     -- simulate no actual change
     test.socket.device_lifecycle:__queue_receive(mock_device_modular_fingerprint:generate_info_changed({}))
   end,
-  { test_init = test_init_modular_fingerprint }
+  {
+    test_init = test_init_modular_fingerprint,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -501,7 +508,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device_modular_fingerprint:generate_test_message("main", capabilities.airQualityHealthConcern.supportedAirQualityValues({"unknown", "good", "unhealthy", "moderate", "slightlyUnhealthy"}, {visibility={displayed=false}})))
     test.socket.matter:__expect_send({mock_device_modular_fingerprint.id, subscribe_request_tvoc})
   end,
-  { test_init = test_init_modular_fingerprint }
+  {
+    test_init = test_init_modular_fingerprint,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -510,7 +520,10 @@ test.register_coroutine_test(
     -- simulate no actual change
     test.socket.device_lifecycle:__queue_receive(mock_device_modular_fingerprint:generate_info_changed({}))
   end,
-  { test_init = test_init_modular_fingerprint }
+  {
+    test_init = test_init_modular_fingerprint,
+    min_api_version = 15
+  }
 )
 
 -- run tests

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_aqara_fp400.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_aqara_fp400.lua
@@ -61,7 +61,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -77,7 +77,7 @@ test.register_coroutine_test(
     assert(mock_device.profile.id == current_profile, "Profile should not change on driverSwitched")
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -112,7 +112,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -134,7 +134,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_bosch_button_contact.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_bosch_button_contact.lua
@@ -82,7 +82,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -168,7 +168,7 @@ test.register_message_test(
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -232,7 +232,7 @@ test.register_message_test(
 
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -257,7 +257,7 @@ test.register_message_test(
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -292,7 +292,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_flow_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_flow_sensor.lua
@@ -71,7 +71,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -101,7 +101,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_freeze_leak_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_freeze_leak_sensor.lua
@@ -99,7 +99,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -135,7 +135,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -191,7 +191,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -211,7 +211,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -244,7 +244,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_pressure_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_pressure_sensor.lua
@@ -94,7 +94,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_rain_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_rain_sensor.lua
@@ -96,7 +96,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor.lua
@@ -163,7 +163,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -185,7 +185,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -207,7 +207,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -242,7 +242,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -264,7 +264,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -299,7 +299,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -336,7 +336,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -366,7 +366,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -381,7 +381,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_presence_sensor,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_battery.lua
@@ -88,7 +88,7 @@ test.register_coroutine_test(
     mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-battery" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -116,7 +116,7 @@ test.register_coroutine_test(
     mock_device_humidity_battery:expect_metadata_update({ profile = "humidity-batteryLevel" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -142,7 +142,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_featuremap.lua
@@ -171,7 +171,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_humidity_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -181,7 +181,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_humidity_no_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -191,7 +191,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_temp_humidity,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_rpc.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_sensor_rpc.lua
@@ -71,7 +71,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm.lua
@@ -124,7 +124,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -281,7 +281,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -342,7 +342,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -390,7 +390,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -435,7 +435,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -470,7 +470,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -492,7 +492,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -527,7 +527,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -578,7 +578,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_smoke_co_alarm_battery.lua
@@ -92,7 +92,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "smoke-co-temp-humidity-comeas-battery" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -107,7 +107,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -127,7 +127,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-sensor/src/test/test_matter_soil_sensor.lua
+++ b/drivers/SmartThings/matter-sensor/src/test/test_matter_soil_sensor.lua
@@ -80,7 +80,10 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed({ profile = updated_device_profile }))
     test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "Relative humidity reports should generate correct messages",
@@ -105,7 +108,10 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", capabilities.relativeHumidityMeasurement.humidity({ value = 41 }))
     )
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "Temperature reports should generate correct messages",
@@ -120,7 +126,10 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 40.0, unit = "C" }))
     )
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "Min and max temperature attributes set capability constraint",
@@ -144,7 +153,10 @@ test.register_coroutine_test(
       )
     )
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "Soil moisture is reported raw when no limits are set",
@@ -159,7 +171,10 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", capabilities.relativeHumidityMeasurement.humidity({ value = 55 }))
     )
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 local function build_soil_moisture_limits(min_value, max_value)
   if version.api < 21 then
@@ -194,7 +209,10 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", capabilities.relativeHumidityMeasurement.humidity({ value = 25 }))
     )
   end
-)
+,
+    {
+      min_api_version = 17
+    })
 
 test.register_coroutine_test(
   "Soil moisture scaling rounds correctly",
@@ -224,6 +242,9 @@ test.register_coroutine_test(
       mock_device:generate_test_message("main", capabilities.relativeHumidityMeasurement.humidity({ value = 90 }))
     )
   end
-)
+,
+    {
+      min_api_version = 17
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_climate_sensor_w100.lua
@@ -160,7 +160,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -185,7 +185,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -213,7 +213,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -232,7 +232,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -257,7 +257,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -282,7 +282,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -323,7 +323,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(aqara_mock_device:generate_test_message("button2", capabilities.button.button.double({state_change = true})))
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -352,7 +352,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -381,7 +381,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -400,7 +400,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -419,7 +419,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -444,7 +444,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -467,7 +467,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -490,7 +490,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_cube.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_cube.lua
@@ -235,7 +235,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -270,7 +270,7 @@ test.register_coroutine_test(
     end,
     {
       test_init = test_init_exhausted,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_aqara_light_switch_h2.lua
@@ -263,7 +263,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_set.lua
@@ -227,7 +227,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -295,7 +295,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -320,7 +320,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -382,7 +382,7 @@ test.register_coroutine_test(
     end,
     {
       test_init = test_init_periodic,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -407,7 +407,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -422,7 +422,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_periodic,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -553,7 +553,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -624,7 +624,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_periodic,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -707,7 +707,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_tree.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_electrical_sensor_tree.lua
@@ -163,7 +163,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -231,7 +231,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -257,7 +257,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -340,7 +340,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_eve_energy.lua
@@ -197,7 +197,7 @@ test.register_coroutine_test(
     assert(sub_driver ~= nil, "sub_driver should be returned")
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -209,7 +209,7 @@ test.register_coroutine_test(
     assert(result == false, "can_handle should return false for device without Eve Private Cluster")
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -242,7 +242,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -295,7 +295,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -310,7 +310,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
 
       test.timer.__create_and_queue_test_time_advance_timer(60, "interval", "create_poll_schedule")
     end,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -362,7 +362,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -389,7 +389,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -416,7 +416,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -455,7 +455,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -483,7 +483,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -510,7 +510,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -546,7 +546,7 @@ test.register_coroutine_test(
       test.timer.__create_and_queue_test_time_advance_timer(60 * 15, "interval", "create_poll_report_schedule")
       test.timer.__create_and_queue_test_time_advance_timer(60, "interval", "create_poll_schedule")
     end,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -643,7 +643,7 @@ test.register_coroutine_test(
         test.disable_startup_messages()
         test.mock_device.add_test_device(mock_eve_device_using_electrical_sensor)
       end,
-      min_api_version = 17
+      min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_hager_waasys.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_hager_waasys.lua
@@ -592,7 +592,10 @@ test.register_coroutine_test("Test: 4-Button Device Detection - Profile Changes 
     }))
   })
 
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: Button Event Handling - Pushed, Double Press, and Held Events on 4-Button Device", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -796,7 +799,10 @@ test.register_coroutine_test("Test: Button Event Handling - Pushed, Double Press
     )
   })
   test.socket.capability:__expect_send(matter_device:generate_test_message("button4", capabilities.button.button.held({ state_change = true })))
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: Device Type Handler - Handles Button (Type 15) and OnOff (Type 256) Device Types with Child Creation", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -889,7 +895,10 @@ test.register_coroutine_test("Test: Device Type Handler - Handles Button (Type 1
     parent.id,
     clusters.OnOff.attributes.OnOff:subscribe(parent, nil)
   })
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: 2G Relay - Profile Changes Between light-binary and 2-button Based On Endpoint Availability", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1131,7 +1140,10 @@ test.register_coroutine_test("Test: 2G Relay - Profile Changes Between light-bin
     parent_device_id = parent.id,
     parent_assigned_child_key = "4"
   })
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: Dimmer Device - Child Creation for Dimmable Endpoint with Button Support", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1227,7 +1239,10 @@ test.register_coroutine_test("Test: Dimmer Device - Child Creation for Dimmable 
     clusters.LevelControl.server.commands.MoveToLevelWithOnOff(child_dimmer, 3, 51, nil, 0, 0)
   })
 
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: 1G Dimmer - Initialization and Profile Update to light-level", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1236,7 +1251,10 @@ test.register_coroutine_test("Test: 1G Dimmer - Initialization and Profile Updat
   add_matter_device(dimmer, parent, "2-button")
   test.wait_for_events()
   configure_parent(parent)
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: 1G Dimmer - Host Commands and Level Control Capabilities", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1308,7 +1326,10 @@ test.register_coroutine_test("Test: 1G Dimmer - Host Commands and Level Control 
     parent_1g.id,
     clusters.LevelControl.server.commands.MoveToLevelWithOnOff(dimmer, 4, 51, nil, 0, 0)
   })
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: PIR Device - Initialization with Motion and Illuminance Capabilities", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1318,7 +1339,10 @@ test.register_coroutine_test("Test: PIR Device - Initialization with Motion and 
   test.wait_for_events()
   configure_parent(parent_pir)
 
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: PIR Device - Complete Functionality with Motion, Illuminance, and Dimmer Support", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1472,7 +1496,10 @@ test.register_coroutine_test("Test: PIR Device - Complete Functionality with Mot
   })
   test.socket.capability:__expect_send(child_dimmer:generate_test_message("main", capabilities.switchLevel.level(50)))
   parent_pir.expect_native_attr_handler_registration(parent_pir, "switchLevel", "level")
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: Host with Window Covering - 2-Button Profile with Window Covering Child Device", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1610,7 +1637,10 @@ test.register_coroutine_test("Test: Host with Window Covering - 2-Button Profile
   test.socket.capability:__expect_send(child_wc:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(0)))
   test.socket.capability:__expect_send(child_wc:generate_test_message("main", capabilities.windowShade.windowShade.closed()))
 
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test("Test: Window Covering - Preference Changes for Reverse Polarity and Preset Position", function()
   test.socket.matter:__set_channel_ordering("relaxed")
@@ -1775,6 +1805,9 @@ test.register_coroutine_test("Test: Window Covering - Preference Changes for Rev
     parent.id,
     cluster_base.subscribe(parent, nil, clusters.WindowCovering.ID, clusters.WindowCovering.attributes.CurrentPositionLiftPercent100ths.ID, nil)
   })
-end)
+end,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_ikea_scroll.lua
@@ -233,7 +233,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -347,7 +347,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -461,7 +461,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -512,7 +512,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -563,7 +563,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -614,7 +614,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -665,7 +665,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -699,7 +699,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -733,7 +733,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -747,7 +747,10 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_ikea_scroll.id, read_request})
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- Coroutine tests for sensitivity preference logic.
 -- KNOB_SENSITIVITY_FACTORS = {0.5, 1.0, 2.0}, indexed by the preference value.
@@ -797,7 +800,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -845,7 +848,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -893,7 +896,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -941,7 +944,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_light_illuminance_motion.lua
@@ -78,7 +78,10 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, clusters.ColorControl.attributes.Options:write(mock_device, 1, clusters.ColorControl.types.OptionsBitmap.EXECUTE_IF_OFF)})
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "init should cause device to subscribe to all appropriate clusters", function()
@@ -109,7 +112,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, subscribe_request})
    end,
    {
-     min_api_version = 17
+     min_api_version = 15
    }
 )
 
@@ -131,7 +134,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -166,7 +169,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -245,7 +248,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_light_level_motion,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_bridge.lua
@@ -101,7 +101,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_mock_bridge,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_button.lua
@@ -87,7 +87,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_for_lifecycle_tests,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -109,7 +109,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_for_lifecycle_tests,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -209,7 +209,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -257,7 +257,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -281,7 +281,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -305,7 +305,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -329,7 +329,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -368,7 +368,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -407,7 +407,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -482,7 +482,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -509,7 +509,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_profile_change_with_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_profile_change_with_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -536,7 +536,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_profile_change_with_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -551,7 +551,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_profile_change_with_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -571,7 +571,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_profile_change_with_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -594,7 +594,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -1,12 +1,19 @@
 -- Copyright © 2025 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
+local version = require "version"
+local test = require "integration_test"
+if version.api < 17 then
+  -- Run an empty test suite to avoid an error being thrown
+  test.run_registered_tests()
+  os.exit(0)
+end
+
 local capabilities = require "st.capabilities"
 local cluster_base = require "st.matter.cluster_base"
 local clusters = require "st.matter.clusters"
 local camera_fields = require "sub_drivers.camera.camera_utils.fields"
 local t_utils = require "integration_test.utils"
-local test = require "integration_test"
 local uint32 = require "st.matter.data_types.Uint32"
 
 test.disable_startup_messages()
@@ -666,7 +673,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, DOORBELL_EP)})
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -732,7 +739,7 @@ test.register_coroutine_test(
     assert(not configure_buttons_called, "configure_buttons should not be called when capability state is unchanged")
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -759,7 +766,7 @@ test.register_coroutine_test(
     assert(reconcile_called, "reconcile_profile_and_capabilities should be called")
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -807,7 +814,7 @@ test.register_coroutine_test(
     assert(init_event_count == 0, "cameraPrivacyMode should not be reinitialized for equal values with metatable differences")
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -857,7 +864,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -900,7 +907,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -929,7 +936,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -973,7 +980,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1004,7 +1011,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1054,7 +1061,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1079,7 +1086,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1132,7 +1139,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1256,7 +1263,7 @@ test.register_coroutine_test(
     emit_supported_resolutions()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1274,7 +1281,7 @@ test.register_coroutine_test(
     emit_supported_resolutions()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1292,7 +1299,7 @@ test.register_coroutine_test(
     emit_supported_resolutions()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1347,7 +1354,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1371,7 +1378,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1389,7 +1396,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1407,7 +1414,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1455,7 +1462,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1493,7 +1500,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1519,7 +1526,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1548,7 +1555,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.sounds.selectedSound(2)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1591,7 +1598,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1632,7 +1639,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1658,7 +1665,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1698,7 +1705,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1734,7 +1741,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1759,7 +1766,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1826,7 +1833,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1934,7 +1941,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1960,7 +1967,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1985,7 +1992,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2017,7 +2024,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2098,7 +2105,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2130,7 +2137,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2155,7 +2162,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2229,7 +2236,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2302,7 +2309,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2378,7 +2385,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2470,7 +2477,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2576,7 +2583,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -2652,7 +2659,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -3263,7 +3270,7 @@ test.register_coroutine_test(
     camera_cfg.reconcile_profile_and_capabilities = original_reconcile
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -3304,7 +3311,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, clusters.Switch.attributes.MultiPressMax:read(mock_device, DOORBELL_EP)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -3316,7 +3323,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_per_zone_sensitivity,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -3328,7 +3335,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_user_defined_zone,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -3347,7 +3354,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_user_defined_zone,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -3364,7 +3371,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_user_defined_zone,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_irrigation_system.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_irrigation_system.lua
@@ -1,6 +1,14 @@
 -- Copyright © 2026 SmartThings, Inc.
 -- Licensed under the Apache License, Version 2.0
 
+local version = require "version"
+local test = require "integration_test"
+if version.api < 17 then
+  test.run_registered_tests()
+  os.exit(0)
+end
+
+
 local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 local t_utils = require "integration_test.utils"

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_light_fan.lua
@@ -157,7 +157,10 @@ test.register_coroutine_test(
     )
     test.socket.matter:__expect_send({mock_device_capabilities_disabled.id, subscribe_request})
   end,
-  { test_init = function() test.mock_device.add_test_device(mock_device_capabilities_disabled) end }
+  {
+    test_init = function() test.mock_device.add_test_device(mock_device_capabilities_disabled) end,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -165,7 +168,10 @@ test.register_coroutine_test(
     -- simulate no actual change
     test.socket.device_lifecycle:__queue_receive(mock_device_capabilities_disabled:generate_info_changed({}))
   end,
-  { test_init = function() test.mock_device.add_test_device(mock_device_capabilities_disabled) end }
+  {
+    test_init = function() test.mock_device.add_test_device(mock_device_capabilities_disabled) end,
+    min_api_version = 15
+  }
 )
 
 local FanMode = clusters.FanControl.attributes.FanMode
@@ -213,7 +219,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -249,7 +255,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -274,7 +280,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -299,7 +305,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button.lua
@@ -278,7 +278,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -302,7 +302,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_battery,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -325,7 +325,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -358,7 +358,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -383,7 +383,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.held({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -408,7 +408,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -432,7 +432,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -472,7 +472,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button5", button_attr.double({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -500,7 +500,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -528,7 +528,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -566,7 +566,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -605,7 +605,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -653,7 +653,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -677,7 +677,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -701,7 +701,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -725,7 +725,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -764,7 +764,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -803,7 +803,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -827,7 +827,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -871,7 +871,7 @@ test.register_message_test(
     -- no double event
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -929,7 +929,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -951,7 +951,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -972,7 +972,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "5-button-batteryLevel" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -993,7 +993,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "5-button-battery" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_motion.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_motion.lua
@@ -184,7 +184,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -217,7 +217,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+  min_api_version = 15
 }
 )
 
@@ -242,7 +242,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button2", button_attr.held({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -267,7 +267,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -331,7 +331,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button6", button_attr.double({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -359,7 +359,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -378,7 +378,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -406,7 +406,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -444,7 +444,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -483,7 +483,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -531,7 +531,7 @@ test.register_message_test(
   },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -555,7 +555,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -579,7 +579,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -603,7 +603,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -643,7 +643,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -683,7 +683,7 @@ test.register_message_test(
 
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -707,7 +707,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -751,7 +751,7 @@ test.register_message_test(
   -- no double event
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -809,7 +809,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 -- run the tests

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_multi_button_switch_mcd.lua
@@ -271,7 +271,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -327,7 +327,7 @@ test.register_message_test(
   }
 },
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -352,7 +352,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("button3", button_attr.pushed({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -411,7 +411,7 @@ test.register_coroutine_test(
     end,
   {
     test_init = test_init_mcd_unsupported_switch_device_type,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -432,7 +432,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -450,7 +450,7 @@ test.register_coroutine_test(
     expect_configure_buttons()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -464,7 +464,7 @@ test.register_coroutine_test(
     expect_configure_buttons()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -484,7 +484,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_child.id, "doConfigure" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_device_configuration.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_device_configuration.lua
@@ -50,7 +50,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_onoff_switch_as_server) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -83,7 +83,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_onoff_switch_as_client) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -122,7 +122,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_dimmer_switch_as_server) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_plug_with_switch_profile_vendor_override) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -196,7 +196,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_color_dimmer) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -241,7 +241,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_mounted_on_off_control) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -296,7 +296,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_mounted_dimmable_load_control) end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_on_off_parent_child.lua
@@ -177,7 +177,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_for_lifecycle_tests,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -193,7 +193,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_for_lifecycle_tests,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -207,7 +207,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_for_generate_info_changed_tests,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -238,7 +238,7 @@ test.register_message_test(
     },
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -289,7 +289,7 @@ test.register_message_test(
     }
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -320,6 +320,9 @@ test.register_message_test(
         clusters.ColorControl.server.commands.MoveToColor:build_test_command_response(mock_device, extended_color_ep_id)
       }
     },
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -354,7 +357,7 @@ test.register_message_test(
     }
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -460,7 +463,7 @@ test.register_message_test(
     },
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -514,7 +517,7 @@ test.register_message_test(
     },
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -613,7 +616,7 @@ test.register_message_test(
     },
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -692,7 +695,7 @@ test.register_coroutine_test(
     test_init = function()
       test.mock_device.add_test_device(mock_plug)
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -710,7 +713,7 @@ test.register_coroutine_test(
     test_init = function()
       test.mock_device.add_test_device(mock_plug)
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -771,7 +774,7 @@ test.register_coroutine_test(
     test_init = function()
       test.mock_device.add_test_device(mock_plug_profile_override)
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -871,7 +874,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_switch) end,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_sensor_offset_preferences.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_sensor_offset_preferences.lua
@@ -61,7 +61,7 @@ test.register_coroutine_test("Read appropriate attribute values after tempOffset
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -84,7 +84,7 @@ test.register_coroutine_test("Read appropriate attribute values after humidityOf
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_switch.lua
@@ -93,7 +93,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -110,7 +110,7 @@ test.register_coroutine_test(
     test.socket.matter:__expect_send({mock_device.id, subscribe_request})
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -143,7 +143,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -176,7 +176,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -291,7 +291,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -316,7 +316,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -346,7 +346,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -376,7 +376,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -448,7 +448,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -526,7 +526,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -551,7 +551,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -576,7 +576,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -606,7 +606,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -631,7 +631,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -676,7 +676,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -694,7 +694,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -759,7 +759,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_x_y_color_mode,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -791,7 +791,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_x_y_color_mode,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -823,7 +823,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_x_y_color_mode,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -881,7 +881,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_x_y_color_mode,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -979,7 +979,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_with_hue_sat_color_mode_set,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1065,7 +1065,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_with_hue_sat_color_mode_set,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1143,7 +1143,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_hue_sat,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -1195,7 +1195,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_color_temp,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -1222,7 +1222,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_color_temp,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_water_valve.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_water_valve.lua
@@ -69,7 +69,10 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
     mock_device:expect_metadata_update({ profile = "water-valve-level" })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_message_test(
@@ -93,7 +96,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -118,7 +121,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -159,7 +162,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -179,8 +182,6 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.valve.valve.closed())
     },
-  },
-  {
     {
       channel = "matter",
       direction = "receive",
@@ -209,7 +210,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -231,7 +232,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_multi_switch_mcd.lua
@@ -200,7 +200,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_mock_3switch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -227,7 +227,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_mock_2switch,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -254,7 +254,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_mock_3switch_non_sequential,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_stateless_step.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_stateless_step.lua
@@ -128,7 +128,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/matter-switch/src/test/test_third_reality_subdrivers.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_third_reality_subdrivers.lua
@@ -95,6 +95,9 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.doorControl.door.open())
     }
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -114,6 +117,9 @@ test.register_message_test(
       direction = "send",
       message = mock_device:generate_test_message("main", capabilities.doorControl.door.closed())
     }
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -143,6 +149,9 @@ test.register_message_test(
         clusters.OnOff.server.commands.On(mock_device, 1)
       }
     }
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -170,6 +179,9 @@ test.register_message_test(
         clusters.OnOff.server.commands.Off(mock_device, 1)
       }
     }
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -192,6 +204,9 @@ test.register_message_test(
       -- BatPercentRemaining is in units of 0.5%, so 200 = 100%
       message = mock_device:generate_test_message("main", capabilities.battery.battery(100))
     }
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -212,6 +227,9 @@ test.register_message_test(
       -- 150 * 0.5 = 75%
       message = mock_device:generate_test_message("main", capabilities.battery.battery(75))
     }
+  },
+  {
+    min_api_version = 15
   }
 )
 
@@ -224,7 +242,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({profile = "garage-door-battery"})
     mock_device:expect_metadata_update({provisioning_state = "PROVISIONED"})
   end,
-  {min_api_version = 17}
+  {min_api_version = 15}
 )
 
 test.register_coroutine_test(
@@ -234,7 +252,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({profile = "garage-door-battery"})
     mock_device:expect_metadata_update({provisioning_state = "PROVISIONED"})
   end,
-  {min_api_version = 17}
+  {min_api_version = 15}
 )
 
 
@@ -298,6 +316,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = function() test.mock_device.add_test_device(mock_device_misprofiled) end,
+    min_api_version = 15
   }
 )
 
@@ -525,7 +544,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_mk1,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier.lua
@@ -432,7 +432,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_aqs,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -448,7 +448,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -473,7 +473,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -530,7 +530,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -574,7 +574,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -612,7 +612,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -660,7 +660,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -721,7 +721,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -777,7 +777,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -799,7 +799,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -870,7 +870,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -888,7 +888,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -914,7 +914,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier_api9.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier_api9.lua
@@ -6,9 +6,6 @@ local capabilities = require "st.capabilities"
 local clusters = require "st.matter.clusters"
 local SinglePrecisionFloat = require "st.matter.data_types.SinglePrecisionFloat"
 local t_utils = require "integration_test.utils"
-local version = require "version"
-
-version.api = 9
 
 -- include driver-side cluster definitions to test embedded clusters on lower api versions
 clusters.HepaFilterMonitoring = require "embedded_clusters.HepaFilterMonitoring"
@@ -432,7 +429,8 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_aqs,
-    min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -448,7 +446,8 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs,
-    min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -473,7 +472,8 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -530,7 +530,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -574,7 +575,8 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -612,7 +614,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -660,7 +663,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -721,7 +725,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -778,7 +783,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -800,7 +806,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -872,7 +879,8 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -890,7 +898,8 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 
@@ -916,7 +925,8 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 9,
+    max_api_version = 10
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_air_purifier_modular.lua
@@ -317,7 +317,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_basic,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -394,7 +394,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_ap_thermo_aqs_preconfigured,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_fan.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_fan.lua
@@ -113,7 +113,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -128,7 +128,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_generic,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_heat_pump.lua
@@ -148,7 +148,7 @@ test.register_coroutine_test(
     assert(component_to_endpoint_map["thermostatTwo"] == THERMOSTAT_TWO_EP, string.format("Thermostat Two Endpoint must be %d", THERMOSTAT_TWO_EP))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -193,7 +193,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -238,7 +238,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -279,7 +279,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -320,7 +320,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -387,7 +387,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -475,7 +475,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -546,7 +546,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -613,7 +613,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_auto,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -637,7 +637,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -662,7 +662,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -710,7 +710,7 @@ test.register_coroutine_test(
     test_init = function()
       test_init()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -763,7 +763,7 @@ test.register_coroutine_test(
     test_init = function()
       test_init()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac.lua
@@ -296,7 +296,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_configure,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -317,7 +317,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_nostate,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -355,7 +355,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -411,7 +411,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -459,7 +459,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -495,7 +495,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -544,7 +544,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -584,7 +584,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_room_ac_modular.lua
@@ -314,7 +314,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_basic,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -342,7 +342,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_no_state,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_battery.lua
@@ -107,7 +107,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -129,7 +129,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "thermostat-cooling-only-nostate-batteryLevel" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_featuremap.lua
@@ -228,7 +228,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ profile = "thermostat-humidity-fan-heating-only" })
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -252,7 +252,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed(updates))
 end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -277,7 +277,7 @@ test.register_coroutine_test(
     mock_device_simple:expect_metadata_update({ profile = "thermostat-cooling-only-nostate" })
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -294,7 +294,7 @@ test.register_coroutine_test(
     mock_device_no_battery:expect_metadata_update({ profile = "thermostat-cooling-only-nostate-nobattery" })
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_multiple_device_types.lua
@@ -240,7 +240,7 @@ test.register_coroutine_test(
       get_subscribe_request(mock_device, new_cluster_subscribe_list))
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -252,7 +252,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init_disorder_endpoints,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -286,7 +286,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits.lua
@@ -150,7 +150,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -179,7 +179,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -237,7 +237,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -259,7 +259,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -281,7 +281,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -297,7 +297,7 @@ test.register_coroutine_test(
     assert(min_setpoint_deadband_checked == true, "min_setpoint_deadband_checked is True")
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -327,7 +327,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -357,7 +357,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -387,7 +387,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits_rpc.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermo_setpoint_limits_rpc.lua
@@ -101,7 +101,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -151,7 +151,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat.lua
@@ -169,7 +169,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -191,7 +191,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -240,7 +240,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -289,7 +289,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -311,7 +311,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -333,7 +333,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -355,7 +355,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -392,7 +392,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -441,7 +441,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -490,7 +490,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_auto,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -530,7 +530,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -571,7 +571,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_auto,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -623,7 +623,7 @@ test.register_message_test(
   },
   {
     test_init = test_init_auto,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -680,7 +680,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -716,7 +716,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -741,7 +741,7 @@ test.register_message_test(
 		}
 	},
 	{
-	   min_api_version = 17
+	   min_api_version = 15
 	}
 )
 
@@ -766,7 +766,7 @@ test.register_message_test(
 		}
 	},
 	{
-	   min_api_version = 17
+	   min_api_version = 15
 	}
 )
 
@@ -791,7 +791,7 @@ test.register_message_test(
 		}
 	},
 	{
-	   min_api_version = 17
+	   min_api_version = 15
 	}
 )
 
@@ -832,7 +832,7 @@ test.register_message_test(
     },
 	},
 	{
-	   min_api_version = 17
+	   min_api_version = 15
 	}
 )
 
@@ -857,7 +857,7 @@ test.register_message_test(
 		}
 	},
 	{
-	   min_api_version = 17
+	   min_api_version = 15
 	}
 )
 
@@ -878,7 +878,7 @@ test.register_coroutine_test("Battery percent reports should generate correct me
   test.wait_for_events()
 end,
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -933,7 +933,7 @@ test.register_message_test(
 		}
 	},
 	{
-	   min_api_version = 17
+	   min_api_version = 15
 	}
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_composed_bridged.lua
@@ -98,7 +98,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -121,7 +121,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -144,7 +144,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -173,7 +173,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -202,7 +202,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -225,7 +225,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -271,7 +271,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -329,7 +329,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -382,7 +382,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -424,7 +424,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -474,7 +474,7 @@ test.register_message_test(
 
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -512,7 +512,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -537,7 +537,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -562,7 +562,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -587,7 +587,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -628,7 +628,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -653,7 +653,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -674,7 +674,7 @@ test.register_coroutine_test("Battery percent reports should generate correct me
   test.wait_for_events()
 end,
 {
-   min_api_version = 17
+   min_api_version = 15
 }
 )
 
@@ -729,7 +729,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_modular.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_modular.lua
@@ -179,7 +179,7 @@ test.register_coroutine_test(
   end,
   {
     test_init = test_init,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -245,7 +245,10 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device_modular:generate_info_changed({ profile = updated_device_profile }))
     test.socket.matter:__expect_send({mock_device_modular.id, subscribe_request})
   end,
-  { test_init = test_init_modular_fingerprint }
+  {
+    test_init = test_init_modular_fingerprint,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -253,7 +256,10 @@ test.register_coroutine_test(
     -- simulate no actual change
     test.socket.device_lifecycle:__queue_receive(mock_device_modular:generate_info_changed({}))
   end,
-  { test_init = function() test.mock_device.add_test_device(mock_device_modular) end }
+  {
+    test_init = function() test.mock_device.add_test_device(mock_device_modular) end,
+    min_api_version = 15
+  }
 )
 
 local function initialize_subscribe_request(mock_device, subscribed_attributes)
@@ -318,7 +324,10 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device_modular:generate_info_changed({ profile = updated_device_profile }))
     test.socket.matter:__expect_send({mock_device_modular.id, subscribe_request})
   end,
-  { test_init = test_init_modular_fingerprint }
+  {
+    test_init = test_init_modular_fingerprint,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -326,7 +335,10 @@ test.register_coroutine_test(
     -- simulate no actual change
     test.socket.device_lifecycle:__queue_receive(mock_device_modular:generate_info_changed({}))
   end,
-  { test_init = function() test.mock_device.add_test_device(mock_device_modular) end }
+  {
+    test_init = function() test.mock_device.add_test_device(mock_device_modular) end,
+    min_api_version = 15
+  }
 )
 
 -- run tests

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_rpc5.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_thermostat_rpc5.lua
@@ -137,7 +137,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-thermostat/src/test/test_matter_water_heater.lua
+++ b/drivers/SmartThings/matter-thermostat/src/test/test_matter_water_heater.lua
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -204,7 +204,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -236,7 +236,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -261,7 +261,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -331,7 +331,7 @@ test.register_coroutine_test(
     test_init = function()
       test_init()
     end,
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -433,7 +433,7 @@ test.register_message_test(
     }
   },
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_closure.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_closure.lua
@@ -300,7 +300,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closing())
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -323,7 +326,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.opening())
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -343,7 +349,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closed())
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -363,7 +372,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.open())
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -383,7 +395,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.partially_open())
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -427,7 +442,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.windowShade.windowShade.closed())
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -442,7 +460,10 @@ test.register_coroutine_test(
         mock_device, 10, clusters.ClosureControl.types.TargetPositionEnum.MOVE_TO_FULLY_CLOSED
       )
     })
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -457,7 +478,10 @@ test.register_coroutine_test(
         mock_device, 10, clusters.ClosureControl.types.TargetPositionEnum.MOVE_TO_FULLY_OPEN
       )
     })
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -470,7 +494,10 @@ test.register_coroutine_test(
       mock_device.id,
       clusters.ClosureControl.server.commands.Stop(mock_device, 10)
     })
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -484,7 +511,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("main", capabilities.battery.battery(math.floor(150 / 2.0 + 0.5)))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -499,7 +529,10 @@ test.register_coroutine_test(
       mock_device.id,
       clusters.ClosureDimension.server.commands.SetTarget(mock_device, 11, 75 * 100)
     })
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -514,7 +547,10 @@ test.register_coroutine_test(
       mock_device.id,
       clusters.ClosureDimension.server.commands.SetTarget(mock_device, 12, 40 * 100)
     })
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -534,7 +570,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("windowShade1", capabilities.windowShadeLevel.shadeLevel(60))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -554,7 +593,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("windowShade2", capabilities.windowShadeLevel.shadeLevel(25))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -574,7 +616,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("windowShade1", capabilities.windowShadeLevel.shadeLevel(0))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -594,7 +639,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_device:generate_test_message("windowShade1", capabilities.windowShadeLevel.shadeLevel(100))
     )
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 -- ---------------------------------------------------------------------------
@@ -622,7 +670,10 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("main", capabilities.doorControl.door.closing())
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -646,7 +697,10 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("main", capabilities.doorControl.door.opening())
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -667,8 +721,12 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("main", capabilities.doorControl.door.closed())
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
+
 
 test.register_coroutine_test(
   "doorControl open following OverallCurrentState FULLY_OPENED", function()
@@ -688,7 +746,10 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("main", capabilities.doorControl.door.open())
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -710,7 +771,10 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("main", capabilities.doorControl.door.open())
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -726,7 +790,10 @@ test.register_coroutine_test(
       )
     })
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -742,9 +809,11 @@ test.register_coroutine_test(
       )
     })
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 15
+  }
 )
-
 test.register_coroutine_test(
   "ClosureDimension CurrentState on endpoint 11 emits level on door1 for door device", function()
     update_profile_door()
@@ -763,7 +832,10 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("door1", capabilities.level.level(75))
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -784,7 +856,10 @@ test.register_coroutine_test(
       mock_door_device:generate_test_message("door2", capabilities.level.level(30))
     )
   end,
-  {test_init = test_init_door}
+  {
+    test_init = test_init_door,
+    min_api_version = 17
+  }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
+++ b/drivers/SmartThings/matter-window-covering/src/test/test_matter_window_covering.lua
@@ -520,7 +520,10 @@ test.register_coroutine_test(
         "main", capabilities.windowShade.windowShade.partially_open()
       )
     )
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(

--- a/drivers/SmartThings/virtual-switch/src/test/test_virtual_switch.lua
+++ b/drivers/SmartThings/virtual-switch/src/test/test_virtual_switch.lua
@@ -46,7 +46,7 @@ test.register_message_test(
      }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -65,7 +65,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -84,7 +84,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -104,7 +104,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -123,7 +123,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_simple_device:generate_test_message("main", capabilities.switch.switch.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-air-quality-detector/src/test/test_MultiIR_air_quality_detector.lua
+++ b/drivers/SmartThings/zigbee-air-quality-detector/src/test/test_MultiIR_air_quality_detector.lua
@@ -73,7 +73,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, read_AQI_messge})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -137,7 +137,7 @@ test.register_coroutine_test(
       capabilities.carbonDioxideHealthConcern.carbonDioxideHealthConcern({value = "good"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
       capabilities.fineDustHealthConcern.fineDustHealthConcern.good()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_coroutine_test(
       capabilities.veryFineDustHealthConcern.veryFineDustHealthConcern.good()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
      capabilities.dustHealthConcern.dustHealthConcern.good()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -215,7 +215,7 @@ test.register_coroutine_test(
       capabilities.formaldehydeMeasurement.formaldehydeLevel({value = 1000.0, unit = "mg/m^3"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -235,7 +235,7 @@ test.register_coroutine_test(
       capabilities.tvocHealthConcern.tvocHealthConcern({value = "unhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -253,7 +253,7 @@ test.register_coroutine_test(
       capabilities.airQualityHealthConcern.airQualityHealthConcern({value = "good"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -271,7 +271,7 @@ test.register_coroutine_test(
       capabilities.airQualityHealthConcern.airQualityHealthConcern({value = "moderate"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_coroutine_test(
       capabilities.airQualityHealthConcern.airQualityHealthConcern({value = "slightlyUnhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -307,7 +307,7 @@ test.register_coroutine_test(
       capabilities.airQualityHealthConcern.airQualityHealthConcern({value = "unhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -325,7 +325,7 @@ test.register_coroutine_test(
       capabilities.airQualityHealthConcern.airQualityHealthConcern({value = "veryUnhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
       capabilities.airQualityHealthConcern.airQualityHealthConcern({value = "hazardous"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -363,7 +363,7 @@ test.register_coroutine_test(
       capabilities.carbonDioxideHealthConcern.carbonDioxideHealthConcern({value = "moderate"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -383,7 +383,7 @@ test.register_coroutine_test(
       capabilities.carbonDioxideHealthConcern.carbonDioxideHealthConcern({value = "unhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -403,7 +403,7 @@ test.register_coroutine_test(
       capabilities.fineDustHealthConcern.fineDustHealthConcern({value = "moderate"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -423,7 +423,7 @@ test.register_coroutine_test(
       capabilities.fineDustHealthConcern.fineDustHealthConcern({value = "unhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -443,7 +443,7 @@ test.register_coroutine_test(
       capabilities.veryFineDustHealthConcern.veryFineDustHealthConcern({value = "unhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -463,7 +463,7 @@ test.register_coroutine_test(
       capabilities.dustHealthConcern.dustHealthConcern({value = "unhealthy"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -483,7 +483,7 @@ test.register_coroutine_test(
       capabilities.tvocHealthConcern.tvocHealthConcern({value = "good"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-bed/src/test/test_shus_mattress.lua
+++ b/drivers/SmartThings/zigbee-bed/src/test/test_shus_mattress.lua
@@ -86,7 +86,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, read_0x0011_messge})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, read_0x0011_messge})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftback.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftback.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -185,7 +185,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftwaist.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftwaist.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.lefthip.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -239,7 +239,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.lefthip.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -257,7 +257,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightback.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightback.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -293,7 +293,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightwaist.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -311,7 +311,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightwaist.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -329,7 +329,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.righthip.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -347,7 +347,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.righthip.idle({ visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -365,7 +365,7 @@ test.register_coroutine_test(
       custom_capabilities.mattressHardness.leftBackHardness(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -383,7 +383,7 @@ test.register_coroutine_test(
       custom_capabilities.mattressHardness.leftWaistHardness(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -401,7 +401,7 @@ test.register_coroutine_test(
       custom_capabilities.mattressHardness.leftHipHardness(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -419,7 +419,7 @@ test.register_coroutine_test(
       custom_capabilities.mattressHardness.rightBackHardness(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -437,7 +437,7 @@ test.register_coroutine_test(
       custom_capabilities.mattressHardness.rightWaistHardness(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -455,7 +455,7 @@ test.register_coroutine_test(
       custom_capabilities.mattressHardness.rightHipHardness(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -473,7 +473,7 @@ test.register_coroutine_test(
       custom_capabilities.yoga.state.both()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -491,7 +491,7 @@ test.register_coroutine_test(
       custom_capabilities.yoga.state.right()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -509,7 +509,7 @@ test.register_coroutine_test(
       custom_capabilities.yoga.state.left()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -527,7 +527,7 @@ test.register_coroutine_test(
       custom_capabilities.yoga.state.stop()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -545,7 +545,7 @@ test.register_coroutine_test(
       custom_capabilities.ai_mode.left.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -563,7 +563,7 @@ test.register_coroutine_test(
       custom_capabilities.ai_mode.left.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -581,7 +581,7 @@ test.register_coroutine_test(
       custom_capabilities.ai_mode.right.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -599,7 +599,7 @@ test.register_coroutine_test(
       custom_capabilities.ai_mode.right.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -617,7 +617,7 @@ test.register_coroutine_test(
       custom_capabilities.auto_inflation.inflationState.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -635,7 +635,7 @@ test.register_coroutine_test(
       custom_capabilities.auto_inflation.inflationState.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -653,7 +653,7 @@ test.register_coroutine_test(
       custom_capabilities.strong_exp_mode.expState.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -671,7 +671,7 @@ test.register_coroutine_test(
       custom_capabilities.strong_exp_mode.expState.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -689,7 +689,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -706,7 +706,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -723,7 +723,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -740,7 +740,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -757,7 +757,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -774,7 +774,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -791,7 +791,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -808,7 +808,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -827,7 +827,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftback.soft()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -846,7 +846,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftwaist.soft()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -865,7 +865,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.lefthip.soft()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -884,7 +884,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftback.hard()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -903,7 +903,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftwaist.hard()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -922,7 +922,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.lefthip.hard()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -941,7 +941,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightback.soft()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -960,7 +960,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightwaist.soft()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -979,7 +979,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.righthip.soft()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -998,7 +998,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightback.hard()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1017,7 +1017,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.rightwaist.hard()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1036,7 +1036,7 @@ test.register_coroutine_test(
       custom_capabilities.right_control.righthip.hard()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1053,7 +1053,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1070,7 +1070,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1087,7 +1087,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1112,7 +1112,7 @@ test.register_coroutine_test(
       custom_capabilities.left_control.leftback("idle", { visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_SLED_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_SLED_button.lua
@@ -50,7 +50,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -74,7 +74,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -89,7 +89,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_aduro_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_aduro_button.lua
@@ -93,7 +93,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -179,7 +179,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_aqara_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_aqara_button.lua
@@ -99,7 +99,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
     mock_device_e1:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -166,7 +166,7 @@ test.register_coroutine_test(
     mock_device_h1_double_rocker:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -187,7 +187,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
       capabilities.button.button.double({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_coroutine_test(
       capabilities.button.button.held({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_message_test(
@@ -266,7 +266,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_message_test(
@@ -284,7 +284,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -328,7 +328,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -350,7 +350,7 @@ test.register_coroutine_test(
       capabilities.batteryLevel.quantity(1)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_centralite_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_centralite_button.lua
@@ -95,7 +95,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -152,7 +152,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -191,7 +191,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -205,7 +205,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_dimming_remote.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_dimming_remote.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -117,7 +117,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_ewelink_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ewelink_button.lua
@@ -64,7 +64,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -79,7 +79,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -111,7 +111,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -151,7 +151,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_ezviz_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ezviz_button.lua
@@ -55,7 +55,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -137,7 +137,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({ mock_device_ezviz_button.id, ZoneStatusAttribute:read(mock_device_ezviz_button) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -199,7 +199,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_frient_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_frient_button.lua
@@ -88,7 +88,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -113,7 +113,7 @@ test.register_message_test("Refresh should read all necessary attributes", {
     },
 },
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test("panicAlarm should be triggered and cleared", funct
 
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -184,7 +184,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -226,7 +226,7 @@ test.register_coroutine_test(
         mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ function()
     test.socket.zigbee:__expect_send({mock_device.id, buttonDelay_msg})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -286,7 +286,7 @@ test.register_coroutine_test(" Configuration and Switching to button-profile-pan
     --test.socket.capability:__expect_send({mock_device.id, capabilities.panicAlarm.panicAlarm.clear({state_change = true})})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -302,7 +302,7 @@ test.register_coroutine_test("Switching from button-profile-panic-frient to butt
     test.socket.zigbee:__expect_send({mock_device_panic.id, cluster_base.write_manufacturer_specific_attribute(mock_device_panic,BasicInput.ID,0x8000,DEVELCO_MANUFACTURER_CODE,data_types.Uint16,0xFFFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -324,7 +324,7 @@ test.register_coroutine_test("New preferences after switching the profile should
     test.socket.zigbee:__expect_send({mock_device_panic.id, cluster_base.write_manufacturer_specific_attribute(mock_device_panic, IASZone.ID,0x8005,DEVELCO_MANUFACTURER_CODE,data_types.Enum8, 1)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_heiman_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_heiman_button.lua
@@ -92,7 +92,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -127,7 +127,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -174,7 +174,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -198,7 +198,7 @@ test.register_coroutine_test(
       mock_device_hs6ssb:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -279,7 +279,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -313,7 +313,7 @@ test.register_coroutine_test(
       mock_device_hs6ssb:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -361,7 +361,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -409,7 +409,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_ikea_on_off.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ikea_on_off.lua
@@ -75,7 +75,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -143,7 +143,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_add_hub_to_group(0xB9F2)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -205,7 +205,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -304,7 +304,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_ikea_open_close.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ikea_open_close.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -124,7 +124,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_add_hub_to_group(0xB9F2)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({mock_device.id, Groups.commands.AddGroup(mock_device, 0x0000) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -247,7 +247,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_ikea_remote_control.lua
@@ -109,7 +109,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -154,7 +154,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -179,7 +179,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_add_hub_to_group(0xB9F2)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -286,7 +286,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -305,7 +305,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_iris_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_iris_button.lua
@@ -47,7 +47,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -63,7 +63,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -105,7 +105,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -177,7 +177,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -198,7 +198,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -240,7 +240,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -261,7 +261,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_linxura_aura_smart_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_linxura_aura_smart_button.lua
@@ -57,7 +57,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
         end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
         end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_linxura_smart_controller_4x_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_linxura_smart_controller_4x_button.lua
@@ -57,7 +57,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
         end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
         end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_push_only_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_push_only_button.lua
@@ -48,7 +48,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_message_test(
@@ -61,7 +61,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -80,7 +80,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -164,7 +164,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_robb_4x_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_robb_4x_button.lua
@@ -81,7 +81,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -124,7 +124,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -212,7 +212,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -326,7 +326,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -368,7 +368,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -386,7 +386,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_robb_8x_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_robb_8x_button.lua
@@ -126,7 +126,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -284,7 +284,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -329,7 +329,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -444,7 +444,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -486,7 +486,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -504,7 +504,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_samjin_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_samjin_button.lua
@@ -90,7 +90,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -140,7 +140,7 @@ test.register_coroutine_test(
     -- })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_shinasystem_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_shinasystem_button.lua
@@ -85,7 +85,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -142,7 +142,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -199,7 +199,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -239,7 +239,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -287,7 +287,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_1_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_1_button.lua
@@ -65,7 +65,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -140,7 +140,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_add_hub_to_group(0xB9F2)
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -250,7 +250,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_4_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_somfy_situo_4_button.lua
@@ -94,7 +94,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -163,7 +163,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -187,7 +187,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_add_hub_to_group(0xB9F2)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -235,7 +235,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_sonoff_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_sonoff_button.lua
@@ -161,7 +161,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -180,7 +180,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -199,7 +199,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -218,7 +218,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -237,7 +237,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -256,7 +256,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -271,7 +271,7 @@ test.register_coroutine_test(
     )
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_thirdreality_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_thirdreality_button.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -65,7 +65,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -82,7 +82,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.button.button.double({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -99,7 +99,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.button.button.held({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_vimar_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_vimar_button.lua
@@ -77,7 +77,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_wallhero_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_wallhero_button.lua
@@ -306,7 +306,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -347,7 +347,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_zigbee_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_zigbee_button.lua
@@ -39,7 +39,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -58,7 +58,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -77,7 +77,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -91,7 +91,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -110,7 +110,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -167,7 +167,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -187,7 +187,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -296,7 +296,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -373,7 +373,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_zigbee_ecosmart_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_zigbee_ecosmart_button.lua
@@ -50,7 +50,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -98,7 +98,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -212,7 +212,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -261,7 +261,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-button/src/test/test_zunzunbee_8_button.lua
+++ b/drivers/SmartThings/zigbee-button/src/test/test_zunzunbee_8_button.lua
@@ -81,7 +81,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -142,7 +142,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -199,7 +199,7 @@ test.register_coroutine_test(
         end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_climax_technology_carbon_monoxide.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_climax_technology_carbon_monoxide.lua
@@ -42,7 +42,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_frient_co_smoke_temperature_battery.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_frient_co_smoke_temperature_battery.lua
@@ -447,7 +447,10 @@ test.register_coroutine_test(
 			)
 		})
 	end
-)
+,
+    {
+      min_api_version = 17
+    })
 
 test.register_coroutine_test(
 	"Alarm off command should send StartWarning stop",
@@ -474,7 +477,10 @@ test.register_coroutine_test(
 			)
 		})
 	end
-)
+,
+    {
+      min_api_version = 17
+    })
 
 test.register_coroutine_test(
 	"Default response to StartWarning should emit alarm events",
@@ -500,7 +506,10 @@ test.register_coroutine_test(
 		)
 		test.wait_for_events()
 	end
-)
+,
+    {
+      min_api_version = 17
+    })
 
 test.run_registered_tests()
 

--- a/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_zigbee_carbon_monoxide.lua
+++ b/drivers/SmartThings/zigbee-carbon-monoxide-detector/src/test/test_zigbee_carbon_monoxide.lua
@@ -44,7 +44,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -71,7 +71,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
 
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -216,7 +216,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_aqara_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_aqara_contact_sensor.lua
@@ -66,7 +66,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -90,7 +90,7 @@ test.register_coroutine_test(
       capabilities.batteryLevel.battery("normal")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -108,7 +108,7 @@ test.register_coroutine_test(
     capabilities.batteryLevel.battery("normal")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -126,7 +126,7 @@ test.register_coroutine_test(
     capabilities.batteryLevel.battery("critical")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     capabilities.batteryLevel.battery("normal")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -162,7 +162,7 @@ test.register_coroutine_test(
     capabilities.batteryLevel.battery("warning")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -180,7 +180,7 @@ test.register_coroutine_test(
     capabilities.batteryLevel.battery("critical")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -198,7 +198,7 @@ test.register_coroutine_test(
       capabilities.contactSensor.contact.closed()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_coroutine_test(
       capabilities.contactSensor.contact.open()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_aurora_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_aurora_contact_sensor.lua
@@ -44,7 +44,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryVoltage:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_centralite_multi_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_centralite_multi_sensor.lua
@@ -108,7 +108,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({300, 200, 100})) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -134,7 +134,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.inactive()) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.contactSensor.contact.open()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -282,7 +282,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -307,7 +307,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_contact_temperature_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_contact_temperature_sensor.lua
@@ -46,7 +46,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -108,7 +108,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -146,7 +146,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_ecolink_contact.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_ecolink_contact.lua
@@ -47,7 +47,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -117,7 +117,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_ewelink_heiman_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_ewelink_heiman_sensor.lua
@@ -45,7 +45,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
             test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryVoltage:read(mock_device) })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -135,7 +135,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -154,7 +154,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -173,7 +173,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -207,7 +207,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -226,7 +226,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -245,7 +245,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -264,7 +264,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -283,7 +283,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor_2_pro.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor_2_pro.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -178,7 +178,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 15
         }
 )
 
@@ -224,7 +224,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -322,7 +322,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -341,7 +341,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -360,7 +360,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -379,7 +379,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -398,7 +398,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -426,7 +426,7 @@ test.register_coroutine_test(
             })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor_pro.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_frient_contact_sensor_pro.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -178,7 +178,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 15
         }
 )
 
@@ -224,7 +224,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -322,7 +322,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -346,7 +346,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -370,7 +370,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -394,7 +394,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -418,7 +418,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -446,7 +446,7 @@ test.register_coroutine_test(
             })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_frient_vibration_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_frient_vibration_sensor.lua
@@ -300,7 +300,7 @@ test.register_coroutine_test(
             mock_device_contact:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -328,7 +328,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -347,7 +347,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -366,7 +366,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -407,7 +407,7 @@ function()
     })
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -431,7 +431,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -455,7 +455,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -477,7 +477,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -505,7 +505,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -533,7 +533,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_orvibo_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_orvibo_contact_sensor.lua
@@ -44,7 +44,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_samjin_multi_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_samjin_multi_sensor.lua
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -180,7 +180,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_sengled_contact_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_sengled_contact_sensor.lua
@@ -44,7 +44,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryVoltage:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_smartsense_multi.lua
@@ -116,7 +116,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.active()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -134,7 +134,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -152,7 +152,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -188,7 +188,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -206,7 +206,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -224,7 +224,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -242,7 +242,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -260,7 +260,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -278,7 +278,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(97)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -296,7 +296,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -314,7 +314,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(60)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -332,7 +332,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(0)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -350,7 +350,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(0)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -368,7 +368,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(0)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -383,7 +383,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({1050, 3, 9})) )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -398,7 +398,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({-1050, -3, -9})) )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -413,7 +413,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({10, 1020, 7})) )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -428,7 +428,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({-10, -1020, -7})) )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -443,7 +443,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({116, 4, 1003})) )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -458,7 +458,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({-116, -4, -1003})) )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -491,7 +491,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.contactSensor.contact.open()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -510,7 +510,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -529,7 +529,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -548,7 +548,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -567,7 +567,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_smartthings_multi_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_smartthings_multi_sensor.lua
@@ -89,7 +89,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -134,7 +134,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.inactive()) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -151,7 +151,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.active()) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({300, 100, -200})) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -206,7 +206,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.contactSensor.contact.open()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -236,7 +236,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -255,7 +255,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -274,7 +274,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -325,7 +325,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -390,7 +390,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -434,7 +434,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_third_reality_contact.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_third_reality_contact.lua
@@ -44,7 +44,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_thirdreality_multi_sensor.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_thirdreality_multi_sensor.lua
@@ -54,7 +54,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.inactive()) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -71,7 +71,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.accelerationSensor.acceleration.active()) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -90,7 +90,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.threeAxis.threeAxis({200, 100, 300})) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact.lua
@@ -46,7 +46,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -73,7 +73,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -185,7 +185,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -250,7 +250,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:read(mock_device) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -344,7 +344,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact_battery.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact_battery.lua
@@ -88,7 +88,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -128,7 +128,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact_tyco.lua
+++ b/drivers/SmartThings/zigbee-contact/src/test/test_zigbee_contact_tyco.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
         end
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 
   )
@@ -84,7 +84,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -105,7 +105,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 
   )

--- a/drivers/SmartThings/zigbee-fan/src/test/test_fan_light.lua
+++ b/drivers/SmartThings/zigbee-fan/src/test/test_fan_light.lua
@@ -50,7 +50,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -71,7 +71,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -92,7 +92,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -113,7 +113,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -183,7 +183,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -203,7 +203,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -223,7 +223,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -263,7 +263,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -287,7 +287,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -311,7 +311,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -335,7 +335,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -365,7 +365,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -395,7 +395,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -425,7 +425,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -455,7 +455,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -485,7 +485,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -509,7 +509,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -533,7 +533,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_aqara_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_aqara_sensor.lua
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -241,7 +241,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -263,7 +263,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -285,7 +285,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -307,7 +307,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_centralite_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_centralite_sensor.lua
@@ -95,7 +95,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -231,7 +231,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_ewelink_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_ewelink_sensor.lua
@@ -66,7 +66,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -114,7 +114,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_frient_air_quality_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_frient_air_quality_sensor.lua
@@ -85,7 +85,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -104,7 +104,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -123,7 +123,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -221,7 +221,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -262,7 +262,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -298,7 +298,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -328,7 +328,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -345,7 +345,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_frient_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_frient_sensor.lua
@@ -67,7 +67,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -189,7 +189,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -268,7 +268,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_heiman_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_heiman_sensor.lua
@@ -66,7 +66,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -125,7 +125,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_battery_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_battery_sensor.lua
@@ -48,7 +48,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -70,7 +70,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -92,7 +92,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_plaid_systems.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_plaid_systems.lua
@@ -51,7 +51,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -73,7 +73,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -151,7 +151,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -172,7 +172,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -287,7 +287,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature.lua
@@ -48,7 +48,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -100,7 +100,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -137,7 +137,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -171,7 +171,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.relativeHumidityMeasurement.humidity({ value = 79 })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_battery.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_battery.lua
@@ -60,7 +60,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -90,7 +90,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -112,7 +112,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -191,7 +191,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.relativeHumidityMeasurement.humidity({ value = 79 })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_sensor.lua
+++ b/drivers/SmartThings/zigbee-humidity-sensor/src/test/test_humidity_temperature_sensor.lua
@@ -55,7 +55,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -85,7 +85,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor.lua
@@ -46,7 +46,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -106,7 +106,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor_aqara.lua
+++ b/drivers/SmartThings/zigbee-illuminance-sensor/src/test/test_illuminance_sensor_aqara.lua
@@ -59,7 +59,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_coroutine_test(
         MFG_CODE, data_types.Uint16, frequency) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
       detectionFrequency.detectionFrequency(FREQUENCY_DEFAULT_VALUE, { visibility = { displayed = false } })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_bad_battery_reporter.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_bad_battery_reporter.lua
@@ -46,7 +46,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -84,7 +84,7 @@ test.register_message_test(
     },
     {
       test_init = test_init_yrd,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_c2o_lock.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_c2o_lock.lua
@@ -41,7 +41,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.LockState:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -75,7 +75,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -88,7 +88,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.LockState:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -101,7 +101,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -114,7 +114,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -129,7 +129,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.LockState:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.LockState:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -154,7 +154,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id, DoorLock.attributes.NumberOfPINUsersSupported:build_test_attr_report(mock_device, 8)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_generic_fingerprint_profile_update.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_generic_fingerprint_profile_update.lua
@@ -46,7 +46,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, DoorLock.attributes.NumberOfPINUsersSupported:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_legacy.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_legacy.lua
@@ -81,7 +81,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({mock_device.id, Alarm.attributes.AlarmCount:read(mock_device)})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -215,7 +215,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -273,7 +273,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -284,7 +284,7 @@ test.register_coroutine_test(
       expect_reload_all_codes_messages()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -303,7 +303,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -345,7 +345,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -395,7 +395,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "test"}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -453,7 +453,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "foo"}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -471,7 +471,7 @@ test.register_coroutine_test(
       capabilities.lockCodes.lockCodes(json.encode({["1"] = "foo"}), { visibility = { displayed = false } })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -545,7 +545,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -580,7 +580,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -615,7 +615,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -654,7 +654,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -689,7 +689,7 @@ test.register_coroutine_test(
           capabilities.lockCodes.lockCodes(json.encode({}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -746,7 +746,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -777,7 +777,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -843,7 +843,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -862,7 +862,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -881,7 +881,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -909,7 +909,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -939,7 +939,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "Code 1"}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_v10.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_lock_v10.lua
@@ -81,7 +81,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({mock_device.id, Alarm.attributes.AlarmCount:read(mock_device)})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -215,7 +215,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -273,7 +273,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -284,7 +284,7 @@ test.register_coroutine_test(
       expect_reload_all_codes_messages()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -303,7 +303,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -345,7 +345,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -395,7 +395,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "test"}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -453,7 +453,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "foo"}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -471,7 +471,7 @@ test.register_coroutine_test(
       capabilities.lockCodes.lockCodes(json.encode({["1"] = "foo"}), { visibility = { displayed = false } })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -545,7 +545,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -580,7 +580,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -615,7 +615,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -654,7 +654,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -689,7 +689,7 @@ test.register_coroutine_test(
           capabilities.lockCodes.lockCodes(json.encode({}), { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -746,7 +746,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -777,7 +777,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -843,7 +843,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale_fingerprint-lock.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale_fingerprint-lock.lua
@@ -48,7 +48,7 @@ test.register_message_test(
     },
     {
        test_init = test_init,
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale_legacy.lua
+++ b/drivers/SmartThings/zigbee-lock/src/test/test_zigbee_yale_legacy.lua
@@ -47,7 +47,7 @@ test.register_coroutine_test(
       expect_reload_all_codes_messages()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -89,7 +89,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "test"}), { visibility = { displayed = false }})))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -189,7 +189,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["0"] = "test"}), { visibility = { displayed = false }})))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -218,7 +218,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -276,7 +276,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "foo"}), { visibility = { displayed = false }})))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -321,7 +321,7 @@ test.register_coroutine_test(
       capabilities.lockCodes.codeChanged("1 failed", { state_change = true  })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -339,7 +339,7 @@ test.register_coroutine_test(
       capabilities.lockCodes.lockCodes(json.encode({["1"] = "foo"}), { visibility = { displayed = false }})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -382,7 +382,7 @@ test.register_coroutine_test(
           capabilities.lockCodes.codeChanged("1 is not set", { state_change = true })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -412,7 +412,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({["1"] = "initialName"}), { visibility = { displayed = false }})))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -442,7 +442,7 @@ test.register_coroutine_test(
         capabilities.lockCodes.lockCodes(json.encode({}), { visibility = { displayed = false }})))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_all_capabilities_zigbee_motion.lua
@@ -48,7 +48,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -75,7 +75,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -156,7 +156,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -182,7 +182,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -201,7 +201,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -329,7 +329,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -416,7 +416,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -437,7 +437,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -457,7 +457,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_high_precision.lua
@@ -73,7 +73,7 @@ test.register_coroutine_test(
       capabilities.battery.battery(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
       capabilities.motionSensor.motion.inactive()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ test.register_coroutine_test(
     detectionFrequency.detectionFrequency(value, {visibility = {displayed = false}})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -205,7 +205,7 @@ test.register_coroutine_test(
       sensitivityAdjustment.sensitivityAdjustment.High()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_coroutine_test(
       sensitivityAdjustment.sensitivityAdjustment.Medium()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -239,7 +239,7 @@ test.register_coroutine_test(
       sensitivityAdjustment.sensitivityAdjustment.Low()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -277,7 +277,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aqara_motion_illuminance.lua
@@ -88,7 +88,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -111,7 +111,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
       capabilities.motionSensor.motion.inactive()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -158,7 +158,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_coroutine_test(
       capabilities.motionSensor.motion.inactive()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
       detectionFrequency.detectionFrequency(PREF_FREQUENCY_VALUE_DEFAULT, {visibility = {displayed = false}})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aurora_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_aurora_motion.lua
@@ -56,7 +56,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -83,7 +83,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -110,7 +110,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -137,7 +137,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -176,7 +176,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_battery_voltage_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_battery_voltage_motion.lua
@@ -52,7 +52,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_centralite_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_centralite_motion.lua
@@ -71,7 +71,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_compacta_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_compacta_motion.lua
@@ -77,7 +77,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -101,7 +101,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor.lua
@@ -71,7 +71,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -84,7 +84,7 @@ test.register_coroutine_test(
             test.socket.zigbee:__expect_send({ mock_device.id, OccupancySensing.attributes.Occupancy:read(mock_device):to_endpoint(OCCUPANCY_ENDPOINT)})
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -214,7 +214,7 @@ test.register_coroutine_test(
             })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -233,7 +233,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -252,7 +252,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -284,7 +284,7 @@ test.register_coroutine_test(
             })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor2_pet.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor2_pet.lua
@@ -79,7 +79,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -98,7 +98,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 15
         }
 )
 
@@ -147,7 +147,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -201,7 +201,7 @@ test.register_coroutine_test(
             test.socket.zigbee:__expect_send({mock_device.id, IlluminanceMeasurement.attributes.MeasuredValue:read(mock_device):to_endpoint(ILLUMINANCE_ENDPOINT)})
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -359,7 +359,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -402,7 +402,7 @@ test.register_coroutine_test(
             })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor_pro.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_frient_motion_sensor_pro.lua
@@ -82,7 +82,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -101,7 +101,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -121,7 +121,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -141,7 +141,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -168,7 +168,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 15
         }
 )
 
@@ -190,7 +190,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -206,7 +206,7 @@ test.register_coroutine_test(
             test.socket.zigbee:__expect_send({mock_device.id, IlluminanceMeasurement.attributes.MeasuredValue:read(mock_device):to_endpoint(ILLUMINANCE_ENDPOINT)})
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -367,7 +367,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -410,7 +410,7 @@ test.register_coroutine_test(
             })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -430,7 +430,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -450,7 +450,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_gator_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_gator_motion.lua
@@ -46,7 +46,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -65,7 +65,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.presenceSensor.presence.not_present()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -81,7 +81,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.contactSensor.contact.open()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.contactSensor.contact.closed()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -129,7 +129,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(0)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(10)))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -163,7 +163,7 @@ test.register_coroutine_test(
       test.socket.device_lifecycle:__queue_receive({ mock_device.id, "doConfigure" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -182,7 +182,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_ikea_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_ikea_motion.lua
@@ -60,7 +60,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -125,7 +125,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_add_hub_to_group(0xB9F2)
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -211,7 +211,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -237,7 +237,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -265,7 +265,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.motionSensor.motion.inactive()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_samjin_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_samjin_sensor.lua
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_sengled_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_sengled_motion.lua
@@ -46,7 +46,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:configure_reporting(mock_device, 0xFFFF, 0x0000, 0) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -98,7 +98,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartsense_motion_sensor.lua
@@ -69,7 +69,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -103,7 +103,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -152,7 +152,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({ value = -50, unit = "dBm" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -182,7 +182,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.signalStrength.rssi({value = -100, unit = 'dBm'})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartthings_motion.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_smartthings_motion.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_thirdreality_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_thirdreality_sensor.lua
@@ -70,7 +70,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -122,7 +122,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_iris.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_iris.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -143,7 +143,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_nyce.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_nyce.lua
@@ -46,7 +46,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -65,7 +65,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -94,7 +94,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_orvibo.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_motion_orvibo.lua
@@ -46,7 +46,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -65,7 +65,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -84,7 +84,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -103,7 +103,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -130,7 +130,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_plugin_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-motion-sensor/src/test/test_zigbee_plugin_motion_sensor.lua
@@ -49,7 +49,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -115,7 +115,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_frient_power_energy_battery_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_frient_power_energy_battery_consumption_report.lua
@@ -155,7 +155,10 @@ test.register_coroutine_test(
 
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_message_test(
         "Refresh should read all necessary attributes",

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_frient_power_energy_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_frient_power_energy_consumption_report.lua
@@ -140,7 +140,10 @@ test.register_coroutine_test(
 
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_message_test(
         "Refresh should read all necessary attributes",

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_frient_power_energy_current_voltage.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_frient_power_energy_current_voltage.lua
@@ -356,6 +356,9 @@ test.register_coroutine_test(
 
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter.lua
@@ -91,7 +91,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -195,7 +195,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -219,7 +219,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_1p.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_1p.lua
@@ -76,7 +76,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -156,7 +156,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -240,7 +240,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -259,7 +259,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -305,7 +305,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -324,7 +324,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -347,7 +347,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_1p_ZM.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_1p_ZM.lua
@@ -206,6 +206,9 @@ test.register_coroutine_test(
     })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_2p.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_2p.lua
@@ -73,7 +73,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -93,7 +93,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -113,7 +113,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -153,7 +153,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -173,7 +173,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -193,7 +193,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_2p_ZM.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_2p_ZM.lua
@@ -279,6 +279,9 @@ test.register_coroutine_test(
     })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_3p.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_3p.lua
@@ -72,7 +72,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -92,7 +92,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -112,7 +112,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -152,7 +152,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -212,7 +212,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -232,7 +232,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -252,7 +252,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -384,7 +384,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_3p_ZM.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_3p_ZM.lua
@@ -353,6 +353,9 @@ test.register_coroutine_test(
     })
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_consumption_report_sihas.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_consumption_report_sihas.lua
@@ -100,7 +100,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -209,7 +209,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -236,7 +236,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 test.register_coroutine_test(
@@ -254,7 +254,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -277,7 +277,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_ezex.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_ezex.lua
@@ -93,7 +93,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -166,7 +166,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -193,7 +193,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_frient.lua
+++ b/drivers/SmartThings/zigbee-power-meter/src/test/test_zigbee_power_meter_frient.lua
@@ -193,7 +193,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-presence-sensor/src/test/test_aqara_presence_sensor_fp1.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/test/test_aqara_presence_sensor_fp1.lua
@@ -63,7 +63,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -91,7 +91,7 @@ test.register_coroutine_test(
         data_types.Uint8, updates.preferences["stse.sensitivity"]) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
         data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -147,7 +147,7 @@ test.register_coroutine_test(
         data_types.Uint8, updates.preferences["stse.approachDistance"]) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_coroutine_test(
       PresenceSensor.presence("present")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_coroutine_test(
       PresenceSensor.presence("not present")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -206,7 +206,7 @@ test.register_coroutine_test(
       MovementSensor.movement("noMovement")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_coroutine_test(
       MovementSensor.movement("noMovement")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -252,7 +252,7 @@ test.register_coroutine_test(
       MovementSensor.movement("noMovement")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
       MovementSensor.movement("noMovement")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-presence-sensor/src/test/test_st_arrival_sensor_v1.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/test/test_st_arrival_sensor_v1.lua
@@ -98,7 +98,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -129,7 +129,7 @@ test.register_coroutine_test(
       add_device_after_switch_over()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("present")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -160,7 +160,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("present")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -176,7 +176,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("present")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("present")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -207,7 +207,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send( mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("not present")) )
     end,
     {
-      test_init = function()      end,      min_api_version = 17
+      test_init = function()      end,      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-presence-sensor/src/test/test_zigbee_presence_sensor.lua
+++ b/drivers/SmartThings/zigbee-presence-sensor/src/test/test_zigbee_presence_sensor.lua
@@ -79,7 +79,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -98,7 +98,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -152,7 +152,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -199,7 +199,7 @@ test.register_coroutine_test(
       add_device_after_switch_over()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -214,7 +214,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send( mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("not present")) )
     end,
     {
-      test_init = function()      end,      min_api_version = 17
+      test_init = function()      end,      min_api_version = 14
     }
 )
 
@@ -245,7 +245,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_simple_device:generate_test_message("main", capabilities.presenceSensor.presence("not present")) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -280,7 +280,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -313,7 +313,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -334,7 +334,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -349,7 +349,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -397,7 +397,7 @@ test.register_coroutine_test(
       mock_device_str_interval:generate_test_message("main", capabilities.presenceSensor.presence("not present"))
     )
   end,
-  { test_init = function() end, min_api_version = 17
+  { test_init = function() end, min_api_version = 14
   }
 )
 
@@ -413,7 +413,7 @@ test.register_coroutine_test(
       mock_device_nil_interval:generate_test_message("main", capabilities.presenceSensor.presence("not present"))
     )
   end,
-  { test_init = function() end, min_api_version = 17
+  { test_init = function() end, min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-range-extender/src/test/test_frient_zigbee_range_extender.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/test/test_frient_zigbee_range_extender.lua
@@ -52,7 +52,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -115,7 +115,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -134,7 +134,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -153,7 +153,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -191,7 +191,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -229,7 +229,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-range-extender/src/test/test_zigbee_extend.lua
+++ b/drivers/SmartThings/zigbee-range-extender/src/test/test_zigbee_extend.lua
@@ -30,7 +30,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-sensor/src/test/test_zigbee_sensor.lua
+++ b/drivers/SmartThings/zigbee-sensor/src/test/test_zigbee_sensor.lua
@@ -121,7 +121,7 @@ test.register_coroutine_test(
       mock_device_generic_sensor:expect_metadata_update({profile = ZIGBEE_GENERIC_CONTACT_SENSOR_PROFILE})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -133,7 +133,7 @@ test.register_coroutine_test(
       mock_device_generic_sensor:expect_metadata_update({profile = ZIGBEE_GENERIC_MOTION_SENSOR_PROFILE})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
       mock_device_motion_illuminance:expect_metadata_update({profile = ZIGBEE_GENERIC_MOTION_ILLUMINANCE_PROFILE})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
       mock_device_generic_sensor:expect_metadata_update({profile = ZIGBEE_GENERIC_WATERLEAK_SENSOR_PROFILE})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -174,7 +174,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -193,7 +193,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -212,7 +212,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -231,7 +231,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -269,7 +269,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -290,7 +290,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -311,7 +311,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -330,7 +330,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -349,7 +349,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -368,7 +368,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -387,7 +387,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -406,7 +406,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -425,7 +425,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -447,7 +447,7 @@ test.register_message_test(
      }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -466,7 +466,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -485,7 +485,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -504,7 +504,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -523,7 +523,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -542,7 +542,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -561,7 +561,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -674,7 +674,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -694,7 +694,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({ mock_device_motion_sensor.id, ZoneStatusAttribute:read(mock_device_motion_sensor) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -714,7 +714,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({ mock_device_motion_illuminance.id, ZoneStatusAttribute:read(mock_device_motion_illuminance) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -734,7 +734,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({ mock_device_waterleak_sensor.id, ZoneStatusAttribute:read(mock_device_waterleak_sensor) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -808,7 +808,7 @@ test.register_coroutine_test(
       mock_device_contact_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -874,7 +874,7 @@ test.register_coroutine_test(
       mock_device_motion_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -940,7 +940,7 @@ test.register_coroutine_test(
       mock_device_motion_illuminance:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1007,7 +1007,7 @@ test.register_coroutine_test(
       mock_device_waterleak_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-siren/src/test/test_frient_siren.lua
+++ b/drivers/SmartThings/zigbee-siren/src/test/test_frient_siren.lua
@@ -259,7 +259,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -379,7 +379,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -410,7 +410,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -440,7 +440,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -456,7 +456,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -516,7 +516,7 @@ test.register_coroutine_test(
             get_siren_OFF_commands()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -602,7 +602,7 @@ test.register_coroutine_test(
             get_siren_OFF_commands()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -681,7 +681,7 @@ test.register_coroutine_test(
             get_siren_OFF_commands(expectedWarningDuration)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -708,7 +708,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -734,7 +734,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -779,7 +779,7 @@ test.register_coroutine_test(
             get_squawk_command_new_fw(SquawkMode.SOUND_FOR_SYSTEM_IS_DISARMED, IaswdLevel.MEDIUM_LEVEL)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -824,7 +824,7 @@ test.register_coroutine_test(
             get_squawk_command_older_fw(SquawkMode.SOUND_FOR_SYSTEM_IS_DISARMED, IaswdLevel.MEDIUM_LEVEL)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -881,7 +881,7 @@ test.register_coroutine_test(
             get_squawk_command_new_fw(SquawkMode.SOUND_FOR_SYSTEM_IS_DISARMED, IaswdLevel.MEDIUM_LEVEL)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -915,7 +915,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -962,7 +962,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -981,7 +981,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1000,7 +1000,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1019,7 +1019,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1038,7 +1038,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1057,7 +1057,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1103,7 +1103,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1121,7 +1121,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1182,7 +1182,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-siren/src/test/test_frient_siren_tamper.lua
+++ b/drivers/SmartThings/zigbee-siren/src/test/test_frient_siren_tamper.lua
@@ -277,7 +277,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -404,7 +404,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -435,7 +435,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -465,7 +465,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -481,7 +481,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -542,7 +542,7 @@ test.register_coroutine_test(
             get_siren_OFF_commands()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -628,7 +628,7 @@ test.register_coroutine_test(
             get_siren_OFF_commands()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -707,7 +707,7 @@ test.register_coroutine_test(
             get_siren_OFF_commands(expectedWarningDuration)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -733,7 +733,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -759,7 +759,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -804,7 +804,7 @@ test.register_coroutine_test(
             get_squawk_command_new_fw(SquawkMode.SOUND_FOR_SYSTEM_IS_DISARMED, IaswdLevel.MEDIUM_LEVEL)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -849,7 +849,7 @@ test.register_coroutine_test(
             get_squawk_command_older_fw(SquawkMode.SOUND_FOR_SYSTEM_IS_DISARMED, IaswdLevel.MEDIUM_LEVEL)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -906,7 +906,7 @@ test.register_coroutine_test(
             get_squawk_command_new_fw(SquawkMode.SOUND_FOR_SYSTEM_IS_DISARMED, IaswdLevel.MEDIUM_LEVEL)
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -940,7 +940,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -989,7 +989,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1014,7 +1014,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -1039,7 +1039,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -1058,7 +1058,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1077,7 +1077,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1096,7 +1096,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -1134,7 +1134,7 @@ test.register_coroutine_test(
         { test_init = function()
             test.mock_device.add_test_device(mock_device_112)
         end,
-        min_api_version = 17
+        min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-siren/src/test/test_ozom_siren.lua
+++ b/drivers/SmartThings/zigbee-siren/src/test/test_ozom_siren.lua
@@ -62,7 +62,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -99,7 +99,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_gas_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_gas_detector.lua
@@ -65,7 +65,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", lifeTimeReport.lifeTimeState.normal()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -105,7 +105,7 @@ test.register_coroutine_test(
       capabilities.gasDetector.gas.detected()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_coroutine_test(
       capabilities.gasDetector.gas.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
       capabilities.audioMute.mute.muted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
       capabilities.audioMute.mute.unmuted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
       PRIVATE_MUTE_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 1) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_coroutine_test(
       capabilities.audioMute.mute.muted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -206,7 +206,7 @@ test.register_coroutine_test(
       selfCheck.selfCheckState.selfCheckCompleted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -223,7 +223,7 @@ test.register_coroutine_test(
       PRIVATE_SELF_CHECK_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -243,7 +243,7 @@ test.register_coroutine_test(
       lifeTimeReport.lifeTimeState.endOfLife()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -261,7 +261,7 @@ test.register_coroutine_test(
       lifeTimeReport.lifeTimeState.normal()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -279,7 +279,7 @@ test.register_coroutine_test(
       sensitivityAdjustment.sensitivityAdjustment.Low()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -297,7 +297,7 @@ test.register_coroutine_test(
       selfCheck.selfCheckState.idle()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -315,7 +315,7 @@ test.register_coroutine_test(
       sensitivityAdjustment.sensitivityAdjustment.High()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -349,7 +349,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -384,7 +384,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_aqara_smoke_detector.lua
@@ -51,7 +51,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -82,7 +82,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
     capabilities.smokeDetector.smoke.detected()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -118,7 +118,7 @@ test.register_coroutine_test(
       capabilities.audioMute.mute.muted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -132,7 +132,7 @@ test.register_coroutine_test(
       PRIVATE_MUTE_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 1) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -150,7 +150,7 @@ test.register_coroutine_test(
     selfCheck.selfCheckState.selfCheckCompleted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_coroutine_test(
       PRIVATE_SELF_CHECK_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_coroutine_test(
       capabilities.smokeDetector.smoke.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -201,7 +201,7 @@ test.register_coroutine_test(
       capabilities.audioMute.mute.unmuted()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
       selfCheck.selfCheckState.idle()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -238,7 +238,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_heat_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_heat_detector.lua
@@ -76,7 +76,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -198,7 +198,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -217,7 +217,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -236,7 +236,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -255,7 +255,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -276,7 +276,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -303,7 +303,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 15
         }
 )
 
@@ -345,7 +345,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -382,7 +382,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -418,7 +418,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -455,7 +455,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -491,7 +491,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -528,7 +528,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -605,7 +605,7 @@ test.register_coroutine_test(
             end
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -624,7 +624,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -643,7 +643,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_frient_smoke_detector.lua
@@ -83,7 +83,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -205,7 +205,7 @@ test.register_coroutine_test(
             mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -224,7 +224,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -244,7 +244,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -264,7 +264,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -285,7 +285,7 @@ test.register_coroutine_test(
             test.wait_for_events()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -312,7 +312,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 15
         }
 )
 
@@ -391,7 +391,7 @@ test.register_message_test(
         },
         {
             inner_block_ordering = "relaxed",
-            min_api_version = 17
+            min_api_version = 14
         }
 )
 
@@ -428,7 +428,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -464,7 +464,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -501,7 +501,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -537,7 +537,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -574,7 +574,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -651,7 +651,7 @@ test.register_coroutine_test(
         end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -693,7 +693,7 @@ test.register_message_test(
         }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -712,7 +712,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -731,7 +731,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -747,7 +747,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-smoke-detector/src/test/test_zigbee_smoke_detector.lua
+++ b/drivers/SmartThings/zigbee-smoke-detector/src/test/test_zigbee_smoke_detector.lua
@@ -45,7 +45,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -72,7 +72,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -245,7 +245,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -284,7 +284,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-sound-sensor/src/test/test_zigbee_sound_sensor.lua
+++ b/drivers/SmartThings/zigbee-sound-sensor/src/test/test_zigbee_sound_sensor.lua
@@ -123,7 +123,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -191,7 +191,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -318,7 +318,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_all_capability_zigbee_bulb.lua
@@ -103,7 +103,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -188,7 +188,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -216,7 +216,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -236,7 +236,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -593,7 +593,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17,
+       min_api_version = 15,
        max_api_version = 19
     }
 )
@@ -790,7 +790,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -818,7 +818,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -845,7 +845,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -872,7 +872,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to override auto device add on startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -909,7 +909,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device)})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -928,7 +928,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("colorTemperature", "colorTemperature")
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -962,7 +962,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.energyMeter.energy({ value = 14.0, unit = "kWh" })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_led_bulb.lua
@@ -54,7 +54,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorTemperature.colorTemperatureRange({ minimum = 2700, maximum = 6000 })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -109,7 +109,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -204,7 +204,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_light.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorTemperature.colorTemperatureRange({ minimum = 2700, maximum = 6000 })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -211,7 +211,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -226,7 +226,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -241,7 +241,7 @@ test.register_coroutine_test(
         TURN_OFF_INDICATOR_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -254,7 +254,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OnTransitionTime:write(mock_device, 10) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -267,7 +267,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OffTransitionTime:write(mock_device, 10) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -302,7 +302,7 @@ test.register_coroutine_test(
     test_init = function()
       test.mock_device.add_test_device(mock_device_cwacn1)
     end,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug.lua
@@ -78,7 +78,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -156,7 +156,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -187,7 +187,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -201,7 +201,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -223,7 +223,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -258,7 +258,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -273,7 +273,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -288,7 +288,7 @@ test.register_coroutine_test(
         MFG_CODE, data_types.SinglePrecisionFloat, SinglePrecisionFloat(0, 6, 0.5625)) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -317,7 +317,7 @@ test.register_coroutine_test(
       SimpleMetering.attributes.CurrentSummationDelivered:read(mock_standard) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -368,7 +368,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_smart_plug_t1.lua
@@ -79,7 +79,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -121,7 +121,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -140,7 +140,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -174,7 +174,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -224,7 +224,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -259,7 +259,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -274,7 +274,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_coroutine_test(
         MFG_CODE, data_types.SinglePrecisionFloat, SinglePrecisionFloat(0, 6, 0.5625)) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -304,7 +304,7 @@ test.register_coroutine_test(
       RESTORE_TURN_OFF_INDICATOR_LIGHT_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
       SimpleMetering.attributes.CurrentSummationDelivered:read(mock_standard) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -359,7 +359,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -384,7 +384,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -73,7 +73,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -90,7 +90,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -104,7 +104,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -118,7 +118,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -140,7 +140,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -182,7 +182,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
         ELECTRIC_SWITCH_TYPE_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 1) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module_no_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_module_no_power.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive({ mock_device.id, "added" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -62,7 +62,7 @@ test.register_coroutine_test(
       OnOff.attributes.OnOff:read(mock_device) })
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -75,7 +75,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -88,7 +88,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -116,7 +116,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -146,7 +146,7 @@ test.register_coroutine_test(
         ELECTRIC_SWITCH_TYPE_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 1) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_no_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_no_power.lua
@@ -99,7 +99,7 @@ test.register_coroutine_test(
     { visibility = { displayed = false } })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_coroutine_test(
     { visibility = { displayed = false } })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -150,7 +150,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_base_device:generate_test_message("main", capabilities.button.button.pushed({ state_change = false })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -164,7 +164,7 @@ test.register_coroutine_test(
       OnOff.attributes.OnOff:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_child:generate_test_message("main", capabilities.switch.switch.on()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_child:generate_test_message("main", capabilities.switch.switch.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -230,7 +230,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -258,7 +258,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -272,7 +272,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -306,7 +306,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -323,7 +323,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -338,7 +338,7 @@ test.register_coroutine_test(
         CHANGE_TO_WIRELESS_SWITCH_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_switch_power.lua
@@ -86,7 +86,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_child:generate_test_message("main", capabilities.button.button.pushed({ state_change = false })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -121,7 +121,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -138,7 +138,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -189,7 +189,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(POWER_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -217,7 +217,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -231,7 +231,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -245,7 +245,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -262,7 +262,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -279,7 +279,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
       AnalogInput.attributes.PresentValue:read(mock_device):to_endpoint(ENERGY_METER_ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -328,7 +328,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
         RESTORE_POWER_STATE_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, true) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -358,7 +358,7 @@ test.register_coroutine_test(
         CHANGE_TO_WIRELESS_SWITCH_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aqara_wall_switch.lua
@@ -60,7 +60,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("switch", "switch")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -73,7 +73,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("switch", "switch")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("switch", "switch")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -99,7 +99,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("switch", "switch")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -127,7 +127,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -189,7 +189,7 @@ test.register_coroutine_test(
       capabilities.button.button.pushed({ state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_coroutine_test(
         CHANGE_TO_WIRELESS_SWITCH_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_aurora_relay.lua
@@ -42,7 +42,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, SimpleMetering.attributes.InstantaneousDemand:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -69,7 +69,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -96,7 +96,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_bad_data_type.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_bad_data_type.lua
@@ -43,7 +43,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_bad_device_kind.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_bad_device_kind.lua
@@ -33,7 +33,7 @@ test.register_coroutine_test("zwave_device_handled", function()
     test.wait_for_events()
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -45,7 +45,7 @@ test.register_message_test(
         message = { mock_device.id, { capability = "switch", component = "main", command = "on", args = { } } }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_cree_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_cree_bulb.lua
@@ -66,7 +66,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -77,7 +77,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",capabilities.switchLevel.level(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -90,7 +90,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -104,7 +104,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_duragreen_color_temp_bulb.lua
@@ -143,7 +143,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -238,7 +238,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -269,7 +269,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_enbrighten_metering_dimmer.lua
@@ -130,7 +130,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -157,7 +157,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -184,7 +184,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -214,7 +214,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -263,7 +263,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -282,7 +282,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_frient_IO_module.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_frient_IO_module.lua
@@ -522,7 +522,7 @@ test.register_coroutine_test(
 		assert(parent_native, "expected parent device to register native switch handler for input 3")
 	end,
 	{
-	   min_api_version = 17
+	   min_api_version = 14
 	}
 )
 
@@ -556,7 +556,7 @@ test.register_coroutine_test(
 		test.wait_for_events()
 	end,
 	{
-	   min_api_version = 17
+	   min_api_version = 14
 	}
 )
 
@@ -616,7 +616,7 @@ test.register_coroutine_test(
 		test.wait_for_events()
 	end,
 	{
-	   min_api_version = 17
+	   min_api_version = 14
 	}
 )
 
@@ -640,7 +640,7 @@ test.register_coroutine_test(
 		test.wait_for_events()
 	end,
 	{
-	   min_api_version = 17
+	   min_api_version = 14
 	}
 )
 
@@ -691,7 +691,7 @@ test.register_coroutine_test(
 		test.wait_for_events()
 	end,
 	{
-	   min_api_version = 17
+	   min_api_version = 14
 	}
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_frient_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_frient_switch.lua
@@ -81,7 +81,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test("Current divisor, multiplier, summation should be han
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -153,7 +153,7 @@ test.register_coroutine_test("Refresh command should read all necessary attribut
     )
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -180,7 +180,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -207,7 +207,7 @@ test.register_message_test(
       },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -239,7 +239,7 @@ test.register_message_test(
         }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -264,7 +264,7 @@ test.register_message_test(
         }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -277,7 +277,7 @@ test.register_coroutine_test(
             test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.powerSource.powerSource.mains()))
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -341,7 +341,7 @@ test.register_coroutine_test("doConfigure should send bind request, read attribu
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -357,7 +357,7 @@ test.register_coroutine_test(
             test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.powerSource.powerSource.unknown()))
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_ge_link_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_ge_link_bulb.lua
@@ -47,7 +47,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -64,7 +64,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OnOffTransitionTime:write(mock_device, 50) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -79,7 +79,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed(updates))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -112,7 +112,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OnOffTransitionTime:write(mock_device, 0) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -189,7 +189,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.OnOffTransitionTime:write(mock_device, 50) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_hanssem_switch.lua
@@ -128,7 +128,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -161,7 +161,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -194,7 +194,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -227,7 +227,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -260,7 +260,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -293,7 +293,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -326,7 +326,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -359,7 +359,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -392,7 +392,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -425,7 +425,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -458,7 +458,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -491,7 +491,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -523,7 +523,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -550,7 +550,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -577,7 +577,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -604,7 +604,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -631,7 +631,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -658,7 +658,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -685,7 +685,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -712,7 +712,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -739,7 +739,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -766,7 +766,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -793,7 +793,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -820,7 +820,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -870,7 +870,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm30_sn.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm30_sn.lua
@@ -105,7 +105,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -168,7 +168,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -321,7 +321,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -359,7 +359,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -382,7 +382,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -405,7 +405,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -427,7 +427,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -448,7 +448,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -497,7 +497,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -556,7 +556,7 @@ test.register_coroutine_test(
     mock_inovelli_vzm30_sn:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm30_sn_child.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm30_sn_child.lua
@@ -91,7 +91,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -146,7 +146,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -180,7 +180,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -239,7 +239,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -302,7 +302,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -365,7 +365,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm30_sn_preferences.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm30_sn_preferences.lua
@@ -63,7 +63,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -88,7 +88,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -112,7 +112,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -160,7 +160,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -184,7 +184,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -227,7 +227,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_inovelli_vzm30_sn:generate_info_changed({preferences = {notificationChild = true}}))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn.lua
@@ -73,7 +73,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -121,7 +121,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -218,7 +218,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -288,7 +288,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -310,7 +310,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -332,7 +332,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -381,7 +381,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -433,7 +433,7 @@ test.register_coroutine_test(
     mock_inovelli_vzm31_sn:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_child.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_child.lua
@@ -80,7 +80,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -135,7 +135,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -228,7 +228,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -354,7 +354,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_preferences.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm31_sn_preferences.lua
@@ -52,7 +52,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -77,7 +77,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -101,7 +101,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -125,7 +125,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_inovelli_vzm31_sn:generate_info_changed({preferences = {notificationChild = true}}))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn.lua
@@ -84,7 +84,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -166,7 +166,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -193,7 +193,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -263,7 +263,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -295,7 +295,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -356,7 +356,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -379,7 +379,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -402,7 +402,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -425,7 +425,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -445,7 +445,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -494,7 +494,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -549,7 +549,7 @@ test.register_coroutine_test(
     mock_inovelli_vzm32_sn:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_child.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_child.lua
@@ -80,7 +80,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -135,7 +135,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -228,7 +228,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -354,7 +354,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_preferences.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_inovelli_vzm32_sn_preferences.lua
@@ -52,7 +52,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -77,7 +77,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -101,7 +101,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -125,7 +125,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_inovelli_vzm32_sn:generate_info_changed({preferences = {notificationChild = true}}))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -174,7 +174,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_jasco_switch.lua
@@ -56,7 +56,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -83,7 +83,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_laisiao_bath_heather.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_laisiao_bath_heather.lua
@@ -50,7 +50,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -70,7 +70,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -90,7 +90,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -110,7 +110,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -130,7 +130,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -150,7 +150,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -190,7 +190,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -212,7 +212,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -232,7 +232,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -252,7 +252,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -272,7 +272,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -292,7 +292,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -312,7 +312,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -332,7 +332,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -352,7 +352,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -365,7 +365,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -378,7 +378,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x03) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -391,7 +391,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x04) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -404,7 +404,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x05) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -417,7 +417,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x06) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -430,7 +430,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x07) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -443,7 +443,7 @@ test.register_coroutine_test(
       OnOff.server.commands.On(mock_device):to_endpoint(0x08) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -456,7 +456,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -469,7 +469,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x02) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -482,7 +482,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x03) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -495,7 +495,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x04) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -508,7 +508,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x05) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x06) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -534,7 +534,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x07) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -547,7 +547,7 @@ test.register_coroutine_test(
       OnOff.server.commands.Off(mock_device):to_endpoint(0x08) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -567,7 +567,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_ledvance_metering_plug.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_ledvance_metering_plug.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
     assert(mock_device:get_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY) == 100)
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -70,7 +70,7 @@ test.register_coroutine_test(
     assert(mock_device:get_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY) == 1000)
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -85,7 +85,7 @@ test.register_coroutine_test(
     assert(mock_device_eu_em_t:get_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY) == 100)
   end,
   {
-    min_api_version = 17
+    min_api_version = 15
   }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
     assert(mock_device_eu_em_t:get_field(zigbee_constants.SIMPLE_METERING_DIVISOR_KEY) == 1000)
   end,
   {
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch.lua
@@ -39,7 +39,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -59,7 +59,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_message_test(
@@ -78,7 +78,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -98,7 +98,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_no_master.lua
@@ -105,7 +105,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -171,7 +171,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -237,7 +237,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -270,7 +270,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -297,7 +297,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -324,7 +324,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -351,7 +351,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -378,7 +378,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -405,7 +405,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -432,7 +432,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -511,7 +511,7 @@ test.register_coroutine_test(
     mock_base_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -553,7 +553,7 @@ test.register_coroutine_test(
     test_init = function()
       test.mock_device.add_test_device(mock_non_mns_device)
     end,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_multi_switch_power.lua
@@ -117,7 +117,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to avoid auto device add and immediate init event on driver startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
       test_init = function()
         -- no op to avoid auto device add and immediate init event on driver startup
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -203,7 +203,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -231,7 +231,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -259,7 +259,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -287,7 +287,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -315,7 +315,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -345,7 +345,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -375,7 +375,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -402,7 +402,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -429,7 +429,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -456,7 +456,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -483,7 +483,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -509,7 +509,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -528,7 +528,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_on_off_zigbee_bulb.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -75,7 +75,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -103,7 +103,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -175,7 +175,7 @@ test.register_coroutine_test(
       mock_simple_device:expect_metadata_update({provisioning_state = "PROVISIONED"})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_osram_iqbr30_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_osram_iqbr30_light.lua
@@ -65,7 +65,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",capabilities.switchLevel.level(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "RELAXED",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_osram_light.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_osram_light.lua
@@ -65,7 +65,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",capabilities.switchLevel.level(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgb_bulb.lua
@@ -67,7 +67,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -114,7 +114,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -168,7 +168,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -200,7 +200,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_rgbw_bulb.lua
@@ -165,7 +165,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -221,7 +221,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -304,7 +304,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -330,7 +330,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -346,7 +346,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_2-wire_dimmer.lua
@@ -56,7 +56,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -83,7 +83,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -111,7 +111,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -152,7 +152,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_robb_smarrt_knob_dimmer.lua
@@ -56,7 +56,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -83,7 +83,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -111,7 +111,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sengled_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sengled_color_temp_bulb.lua
@@ -143,7 +143,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -238,7 +238,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -269,7 +269,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sengled_dimmer_bulb_with_motion_sensor.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sengled_dimmer_bulb_with_motion_sensor.lua
@@ -69,7 +69,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -83,7 +83,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -163,7 +163,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, IASZone.attributes.ZoneStatus:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -217,7 +217,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sinope_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sinope_dimmer.lua
@@ -73,7 +73,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -109,7 +109,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -148,7 +148,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -184,7 +184,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -214,7 +214,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -240,7 +240,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -280,7 +280,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -316,7 +316,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -360,7 +360,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_sinope_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_sinope_switch.lua
@@ -57,7 +57,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -84,7 +84,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -111,7 +111,7 @@ test.register_coroutine_test(
 
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_switch_power.lua
@@ -125,7 +125,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -180,7 +180,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -242,7 +242,7 @@ test.register_coroutine_test(
     mock_aurora_relay_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -312,7 +312,7 @@ test.register_coroutine_test(
     mock_vimar_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi.lua
@@ -78,7 +78,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_tuya_multi_switch.lua
@@ -39,7 +39,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -59,7 +59,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_message_test(
@@ -78,7 +78,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -98,7 +98,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_wallhero_switch.lua
@@ -182,7 +182,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -215,7 +215,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -281,7 +281,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -314,7 +314,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -347,7 +347,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -380,7 +380,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -413,7 +413,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -428,7 +428,7 @@ test.register_coroutine_test(
         0x6000, 0x1235, data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -443,7 +443,7 @@ test.register_coroutine_test(
         0x6000, 0x1235, data_types.Uint8, 0x00) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -475,7 +475,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -502,7 +502,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -529,7 +529,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -556,7 +556,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -584,7 +584,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -611,7 +611,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -638,7 +638,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -665,7 +665,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -682,7 +682,7 @@ test.register_coroutine_test(
                                             )))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -698,7 +698,7 @@ test.register_coroutine_test(
                                             )))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -714,7 +714,7 @@ test.register_coroutine_test(
                                             )))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -730,7 +730,7 @@ test.register_coroutine_test(
                                             )))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -794,7 +794,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -808,7 +808,7 @@ test.register_coroutine_test(
         capabilities.button.supportedButtonValues({ "pushed" }, { visibility = { displayed = false } })))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_white_color_temp_bulb.lua
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -239,7 +239,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -270,7 +270,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_yanmi_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_yanmi_switch.lua
@@ -101,7 +101,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -134,7 +134,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -167,7 +167,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -201,7 +201,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -300,7 +300,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -327,7 +327,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -354,7 +354,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -384,7 +384,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -411,7 +411,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -438,7 +438,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_ezex_switch.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -100,7 +100,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -146,7 +146,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_power_consumption_report.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_power_consumption_report.lua
@@ -66,7 +66,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -85,7 +85,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -153,7 +153,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_rexense.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zigbee_metering_plug_rexense.lua
@@ -49,7 +49,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -73,7 +73,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_color_temp_bulb.lua
@@ -66,7 +66,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -115,7 +115,7 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(30, "interval", "polling")
       end,
-      min_api_version = 17,
+      min_api_version = 14,
       max_api_version = 19
     }
 )
@@ -156,7 +156,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -197,7 +197,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -238,7 +238,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -281,7 +281,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.ColorTemperatureMireds:read(mock_device) })
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer.lua
@@ -67,7 +67,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -78,7 +78,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main",capabilities.switchLevel.level(100)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -91,7 +91,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(5*60, "interval", "polling")
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -171,7 +171,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_dimmer_bulb.lua
@@ -67,7 +67,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -80,7 +80,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -93,7 +93,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(30, "interval", "polling")
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -178,7 +178,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, Level.attributes.CurrentLevel:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgb_bulb.lua
@@ -85,7 +85,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(30, "interval", "polling")
       end,
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -162,7 +162,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -185,7 +185,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -286,7 +286,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-      min_api_version = 17
+      min_api_version = 14
   }
 )
 
@@ -365,7 +365,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-      min_api_version = 17
+      min_api_version = 14
   }
 )
 
@@ -406,7 +406,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -447,7 +447,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -474,7 +474,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentY:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -489,7 +489,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorControl.saturation(65)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -504,7 +504,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorControl.saturation(65)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -519,7 +519,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorControl.saturation(65)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -534,7 +534,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.colorControl.saturation(65)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
+++ b/drivers/SmartThings/zigbee-switch/src/test/test_zll_rgbw_bulb.lua
@@ -195,7 +195,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
   end,
   {
-    min_api_version = 17,
+    min_api_version = 14,
     max_api_version = 19
   }
 )
@@ -248,7 +248,7 @@ test.register_coroutine_test(
         test.mock_device.add_test_device(mock_device)
         test.timer.__create_and_queue_test_time_advance_timer(5*60, "interval", "polling")
       end,
-      min_api_version = 17,
+      min_api_version = 14,
       max_api_version = 19
     }
 )
@@ -301,7 +301,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -354,7 +354,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -407,7 +407,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -462,7 +462,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17,
+     min_api_version = 14,
      max_api_version = 19
   }
 )
@@ -491,7 +491,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentHue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -519,7 +519,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -549,7 +549,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, ColorControl.attributes.CurrentSaturation:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_aqara_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_aqara_thermostat.lua
@@ -77,7 +77,7 @@ test.register_coroutine_test(
       PRIVATE_THERM0STAT_VALVE_DETECTION_SWITCH_ID, MFG_CODE, data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -92,7 +92,7 @@ test.register_coroutine_test(
       PRIVATE_ANTIFREEZE_MODE_TEMPERATURE_SETTING_ID, MFG_CODE, data_types.Uint32, 500) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
     capabilities.hardwareFault.hardwareFault.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -158,7 +158,7 @@ test.register_coroutine_test(
       valveCalibration.calibrationState.calibrationFailure()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_coroutine_test(
       invisibleCapabilities.invisibleCapabilities({"thermostatHeatingSetpoint"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -258,7 +258,7 @@ test.register_coroutine_test(
       invisibleCapabilities.invisibleCapabilities({"thermostatHeatingSetpoint"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -286,7 +286,7 @@ test.register_coroutine_test(
       capabilities.lock.lock.locked()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -305,7 +305,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -366,7 +366,7 @@ test.register_coroutine_test(
       PRIVATE_VALVE_SWITCH_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -380,7 +380,7 @@ test.register_coroutine_test(
       PRIVATE_VALVE_CALIBRATION_ID, MFG_CODE, data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -395,7 +395,7 @@ test.register_coroutine_test(
       PRIVATE_CHILD_LOCK_ID, MFG_CODE, data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 --]]
@@ -470,7 +470,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_centralite_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_centralite_thermostat.lua
@@ -48,7 +48,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -88,7 +88,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -150,7 +150,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_danfoss_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_danfoss_thermostat.lua
@@ -44,7 +44,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -55,7 +55,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device_danfoss:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.0, unit = "C"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -66,7 +66,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device_danfoss:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpoint({ value = 21.0, unit = "C"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device_danfoss.id, Thermostat.attributes.OccupiedCoolingSetpoint:build_test_attr_report(mock_device_danfoss, 2100) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -121,7 +121,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_fidure_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_fidure_thermostat.lua
@@ -63,7 +63,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_leviton_rc.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_leviton_rc.lua
@@ -53,7 +53,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -70,7 +70,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.LocalTemperature:read(mock_device):to_endpoint(ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -81,7 +81,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({value = 21.0, unit = "C"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -92,7 +92,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatFanMode.thermostatFanMode.auto()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -130,7 +130,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatCoolingSetpoint.coolingSetpoint({value = 21.0, unit = "C"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatHeatingSetpoint.heatingSetpoint({value = 21.0, unit = "C"})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id, Thermostat.attributes.OccupiedHeatingSetpoint:build_test_attr_report(mock_device, 2100) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__queue_receive({ mock_device.id, Thermostat.attributes.OccupiedCoolingSetpoint:build_test_attr_report(mock_device, 2100) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -185,7 +185,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 2100):to_endpoint(ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.OccupiedCoolingSetpoint:write(mock_device, 2100):to_endpoint(ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.SystemMode:write(mock_device, 3):to_endpoint(ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send( { mock_device.id, FanControl.attributes.FanMode:write(mock_device, 5):to_endpoint(ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -253,7 +253,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send( { mock_device.id, Thermostat.attributes.LocalTemperature:read(mock_device):to_endpoint(ENDPOINT) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_popp_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_popp_thermostat.lua
@@ -69,7 +69,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -122,7 +122,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -168,7 +168,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -254,7 +254,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -319,7 +319,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -356,7 +356,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -393,7 +393,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -410,7 +410,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.thermostatMode.thermostatMode.eco()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -462,7 +462,7 @@ test.register_coroutine_test(
       )})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -479,7 +479,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureAlarm.temperatureAlarm.cleared()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -496,7 +496,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_resideo_dt300st_m000.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_resideo_dt300st_m000.lua
@@ -102,7 +102,7 @@ test.register_coroutine_test("Configure should configure all necessary attribute
   })
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -125,7 +125,7 @@ test.register_coroutine_test("Refresh should read all necessary attributes", fun
   end
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test("Temperature reporting should create the appropriat
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -156,7 +156,7 @@ test.register_coroutine_test("Thermostat mode reporting should create the approp
     .thermostatMode.heat()))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -172,7 +172,7 @@ test.register_coroutine_test("ControlSequenceOfOperation reporting should create
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -187,7 +187,7 @@ test.register_coroutine_test("OccupiedHeatingSetpoint reporting shoulb create th
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -202,7 +202,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
                                     Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_device, 2100)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -218,7 +218,7 @@ test.register_coroutine_test("Setting the thermostat mode to away should generat
     Thermostat.attributes.SystemMode.OFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -234,7 +234,7 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -257,7 +257,7 @@ test.register_coroutine_test("Refresh should read all necessary attributes with 
   end
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -271,7 +271,7 @@ test.register_coroutine_test("Temperature reporting should create the appropriat
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -288,7 +288,7 @@ test.register_coroutine_test("Thermostat mode reporting should create the approp
     .thermostatMode.heat()))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -304,7 +304,7 @@ test.register_coroutine_test("ControlSequenceOfOperation reporting should create
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -319,7 +319,7 @@ test.register_coroutine_test("OccupiedHeatingSetpoint reporting shoulb create th
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -334,7 +334,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
                                     Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_first_child, 2100)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -350,7 +350,7 @@ test.register_coroutine_test("Setting the thermostat mode to away should generat
     Thermostat.attributes.SystemMode.OFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -366,7 +366,7 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -389,7 +389,7 @@ test.register_coroutine_test("Refresh should read all necessary attributes with 
   end
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -403,7 +403,7 @@ test.register_coroutine_test("Temperature reporting should create the appropriat
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -420,7 +420,7 @@ test.register_coroutine_test("Thermostat mode reporting should create the approp
     .thermostatMode.heat()))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -436,7 +436,7 @@ test.register_coroutine_test("ControlSequenceOfOperation reporting should create
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -451,7 +451,7 @@ test.register_coroutine_test("OccupiedHeatingSetpoint reporting shoulb create th
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -466,7 +466,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
                                     Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_second_child, 2100)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -482,7 +482,7 @@ test.register_coroutine_test("Setting the thermostat mode to away should generat
     Thermostat.attributes.SystemMode.OFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -498,7 +498,7 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test("Refresh should read all necessary attributes with 
   end
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -535,7 +535,7 @@ test.register_coroutine_test("Temperature reporting should create the appropriat
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -552,7 +552,7 @@ test.register_coroutine_test("Thermostat mode reporting should create the approp
     .thermostatMode.heat()))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -568,7 +568,7 @@ test.register_coroutine_test("ControlSequenceOfOperation reporting should create
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -583,7 +583,7 @@ test.register_coroutine_test("OccupiedHeatingSetpoint reporting shoulb create th
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -598,7 +598,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
                                     Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_third_child, 2100)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -614,7 +614,7 @@ test.register_coroutine_test("Setting the thermostat mode to away should generat
     Thermostat.attributes.SystemMode.OFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -630,7 +630,7 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -653,7 +653,7 @@ test.register_coroutine_test("Refresh should read all necessary attributes with 
   end
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -667,7 +667,7 @@ test.register_coroutine_test("Temperature reporting should create the appropriat
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -684,7 +684,7 @@ test.register_coroutine_test("Thermostat mode reporting should create the approp
     .thermostatMode.heat()))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -700,7 +700,7 @@ test.register_coroutine_test("ControlSequenceOfOperation reporting should create
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -715,7 +715,7 @@ test.register_coroutine_test("OccupiedHeatingSetpoint reporting shoulb create th
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -730,7 +730,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
                                     Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_forth_child, 2100)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -746,7 +746,7 @@ test.register_coroutine_test("Setting the thermostat mode to away should generat
     Thermostat.attributes.SystemMode.OFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -762,7 +762,7 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -785,7 +785,7 @@ test.register_coroutine_test("Refresh should read all necessary attributes with 
   end
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -799,7 +799,7 @@ test.register_coroutine_test("Temperature reporting should create the appropriat
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -816,7 +816,7 @@ test.register_coroutine_test("Thermostat mode reporting should create the approp
     .thermostatMode.heat()))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -832,7 +832,7 @@ test.register_coroutine_test("ControlSequenceOfOperation reporting should create
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -847,7 +847,7 @@ test.register_coroutine_test("OccupiedHeatingSetpoint reporting shoulb create th
     })))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -862,7 +862,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
                                     Thermostat.attributes.OccupiedHeatingSetpoint:write(mock_fifth_child, 2100)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -878,7 +878,7 @@ test.register_coroutine_test("Setting the thermostat mode to away should generat
     Thermostat.attributes.SystemMode.OFF)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -894,7 +894,7 @@ test.register_coroutine_test("Setting the thermostat mode to heat should generat
     Thermostat.attributes.SystemMode.HEAT)})
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -913,7 +913,7 @@ test.register_coroutine_test("ThermostatRunningState reporting shoulb create the
     capabilities.thermostatOperatingState.thermostatOperatingState({value="fan only"})))
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_sinope_th1300_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_sinope_th1300_thermostat.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -66,7 +66,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -198,7 +198,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_sinope_th1400_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_sinope_th1400_thermostat.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -66,7 +66,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_sinope_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_sinope_thermostat.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -66,7 +66,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -182,7 +182,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -212,7 +212,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_ki_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_ki_zigbee_thermostat.lua
@@ -59,7 +59,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -150,7 +150,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -242,7 +242,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", ThermostatOperatingState.thermostatOperatingState("idle")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -265,7 +265,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", ThermostatMode.thermostatMode.heat()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -298,7 +298,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -331,7 +331,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -423,7 +423,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -508,7 +508,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -531,7 +531,7 @@ test.register_coroutine_test("Setting the heating setpoint should generate the a
     })
 end,
 {
-   min_api_version = 17
+   min_api_version = 14
 }
 )
 
@@ -563,7 +563,7 @@ test.register_coroutine_test(
       })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_coroutine_test(
@@ -588,7 +588,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -615,7 +615,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_stelpro_thermostat.lua
@@ -51,7 +51,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -75,7 +75,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -133,7 +133,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -190,7 +190,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -213,7 +213,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -237,7 +237,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -256,7 +256,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -275,7 +275,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -313,7 +313,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -355,7 +355,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__set_channel_ordering("relaxed")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -400,7 +400,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -440,7 +440,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__set_channel_ordering("relaxed")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -485,7 +485,7 @@ test.register_coroutine_test(
       mock_device_maestro:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -500,7 +500,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_device:generate_info_changed({preferences = { lock = 1 } }))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -513,7 +513,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -551,7 +551,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_vimar_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_vimar_thermostat.lua
@@ -87,7 +87,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -149,7 +149,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -227,7 +227,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -269,7 +269,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -311,7 +311,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -375,7 +375,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -415,7 +415,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -454,7 +454,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -496,7 +496,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -538,7 +538,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -602,7 +602,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -637,7 +637,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -671,7 +671,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -730,7 +730,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -790,7 +790,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -820,7 +820,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -850,7 +850,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zenwithin_thermostat.lua
@@ -49,7 +49,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -69,7 +69,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_message_test(
@@ -88,7 +88,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -149,7 +149,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -211,7 +211,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -291,7 +291,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -426,7 +426,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -461,7 +461,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -476,7 +476,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -519,7 +519,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -534,7 +534,7 @@ test.register_coroutine_test(
       assert(mock_device:get_field("minHeatSetpoint") == 500, "minHeatSetpoint field not stored correctly")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -549,7 +549,7 @@ test.register_coroutine_test(
       assert(mock_device:get_field("maxHeatSetpoint") == 3500, "maxHeatSetpoint field not stored correctly")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -564,7 +564,7 @@ test.register_coroutine_test(
       assert(mock_device:get_field("minCoolSetpoint") == 1600, "minCoolSetpoint field not stored correctly")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -579,7 +579,7 @@ test.register_coroutine_test(
       assert(mock_device:get_field("maxCoolSetpoint") == 3200, "maxCoolSetpoint field not stored correctly")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -617,7 +617,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -655,7 +655,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -691,7 +691,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -727,7 +727,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -884,7 +884,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat.lua
@@ -38,7 +38,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -58,7 +58,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -85,7 +85,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -124,7 +124,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -168,7 +168,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -188,7 +188,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -219,7 +219,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -300,7 +300,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -320,7 +320,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -361,7 +361,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -381,7 +381,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -412,7 +412,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -443,7 +443,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -474,7 +474,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -505,7 +505,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -535,7 +535,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -566,7 +566,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -597,7 +597,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -643,7 +643,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -785,7 +785,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -911,7 +911,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -931,7 +931,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat_wallhero_3in1.lua
+++ b/drivers/SmartThings/zigbee-thermostat/src/test/test_zigbee_thermostat_wallhero_3in1.lua
@@ -212,7 +212,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -233,7 +233,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -273,7 +273,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -293,7 +293,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -313,7 +313,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -333,7 +333,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -353,7 +353,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -373,7 +373,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -393,7 +393,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -413,7 +413,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -433,7 +433,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -453,7 +453,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -473,7 +473,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -493,7 +493,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -513,7 +513,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -533,7 +533,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -553,7 +553,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -573,7 +573,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -593,7 +593,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -613,7 +613,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -633,7 +633,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -652,7 +652,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -671,7 +671,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -690,7 +690,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -709,7 +709,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -728,7 +728,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -747,7 +747,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -766,7 +766,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -785,7 +785,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -804,7 +804,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -823,7 +823,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -842,7 +842,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -861,7 +861,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -880,7 +880,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -899,7 +899,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -918,7 +918,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -937,7 +937,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -956,7 +956,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -975,7 +975,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -994,7 +994,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1013,7 +1013,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1233,7 +1233,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-valve/src/test/test_ezex_valve.lua
+++ b/drivers/SmartThings/zigbee-valve/src/test/test_ezex_valve.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -87,7 +87,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -106,7 +106,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -146,7 +146,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -166,7 +166,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -186,7 +186,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -224,7 +224,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -272,7 +272,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -314,7 +314,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -353,7 +353,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-valve/src/test/test_sinope_valve.lua
+++ b/drivers/SmartThings/zigbee-valve/src/test/test_sinope_valve.lua
@@ -49,7 +49,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.battery.battery(20)) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.battery.battery(0)) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -153,7 +153,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send( mock_device:generate_test_message("main", capabilities.battery.battery(100)) )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-valve/src/test/test_zigbee_valve.lua
+++ b/drivers/SmartThings/zigbee-valve/src/test/test_zigbee_valve.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -87,7 +87,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -147,7 +147,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -167,7 +167,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -186,7 +186,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -254,7 +254,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -296,7 +296,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -335,7 +335,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-vent/src/test/test_zigbee_vent.lua
+++ b/drivers/SmartThings/zigbee-vent/src/test/test_zigbee_vent.lua
@@ -61,7 +61,7 @@ test.register_message_test(
           }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
           }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -101,7 +101,7 @@ test.register_message_test(
           }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -119,7 +119,7 @@ test.register_coroutine_test(
           test.socket.zigbee:__expect_send({mock_device.id, Level.attributes.CurrentLevel:read(mock_device)})
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
           }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -162,7 +162,7 @@ test.register_message_test(
           }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -241,7 +241,7 @@ test.register_message_test(
         },
         {
           inner_block_ordering = "relaxed",
-          min_api_version = 17
+          min_api_version = 14
         }
 )
 
@@ -299,7 +299,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -320,7 +320,7 @@ test.register_coroutine_test(
           test.socket.zigbee:__expect_send({mock_device.id, Level.commands.MoveToLevelWithOnOff(mock_device, math.floor(83 / 100 * 254), 0xFFFF)})
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
           test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.battery.battery(50)))
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -345,7 +345,7 @@ test.register_coroutine_test(
           test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.atmosphericPressureMeasurement.atmosphericPressure({value = 1, unit = "kPa"})))
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_aqara_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_aqara_water_leak_sensor.lua
@@ -53,7 +53,7 @@ test.register_coroutine_test(
         data_types.Uint8, 1) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -80,7 +80,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_centralite_water_leak_sensor.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -110,7 +110,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -240,7 +240,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -272,7 +272,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_frient_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_frient_water_leak_sensor.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -116,7 +116,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -135,7 +135,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -154,7 +154,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -246,7 +246,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -278,7 +278,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_leaksmart_water.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_leaksmart_water.lua
@@ -42,7 +42,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.waterSensor.water.wet()))
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 
@@ -54,7 +54,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.waterSensor.water.dry()))
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 
@@ -66,7 +66,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.waterSensor.water.dry()))
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 
@@ -78,7 +78,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.waterSensor.water.dry()))
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 
@@ -90,7 +90,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.waterSensor.water.dry()))
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 
@@ -103,7 +103,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_samjin_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_samjin_water_leak_sensor.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -110,7 +110,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -175,7 +175,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_sengled_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_sengled_water_leak_sensor.lua
@@ -45,7 +45,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryVoltage:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_sinope_zigbee_water.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_sinope_zigbee_water.lua
@@ -48,7 +48,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -67,7 +67,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -86,7 +86,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -124,7 +124,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -151,7 +151,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -313,7 +313,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -376,7 +376,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_smartthings_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_smartthings_water_leak_sensor.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, TemperatureMeasurement.attributes.MeasuredValue:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -110,7 +110,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -143,7 +143,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_thirdreality_water_leak_sensor.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_thirdreality_water_leak_sensor.lua
@@ -43,7 +43,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, Basic.attributes.ApplicationVersion:read(mock_device)})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, PowerConfiguration.attributes.BatteryPercentageRemaining:read(mock_device) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -81,7 +81,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -106,7 +106,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -156,7 +156,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water.lua
@@ -46,7 +46,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -73,7 +73,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -100,7 +100,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -154,7 +154,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -184,7 +184,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -346,7 +346,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -409,7 +409,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water_freeze.lua
+++ b/drivers/SmartThings/zigbee-water-leak-sensor/src/test/test_zigbee_water_freeze.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -226,7 +226,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -289,7 +289,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-watering-kit/src/test/test_thirdreality_watering_kit.lua
+++ b/drivers/SmartThings/zigbee-watering-kit/src/test/test_thirdreality_watering_kit.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.mode.mode("0")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -67,7 +67,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -86,7 +86,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -124,7 +124,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -143,7 +143,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -162,7 +162,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -181,7 +181,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -198,7 +198,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.fanSpeed.fanSpeed(10)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -215,7 +215,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.fanSpeed.fanSpeed(30)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -232,7 +232,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.mode.mode("4")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_coroutine_test(
     THIRDREALITY_WATERING_CLUSTER, WATERING_TIME_ATTR, 0x1407, data_types.Uint16, 20) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -256,7 +256,7 @@ test.register_coroutine_test(
     THIRDREALITY_WATERING_CLUSTER, WATERING_INTERVAL_ATTR, 0x1407, data_types.Uint8, 2) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -311,7 +311,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.fanSpeed.fanSpeed(0)))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_battery_ikea.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_battery_ikea.lua
@@ -56,7 +56,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -78,7 +78,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -100,7 +100,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -133,7 +133,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -186,7 +186,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -213,7 +213,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -232,7 +232,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -273,7 +273,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -312,7 +312,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -351,7 +351,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_only_HOPOsmart.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_shade_only_HOPOsmart.lua
@@ -45,7 +45,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, read_0x0000_messge})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -69,7 +69,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_coroutine_test(
       capabilities.windowShade.windowShade.open()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -154,7 +154,7 @@ test.register_coroutine_test(
       capabilities.windowShade.windowShade.opening()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_coroutine_test(
       capabilities.windowShade.windowShade.closed()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_coroutine_test(
       capabilities.windowShade.windowShade.closing()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
       capabilities.windowShade.windowShade.partially_open()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -108,7 +108,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -181,7 +181,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -209,7 +209,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -272,7 +272,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -298,7 +298,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -367,7 +367,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -401,7 +401,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -456,7 +456,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -491,7 +491,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -526,7 +526,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -556,7 +556,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -588,7 +588,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_VWSDSTUST120H.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_VWSDSTUST120H.lua
@@ -51,7 +51,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, read_0x0001_messge})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -70,7 +70,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({mock_device.id, read_0x0001_messge})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -94,7 +94,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -121,7 +121,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -143,7 +143,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -160,7 +160,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -194,7 +194,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -211,7 +211,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_coroutine_test(
       capabilities.mode.mode("Delete upper limit")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_coroutine_test(
       capabilities.mode.mode("Set the upper limit")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -265,7 +265,7 @@ test.register_coroutine_test(
       capabilities.mode.mode("Delete lower limit")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -283,7 +283,7 @@ test.register_coroutine_test(
       capabilities.mode.mode("Set the lower limit")))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
       capabilities.hardwareFault.hardwareFault.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -319,7 +319,7 @@ test.register_coroutine_test(
       capabilities.hardwareFault.hardwareFault.detected()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -340,7 +340,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -361,7 +361,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara.lua
@@ -143,7 +143,7 @@ test.register_coroutine_test(
         PREF_SOFT_TOUCH_ON) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -178,7 +178,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -200,7 +200,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -263,7 +263,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -282,7 +282,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -348,7 +348,7 @@ test.register_coroutine_test(
       deviceInitialization.initializedState.initialized()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -380,7 +380,7 @@ test.register_coroutine_test(
         PREF_SOFT_TOUCH_OFF) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -404,7 +404,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -434,7 +434,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -464,7 +464,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -494,7 +494,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -514,7 +514,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -544,7 +544,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -576,7 +576,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -609,7 +609,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -631,7 +631,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -653,7 +653,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_curtain_driver_e1.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_curtain_driver_e1.lua
@@ -111,7 +111,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -158,7 +158,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -175,7 +175,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_coroutine_test(
       PRIVATE_CURTAIN_MANUAL_ATTRIBUTE_ID, MFG_CODE, data_types.Boolean, false) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -250,7 +250,7 @@ test.register_coroutine_test(
     -- })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -280,7 +280,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -298,7 +298,7 @@ test.register_coroutine_test(
       PRIVATE_CURTAIN_LOCKING_SETTING_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0x01) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -316,7 +316,7 @@ test.register_coroutine_test(
       PRIVATE_CURTAIN_LOCKING_SETTING_ATTRIBUTE_ID, MFG_CODE, data_types.Uint8, 0x00) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -348,7 +348,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -368,7 +368,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -388,7 +388,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -407,7 +407,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -426,7 +426,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -445,7 +445,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_aqara_roller_shade_rotate.lua
@@ -116,7 +116,7 @@ test.register_coroutine_test(
         PREF_REVERSE_OFF) })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -151,7 +151,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -195,7 +195,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -217,7 +217,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -246,7 +246,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -294,7 +294,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -313,7 +313,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -371,7 +371,7 @@ test.register_coroutine_test(
       initializedStateWithGuide.initializedStateWithGuide.initialized()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -395,7 +395,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -427,7 +427,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -446,7 +446,7 @@ test.register_coroutine_test(
       initializedStateWithGuide.initializedStateWithGuide.notInitialized()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -466,7 +466,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -507,7 +507,7 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_device.id, message })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_axis.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_axis.lua
@@ -82,7 +82,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -123,7 +123,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -176,7 +176,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -204,7 +204,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -236,7 +236,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -264,7 +264,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -296,7 +296,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -336,7 +336,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -378,7 +378,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -406,7 +406,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -441,7 +441,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -469,7 +469,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -506,7 +506,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -541,7 +541,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -586,7 +586,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -624,7 +624,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -679,7 +679,7 @@ test.register_coroutine_test(
       test.socket.zigbee:__expect_send({ mock_device.id, WindowCovering.attributes.CurrentPositionLiftPercentage:read(mock_device) })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_rooms.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_rooms.lua
@@ -58,7 +58,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -80,7 +80,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -124,7 +124,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -146,7 +146,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -169,7 +169,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -189,7 +189,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -209,7 +209,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -229,7 +229,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -251,7 +251,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -296,7 +296,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.windowShadeLevel.shadeLevel(100)))
    end,
    {
-      min_api_version = 17
+      min_api_version = 14
    }
 
   )
@@ -335,7 +335,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -384,7 +384,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_screen_innovations.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_screen_innovations.lua
@@ -64,7 +64,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -86,7 +86,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -135,7 +135,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -175,7 +175,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -196,7 +196,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -271,7 +271,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -303,7 +303,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -346,7 +346,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -389,7 +389,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -432,7 +432,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -457,7 +457,7 @@ test.register_coroutine_test(
         test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_sombra.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_sombra.lua
@@ -59,7 +59,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -81,7 +81,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -126,7 +126,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -171,7 +171,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -191,7 +191,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -211,7 +211,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -231,7 +231,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -253,7 +253,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -295,7 +295,7 @@ test.register_coroutine_test(
       end
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -320,7 +320,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -395,7 +395,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -427,7 +427,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_somfy.lua
+++ b/drivers/SmartThings/zigbee-window-treatment/src/test/test_zigbee_window_treatment_somfy.lua
@@ -68,7 +68,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -121,7 +121,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -161,7 +161,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -243,7 +243,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -316,7 +316,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -344,7 +344,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -372,7 +372,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -400,7 +400,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -427,7 +427,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -448,7 +448,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -475,7 +475,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -500,7 +500,7 @@ test.register_coroutine_test(
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -536,7 +536,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -561,7 +561,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -591,7 +591,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -621,7 +621,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -662,7 +662,7 @@ test.register_coroutine_test(
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 

--- a/drivers/SmartThings/zwave-bulb/src/test/test_aeon_multiwhite_bulb.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_aeon_multiwhite_bulb.lua
@@ -62,7 +62,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -83,7 +83,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -183,7 +183,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -207,7 +207,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -232,7 +232,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -257,7 +257,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -281,7 +281,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -313,7 +313,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -347,7 +347,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -379,7 +379,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -408,7 +408,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -438,7 +438,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -465,7 +465,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -493,7 +493,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -570,7 +570,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-bulb/src/test/test_aeotec_led_bulb_6.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_aeotec_led_bulb_6.lua
@@ -105,7 +105,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-bulb/src/test/test_fibaro_rgbw_controller.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_fibaro_rgbw_controller.lua
@@ -99,7 +99,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -234,7 +234,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -265,7 +265,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -297,7 +297,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -321,7 +321,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -349,7 +349,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -398,7 +398,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -478,7 +478,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -509,7 +509,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -540,7 +540,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-bulb/src/test/test_zwave_bulb.lua
+++ b/drivers/SmartThings/zwave-bulb/src/test/test_zwave_bulb.lua
@@ -100,7 +100,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -161,7 +161,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -195,7 +195,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -228,7 +228,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -263,7 +263,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -315,7 +315,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -386,7 +386,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -431,7 +431,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -479,7 +479,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
   )
 end

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_aeotec_nanomote_one.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_aeotec_nanomote_one.lua
@@ -58,7 +58,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_button.lua
@@ -49,7 +49,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -89,7 +89,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -110,7 +110,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -141,7 +141,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -173,7 +173,7 @@ test.register_coroutine_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_fibaro_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_fibaro_button.lua
@@ -57,7 +57,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
+++ b/drivers/SmartThings/zwave-button/src/test/test_zwave_multi_button.lua
@@ -108,7 +108,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -137,7 +137,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -163,7 +163,7 @@ test.register_coroutine_test(
       capabilities.button.button.double({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_coroutine_test(
       capabilities.button.button.double({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -276,7 +276,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -305,7 +305,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -334,7 +334,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -359,7 +359,7 @@ test.register_coroutine_test(
       capabilities.button.button.held({state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -378,7 +378,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -408,7 +408,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -437,7 +437,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -466,7 +466,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -495,7 +495,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -520,7 +520,7 @@ test.register_coroutine_test(
     mock_aeotec_keyfob_button:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -608,7 +608,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -649,7 +649,7 @@ test.register_coroutine_test(
     mock_fibaro_keyfob_button:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -765,7 +765,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -853,7 +853,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -913,7 +913,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -942,7 +942,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeon_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeon_meter.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -139,7 +139,7 @@ test.register_coroutine_test(
       mock_meter:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_gen5_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_aeotec_gen5_meter.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -143,7 +143,7 @@ test.register_coroutine_test(
       mock_meter:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_3_phase_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_3_phase_meter.lua
@@ -96,7 +96,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -180,7 +180,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_coroutine_test(
       mock_meter:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_smart_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_qubino_smart_meter.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -127,7 +127,7 @@ test.register_coroutine_test(
       mock_meter:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-electric-meter/src/test/test_zwave_electric_meter.lua
+++ b/drivers/SmartThings/zwave-electric-meter/src/test/test_zwave_electric_meter.lua
@@ -47,7 +47,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -69,7 +69,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -100,7 +100,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-fan/src/test/test_zwave_fan_3_speed.lua
+++ b/drivers/SmartThings/zwave-fan/src/test/test_zwave_fan_3_speed.lua
@@ -64,7 +64,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -160,7 +160,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -194,7 +194,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-fan/src/test/test_zwave_fan_4_speed.lua
+++ b/drivers/SmartThings/zwave-fan/src/test/test_zwave_fan_4_speed.lua
@@ -63,7 +63,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -94,7 +94,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -158,7 +158,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -192,7 +192,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-garage-door-opener/src/test/test_ecolink_garage_door_operator.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/test/test_ecolink_garage_door_operator.lua
@@ -59,7 +59,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
   {
     test_init = test_init,
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -160,7 +160,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -206,7 +206,7 @@ test.register_message_test(
           }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -234,7 +234,7 @@ test.register_coroutine_test(
       mock_garage_door:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -264,7 +264,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -294,7 +294,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -311,7 +311,7 @@ test.register_coroutine_test(
       test.mock_time.advance_time(1)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -328,7 +328,7 @@ test.register_coroutine_test(
       test.mock_time.advance_time(1)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-garage-door-opener/src/test/test_mimolite_garage_door.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/test/test_mimolite_garage_door.lua
@@ -59,7 +59,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -83,7 +83,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -155,7 +155,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -179,7 +179,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -247,7 +247,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -277,7 +277,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -307,7 +307,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -327,7 +327,7 @@ test.register_coroutine_test(
       mock_garage_door:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -350,7 +350,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-garage-door-opener/src/test/test_zwave_garage_door_opener.lua
+++ b/drivers/SmartThings/zwave-garage-door-opener/src/test/test_zwave_garage_door_opener.lua
@@ -50,7 +50,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -69,7 +69,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -93,7 +93,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -156,7 +156,7 @@ test.register_message_test(
   },
   {
     test_init = test_init,
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_message_test(
   {
     test_init = test_init,
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_keywe_lock.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_keywe_lock.lua
@@ -89,6 +89,9 @@ test.register_coroutine_test(
     test.socket.zwave:__queue_receive({ mock_device.id, Notification:Report({notification_type = 6, event = 25}) } )
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lock.lock.locked({data={method="manual"}})))
   end
-)
+,
+    {
+      min_api_version = 17
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-lock/src/test/test_keywe_lock_legacy.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_keywe_lock_legacy.lua
@@ -46,7 +46,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lock.lock.unlocked()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -59,7 +59,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lock.lock.locked()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_lock_battery.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_lock_battery.lua
@@ -60,7 +60,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lock.lock.unlocked()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -79,7 +79,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -98,7 +98,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -115,7 +115,7 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(DoorLock:OperationGet({}):build_test_tx(mock_device.id))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_coroutine_test(
     }):build_test_tx(mock_device.id))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_coroutine_test(
     }):build_test_tx(mock_device.id))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_lock_credentials_commands.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_lock_credentials_commands.lua
@@ -175,7 +175,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -200,7 +203,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -229,7 +235,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 -- ============================================================================
@@ -253,7 +262,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -275,7 +287,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -297,7 +312,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 -- ============================================================================
@@ -321,7 +339,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -341,7 +362,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -363,7 +387,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -385,7 +412,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 -- ============================================================================
@@ -423,7 +453,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -445,7 +478,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.register_coroutine_test(
@@ -474,7 +510,10 @@ test.register_coroutine_test(
         ))
     )
     test.wait_for_events()
-  end
+  end,
+  {
+    min_api_version = 15
+  }
 )
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-lock/src/test/test_lock_pre_configured.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_lock_pre_configured.lua
@@ -205,7 +205,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- updateUser — pre-configured device
@@ -240,7 +243,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "updateUser (pre-configured): returns failure for a userIndex that does not exist",
@@ -273,7 +279,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- deleteUser with associated credential — exercises clear_pin_code_response
@@ -324,7 +333,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- addCredential response states — set_pin_code_response
@@ -365,7 +377,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "addCredential (pre-configured): emits duplicate when the lock rejects with DUPLICATE_CODE",
@@ -392,7 +407,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "addCredential (pre-configured): emits failure when the lock returns available",
@@ -419,7 +437,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- updateCredential response states — set_pin_code_response
@@ -450,7 +471,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "updateCredential (pre-configured): returns failure immediately for a non-existent credentialIndex",
@@ -472,7 +496,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- deleteCredential standalone (lockCredentials.DELETE path)
@@ -509,6 +536,9 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-lock/src/test/test_lock_users_commands.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_lock_users_commands.lua
@@ -192,7 +192,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "addUser: assigns the next sequential userIndex when users already exist",
@@ -223,7 +226,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "addUser: fills a gap left by a deleted user rather than appending beyond max",
@@ -259,7 +265,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "addUser: returns resourceExhausted when totalUsersSupported has been reached",
@@ -284,7 +293,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- updateUser
@@ -322,7 +334,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "updateUser: creates user when userIndex does not exist",
@@ -352,7 +367,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "updateUser: can change a user's type as well as name",
@@ -380,7 +398,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- deleteUser (no associated credential — pure local delete)
@@ -415,7 +436,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "deleteUser: returns failure when the target userIndex is not in the users table",
@@ -435,7 +459,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- deleteAllUsers  (injects deleteAllCredentials → ClearAllPINCodes z-wave flow)
@@ -495,7 +522,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "deleteAllUsers: emits busy when another lock command is in progress",
@@ -517,7 +547,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- State-consistency: add → delete → re-add (indices 1, 2, 3 lifecycle)
@@ -590,7 +623,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "State-consistency: add users+credentials 1-3, deleteUser 2 (with credential), re-add user+credential reclaims index 2 cleanly",
@@ -700,6 +736,9 @@ test.register_coroutine_test(
     }) == constants.COMMAND_RESULT.SUCCESS)
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-lock/src/test/test_samsung_lock_legacy.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_samsung_lock_legacy.lua
@@ -51,7 +51,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -114,7 +114,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lockCodes.codeChanged("2 failed", { state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lockCodes.codeChanged(2 .. " failed", { state_change = true })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -176,7 +176,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_schlage_lock_legacy.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_schlage_lock_legacy.lua
@@ -77,7 +77,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -116,7 +116,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -232,7 +232,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -259,7 +259,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_legacy.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_lock_legacy.lua
@@ -62,7 +62,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.lock.lock.locked()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -137,7 +137,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -162,7 +162,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -179,7 +179,7 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(DoorLock:OperationGet({}):build_test_tx(mock_device.id))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -198,7 +198,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -209,7 +209,7 @@ test.register_coroutine_test(
     expect_reload_all_codes_messages()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -228,7 +228,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(UserCode:Get( {user_identifier = 1}):build_test_tx(mock_device.id))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -264,7 +264,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_coroutine_test(
             {state_change = true})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -316,7 +316,7 @@ test.register_coroutine_test(
     test.wait_for_events()
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -341,7 +341,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -371,7 +371,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -395,7 +395,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -438,7 +438,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -463,7 +463,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -488,7 +488,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -519,7 +519,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -754,7 +754,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -779,7 +779,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -808,7 +808,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-lock/src/test/test_zwave_responses.lua
+++ b/drivers/SmartThings/zwave-lock/src/test/test_zwave_responses.lua
@@ -100,7 +100,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "user_code_report: sync completes when the last slot is reached",
@@ -140,7 +143,10 @@ test.register_coroutine_test(
     assert(mock_device:get_field(constants.DRIVER_STATE.BUSY) == false,
       "BUSY must be false after sync completes")
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "user_code_report: out-of-band ENABLED code creates user and credential entries",
@@ -173,7 +179,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- user_code_event_handler (ACCESS_CONTROL Notification:Report)
@@ -208,7 +217,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "user_code_event: multi-byte event_parameter uses byte 3 to extract user_id",
@@ -239,7 +251,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- door_operation_event_handler (ACCESS_CONTROL Notification:Report)
@@ -279,7 +294,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "door_operation_event: KEYPAD_UNLOCK_OPERATION with unknown credential sets userIndex from event_parameter",
@@ -306,7 +324,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "door_operation_event: AUTO_LOCK_LOCKED_OPERATION emits locked with auto method",
@@ -327,7 +348,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- DoorLock:OperationReport → lock state
@@ -346,7 +370,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.register_coroutine_test(
   "OperationReport: DOOR_UNSECURED emits unlocked event",
@@ -360,7 +387,10 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 -- ============================================================================
 -- users_number_report: UserCode:UsersNumberReport
@@ -388,6 +418,9 @@ test.register_coroutine_test(
     )
     test.wait_for_events()
   end
-)
+,
+    {
+      min_api_version = 15
+    })
 
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-mouse-trap/src/test/test_zwave_mouse_trap.lua
+++ b/drivers/SmartThings/zwave-mouse-trap/src/test/test_zwave_mouse_trap.lua
@@ -67,7 +67,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -89,7 +89,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -111,7 +111,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -199,7 +199,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -262,7 +262,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -281,7 +281,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -335,7 +335,7 @@ test.register_coroutine_test(
       mock_mouse_trap:expect_metadata_update({provisioning_state = "PROVISIONED"})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeon_multisensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeon_multisensor.lua
@@ -83,7 +83,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_6.lua
@@ -108,7 +108,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
 
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 test.register_coroutine_test(
@@ -231,7 +231,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -288,7 +288,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -323,7 +323,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -345,7 +345,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -369,7 +369,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -405,7 +405,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -429,7 +429,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -454,7 +454,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_7.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_7.lua
@@ -110,7 +110,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
 
       end,
       {
-         min_api_version = 17
+         min_api_version = 14
       }
 )
 test.register_coroutine_test(
@@ -229,7 +229,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -251,7 +251,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -286,7 +286,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -321,7 +321,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_gen5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_multisensor_gen5.lua
@@ -98,7 +98,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor.lua
@@ -78,7 +78,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -160,7 +160,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -182,7 +182,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -223,7 +223,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -245,7 +245,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -311,7 +311,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor_7.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_aeotec_water_sensor_7.lua
@@ -52,7 +52,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -74,7 +74,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -140,7 +140,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -168,7 +168,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_enerwave_motion_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_enerwave_motion_sensor.lua
@@ -53,7 +53,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -98,7 +98,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everpsring_sp817.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everpsring_sp817.lua
@@ -51,7 +51,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -88,7 +88,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_PIR_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_PIR_sensor.lua
@@ -58,7 +58,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -108,7 +108,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -130,7 +130,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -153,7 +153,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -203,7 +203,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_ST814.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_ST814.lua
@@ -50,7 +50,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_illuminance_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_illuminance_sensor.lua
@@ -54,7 +54,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_everspring_motion_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_everspring_motion_light_sensor.lua
@@ -66,7 +66,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_ezmultipli_multipurpose_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_ezmultipli_multipurpose_sensor.lua
@@ -52,7 +52,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ do
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -159,7 +159,7 @@ do
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -293,7 +293,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor.lua
@@ -73,7 +73,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -97,7 +97,7 @@ test.register_coroutine_test(
       mock_fibaro_door_window_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -160,7 +160,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -183,7 +183,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_1.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_1.lua
@@ -121,7 +121,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -210,7 +210,7 @@ test.register_coroutine_test(
       mock_fibaro_door_window_sensor1:expect_metadata_update({provisioning_state = "PROVISIONED"})
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -229,7 +229,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -251,7 +251,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -273,7 +273,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -300,7 +300,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -327,7 +327,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -349,7 +349,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -370,7 +370,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -401,7 +401,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -431,7 +431,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_2.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_2.lua
@@ -59,7 +59,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -103,7 +103,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -147,7 +147,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -169,7 +169,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -191,7 +191,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -308,7 +308,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -349,7 +349,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -385,7 +385,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_door_window_sensor_with_temperature.lua
@@ -85,7 +85,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
       mock_fibaro_door_window_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -132,7 +132,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -154,7 +154,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -176,7 +176,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -199,7 +199,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -221,7 +221,7 @@ test.register_message_test(
    }
  },
  {
-    min_api_version = 17
+    min_api_version = 14
  }
 )
 
@@ -252,7 +252,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -282,7 +282,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -559,7 +559,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor.lua
@@ -54,7 +54,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -73,7 +73,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -94,7 +94,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -115,7 +115,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -167,7 +167,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -189,7 +189,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -243,7 +243,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -270,7 +270,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -297,7 +297,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -328,7 +328,7 @@ test.register_coroutine_test(
     mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_flood_sensor_zw5.lua
@@ -82,7 +82,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor.lua
@@ -87,7 +87,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -106,7 +106,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -199,7 +199,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -221,7 +221,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -244,7 +244,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -266,7 +266,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -288,7 +288,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -315,7 +315,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -346,7 +346,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -376,7 +376,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_fibaro_motion_sensor_zw5.lua
@@ -69,7 +69,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_firmware_version.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_firmware_version.lua
@@ -86,7 +86,7 @@ test.register_message_test(
       },
       {
         inner_block_ordering = "relaxed",
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -124,7 +124,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_generic_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_generic_sensor.lua
@@ -63,7 +63,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -131,7 +131,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -154,7 +154,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -176,7 +176,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -207,7 +207,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -238,7 +238,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -260,7 +260,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -283,7 +283,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -313,7 +313,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -344,7 +344,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -366,7 +366,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -388,7 +388,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -412,7 +412,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -456,7 +456,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -500,7 +500,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -522,7 +522,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -544,7 +544,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -571,7 +571,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -598,7 +598,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -692,7 +692,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -786,7 +786,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -808,7 +808,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -830,7 +830,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -852,7 +852,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -874,7 +874,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -896,7 +896,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -918,7 +918,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -940,7 +940,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -962,7 +962,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -984,7 +984,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1006,7 +1006,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1028,7 +1028,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1050,7 +1050,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1072,7 +1072,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1105,7 +1105,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1127,7 +1127,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1149,7 +1149,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1171,7 +1171,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1199,7 +1199,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1221,7 +1221,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1243,7 +1243,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1265,7 +1265,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1287,7 +1287,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1309,7 +1309,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1331,7 +1331,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1353,7 +1353,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1375,7 +1375,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1397,7 +1397,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1419,7 +1419,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1441,7 +1441,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1463,7 +1463,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1485,7 +1485,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1506,7 +1506,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1527,7 +1527,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1549,7 +1549,7 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command(mock_device, Battery:Get({})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1571,7 +1571,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1593,7 +1593,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_glentronics_water_leak_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_glentronics_water_leak_sensor.lua
@@ -70,7 +70,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_homeseer_multi_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_homeseer_multi_sensor.lua
@@ -51,7 +51,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -70,7 +70,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -92,7 +92,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -137,7 +137,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_coroutine_test(
@@ -168,7 +168,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.run_registered_tests()

--- a/drivers/SmartThings/zwave-sensor/src/test/test_no_wakeup_poll.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_no_wakeup_poll.lua
@@ -100,7 +100,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_sensative_strip.lua
@@ -61,7 +61,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -72,7 +72,7 @@ test.register_coroutine_test(
     mock_sensor:expect_metadata_update({ profile = "illuminance-temperature" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -94,7 +94,7 @@ test.register_coroutine_test(
     test.socket.zwave:__queue_receive({mock_sensor.id, WakeUp:Notification({})})
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_smartthings_water_leak_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_smartthings_water_leak_sensor.lua
@@ -59,7 +59,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -103,7 +103,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -147,7 +147,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -169,7 +169,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -191,7 +191,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -272,7 +272,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -291,7 +291,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -310,7 +310,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_v1_contact_event.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_v1_contact_event.lua
@@ -57,7 +57,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -84,7 +84,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -104,7 +104,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_vision_motion_detector.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_vision_motion_detector.lua
@@ -58,7 +58,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -80,7 +80,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -102,7 +102,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -124,7 +124,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -187,7 +187,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zooz_4_in_1_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zooz_4_in_1_sensor.lua
@@ -53,7 +53,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -103,7 +103,7 @@ test.register_coroutine_test(
       test.socket.capability:__expect_send(mock_sensor:generate_test_message("main", capabilities.tamperAlert.tamper.clear()))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -169,7 +169,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -214,7 +214,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -239,7 +239,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -260,7 +260,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_light_sensor.lua
@@ -59,7 +59,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -86,7 +86,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -151,7 +151,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -173,7 +173,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -218,7 +218,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -245,7 +245,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -292,7 +292,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -307,7 +307,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_temp_light_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_motion_temp_light_sensor.lua
@@ -55,7 +55,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -82,7 +82,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -104,7 +104,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -126,7 +126,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -148,7 +148,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -192,7 +192,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_sensor.lua
@@ -131,7 +131,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -235,7 +235,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -272,7 +272,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -294,7 +294,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -316,7 +316,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -338,7 +338,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -359,7 +359,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -380,7 +380,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -411,7 +411,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -438,7 +438,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -460,7 +460,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -482,7 +482,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -504,7 +504,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -526,7 +526,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -548,7 +548,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -570,7 +570,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -602,7 +602,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -624,7 +624,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -646,7 +646,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -673,7 +673,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -700,7 +700,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -727,7 +727,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -749,7 +749,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -771,7 +771,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -794,7 +794,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -815,7 +815,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -836,7 +836,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-sensor/src/test/test_zwave_water_sensor.lua
+++ b/drivers/SmartThings/zwave-sensor/src/test/test_zwave_water_sensor.lua
@@ -57,7 +57,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -161,7 +161,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -224,7 +224,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -246,7 +246,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -268,7 +268,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -290,7 +290,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_aeon_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_aeon_siren.lua
@@ -56,7 +56,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -82,7 +82,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -144,7 +144,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -176,7 +176,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -207,7 +207,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -238,7 +238,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -265,7 +265,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -293,7 +293,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -322,7 +322,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_aeotec_doorbell_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_aeotec_doorbell_siren.lua
@@ -113,7 +113,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -151,7 +151,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -189,7 +189,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -227,7 +227,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -265,7 +265,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -303,7 +303,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -341,7 +341,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -379,7 +379,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -424,7 +424,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -469,7 +469,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -514,7 +514,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -559,7 +559,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -604,7 +604,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -649,7 +649,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -694,7 +694,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -739,7 +739,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -779,7 +779,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -819,7 +819,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -859,7 +859,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -899,7 +899,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -939,7 +939,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -979,7 +979,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1019,7 +1019,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1059,7 +1059,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1099,7 +1099,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1139,7 +1139,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1179,7 +1179,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1219,7 +1219,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1259,7 +1259,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1299,7 +1299,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1339,7 +1339,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1379,7 +1379,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1419,7 +1419,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1459,7 +1459,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1499,7 +1499,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1539,7 +1539,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1579,7 +1579,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1619,7 +1619,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1659,7 +1659,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1699,7 +1699,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1739,7 +1739,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1779,7 +1779,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1819,7 +1819,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1859,7 +1859,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1899,7 +1899,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1939,7 +1939,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1979,7 +1979,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2019,7 +2019,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2059,7 +2059,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2099,7 +2099,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2139,7 +2139,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2179,7 +2179,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2219,7 +2219,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2259,7 +2259,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2299,7 +2299,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2339,7 +2339,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2379,7 +2379,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2419,7 +2419,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2459,7 +2459,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2499,7 +2499,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2539,7 +2539,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2579,7 +2579,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2619,7 +2619,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2659,7 +2659,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2682,7 +2682,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -2705,7 +2705,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -2738,7 +2738,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2754,7 +2754,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_siren:generate_info_changed({ preferences = _preferences}))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2779,7 +2779,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2793,7 +2793,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_siren:generate_info_changed({ preferences = _preferences}))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2818,7 +2818,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2832,7 +2832,7 @@ test.register_coroutine_test(
     test.socket.device_lifecycle:__queue_receive(mock_siren:generate_info_changed({ preferences = _preferences}))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2860,7 +2860,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2888,7 +2888,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2916,7 +2916,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2944,7 +2944,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -2972,7 +2972,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -3000,7 +3000,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -3036,7 +3036,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -3056,7 +3056,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_ecolink_wireless_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_ecolink_wireless_siren.lua
@@ -68,7 +68,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -106,7 +106,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -286,7 +286,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -313,7 +313,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_coroutine_test(
@@ -347,7 +347,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -374,7 +374,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -400,7 +400,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -427,7 +427,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_coroutine_test(
@@ -452,7 +452,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_coroutine_test(
@@ -477,7 +477,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 test.register_coroutine_test(
@@ -502,7 +502,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_fortrezz_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_fortrezz_siren.lua
@@ -61,7 +61,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_siren:generate_test_message("main", capabilities.switch.switch.on({})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_siren:generate_test_message("main", capabilities.switch.switch.on({})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -128,7 +128,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_siren:generate_test_message("main", capabilities.switch.switch.on({})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -161,7 +161,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_siren:generate_test_message("main", capabilities.switch.switch.off({})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_philio_sound_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_philio_sound_siren.lua
@@ -64,7 +64,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -168,7 +168,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -201,7 +201,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -224,7 +224,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -281,7 +281,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -308,7 +308,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -360,7 +360,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -387,7 +387,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -414,7 +414,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -441,7 +441,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -462,7 +462,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -484,7 +484,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -533,7 +533,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -558,7 +558,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_utilitech_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_utilitech_siren.lua
@@ -43,7 +43,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -63,7 +63,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_yale_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_yale_siren.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -75,7 +75,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -152,7 +152,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -190,7 +190,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -227,7 +227,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -263,7 +263,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -311,7 +311,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -331,7 +331,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_zipato_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zipato_siren.lua
@@ -63,7 +63,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -94,7 +94,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -114,7 +114,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -135,7 +135,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -156,7 +156,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_zooz_zse50.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zooz_zse50.lua
@@ -66,7 +66,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -120,7 +120,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -148,7 +148,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -176,7 +176,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -198,7 +198,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -242,7 +242,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -264,7 +264,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -296,7 +296,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -341,7 +341,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -372,7 +372,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -403,7 +403,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -434,7 +434,7 @@ test.register_message_test(
         }
       },
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -453,7 +453,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -472,7 +472,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -491,7 +491,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -516,7 +516,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -541,7 +541,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -566,7 +566,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -591,7 +591,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -616,7 +616,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -641,7 +641,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -663,7 +663,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 
@@ -710,7 +710,7 @@ test.register_coroutine_test(
         )
       end,
       {
-        min_api_version = 17
+        min_api_version = 14
       }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_multifunctional-siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_multifunctional-siren.lua
@@ -52,7 +52,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -74,7 +74,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -96,7 +96,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -146,7 +146,7 @@ test.register_coroutine_test(
     mock_siren:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_notification_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_notification_siren.lua
@@ -51,7 +51,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -100,7 +100,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_siren.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_siren.lua
@@ -84,7 +84,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -110,7 +110,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -162,7 +162,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -188,7 +188,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -214,7 +214,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -240,7 +240,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -266,7 +266,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -297,7 +297,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -328,7 +328,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -360,7 +360,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -391,7 +391,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -422,7 +422,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -463,7 +463,7 @@ test.register_coroutine_test(
     test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-siren/src/test/test_zwave_sound_sensor.lua
+++ b/drivers/SmartThings/zwave-siren/src/test/test_zwave_sound_sensor.lua
@@ -50,7 +50,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -72,7 +72,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -91,7 +91,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_co_sensor_zw5.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_co_sensor_zw5.lua
@@ -70,7 +70,7 @@ test.register_coroutine_test(
     mock_fibaro_CO_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -89,7 +89,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -199,7 +199,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -226,7 +226,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -279,7 +279,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -307,7 +307,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -334,7 +334,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -361,7 +361,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -392,7 +392,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -501,7 +501,7 @@ test.register_coroutine_test(
 
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_fibaro_smoke_sensor.lua
@@ -150,7 +150,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -209,7 +209,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_alarm_v1.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_alarm_v1.lua
@@ -54,7 +54,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -98,7 +98,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -165,7 +165,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -187,7 +187,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -209,7 +209,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_co_detector.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_co_detector.lua
@@ -55,7 +55,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -77,7 +77,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_message_test(
@@ -98,7 +98,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -164,7 +164,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -181,7 +181,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
+++ b/drivers/SmartThings/zwave-smoke-alarm/src/test/test_zwave_smoke_detector.lua
@@ -56,7 +56,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -78,7 +78,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -100,7 +100,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -122,7 +122,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -144,7 +144,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -166,7 +166,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -188,7 +188,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -205,7 +205,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -253,7 +253,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -297,7 +297,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -319,7 +319,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -341,7 +341,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -363,7 +363,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -407,7 +407,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeon_smart_strip.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeon_smart_strip.lua
@@ -152,7 +152,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -241,7 +241,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -292,7 +292,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -343,7 +343,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -377,7 +377,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -411,7 +411,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -445,7 +445,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -515,7 +515,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -549,7 +549,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -621,7 +621,7 @@ test.register_coroutine_test(
       mock_metering_switch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -755,7 +755,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -889,7 +889,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -980,7 +980,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1071,7 +1071,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1162,7 +1162,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1253,7 +1253,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dimmer_switch.lua
@@ -60,7 +60,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -139,7 +139,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -179,7 +179,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -223,7 +223,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -280,7 +280,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -312,7 +312,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -336,7 +336,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -405,7 +405,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -475,7 +475,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -510,7 +510,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dual_nano_switch_configuration.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_dual_nano_switch_configuration.lua
@@ -113,7 +113,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_heavy_duty_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_heavy_duty_switch.lua
@@ -57,7 +57,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_coroutine_test(
       Meter:Get({ scale = Meter.scale.electric_meter.KILOWATT_HOURS })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -193,7 +193,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -246,7 +246,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -273,7 +273,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -300,7 +300,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -327,7 +327,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -354,7 +354,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -381,7 +381,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -408,7 +408,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -435,7 +435,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -462,7 +462,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -489,7 +489,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -516,7 +516,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_metering_switch_configuration.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_metering_switch_configuration.lua
@@ -65,7 +65,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer.lua
@@ -84,7 +84,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -123,7 +123,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -304,7 +304,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -336,7 +336,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -360,7 +360,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -429,7 +429,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -499,7 +499,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -534,7 +534,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_nano_dimmer_preferences.lua
@@ -59,7 +59,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch.lua
@@ -60,7 +60,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -90,7 +90,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch_7_eu.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch_7_eu.lua
@@ -66,7 +66,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -96,7 +96,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -175,7 +175,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch_7_us.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch_7_us.lua
@@ -54,7 +54,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -84,7 +84,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -114,7 +114,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -162,7 +162,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -193,7 +193,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch_gen5.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_aeotec_smart_switch_gen5.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
       mock_switch:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_dawon_smart_plug.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_dawon_smart_plug.lua
@@ -49,7 +49,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -71,7 +71,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_dawon_wall_smart_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_dawon_wall_smart_switch.lua
@@ -77,7 +77,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -106,7 +106,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -138,7 +138,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -266,7 +266,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -298,7 +298,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -321,7 +321,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -385,7 +385,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_eaton_5_scene_keypad.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_eaton_5_scene_keypad.lua
@@ -76,7 +76,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -118,7 +118,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -147,7 +147,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -235,7 +235,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -273,7 +273,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -333,7 +333,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -381,7 +381,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -398,7 +398,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -458,7 +458,7 @@ test.register_coroutine_test(
             -- if group_id and scene_id are same, do nothing.
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -483,7 +483,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -501,7 +501,7 @@ test.register_coroutine_test(
             -- driver should do nothing.
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -541,7 +541,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_eaton_accessory_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_eaton_accessory_dimmer.lua
@@ -44,7 +44,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -68,7 +68,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -95,7 +95,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -130,7 +130,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -176,7 +176,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 end
@@ -203,7 +203,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -257,7 +257,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_eaton_anyplace_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_eaton_anyplace_switch.lua
@@ -73,7 +73,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -119,7 +119,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -184,7 +184,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -203,7 +203,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_eaton_rf_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_eaton_rf_dimmer.lua
@@ -43,7 +43,7 @@ test.register_coroutine_test(
       mock_sensor:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_ecolink_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_ecolink_switch.lua
@@ -63,7 +63,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -94,7 +94,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -177,7 +177,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -217,7 +217,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -249,7 +249,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -274,7 +274,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -299,7 +299,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_double_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_double_switch.lua
@@ -135,7 +135,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -187,7 +187,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 test.register_message_test(
@@ -237,7 +237,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -288,7 +288,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -328,7 +328,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -368,7 +368,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -408,7 +408,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -448,7 +448,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -601,7 +601,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -653,7 +653,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_single_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_single_switch.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -76,7 +76,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -109,7 +109,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -175,7 +175,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -208,7 +208,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -238,7 +238,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -290,7 +290,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -319,7 +319,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -342,7 +342,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -371,7 +371,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -394,7 +394,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -423,7 +423,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -446,7 +446,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -475,7 +475,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -497,7 +497,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -526,7 +526,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -548,7 +548,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -577,7 +577,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -691,7 +691,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_wall_plug_eu.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_wall_plug_eu.lua
@@ -108,7 +108,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_wall_plug_uk_configuration.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_wall_plug_uk_configuration.lua
@@ -57,7 +57,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_wall_plug_us.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_wall_plug_us.lua
@@ -71,7 +71,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -108,7 +108,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -176,7 +176,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -210,7 +210,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -244,7 +244,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -258,7 +258,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -340,7 +340,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_dimmer_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_dimmer_preferences.lua
@@ -53,7 +53,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -77,7 +77,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -101,7 +101,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -125,7 +125,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -149,7 +149,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -174,7 +174,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -198,7 +198,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch.lua
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -173,7 +173,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -254,7 +254,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -310,7 +310,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -366,7 +366,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -413,7 +413,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -452,7 +452,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -522,7 +522,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -591,7 +591,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -658,7 +658,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -727,7 +727,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -771,7 +771,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -806,7 +806,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -841,7 +841,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_fibaro_walli_double_switch_preferences.lua
@@ -53,7 +53,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -73,7 +73,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -93,7 +93,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -133,7 +133,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -153,7 +153,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_generic_zwave_device1.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_generic_zwave_device1.lua
@@ -45,7 +45,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -71,7 +71,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -114,7 +114,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -144,7 +144,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -187,7 +187,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -245,7 +245,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_go_control_plug_in_switch_configuraton.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_go_control_plug_in_switch_configuraton.lua
@@ -49,7 +49,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_honeywell_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_honeywell_dimmer.lua
@@ -55,7 +55,7 @@ test.register_coroutine_test(
       mock_dimmer:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_2_channel_smart_plug.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_2_channel_smart_plug.lua
@@ -97,7 +97,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -161,7 +161,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -204,7 +204,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -290,7 +290,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -405,7 +405,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -478,7 +478,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -538,7 +538,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -598,7 +598,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -662,7 +662,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -726,7 +726,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -774,7 +774,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -822,7 +822,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -862,7 +862,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -903,7 +903,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -943,7 +943,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -984,7 +984,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_button.lua
@@ -131,7 +131,7 @@ test.register_coroutine_test(
     end
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -159,7 +159,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer.lua
@@ -47,7 +47,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -73,7 +73,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -101,7 +101,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -169,7 +169,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -200,7 +200,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -233,7 +233,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
   )
 end

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_led.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_led.lua
@@ -99,7 +99,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -135,7 +135,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_power_energy.lua
@@ -70,7 +70,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -112,7 +112,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -162,7 +162,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -200,7 +200,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -243,7 +243,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -276,7 +276,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -307,7 +307,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -340,7 +340,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_preferences.lua
@@ -56,7 +56,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -84,7 +84,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -112,7 +112,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -140,7 +140,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -169,7 +169,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_scenes.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_dimmer_scenes.lua
@@ -59,7 +59,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -82,7 +82,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -128,7 +128,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -151,7 +151,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -174,7 +174,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -220,7 +220,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -266,7 +266,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -289,7 +289,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_vzw32_sn.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_vzw32_sn.lua
@@ -130,7 +130,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -188,7 +188,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -222,7 +222,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -274,7 +274,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -333,7 +333,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_vzw32_sn_child.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_vzw32_sn_child.lua
@@ -90,7 +90,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -179,7 +179,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -238,7 +238,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -344,7 +344,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_inovelli_vzw32_sn_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_inovelli_vzw32_sn_preferences.lua
@@ -60,7 +60,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -86,7 +86,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -112,7 +112,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -138,7 +138,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -162,7 +162,7 @@ do
       })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_multi_metering_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_multi_metering_switch.lua
@@ -116,7 +116,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -168,7 +168,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -220,7 +220,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -248,7 +248,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -276,7 +276,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -304,7 +304,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -332,7 +332,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -381,7 +381,7 @@ test.register_coroutine_test(
       mock_parent_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -424,7 +424,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -467,7 +467,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -497,7 +497,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -531,7 +531,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -563,7 +563,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -595,7 +595,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -630,7 +630,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -663,7 +663,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -757,7 +757,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -774,7 +774,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_multichannel_device.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_multichannel_device.lua
@@ -169,7 +169,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -206,7 +206,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -243,7 +243,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -280,7 +280,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -330,7 +330,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -375,7 +375,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -420,7 +420,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -470,7 +470,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -520,7 +520,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -565,7 +565,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -610,7 +610,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -660,7 +660,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -703,7 +703,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -746,7 +746,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -789,7 +789,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -832,7 +832,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -888,7 +888,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -931,7 +931,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -987,7 +987,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1057,7 +1057,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1099,7 +1099,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -1141,7 +1141,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -1183,7 +1183,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -1229,7 +1229,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1283,7 +1283,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1312,7 +1312,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1341,7 +1341,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1375,7 +1375,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1409,7 +1409,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1533,7 +1533,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1657,7 +1657,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1786,7 +1786,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1815,7 +1815,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1844,7 +1844,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1873,7 +1873,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1902,7 +1902,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1931,7 +1931,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1960,7 +1960,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1989,7 +1989,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2018,7 +2018,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2047,7 +2047,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2076,7 +2076,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2105,7 +2105,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2134,7 +2134,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2172,7 +2172,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -2201,7 +2201,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2231,7 +2231,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2281,7 +2281,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -2337,7 +2337,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -2465,7 +2465,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -2509,7 +2509,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -2531,7 +2531,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2550,7 +2550,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2572,7 +2572,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2591,7 +2591,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2613,7 +2613,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2632,7 +2632,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2654,7 +2654,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -2673,7 +2673,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_popp_outdoor_plug_configuration.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_popp_outdoor_plug_configuration.lua
@@ -49,7 +49,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer.lua
@@ -70,7 +70,7 @@ test.register_coroutine_test(
       mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -125,7 +125,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -206,7 +206,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -307,7 +307,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -339,7 +339,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -363,7 +363,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -382,7 +382,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -451,7 +451,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -521,7 +521,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -555,7 +555,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_din_dimmer_preferences.lua
@@ -56,7 +56,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -80,7 +80,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -104,7 +104,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -128,7 +128,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -152,7 +152,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -177,7 +177,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -201,7 +201,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_1_relay_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_1_relay_preferences.lua
@@ -48,7 +48,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -72,7 +72,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -96,7 +96,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -120,7 +120,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -144,7 +144,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_1d_relay_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_1d_relay_preferences.lua
@@ -48,7 +48,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -72,7 +72,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -96,7 +96,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_2_relay.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_2_relay.lua
@@ -106,7 +106,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -138,7 +138,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -187,7 +187,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -215,7 +215,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -240,7 +240,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -265,7 +265,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -292,7 +292,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -319,7 +319,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -354,7 +354,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -389,7 +389,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -418,7 +418,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -460,7 +460,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -502,7 +502,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -544,7 +544,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -586,7 +586,7 @@ test.register_coroutine_test(
       ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -639,7 +639,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_2_relay_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_2_relay_preferences.lua
@@ -48,7 +48,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -72,7 +72,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -96,7 +96,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -120,7 +120,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -144,7 +144,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer.lua
@@ -61,7 +61,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -156,7 +156,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -197,7 +197,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -241,7 +241,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -298,7 +298,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -330,7 +330,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -354,7 +354,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -371,7 +371,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.temperatureMeasurement.temperature({ value = 21.5, unit = 'C' })))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -440,7 +440,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -510,7 +510,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -544,7 +544,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer_0_10V_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer_0_10V_preferences.lua
@@ -52,7 +52,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -76,7 +76,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -100,7 +100,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -124,7 +124,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -148,7 +148,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -176,7 +176,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -204,7 +204,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_flush_dimmer_preferences.lua
@@ -51,7 +51,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -75,7 +75,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -99,7 +99,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -123,7 +123,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -147,7 +147,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -171,7 +171,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -195,7 +195,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -220,7 +220,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -244,7 +244,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_mini_dimmer_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_mini_dimmer_preferences.lua
@@ -51,7 +51,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -75,7 +75,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -99,7 +99,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -123,7 +123,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -147,7 +147,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -172,7 +172,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -196,7 +196,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -220,7 +220,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_with_power.lua
@@ -59,7 +59,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -140,7 +140,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -196,7 +196,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -290,7 +290,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -360,7 +360,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -404,7 +404,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_without_power.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_qubino_temperature_sensor_without_power.lua
@@ -60,7 +60,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -92,7 +92,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -117,7 +117,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("switch", "switch")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -224,7 +224,7 @@ test.register_coroutine_test(
     mock_device:expect_native_attr_handler_registration("switch", "switch")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -268,7 +268,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_shelly_multi_metering_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_shelly_multi_metering_switch.lua
@@ -115,7 +115,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -167,7 +167,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -247,7 +247,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -275,7 +275,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -303,7 +303,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -331,7 +331,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -374,7 +374,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -417,7 +417,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -447,7 +447,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -481,7 +481,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -513,7 +513,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -545,7 +545,7 @@ do
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -580,7 +580,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -613,7 +613,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -707,7 +707,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -724,7 +724,7 @@ test.register_coroutine_test(
     })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch.lua
@@ -71,7 +71,7 @@ test.register_coroutine_test(
     mock_parent_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -99,7 +99,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -127,7 +127,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -155,7 +155,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -183,7 +183,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -216,7 +216,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -249,7 +249,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -283,7 +283,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -316,7 +316,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -350,7 +350,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -369,7 +369,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch_configuration.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_wyfy_touch_configuration.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     mock_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_double_plug.lua
@@ -73,7 +73,7 @@ test.register_coroutine_test(
     mock_parent:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -124,7 +124,7 @@ test.register_coroutine_test(
      )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -174,7 +174,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -201,7 +201,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -229,7 +229,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -256,7 +256,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -284,7 +284,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -326,7 +326,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -368,7 +368,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -410,7 +410,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -452,7 +452,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -476,7 +476,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -500,7 +500,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -532,7 +532,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -564,7 +564,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_power_strip.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_power_strip.lua
@@ -85,7 +85,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -124,7 +124,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -202,7 +202,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -241,7 +241,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -280,7 +280,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -319,7 +319,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -359,7 +359,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -399,7 +399,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -439,7 +439,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -483,7 +483,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -526,7 +526,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -569,7 +569,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -612,7 +612,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -655,7 +655,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -698,7 +698,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -741,7 +741,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -784,7 +784,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -827,7 +827,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -870,7 +870,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -932,7 +932,7 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(mock_device:generate_test_message("main", capabilities.switch.switch.off()))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -1011,7 +1011,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1090,7 +1090,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1126,7 +1126,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1162,7 +1162,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1198,7 +1198,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1234,7 +1234,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1270,7 +1270,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1306,7 +1306,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1342,7 +1342,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1378,7 +1378,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1414,7 +1414,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -1450,7 +1450,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay.lua
@@ -94,7 +94,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -114,7 +114,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -146,7 +146,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -178,7 +178,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -218,7 +218,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -263,7 +263,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -312,7 +312,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -348,7 +348,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -380,7 +380,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -412,7 +412,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -443,7 +443,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -474,7 +474,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -505,7 +505,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -536,7 +536,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -572,7 +572,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -621,7 +621,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -648,7 +648,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -675,7 +675,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -702,7 +702,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -729,7 +729,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -756,7 +756,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -783,7 +783,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -810,7 +810,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -837,7 +837,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -864,7 +864,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -891,7 +891,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -918,7 +918,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -945,7 +945,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -972,7 +972,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -999,7 +999,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1026,7 +1026,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1053,7 +1053,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1080,7 +1080,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1107,7 +1107,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1129,7 +1129,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1157,7 +1157,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1185,7 +1185,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1224,7 +1224,7 @@ test.register_coroutine_test(
 
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1272,7 +1272,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -1291,7 +1291,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay_preferences.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zooz_zen_30_dimmer_relay_preferences.lua
@@ -79,7 +79,7 @@ do
       test.wait_for_events()
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dimmer_power_energy.lua
@@ -72,7 +72,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -157,7 +157,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -214,7 +214,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -246,7 +246,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -270,7 +270,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -339,7 +339,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -408,7 +408,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -441,7 +441,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dual_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dual_switch.lua
@@ -82,7 +82,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -150,7 +150,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -184,7 +184,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -218,7 +218,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -252,7 +252,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -286,7 +286,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -320,7 +320,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -360,7 +360,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -400,7 +400,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -440,7 +440,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -480,7 +480,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -520,7 +520,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -560,7 +560,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -600,7 +600,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -640,7 +640,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -664,7 +664,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -688,7 +688,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_dual_switch_migration.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_dual_switch_migration.lua
@@ -74,7 +74,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -101,7 +101,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch.lua
@@ -78,7 +78,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -105,7 +105,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -129,7 +129,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -155,7 +155,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -178,7 +178,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -204,7 +204,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -238,7 +238,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -272,7 +272,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -306,7 +306,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -340,7 +340,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_battery.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_battery.lua
@@ -45,7 +45,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -76,7 +76,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -110,7 +110,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_electric_meter.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_electric_meter.lua
@@ -57,7 +57,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -79,7 +79,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -118,7 +118,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -160,7 +160,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_energy_meter.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_energy_meter.lua
@@ -63,7 +63,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -85,7 +85,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -150,7 +150,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -162,7 +162,7 @@ test.register_coroutine_test(
     test.socket.zwave:__expect_send(zw_test_utils.zwave_test_build_send_command( mock_switch, Meter:Get({scale = Meter.scale.electric_meter.KILOWATT_HOURS})))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_level.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_level.lua
@@ -46,7 +46,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -72,7 +72,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_power_meter.lua
+++ b/drivers/SmartThings/zwave-switch/src/test/test_zwave_switch_power_meter.lua
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -85,7 +85,7 @@ test.register_message_test(
       },
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -116,7 +116,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -150,7 +150,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_aeotec_radiator_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_aeotec_radiator_thermostat.lua
@@ -95,7 +95,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -114,7 +114,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -133,7 +133,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -164,7 +164,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -184,7 +184,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -207,7 +207,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -235,7 +235,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -268,7 +268,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_ct100_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_ct100_thermostat.lua
@@ -137,7 +137,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -165,7 +165,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -193,7 +193,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -221,7 +221,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -280,7 +280,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -339,7 +339,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -404,7 +404,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -473,7 +473,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -499,7 +499,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -524,7 +524,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_fibaro_heat_controller.lua
@@ -116,7 +116,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -174,7 +174,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -193,7 +193,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -216,7 +216,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -235,7 +235,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -266,7 +266,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -286,7 +286,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -309,7 +309,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -355,7 +355,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -383,7 +383,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -416,7 +416,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_popp_radiator_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_popp_radiator_thermostat.lua
@@ -62,7 +62,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -81,7 +81,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -112,7 +112,7 @@ test.register_message_test(
     }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -135,7 +135,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -159,7 +159,7 @@ test.register_coroutine_test(
       test.mock_time.advance_time(200)
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -203,7 +203,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_qubino_flush_thermostat.lua
@@ -123,7 +123,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -146,7 +146,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -172,7 +172,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -193,7 +193,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -213,7 +213,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -240,7 +240,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -267,7 +267,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -324,7 +324,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -376,7 +376,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -404,7 +404,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -437,7 +437,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -465,7 +465,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -487,7 +487,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -517,7 +517,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 15
     }
 )
 
@@ -570,7 +570,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_stelpro_ki_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_stelpro_ki_thermostat.lua
@@ -68,7 +68,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -107,7 +107,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -146,7 +146,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -190,7 +190,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -234,7 +234,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -273,7 +273,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -312,7 +312,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -330,7 +330,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -351,7 +351,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -377,7 +377,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_thermostat_heating_battery.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_thermostat_heating_battery.lua
@@ -104,7 +104,7 @@ test.register_coroutine_test(
             do_initial_setup()
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -123,7 +123,7 @@ test.register_message_test(
             }
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -155,7 +155,7 @@ test.register_coroutine_test(
             ))
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -217,7 +217,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -239,7 +239,7 @@ test.register_message_test(
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -271,7 +271,7 @@ test.register_message_test(
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -303,7 +303,7 @@ test.register_message_test(
             },
         },
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -332,7 +332,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -425,7 +425,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -539,7 +539,7 @@ test.register_coroutine_test(
             )
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -642,7 +642,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -728,7 +728,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 
@@ -770,7 +770,7 @@ test.register_coroutine_test(
         ))
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -810,7 +810,7 @@ test.register_coroutine_test(
 
         end,
         {
-           min_api_version = 17
+           min_api_version = 14
         }
 )
 

--- a/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
+++ b/drivers/SmartThings/zwave-thermostat/src/test/test_zwave_thermostat.lua
@@ -144,7 +144,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -163,7 +163,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -182,7 +182,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -201,7 +201,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -226,7 +226,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -250,7 +250,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -281,7 +281,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -304,7 +304,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -324,7 +324,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -344,7 +344,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -367,7 +367,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -390,7 +390,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -418,7 +418,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -446,7 +446,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -474,7 +474,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -502,7 +502,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -530,7 +530,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -558,7 +558,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -591,7 +591,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -645,7 +645,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -698,7 +698,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -753,7 +753,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-valve/src/test/test_inverse.valve.lua
+++ b/drivers/SmartThings/zwave-valve/src/test/test_inverse.valve.lua
@@ -49,7 +49,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -70,7 +70,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -91,7 +91,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -112,7 +112,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -145,7 +145,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -178,7 +178,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-valve/src/test/test_zwave_valve.lua
+++ b/drivers/SmartThings/zwave-valve/src/test/test_zwave_valve.lua
@@ -71,7 +71,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -90,7 +90,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -121,7 +121,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -152,7 +152,7 @@ test.register_message_test(
     },
     {
       inner_block_ordering = "relaxed",
-      min_api_version = 17
+      min_api_version = 14
     }
 )
 
@@ -185,7 +185,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -218,7 +218,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -251,7 +251,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -284,7 +284,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 

--- a/drivers/SmartThings/zwave-virtual-momentary-switch/src/test/test_zwave_virtual_momentary_switch.lua
+++ b/drivers/SmartThings/zwave-virtual-momentary-switch/src/test/test_zwave_virtual_momentary_switch.lua
@@ -67,7 +67,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -86,7 +86,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -113,7 +113,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -136,7 +136,7 @@ test.register_message_test(
   },
   {
     inner_block_ordering = "relaxed",
-    min_api_version = 17
+    min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -236,7 +236,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -266,7 +266,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_fibaro_roller_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_fibaro_roller_shutter.lua
@@ -68,7 +68,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -94,7 +94,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -120,7 +120,7 @@ test.register_message_test(
       }
     },
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -153,7 +153,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -186,7 +186,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -219,7 +219,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -253,7 +253,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -287,7 +287,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -309,7 +309,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -343,7 +343,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -377,7 +377,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -405,7 +405,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -431,7 +431,7 @@ test.register_coroutine_test(
       assert(mock_fibaro_roller_shutter:get_field("calibration") == "done", "Calibration should be done")
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -456,7 +456,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -483,7 +483,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -510,7 +510,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -537,7 +537,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -564,7 +564,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -591,7 +591,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -618,7 +618,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -645,7 +645,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -672,7 +672,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -699,7 +699,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -726,7 +726,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -753,7 +753,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -780,7 +780,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -807,7 +807,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -834,7 +834,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -851,7 +851,7 @@ test.register_coroutine_test(
     mock_fibaro_roller_shutter_venetian:expect_metadata_update({ profile = "fibaro-roller-shutter" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -867,7 +867,7 @@ test.register_coroutine_test(
     mock_fibaro_roller_shutter_venetian:expect_metadata_update({ profile = "fibaro-roller-shutter-venetian" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_qubino_flush_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_qubino_flush_shutter.lua
@@ -76,7 +76,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -109,7 +109,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -142,7 +142,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -175,7 +175,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -208,7 +208,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -230,7 +230,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -264,7 +264,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -297,7 +297,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -325,7 +325,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -358,7 +358,7 @@ test.register_coroutine_test(
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 )
 
@@ -383,7 +383,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -410,7 +410,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -437,7 +437,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -464,7 +464,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -491,7 +491,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -518,7 +518,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )
@@ -563,7 +563,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -582,7 +582,7 @@ test.register_coroutine_test(
   mock_qubino_flush_shutter:expect_metadata_update({ profile = "qubino-flush-shutter-venetian" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -601,7 +601,7 @@ test.register_coroutine_test(
     mock_qubino_flush_shutter:expect_metadata_update({ profile = "qubino-flush-shutter" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -623,7 +623,7 @@ test.register_coroutine_test(
     assert(targetValue == mock_qubino_flush_shutter.transient_store.shade_target, "driver should chache correct level value")
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -653,7 +653,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -686,7 +686,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -713,7 +713,7 @@ test.register_message_test(
     }
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -739,7 +739,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 15
   }
 )
 
@@ -772,7 +772,7 @@ do
       )
     end,
     {
-       min_api_version = 17
+       min_api_version = 14
     }
 
   )

--- a/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_aeotec_nano_shutter.lua
+++ b/drivers/SmartThings/zwave-window-treatment/src/test/test_zwave_aeotec_nano_shutter.lua
@@ -48,7 +48,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -69,7 +69,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -102,7 +102,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -141,7 +141,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -170,7 +170,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -199,7 +199,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -240,7 +240,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -287,7 +287,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -301,7 +301,7 @@ test.register_coroutine_test(
     mock_window_button:expect_metadata_update({ provisioning_state = "PROVISIONED" })
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -334,7 +334,7 @@ test.register_message_test(
     },
   },
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -349,7 +349,7 @@ test.register_coroutine_test(
     )
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 
@@ -369,7 +369,7 @@ test.register_coroutine_test(
     ))
   end,
   {
-     min_api_version = 17
+     min_api_version = 14
   }
 )
 

--- a/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_curtain.lua
+++ b/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_curtain.lua
@@ -59,7 +59,10 @@ test.register_coroutine_test(
     test.socket.zigbee:__expect_send({ mock_simple_device.id, zigbee_test_utils.build_bind_request(mock_simple_device, zigbee_test_utils.mock_hub_eui, Basic.ID) })
     test.socket.zigbee:__expect_send({ mock_simple_device.id, Basic.attributes.ApplicationVersion:configure_reporting(mock_simple_device, 30, 300, 1) })
     mock_simple_device:expect_metadata_update({ provisioning_state = "PROVISIONED" })
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -89,7 +92,10 @@ test.register_coroutine_test(
         tuya_utils.build_send_tuya_command(mock_simple_device, '\x05', tuya_utils.DP_TYPE_ENUM, '\x00', 1)
       }
     )
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -131,7 +137,10 @@ test.register_coroutine_test(
     test.socket.capability:__expect_send(
       mock_simple_device:generate_test_message("main", capabilities.windowShadePreset.supportedCommands({"presetPosition", "setPresetPosition"}, {visibility = {displayed=false}}))
     )
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -152,7 +161,10 @@ test.register_message_test(
         direction = "send",
         message = mock_simple_device:generate_test_message("main",  capabilities.windowShade.windowShade.opening())
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -173,7 +185,10 @@ test.register_message_test(
         direction = "send",
         message = mock_simple_device:generate_test_message("main",  capabilities.windowShade.windowShade.closing())
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -189,7 +204,10 @@ test.register_message_test(
         direction = "send",
         message = { mock_simple_device.id, tuya_utils.build_send_tuya_command(mock_simple_device, '\x01', tuya_utils.DP_TYPE_ENUM, '\x01', 0) }
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -205,7 +223,10 @@ test.register_message_test(
         direction = "send",
         message = { mock_simple_device.id, tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x3c', 0) }
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -221,7 +242,10 @@ test.register_message_test(
         direction = "send",
         message = { mock_simple_device.id, tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x32', 0) }
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -242,7 +266,10 @@ test.register_message_test(
         direction = "send",
         message = mock_simple_device:generate_test_message("main",  capabilities.windowShade.windowShade("partially open"))
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -259,7 +286,10 @@ test.register_message_test(
         -- For _TZE284_nladmfvf, level is inverted: 100 - 10 = 90 (0x5A)
         message = { mock_simple_device.id, tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x5a', 0) }
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_message_test(
@@ -276,7 +306,10 @@ test.register_message_test(
         -- For _TZE284_nladmfvf, level is inverted: 100 - 0 = 100 (0x64), but clamped to 0 so 100 - 0 = 100
         message = { mock_simple_device.id, tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x64', 0) }
       }
-    }
+    },
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -305,7 +338,10 @@ test.register_coroutine_test(
       mock_simple_device.id,
       tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x28', 0)
     })
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -334,7 +370,10 @@ test.register_coroutine_test(
       mock_simple_device.id,
       tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x00', 0)
     })
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -363,7 +402,10 @@ test.register_coroutine_test(
       mock_simple_device.id,
       tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x64', 0)
     })
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.register_coroutine_test(
@@ -405,7 +447,10 @@ test.register_coroutine_test(
       mock_simple_device.id,
       tuya_utils.build_send_tuya_command(mock_simple_device, '\x02', tuya_utils.DP_TYPE_VALUE, '\x00\x00\x00\x28', 1)
     })
-  end
+  end,
+  {
+    min_api_version = 17
+  }
 )
 
 test.run_registered_tests()

--- a/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_switch.lua
+++ b/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_switch.lua
@@ -254,6 +254,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x02', tuya_utils.DP_TYPE_BOOL, '\x01', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -270,6 +273,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x03', tuya_utils.DP_TYPE_BOOL, '\x01', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -286,6 +292,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x04', tuya_utils.DP_TYPE_BOOL, '\x01', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -302,6 +311,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x05', tuya_utils.DP_TYPE_BOOL, '\x01', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -318,6 +330,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x06', tuya_utils.DP_TYPE_BOOL, '\x01', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -334,6 +349,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x01', tuya_utils.DP_TYPE_BOOL, '\x00', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -350,6 +368,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x02', tuya_utils.DP_TYPE_BOOL, '\x00', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -366,6 +387,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x03', tuya_utils.DP_TYPE_BOOL, '\x00', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -382,6 +406,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x04', tuya_utils.DP_TYPE_BOOL, '\x00', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -398,6 +425,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x05', tuya_utils.DP_TYPE_BOOL, '\x00', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 
@@ -414,6 +444,9 @@ test.register_message_test(
       direction = "send",
       message = { mock_parent_device.id, tuya_utils.build_send_tuya_command(mock_parent_device, '\x06', tuya_utils.DP_TYPE_BOOL, '\x00', 0) }
     }
+  },
+  {
+    min_api_version = 17
   }
 )
 

--- a/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_thermostat.lua
+++ b/drivers/Unofficial/tuya-zigbee/src/test/test_tuya_thermostat.lua
@@ -166,7 +166,9 @@ test.register_message_test(
         }
       }
     },
-    {}
+    {
+      min_api_version = 17
+    }
 )
 
 test.register_message_test(
@@ -200,7 +202,9 @@ test.register_message_test(
         }
       }
     },
-    {}
+    {
+      min_api_version = 17
+    }
 )
 
 test.register_message_test(
@@ -234,7 +238,9 @@ test.register_message_test(
         }
       }
     },
-    {}
+    {
+      min_api_version = 17
+    }
 )
 
 test.register_message_test(
@@ -268,7 +274,9 @@ test.register_message_test(
         }
       }
     },
-    {}
+    {
+      min_api_version = 17
+    }
 )
 
 test.register_message_test(
@@ -302,7 +310,9 @@ test.register_message_test(
         }
       }
     },
-    {}
+    {
+      min_api_version = 17
+    }
 )
 
 test.register_message_test(
@@ -336,7 +346,9 @@ test.register_message_test(
         }
       }
     },
-    {}
+    {
+      min_api_version = 17
+    }
 )
 
 test.register_message_test(


### PR DESCRIPTION
- Updated min/max_api_version for tests passing and failing on HCv57 and 58.
- Fixed bad test manually setting `version.api = 9` and set min/max_api_version so that test only runs on v9