### PR TITLE
Driver test crashing visibility

### DIFF
--- a/tools/run_driver_tests_p.py
+++ b/tools/run_driver_tests_p.py
@@ -63,6 +63,12 @@ def run_test(test_file):
     else:
       successes += 1
     test_cases.append(test_case)
+  if error and error != "" and len(test_cases) == 0:
+    failure_output += "\t{} ERROR: test file failed to run\n".format(test_suite_name)
+    error_case = junit_xml.TestCase("(file error) {}".format(test_suite_name))
+    error_case.add_error_info("ERROR", error)
+    test_cases.append(error_case)
+    failures += 1
   test_suite.test_cases = test_cases
   return (test_suite, successes, failures, failure_output)
 


### PR DESCRIPTION
# Description of Change
- Added handling for error messages coming from tests files and reporting the errors to the XML output. This is then picked up by the GHA driver_test status output

# Summary of Completed Tests
- Made a test fail from a bad require and having the error show up on GH.

Screenshot of error being picked up by GH.
<img width="617" height="635" alt="image" src="https://github.com/user-attachments/assets/0f7f2475-7a69-4320-8671-ce2a4dfc567e" />
