### PR TITLE
WWSTCERT-12431 Update smart plug label

### DIFF
--- a/drivers/SmartThings/zwave-switch/fingerprints.yml
+++ b/drivers/SmartThings/zwave-switch/fingerprints.yml
@@ -874,7 +874,7 @@ zwaveManufacturer:
     productId: 0x1000
     deviceProfileName: metering-switch
   - id: 0312/FF00/FF0E
-    deviceLabel: Minoston Outlet
+    deviceLabel: Smart Plug
     manufacturerId: 0x0312
     productType: 0xFF00
     productId: 0xFF0E


### PR DESCRIPTION
## Summary
- Updates the device label for fingerprint `0312/FF00/FF0E` (Z-Wave Switch driver, `metering-switch` profile) from "Minoston Outlet" to "Smart Plug", per [WWSTCERT-12431](https://smartthings.atlassian.net/browse/WWSTCERT-12431).
- Same change pattern as [WWSTCERT-12427](https://smartthings.atlassian.net/browse/WWSTCERT-12427) / #3163.

## Test plan
- [x] Verified fingerprint entry in `drivers/SmartThings/zwave-switch/fingerprints.yml` updated correctly

[WWSTCERT-12431]: https://smartthings.atlassian.net/browse/WWSTCERT-12431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WWSTCERT-12427]: https://smartthings.atlassian.net/browse/WWSTCERT-12427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ