### PR TITLE
Adding 57 and 58 to the Jenkins driver testing suite

### DIFF
--- a/.github/workflows/jenkins-driver-tests.yml
+++ b/.github/workflows/jenkins-driver-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         version:
-          [ 59, 60, 61, dev]
+          [57, 58, 59, 60, 61, dev]
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With 57/58 testing changes backported, updating testing to include the two versions.