### PR TITLE
Fix profile name in fingerprint for Govee COB Strip Light

### DIFF
--- a/drivers/SmartThings/matter-switch/fingerprints.yml
+++ b/drivers/SmartThings/matter-switch/fingerprints.yml
@@ -927,6 +927,7 @@ matterManufacturer:
     deviceLabel: Govee COB Strip Light 2 Pro 16.4ft/5m
     vendorId: 0x1387
     productId: 0x1AA5
+    deviceProfileName: light-color-level
   - id: "4999/6723"
     deviceLabel: Govee Strip Light 2
     vendorId: 0x1387


### PR DESCRIPTION
This was just merged and is causing driver packaging failure. 
We should probably add some validation in CI/GHA for this.