### PR TITLE
Handle nil in PTZ command for axis clamping

### DIFF
--- a/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_handlers/capability_handlers.lua
+++ b/drivers/SmartThings/matter-switch/src/sub_drivers/camera/camera_handlers/capability_handlers.lua
@@ -157,9 +157,15 @@ CameraCapabilityHandlers.ptz_set_position_factory = function(command)
     -- a single-axis command should only set (and clamp) the axis it targets.
     local pan, tilt, zoom
     if command == capabilities.mechanicalPanTiltZoom.commands.setPanTiltZoom then
-      pan = utils.clamp_value(cmd.args.pan, ptz_map[camera_fields.PAN_IDX].range.minimum, ptz_map[camera_fields.PAN_IDX].range.maximum)
-      tilt = utils.clamp_value(cmd.args.tilt, ptz_map[camera_fields.TILT_IDX].range.minimum, ptz_map[camera_fields.TILT_IDX].range.maximum)
-      zoom = utils.clamp_value(cmd.args.zoom, ptz_map[camera_fields.ZOOM_IDX].range.minimum, ptz_map[camera_fields.ZOOM_IDX].range.maximum)
+      if cmd.args.pan ~= nil then
+        pan = utils.clamp_value(cmd.args.pan, ptz_map[camera_fields.PAN_IDX].range.minimum, ptz_map[camera_fields.PAN_IDX].range.maximum)
+      end
+      if cmd.args.tilt ~= nil then
+        tilt = utils.clamp_value(cmd.args.tilt, ptz_map[camera_fields.TILT_IDX].range.minimum, ptz_map[camera_fields.TILT_IDX].range.maximum)
+      end
+      if cmd.args.zoom ~= nil then
+        zoom = utils.clamp_value(cmd.args.zoom, ptz_map[camera_fields.ZOOM_IDX].range.minimum, ptz_map[camera_fields.ZOOM_IDX].range.maximum)
+      end
     elseif command == capabilities.mechanicalPanTiltZoom.commands.setPan then
       pan = utils.clamp_value(cmd.args.pan, ptz_map[camera_fields.PAN_IDX].range.minimum, ptz_map[camera_fields.PAN_IDX].range.maximum)
     elseif command == capabilities.mechanicalPanTiltZoom.commands.setTilt then

--- a/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
+++ b/drivers/SmartThings/matter-switch/src/test/test_matter_camera.lua
@@ -2353,6 +2353,24 @@ test.register_coroutine_test(
 )
 
 test.register_coroutine_test(
+  "Set PTZ command with a zoom-omitting setPanTiltZoom should not clamp the missing axis",
+  function()
+    update_device_profile()
+    test.wait_for_events()
+    test.socket.capability:__queue_receive({
+      mock_device.id,
+      { capability = "mechanicalPanTiltZoom", component = "main", command = "setPanTiltZoom", args = { 0, 0 } },
+    })
+    test.socket.matter:__expect_send({
+      mock_device.id, clusters.CameraAvSettingsUserLevelManagement.server.commands.MPTZSetPosition(mock_device, CAMERA_EP, 0, 0, nil)
+    })
+  end,
+  {
+     min_api_version = 14
+  }
+)
+
+test.register_coroutine_test(
   "Preset commands should send the appropriate commands",
   function()
     update_device_profile()


### PR DESCRIPTION
# Description of Change

The `mechanicalPanTiltZoom::setPanTiltZoom` command allows individual axes to be omitted (matching Matter's per-axis feature conformance for pan/tilt/zoom), but `ptz_set_position_factory`'s `setPanTiltZoom` branch unconditionally clamped `cmd.args.pan`, `cmd.args.tilt`, and `cmd.args.zoom`, crashing with `bad argument ... Arguments must be numbers` from `utils.clamp_value` whenever one of them came in as nil (e.g. Camera plugin sending setPanTiltZoom with only pan/tilt set for "Original Position" preset on a PT-only camera).

```
<Matter Switch (4bb27c0e)> _devices_thread thread encountered error: [string "st/dispatcher.lua"]:270: Error encountered while processing event for <MatterDevice: 5fcbfee5-039e-49ba-b2b1-7e4c50279ac9
  [45318B1F6D97F441-BF3E9E41FB94D1E5] (Tapo C260)>:
      arg1: {args={pan=0, tilt=0}, capability="mechanicalPanTiltZoom", command="setPanTiltZoom", component="main", named_args=RecursiveTable: args, positional_args={0, 0}}
  "[string "st/dispatcher.lua"]:270: Error encountered while processing event for <MatterDevice: 5fcbfee5-039e-49ba-b2b1-7e4c50279ac9 [45318B1F6D97F441-BF3E9E41FB94D1E5] (Tapo C260)>:
      arg1: {args={pan=0, tilt=0}, capability="mechanicalPanTiltZoom", command="setPanTiltZoom", component="main", named_args=RecursiveTable: args, positional_args={0, 0}}
  "[string "st/utils/clamp_value.lua"]:11: Arguments must be numbers""
```

The fix is to guard each axis with a nil check before clamping, leaving omitted axes as nil, consistent with how the `setPan/setTilt/setZoom`-only branches, and the neighboring `ptz_relative_move_factory`, already handle it.

# Summary of Completed Tests

- Tested with camera that supports PT and issued "Original position" (that results in `setPanTiltZoom` with null zoom field)
- Tested with camera that supports PTZ and issued "Original position" (that results in `setPanTiltZoom` with all fields populated)
- Added a unit test covering the case that was encountered on the original issue
